### PR TITLE
feat: Claude rate-limit session handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ When a terminal session is finished normally, Knowl deterministically promotes a
 
 `knowl init` installs verified project-local hooks for Codex CLI, Claude Code, and Cursor. Those hooks call the internal `knowl agent-hook <host> <event>` translator, which normalizes vendor payloads into bounded session events. Session and prompt starts receive compact current context; successful commands, file changes, tests, failures, compaction checkpoints, and turn completion feed the existing validation/evidence/promotion pipeline.
 
+When Claude emits `StopFailure` with a rate-limit or other hard stop error, Knowl stores a deterministic `pending_handoff` state item (no AI required). The next `SessionStart` injects that handoff first, then normal recent context, and archives the handoff so it is delivered once.
+
 Raw prompts, transcripts, stdout/stderr, environment variables, and unknown fields are not retained. Malformed or secret-bearing payloads are rejected, duplicate stop events are idempotently dropped, and stale sessions recover at the next session start. A generic stdin-JSON contract is available for other hosts, but normal users only run `knowl init` and `knowl doctor`.
 
 Hook support remains host-specific. Knowl never guesses or writes an unverified host configuration. Unsupported hosts retain MCP access; `knowl task run` remains the manual fallback.
@@ -355,3 +357,4 @@ The package payload is limited to:
 ## License
 
 Knowl is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for the full terms.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Knowledge Operating System for AI Agents",
   "main": "dist/index.js",
   "type": "module",
@@ -62,3 +62,4 @@
     "vitest": "^3.0.2"
   }
 }
+

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -125,6 +125,27 @@ function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: 
   return { type: 'checkpoint', payload: { summary: `${toolName || 'Tool'} completed`.slice(0, MAX_STRING) } };
 }
 
+function failurePayload(raw: Record<string, unknown>, failed: boolean): Record<string, unknown> {
+  if (!failed) return { status: 'finished' };
+  const nestedError = recordValue(raw.error);
+  const errorCode = stringValue(raw.error)
+    ?? stringValue(raw.code)
+    ?? stringValue(raw.error_code)
+    ?? stringValue(nestedError?.code)
+    ?? stringValue(nestedError?.type)
+    ?? stringValue(nestedError?.error);
+  const message = stringValue(raw.message)
+    ?? stringValue(raw.summary)
+    ?? stringValue(raw.error_message)
+    ?? stringValue(nestedError?.message)
+    ?? (errorCode ? undefined : stringValue(raw.error));
+  return {
+    status: 'failed',
+    ...(errorCode ? { error: errorCode, code: errorCode } : {}),
+    ...(message ? { message } : {}),
+  };
+}
+
 function normalizeGeneric(eventName: string, raw: Record<string, unknown>, projectRoot: string, ids: ReturnType<typeof externalIds>): NormalizedHostHook {
   const event = eventName as NormalizedHookEventName;
   const allowed: NormalizedHookEventName[] = ['session-start', 'turn-start', 'session-event', 'checkpoint', 'turn-stop', 'session-stop'];
@@ -133,7 +154,7 @@ function normalizeGeneric(eventName: string, raw: Record<string, unknown>, proje
   if (event === 'session-event' && type === undefined) throw new IncompleteHostHookPayloadError('Generic session event requires a type.');
   if (type !== undefined && !isSessionEventType(type)) throw new Error(`Unsupported session event type: ${String(type)}`);
   const payload: Record<string, unknown> = {};
-  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status']) {
+  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message']) {
     if (raw[key] !== undefined) payload[key] = Array.isArray(raw[key]) ? raw[key] : typeof raw[key] === 'string' ? String(raw[key]).slice(0, MAX_STRING) : raw[key];
   }
   return {
@@ -188,8 +209,15 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
     return { host: normalizedHost, event, ...ids, projectRoot, type: 'checkpoint', payload: { changedPaths: changedPaths(projectRoot, raw) } };
   }
   if (event === 'turn-stop' || event === 'session-stop') {
-    const failed = eventName === 'StopFailure';
-    return { host: normalizedHost, event, ...ids, projectRoot, status: failed ? 'failed' : 'finished', payload: { status: failed ? 'failed' : 'finished' } };
+    const failed = eventName === 'StopFailure' || stringValue(raw.status) === 'failed' || Boolean(stringValue(raw.error) || recordValue(raw.error));
+    return {
+      host: normalizedHost,
+      event,
+      ...ids,
+      projectRoot,
+      status: failed ? 'failed' : 'finished',
+      payload: failurePayload(raw, failed),
+    };
   }
   if (eventName === 'PostToolUseFailure' || eventName === 'postToolUseFailure') {
     return { host: normalizedHost, event, ...ids, projectRoot, type: 'error', status: 'failed', payload: { message: stringValue(raw.error) ?? 'Tool failed' } };

--- a/src/cli/agents/lifecycle.ts
+++ b/src/cli/agents/lifecycle.ts
@@ -15,13 +15,14 @@ const ROOT_FIELDS = new Set([
   'session_id', 'sessionId', 'thread_id', 'turn_id', 'turnId', 'conversation_id', 'generation_id', 'cwd', 'workspace_roots',
   'title', 'query', 'agent', 'type', 'status', 'summary', 'command', 'exit_code', 'exitCode', 'passed',
   'message', 'code', 'text', 'changedPaths', 'changed_paths', 'commit', 'file_path', 'filePath', 'path',
-  'tool_name', 'toolName', 'error', 'tool_input', 'toolInput', 'tool_response', 'toolResponse',
+  'tool_name', 'toolName', 'error', 'error_code', 'error_message', 'tool_input', 'toolInput', 'tool_response', 'toolResponse',
 ]);
 const NESTED_FIELDS: Record<string, Set<string>> = {
   tool_input: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path']),
   toolInput: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path']),
   tool_response: new Set(['exit_code', 'exitCode']),
   toolResponse: new Set(['exit_code', 'exitCode']),
+  error: new Set(['code', 'type', 'message', 'error']),
 };
 const ARRAY_FIELDS = new Set(['workspace_roots', 'changedPaths', 'changed_paths', 'file_paths', 'filePaths']);
 
@@ -121,3 +122,5 @@ export function stringPayloadValue(payload: Record<string, unknown>, key: string
   const value = payload[key];
   return typeof value === 'string' ? value : undefined;
 }
+
+

--- a/src/store/host-lifecycle.ts
+++ b/src/store/host-lifecycle.ts
@@ -11,6 +11,8 @@ import {
   getOrCreateHostSession,
   HostSessionKey,
 } from './host-session-bindings.js';
+import { consumePendingSessionHandoff, recordPendingSessionHandoff } from './session-handoff.js';
+import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
 
 export type HostLifecycleResult = {
   accepted: boolean;
@@ -21,6 +23,7 @@ export type HostLifecycleResult = {
   recoveredCount?: number;
   purgedEventCount?: number;
   promotion?: Awaited<ReturnType<typeof finalizeMemorySession>>;
+  handoff?: Awaited<ReturnType<typeof recordPendingSessionHandoff>>;
   hostOutput?: Record<string, unknown>;
 };
 
@@ -44,6 +47,28 @@ function hostContextOutput(input: NormalizedHostHook, context: string | undefine
   };
 }
 
+function mergeBootstrapContext(handoffContext: string | undefined, recentContext: string | undefined): { context?: string; truncated: boolean } {
+  if (!handoffContext && !recentContext) return { context: undefined, truncated: false };
+  if (!handoffContext) {
+    return {
+      context: recentContext,
+      truncated: Boolean(recentContext && recentContext.length > DEFAULT_CONTEXT_MAX_CHARS),
+    };
+  }
+  if (!recentContext) {
+    return {
+      context: handoffContext,
+      truncated: handoffContext.length > DEFAULT_CONTEXT_MAX_CHARS,
+    };
+  }
+  const combined = `${handoffContext}\n\n${recentContext}`;
+  const truncated = combined.length > DEFAULT_CONTEXT_MAX_CHARS;
+  return {
+    context: truncated ? truncateText(combined, DEFAULT_CONTEXT_MAX_CHARS, '\n\n[Context truncated]') : combined,
+    truncated,
+  };
+}
+
 async function startBoundSession(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext = false) {
   return getOrCreateHostSession({
     projectId,
@@ -53,12 +78,26 @@ async function startBoundSession(projectId: string, input: NormalizedHostHook, s
   });
 }
 
+async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext: boolean) {
+  const started = await startBoundSession(projectId, input, scope, includeContext);
+  if (!includeContext) return { ...started, handoff: null as Awaited<ReturnType<typeof consumePendingSessionHandoff>> };
+
+  const handoff = await consumePendingSessionHandoff(projectId);
+  const merged = mergeBootstrapContext(handoff?.context, started.context);
+  return {
+    ...started,
+    context: merged.context,
+    truncated: merged.truncated,
+    handoff,
+  };
+}
+
 export async function handleHostLifecycleEvent(projectId: string, input: NormalizedHostHook): Promise<HostLifecycleResult> {
   if (input.event === 'session-start') {
     const recovered = await recoverAbandonedSessions();
     const purgedEventCount = await purgeExpiredSessionEvents();
     await closeInactiveHostSessionBindings();
-    const started = await startBoundSession(projectId, input, 'session', true);
+    const started = await bootstrapWithHandoff(projectId, input, 'session', true);
     return {
       accepted: true,
       sessionId: started.session.id,
@@ -73,7 +112,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
   if (input.event === 'turn-start') {
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
     if (!sessionBinding && (input.host === 'codex' || input.host === 'claude')) {
-      const started = await startBoundSession(projectId, input, 'session', true);
+      const started = await bootstrapWithHandoff(projectId, input, 'session', true);
       await bindHostSession(bindingKey(input, 'turn'), started.session.id);
       return {
         accepted: true,
@@ -83,7 +122,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         hostOutput: hostContextOutput(input, started.context),
       };
     }
-    const started = await startBoundSession(projectId, input, 'turn', !sessionBinding);
+    const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding);
     if (!sessionBinding) await bindHostSession(bindingKey(input, 'session'), started.session.id);
     return {
       accepted: true,
@@ -104,17 +143,24 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
 
   if (input.event === 'turn-stop') {
     const key = bindingKey(input, 'turn');
-    const session = await findHostSession(key);
-    if (!session) return { accepted: false, reason: 'event-loss' };
+    let session = await findHostSession(key);
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
+    // gpt-5.5 StopFailure may arrive without a turn binding. Fall back to the session binding
+    // so rate-limit handoffs still persist when only SessionStart existed.
+    if (!session && input.status === 'failed' && sessionBinding) {
+      session = sessionBinding;
+    }
+    if (!session) return { accepted: false, reason: 'event-loss' };
     if ((input.host === 'codex' || input.host === 'claude') && sessionBinding?.id === session.id) {
+      const handoff = await recordPendingSessionHandoff(projectId, input, { memorySessionId: session.id });
       await closeHostSessionBinding(key);
-      return { accepted: true, sessionId: session.id };
+      return { accepted: true, sessionId: session.id, handoff };
     }
     await finishMemorySession(session.id, input.status ?? 'finished', typeof input.payload.summary === 'string' ? input.payload.summary : undefined);
     const promotion = await finalizeMemorySession(projectId, session.id);
+    const handoff = await recordPendingSessionHandoff(projectId, input, { memorySessionId: session.id });
     await closeHostSessionBinding(key);
-    return { accepted: true, sessionId: session.id, promotion };
+    return { accepted: true, sessionId: session.id, promotion, handoff };
   }
 
   const key = bindingKey(input, 'session');
@@ -125,7 +171,8 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
   }
   await finishMemorySession(session.id, input.status ?? 'finished', typeof input.payload.summary === 'string' ? input.payload.summary : undefined);
   const promotion = await finalizeMemorySession(projectId, session.id);
+  const handoff = await recordPendingSessionHandoff(projectId, input, { memorySessionId: session.id });
   await closeHostSessionBinding(key);
   await closeHostSessionBindings(bindingKey(input, 'turn'));
-  return { accepted: true, sessionId: session.id, promotion };
+  return { accepted: true, sessionId: session.id, promotion, handoff };
 }

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -1,0 +1,255 @@
+import { NormalizedHostHook } from '../cli/agents/host-hook.js';
+import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
+import { normalizeConflictKey } from './conflicts.js';
+import * as repo from './repository.js';
+import { getClient } from './database.js';
+import { getMemorySession } from './session-repository.js';
+
+export const PENDING_HANDOFF_CONFLICT_KEY = 'pending-session-handoff';
+export const PENDING_HANDOFF_TITLE = 'Pending session handoff';
+export const RATE_LIMIT_URGENCY = 'critical';
+export const GENERIC_FAILURE_URGENCY = 'high';
+
+export type SessionFailureKind = 'rate_limit' | 'failed';
+
+export type PendingHandoff = {
+  kind: SessionFailureKind;
+  urgency: typeof RATE_LIMIT_URGENCY | typeof GENERIC_FAILURE_URGENCY;
+  host: string;
+  projectRoot: string;
+  externalSessionId: string;
+  memorySessionId?: string;
+  sessionTitle?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  lastCheckpoint?: string;
+  changedPaths?: string[];
+  failedAt: string;
+  consumed?: boolean;
+  consumedAt?: string;
+};
+
+const RATE_LIMIT_MARKERS = [
+  'rate_limit',
+  'rate-limit',
+  'ratelimit',
+  'rate limit',
+  'usage_limit',
+  'usage-limit',
+  'usage limit',
+  'quota_exceeded',
+  'quota exceeded',
+  'session limit',
+  'hit your limit',
+  'limit reached',
+];
+
+function asString(value: unknown, max = 2_000): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim().slice(0, max) : undefined;
+}
+
+function collectStrings(value: unknown, out: string[] = [], depth = 0): string[] {
+  if (depth > 4 || value == null) return out;
+  if (typeof value === 'string') {
+    out.push(value);
+    return out;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    out.push(String(value));
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value.slice(0, 20)) collectStrings(entry, out, depth + 1);
+    return out;
+  }
+  if (typeof value === 'object') {
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>).slice(0, 40)) {
+      out.push(key);
+      collectStrings(entry, out, depth + 1);
+    }
+  }
+  return out;
+}
+
+export function detectSessionFailureKind(payload: Record<string, unknown>, status?: 'finished' | 'failed'): SessionFailureKind | null {
+  if (status !== 'failed' && status !== undefined) return null;
+  const haystack = collectStrings(payload).join(' ').toLowerCase();
+  if (RATE_LIMIT_MARKERS.some(marker => haystack.includes(marker))) return 'rate_limit';
+  if (status === 'failed') return 'failed';
+  return null;
+}
+
+function parseHandoffContent(content: string): PendingHandoff | null {
+  try {
+    const parsed = JSON.parse(content) as PendingHandoff;
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (parsed.kind !== 'rate_limit' && parsed.kind !== 'failed') return null;
+    if (!parsed.failedAt || !parsed.host || !parsed.projectRoot || !parsed.externalSessionId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary?: string; changedPaths?: string[] }> {
+  const rows = (await getClient().execute({
+    sql: `SELECT payload FROM memory_session_events
+      WHERE session_id = ? AND type = 'checkpoint'
+      ORDER BY observed_at DESC
+      LIMIT 1`,
+    args: [sessionId],
+  })).rows;
+  if (!rows[0]) return {};
+  try {
+    const payload = JSON.parse(String(rows[0].payload)) as Record<string, unknown>;
+    const summary = asString(payload.summary);
+    const changedPaths = Array.isArray(payload.changedPaths)
+      ? payload.changedPaths.filter((value): value is string => typeof value === 'string').slice(0, 20)
+      : undefined;
+    return { summary, changedPaths };
+  } catch {
+    return {};
+  }
+}
+
+async function findActivePendingHandoff(projectId: string) {
+  void projectId;
+  const conflictKey = normalizeConflictKey(PENDING_HANDOFF_CONFLICT_KEY);
+  const rows = await getClient().execute({
+    sql: `SELECT id, content, tags FROM knowledge_items
+      WHERE status = 'active' AND category = 'state' AND conflict_key = ?
+      ORDER BY updated_at DESC
+      LIMIT 5`,
+    args: [conflictKey],
+  });
+  for (const row of rows.rows) {
+    const handoff = parseHandoffContent(String(row.content));
+    if (!handoff || handoff.consumed) continue;
+    return { id: String(row.id), handoff };
+  }
+  return null;
+}
+
+export function formatPendingHandoffContext(handoff: PendingHandoff): string {
+  const lines = [
+    '# KNOWL - PENDING SESSION HANDOFF',
+    '',
+    'Previous host session ended before a clean finish. Continue from this handoff first.',
+    '',
+    `- Kind: ${handoff.kind}`,
+    `- Urgency: ${handoff.urgency}`,
+    `- Host: ${handoff.host}`,
+    `- Failed at: ${handoff.failedAt}`,
+    `- External session: ${handoff.externalSessionId}`,
+  ];
+  if (handoff.memorySessionId) lines.push(`- Memory session: ${handoff.memorySessionId}`);
+  if (handoff.sessionTitle) lines.push(`- Session title: ${handoff.sessionTitle}`);
+  if (handoff.errorCode) lines.push(`- Error code: ${handoff.errorCode}`);
+  if (handoff.errorMessage) lines.push(`- Error: ${handoff.errorMessage}`);
+  if (handoff.lastCheckpoint) lines.push(`- Last checkpoint: ${handoff.lastCheckpoint}`);
+  if (handoff.changedPaths?.length) lines.push(`- Changed paths: ${handoff.changedPaths.join(', ')}`);
+  lines.push('', 'Do not restart from scratch. Resume the interrupted work using this handoff plus recent project memory.');
+  return truncateText(lines.join('\n'), DEFAULT_CONTEXT_MAX_CHARS);
+}
+
+export async function recordPendingSessionHandoff(
+  projectId: string,
+  input: NormalizedHostHook,
+  options: { memorySessionId?: string } = {},
+): Promise<{ itemId: string; handoff: PendingHandoff } | null> {
+  const kind = detectSessionFailureKind(input.payload, input.status);
+  if (!kind) return null;
+
+  let sessionTitle: string | undefined;
+  let lastCheckpoint: string | undefined;
+  let changedPaths: string[] | undefined;
+  if (options.memorySessionId) {
+    try {
+      const session = await getMemorySession(options.memorySessionId);
+      sessionTitle = session.title;
+    } catch {
+      // Session may already be terminal or missing; handoff still records host failure.
+    }
+    const checkpoint = await loadLatestSessionCheckpoint(options.memorySessionId);
+    lastCheckpoint = checkpoint.summary;
+    changedPaths = checkpoint.changedPaths;
+  }
+
+  const handoff: PendingHandoff = {
+    kind,
+    urgency: kind === 'rate_limit' ? RATE_LIMIT_URGENCY : GENERIC_FAILURE_URGENCY,
+    host: String(input.host),
+    projectRoot: input.projectRoot,
+    externalSessionId: input.externalSessionId,
+    memorySessionId: options.memorySessionId,
+    sessionTitle,
+    errorCode: asString(input.payload.error ?? input.payload.code ?? input.payload.error_code, 200),
+    errorMessage: asString(input.payload.message ?? input.payload.summary ?? input.payload.error_message, 500),
+    lastCheckpoint,
+    changedPaths,
+    failedAt: new Date().toISOString(),
+    consumed: false,
+  };
+
+  const existing = await findActivePendingHandoff(projectId);
+  if (existing) {
+    const updated = await repo.updateKnowledgeItem(existing.id, {
+      title: PENDING_HANDOFF_TITLE,
+      content: JSON.stringify(handoff),
+      tags: ['pending_handoff', kind, handoff.urgency, String(input.host)],
+      source: `host://${input.host}/session-failure`,
+      freshness: 'fresh',
+      confidence: kind === 'rate_limit' ? 1 : 0.9,
+      conflictKey: PENDING_HANDOFF_CONFLICT_KEY,
+      conflictExclusive: true,
+    });
+    await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${kind})`, [
+      { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
+    ]);
+    return { itemId: updated.id, handoff };
+  }
+
+  const created = await repo.createKnowledgeItem(projectId, {
+    category: 'state',
+    title: PENDING_HANDOFF_TITLE,
+    content: JSON.stringify(handoff),
+    tags: ['pending_handoff', kind, handoff.urgency, String(input.host)],
+    source: `host://${input.host}/session-failure`,
+    freshness: 'fresh',
+    confidence: kind === 'rate_limit' ? 1 : 0.9,
+    conflictKey: PENDING_HANDOFF_CONFLICT_KEY,
+    conflictExclusive: true,
+  });
+  await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${kind})`, [
+    { itemId: created.id, action: 'insert', after: created },
+  ]);
+  return { itemId: created.id, handoff };
+}
+
+export async function consumePendingSessionHandoff(
+  projectId: string,
+): Promise<{ itemId: string; handoff: PendingHandoff; context: string } | null> {
+  const existing = await findActivePendingHandoff(projectId);
+  if (!existing) return null;
+
+  const consumed: PendingHandoff = {
+    ...existing.handoff,
+    consumed: true,
+    consumedAt: new Date().toISOString(),
+  };
+  const updated = await repo.updateKnowledgeItem(existing.id, {
+    content: JSON.stringify(consumed),
+    status: 'archived',
+    freshness: 'stale',
+    tags: ['pending_handoff', existing.handoff.kind, existing.handoff.urgency, existing.handoff.host, 'consumed'],
+  });
+  await repo.createKnowledgeCommit(projectId, `Consume pending session handoff (${existing.handoff.kind})`, [
+    { itemId: updated.id, action: 'archive', after: updated },
+  ]);
+
+  return {
+    itemId: updated.id,
+    handoff: existing.handoff,
+    context: formatPendingHandoffContext(existing.handoff),
+  };
+}

--- a/tests/cli/host-hook.test.ts
+++ b/tests/cli/host-hook.test.ts
@@ -113,8 +113,31 @@ describe('host hook normalization', () => {
     expect(result.payload).not.toHaveProperty('stdout');
   });
 
+
+  it('preserves Claude StopFailure rate-limit error codes', () => {
+    const result = normalizeHostHook('claude', 'StopFailure', {
+      session_id: 'session-rate',
+      turn_id: 'turn-rate',
+      cwd: ROOT,
+      error: 'rate_limit',
+      message: 'Claude session limit hit',
+    });
+
+    expect(result).toMatchObject({
+      host: 'claude',
+      event: 'turn-stop',
+      status: 'failed',
+      payload: {
+        status: 'failed',
+        error: 'rate_limit',
+        code: 'rate_limit',
+        message: 'Claude session limit hit',
+      },
+    });
+  });
   it('rejects unsupported hosts and events', () => {
     expect(() => normalizeHostHook('unknown', 'SessionStart', {})).toThrow('Unsupported hook host');
     expect(() => normalizeHostHook('codex', 'UnknownEvent', { session_id: 's', cwd: ROOT })).toThrow('Unsupported codex hook event');
   });
 });
+

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -166,4 +166,77 @@ describe('host lifecycle orchestration', () => {
     expect(event).toEqual({ accepted: true, sessionId: expect.any(String) });
     expect(stop.accepted).toBe(true);
   });
+
+  it('stores a Claude rate-limit handoff and injects it first on the next SessionStart', async () => {
+    const sessionStart = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+    const checkpoint = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'checkpoint',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: 'turn-rate',
+      type: 'checkpoint',
+      payload: { summary: 'Human review gate active', changedPaths: ['src/forge.ts'] },
+    }));
+    const failedStop = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: 'turn-rate',
+      status: 'failed',
+      payload: { status: 'failed', error: 'rate_limit', message: 'Claude session limit hit' },
+    }));
+
+    expect(sessionStart.accepted).toBe(true);
+    expect(checkpoint.accepted).toBe(true);
+    expect(failedStop.accepted).toBe(true);
+    expect(failedStop.handoff?.handoff.kind).toBe('rate_limit');
+    expect(failedStop.handoff?.handoff.lastCheckpoint).toBe('Human review gate active');
+
+    const nextStart = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-resume',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+    const secondStart = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-resume-2',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+
+    expect(String(nextStart.context)).toContain('PENDING SESSION HANDOFF');
+    expect(String(nextStart.context)).toContain('rate_limit');
+    expect(String(nextStart.context)).toContain('Human review gate active');
+    expect(String(nextStart.context)).toContain('Use local memory');
+    expect(String(secondStart.context)).not.toContain('PENDING SESSION HANDOFF');
+  });
+
+  it('records lower-urgency handoffs for non-limit StopFailure events', async () => {
+    await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-generic-fail',
+      externalTurnId: undefined,
+    }));
+    const failedStop = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-generic-fail',
+      externalTurnId: 'turn-fail',
+      status: 'failed',
+      payload: { status: 'failed', error: 'model_error', message: 'provider blew up' },
+    }));
+
+    expect(failedStop.handoff?.handoff.kind).toBe('failed');
+    expect(failedStop.handoff?.handoff.urgency).toBe('high');
+  });
 });

--- a/tests/store/session-handoff.test.ts
+++ b/tests/store/session-handoff.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { detectSessionFailureKind, formatPendingHandoffContext } from '../../src/store/session-handoff.js';
+
+describe('session handoff helpers', () => {
+  it('detects Claude rate-limit failures from structured error codes', () => {
+    expect(detectSessionFailureKind({ status: 'failed', error: 'rate_limit' }, 'failed')).toBe('rate_limit');
+    expect(detectSessionFailureKind({ status: 'failed', error: { code: 'rate_limit', message: 'hit limit' } }, 'failed')).toBe('rate_limit');
+    expect(detectSessionFailureKind({ status: 'failed', message: 'Session limit reached' }, 'failed')).toBe('rate_limit');
+  });
+
+  it('keeps non-limit failures as generic failed handoffs', () => {
+    expect(detectSessionFailureKind({ status: 'failed', message: 'model crashed' }, 'failed')).toBe('failed');
+    expect(detectSessionFailureKind({ status: 'finished' }, 'finished')).toBeNull();
+  });
+
+  it('formats a resume-first handoff block', () => {
+    const text = formatPendingHandoffContext({
+      kind: 'rate_limit',
+      urgency: 'critical',
+      host: 'claude',
+      projectRoot: 'D:/Code/demo',
+      externalSessionId: 'sess-1',
+      memorySessionId: 'mem-1',
+      sessionTitle: 'Agent session',
+      errorCode: 'rate_limit',
+      lastCheckpoint: 'Review loop gated',
+      changedPaths: ['src/forge.ts'],
+      failedAt: '2026-07-12T00:00:00.000Z',
+    });
+
+    expect(text).toContain('PENDING SESSION HANDOFF');
+    expect(text).toContain('rate_limit');
+    expect(text).toContain('Review loop gated');
+    expect(text).toContain('Do not restart from scratch');
+  });
+});


### PR DESCRIPTION
## Summary
Adds deterministic Claude session-limit handoff support so a hard stop can leave a resume note for the next chat without requiring AI after the model dies.

## What changed
- Claude `StopFailure` / failed host stops now preserve structured error codes such as `rate_limit`
- Knowl stores a project-local `pending_handoff` state item from the last checkpoint + failure metadata
- Next `SessionStart` injects that handoff first, then normal recent context, and archives it so it is delivered once
- Non-limit failures still record a lower-urgency handoff
- Tests cover host-hook normalization, handoff detection, and lifecycle store/inject/consume flow
- Version bump to `1.1.1`

## Why
Claude session limits currently kill a turn without a durable resume note. Structured Knowl writes do not need AI, so this path can still save a handoff even when the model is already dead.

## Test plan
- [x] `vitest run tests/store/host-lifecycle.test.ts tests/store/session-handoff.test.ts tests/cli/host-hook.test.ts`
- [ ] Manual Claude project with hooks installed: force/stop-fail with rate limit, restart session, confirm handoff context appears once