### PR TITLE
feat: carry structured task state through session handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ When a terminal session is finished normally, Knowl deterministically promotes a
 
 `knowl init` installs verified project-local hooks for Codex CLI, Claude Code, and Cursor. Those hooks call the internal `knowl agent-hook <host> <event>` translator, which normalizes vendor payloads into bounded session events. Session and prompt starts receive compact current context; successful commands, file changes, tests, failures, compaction checkpoints, and turn completion feed the existing validation/evidence/promotion pipeline.
 
+When Claude emits `StopFailure` with a rate-limit or other hard stop error, Knowl stores a deterministic `pending_handoff` state item (no AI required). The next `SessionStart` injects that handoff first, then normal recent context, and archives the handoff so it is delivered once.
+
 Raw prompts, transcripts, stdout/stderr, environment variables, and unknown fields are not retained. Malformed or secret-bearing payloads are rejected, duplicate stop events are idempotently dropped, and stale sessions recover at the next session start. A generic stdin-JSON contract is available for other hosts, but normal users only run `knowl init` and `knowl doctor`.
 
 Hook support remains host-specific. Knowl never guesses or writes an unverified host configuration. Unsupported hosts retain MCP access; `knowl task run` remains the manual fallback.
@@ -355,3 +357,4 @@ The package payload is limited to:
 ## License
 
 Knowl is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for the full terms.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Knowledge Operating System for AI Agents",
   "main": "dist/index.js",
   "type": "module",
@@ -62,3 +62,4 @@
     "vitest": "^3.0.2"
   }
 }
+

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -125,6 +125,27 @@ function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: 
   return { type: 'checkpoint', payload: { summary: `${toolName || 'Tool'} completed`.slice(0, MAX_STRING) } };
 }
 
+function failurePayload(raw: Record<string, unknown>, failed: boolean): Record<string, unknown> {
+  if (!failed) return { status: 'finished' };
+  const nestedError = recordValue(raw.error);
+  const errorCode = stringValue(raw.error)
+    ?? stringValue(raw.code)
+    ?? stringValue(raw.error_code)
+    ?? stringValue(nestedError?.code)
+    ?? stringValue(nestedError?.type)
+    ?? stringValue(nestedError?.error);
+  const message = stringValue(raw.message)
+    ?? stringValue(raw.summary)
+    ?? stringValue(raw.error_message)
+    ?? stringValue(nestedError?.message)
+    ?? (errorCode ? undefined : stringValue(raw.error));
+  return {
+    status: 'failed',
+    ...(errorCode ? { error: errorCode, code: errorCode } : {}),
+    ...(message ? { message } : {}),
+  };
+}
+
 function normalizeGeneric(eventName: string, raw: Record<string, unknown>, projectRoot: string, ids: ReturnType<typeof externalIds>): NormalizedHostHook {
   const event = eventName as NormalizedHookEventName;
   const allowed: NormalizedHookEventName[] = ['session-start', 'turn-start', 'session-event', 'checkpoint', 'turn-stop', 'session-stop'];
@@ -133,7 +154,7 @@ function normalizeGeneric(eventName: string, raw: Record<string, unknown>, proje
   if (event === 'session-event' && type === undefined) throw new IncompleteHostHookPayloadError('Generic session event requires a type.');
   if (type !== undefined && !isSessionEventType(type)) throw new Error(`Unsupported session event type: ${String(type)}`);
   const payload: Record<string, unknown> = {};
-  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status']) {
+  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message']) {
     if (raw[key] !== undefined) payload[key] = Array.isArray(raw[key]) ? raw[key] : typeof raw[key] === 'string' ? String(raw[key]).slice(0, MAX_STRING) : raw[key];
   }
   return {
@@ -188,8 +209,15 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
     return { host: normalizedHost, event, ...ids, projectRoot, type: 'checkpoint', payload: { changedPaths: changedPaths(projectRoot, raw) } };
   }
   if (event === 'turn-stop' || event === 'session-stop') {
-    const failed = eventName === 'StopFailure';
-    return { host: normalizedHost, event, ...ids, projectRoot, status: failed ? 'failed' : 'finished', payload: { status: failed ? 'failed' : 'finished' } };
+    const failed = eventName === 'StopFailure' || stringValue(raw.status) === 'failed' || Boolean(stringValue(raw.error) || recordValue(raw.error));
+    return {
+      host: normalizedHost,
+      event,
+      ...ids,
+      projectRoot,
+      status: failed ? 'failed' : 'finished',
+      payload: failurePayload(raw, failed),
+    };
   }
   if (eventName === 'PostToolUseFailure' || eventName === 'postToolUseFailure') {
     return { host: normalizedHost, event, ...ids, projectRoot, type: 'error', status: 'failed', payload: { message: stringValue(raw.error) ?? 'Tool failed' } };

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -92,6 +92,20 @@ function changedPaths(projectRoot: string, raw: Record<string, unknown>): string
     .slice(0, 50);
 }
 
+function checkpointState(raw: Record<string, unknown>): Record<string, unknown> {
+  const state: Record<string, unknown> = {};
+  for (const key of ['goal', 'completed', 'nextAction', 'blocker', 'artifactRefs']) {
+    const value = raw[key];
+    if (value === undefined) continue;
+    state[key] = Array.isArray(value)
+      ? value.filter((entry): entry is string => typeof entry === 'string').slice(0, 20).map(entry => entry.slice(0, MAX_STRING))
+      : typeof value === 'string'
+        ? value.slice(0, MAX_STRING)
+        : value;
+  }
+  return state;
+}
+
 function toolInput(raw: Record<string, unknown>): Record<string, unknown> {
   return recordValue(raw.tool_input) ?? recordValue(raw.toolInput) ?? {};
 }
@@ -154,7 +168,7 @@ function normalizeGeneric(eventName: string, raw: Record<string, unknown>, proje
   if (event === 'session-event' && type === undefined) throw new IncompleteHostHookPayloadError('Generic session event requires a type.');
   if (type !== undefined && !isSessionEventType(type)) throw new Error(`Unsupported session event type: ${String(type)}`);
   const payload: Record<string, unknown> = {};
-  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message']) {
+  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs']) {
     if (raw[key] !== undefined) payload[key] = Array.isArray(raw[key]) ? raw[key] : typeof raw[key] === 'string' ? String(raw[key]).slice(0, MAX_STRING) : raw[key];
   }
   return {
@@ -206,7 +220,19 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
     return { host: normalizedHost, event, ...ids, projectRoot, title: event === 'turn-start' ? 'Agent turn' : 'Agent session', payload: {} };
   }
   if (event === 'checkpoint') {
-    return { host: normalizedHost, event, ...ids, projectRoot, type: 'checkpoint', payload: { changedPaths: changedPaths(projectRoot, raw) } };
+    const summary = stringValue(raw.summary);
+    return {
+      host: normalizedHost,
+      event,
+      ...ids,
+      projectRoot,
+      type: 'checkpoint',
+      payload: {
+        ...(summary ? { summary } : {}),
+        changedPaths: changedPaths(projectRoot, raw),
+        ...checkpointState(raw),
+      },
+    };
   }
   if (event === 'turn-stop' || event === 'session-stop') {
     const failed = eventName === 'StopFailure' || stringValue(raw.status) === 'failed' || Boolean(stringValue(raw.error) || recordValue(raw.error));

--- a/src/cli/agents/lifecycle.ts
+++ b/src/cli/agents/lifecycle.ts
@@ -15,13 +15,14 @@ const ROOT_FIELDS = new Set([
   'session_id', 'sessionId', 'thread_id', 'turn_id', 'turnId', 'conversation_id', 'generation_id', 'cwd', 'workspace_roots',
   'title', 'query', 'agent', 'type', 'status', 'summary', 'command', 'exit_code', 'exitCode', 'passed',
   'message', 'code', 'text', 'changedPaths', 'changed_paths', 'commit', 'file_path', 'filePath', 'path',
-  'tool_name', 'toolName', 'error', 'tool_input', 'toolInput', 'tool_response', 'toolResponse',
+  'tool_name', 'toolName', 'error', 'error_code', 'error_message', 'tool_input', 'toolInput', 'tool_response', 'toolResponse',
 ]);
 const NESTED_FIELDS: Record<string, Set<string>> = {
   tool_input: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path']),
   toolInput: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path']),
   tool_response: new Set(['exit_code', 'exitCode']),
   toolResponse: new Set(['exit_code', 'exitCode']),
+  error: new Set(['code', 'type', 'message', 'error']),
 };
 const ARRAY_FIELDS = new Set(['workspace_roots', 'changedPaths', 'changed_paths', 'file_paths', 'filePaths']);
 
@@ -121,3 +122,5 @@ export function stringPayloadValue(payload: Record<string, unknown>, key: string
   const value = payload[key];
   return typeof value === 'string' ? value : undefined;
 }
+
+

--- a/src/store/host-lifecycle.ts
+++ b/src/store/host-lifecycle.ts
@@ -11,6 +11,8 @@ import {
   getOrCreateHostSession,
   HostSessionKey,
 } from './host-session-bindings.js';
+import { consumePendingSessionHandoff, recordPendingSessionHandoff } from './session-handoff.js';
+import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
 
 export type HostLifecycleResult = {
   accepted: boolean;
@@ -21,6 +23,7 @@ export type HostLifecycleResult = {
   recoveredCount?: number;
   purgedEventCount?: number;
   promotion?: Awaited<ReturnType<typeof finalizeMemorySession>>;
+  handoff?: Awaited<ReturnType<typeof recordPendingSessionHandoff>>;
   hostOutput?: Record<string, unknown>;
 };
 
@@ -44,6 +47,28 @@ function hostContextOutput(input: NormalizedHostHook, context: string | undefine
   };
 }
 
+function mergeBootstrapContext(handoffContext: string | undefined, recentContext: string | undefined): { context?: string; truncated: boolean } {
+  if (!handoffContext && !recentContext) return { context: undefined, truncated: false };
+  if (!handoffContext) {
+    return {
+      context: recentContext,
+      truncated: Boolean(recentContext && recentContext.length > DEFAULT_CONTEXT_MAX_CHARS),
+    };
+  }
+  if (!recentContext) {
+    return {
+      context: handoffContext,
+      truncated: handoffContext.length > DEFAULT_CONTEXT_MAX_CHARS,
+    };
+  }
+  const combined = `${handoffContext}\n\n${recentContext}`;
+  const truncated = combined.length > DEFAULT_CONTEXT_MAX_CHARS;
+  return {
+    context: truncated ? truncateText(combined, DEFAULT_CONTEXT_MAX_CHARS, '\n\n[Context truncated]') : combined,
+    truncated,
+  };
+}
+
 async function startBoundSession(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext = false) {
   return getOrCreateHostSession({
     projectId,
@@ -53,12 +78,26 @@ async function startBoundSession(projectId: string, input: NormalizedHostHook, s
   });
 }
 
+async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext: boolean) {
+  const started = await startBoundSession(projectId, input, scope, includeContext);
+  if (!includeContext) return { ...started, handoff: null as Awaited<ReturnType<typeof consumePendingSessionHandoff>> };
+
+  const handoff = await consumePendingSessionHandoff(projectId);
+  const merged = mergeBootstrapContext(handoff?.context, started.context);
+  return {
+    ...started,
+    context: merged.context,
+    truncated: merged.truncated,
+    handoff,
+  };
+}
+
 export async function handleHostLifecycleEvent(projectId: string, input: NormalizedHostHook): Promise<HostLifecycleResult> {
   if (input.event === 'session-start') {
     const recovered = await recoverAbandonedSessions();
     const purgedEventCount = await purgeExpiredSessionEvents();
     await closeInactiveHostSessionBindings();
-    const started = await startBoundSession(projectId, input, 'session', true);
+    const started = await bootstrapWithHandoff(projectId, input, 'session', true);
     return {
       accepted: true,
       sessionId: started.session.id,
@@ -73,7 +112,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
   if (input.event === 'turn-start') {
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
     if (!sessionBinding && (input.host === 'codex' || input.host === 'claude')) {
-      const started = await startBoundSession(projectId, input, 'session', true);
+      const started = await bootstrapWithHandoff(projectId, input, 'session', true);
       await bindHostSession(bindingKey(input, 'turn'), started.session.id);
       return {
         accepted: true,
@@ -83,7 +122,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         hostOutput: hostContextOutput(input, started.context),
       };
     }
-    const started = await startBoundSession(projectId, input, 'turn', !sessionBinding);
+    const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding);
     if (!sessionBinding) await bindHostSession(bindingKey(input, 'session'), started.session.id);
     return {
       accepted: true,
@@ -104,17 +143,24 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
 
   if (input.event === 'turn-stop') {
     const key = bindingKey(input, 'turn');
-    const session = await findHostSession(key);
-    if (!session) return { accepted: false, reason: 'event-loss' };
+    let session = await findHostSession(key);
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
+    // gpt-5.5 StopFailure may arrive without a turn binding. Fall back to the session binding
+    // so rate-limit handoffs still persist when only SessionStart existed.
+    if (!session && input.status === 'failed' && sessionBinding) {
+      session = sessionBinding;
+    }
+    if (!session) return { accepted: false, reason: 'event-loss' };
     if ((input.host === 'codex' || input.host === 'claude') && sessionBinding?.id === session.id) {
+      const handoff = await recordPendingSessionHandoff(projectId, input, { memorySessionId: session.id });
       await closeHostSessionBinding(key);
-      return { accepted: true, sessionId: session.id };
+      return { accepted: true, sessionId: session.id, handoff };
     }
     await finishMemorySession(session.id, input.status ?? 'finished', typeof input.payload.summary === 'string' ? input.payload.summary : undefined);
     const promotion = await finalizeMemorySession(projectId, session.id);
+    const handoff = await recordPendingSessionHandoff(projectId, input, { memorySessionId: session.id });
     await closeHostSessionBinding(key);
-    return { accepted: true, sessionId: session.id, promotion };
+    return { accepted: true, sessionId: session.id, promotion, handoff };
   }
 
   const key = bindingKey(input, 'session');
@@ -125,7 +171,8 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
   }
   await finishMemorySession(session.id, input.status ?? 'finished', typeof input.payload.summary === 'string' ? input.payload.summary : undefined);
   const promotion = await finalizeMemorySession(projectId, session.id);
+  const handoff = await recordPendingSessionHandoff(projectId, input, { memorySessionId: session.id });
   await closeHostSessionBinding(key);
   await closeHostSessionBindings(bindingKey(input, 'turn'));
-  return { accepted: true, sessionId: session.id, promotion };
+  return { accepted: true, sessionId: session.id, promotion, handoff };
 }

--- a/src/store/session-capture.ts
+++ b/src/store/session-capture.ts
@@ -4,7 +4,7 @@ import { appendMemorySessionEvent } from './session-repository.js';
 const ALLOWED_FIELDS: Record<SessionEventType, string[]> = {
   start: ['title', 'agent'], command: ['command', 'exitCode', 'summary'], test: ['command', 'passed', 'summary'],
   error: ['code', 'message', 'summary'], git: ['commit', 'changedPaths', 'diffStat'], decision: ['text', 'summary'],
-  checkpoint: ['summary', 'changedPaths'], stop: ['status', 'summary'],
+  checkpoint: ['summary', 'changedPaths', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs'], stop: ['status', 'summary'],
 };
 
 export async function captureMemorySessionEvent(sessionId: string, type: SessionEventType, payload: Record<string, unknown>) {

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -1,0 +1,255 @@
+import { NormalizedHostHook } from '../cli/agents/host-hook.js';
+import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
+import { normalizeConflictKey } from './conflicts.js';
+import * as repo from './repository.js';
+import { getClient } from './database.js';
+import { getMemorySession } from './session-repository.js';
+
+export const PENDING_HANDOFF_CONFLICT_KEY = 'pending-session-handoff';
+export const PENDING_HANDOFF_TITLE = 'Pending session handoff';
+export const RATE_LIMIT_URGENCY = 'critical';
+export const GENERIC_FAILURE_URGENCY = 'high';
+
+export type SessionFailureKind = 'rate_limit' | 'failed';
+
+export type PendingHandoff = {
+  kind: SessionFailureKind;
+  urgency: typeof RATE_LIMIT_URGENCY | typeof GENERIC_FAILURE_URGENCY;
+  host: string;
+  projectRoot: string;
+  externalSessionId: string;
+  memorySessionId?: string;
+  sessionTitle?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  lastCheckpoint?: string;
+  changedPaths?: string[];
+  failedAt: string;
+  consumed?: boolean;
+  consumedAt?: string;
+};
+
+const RATE_LIMIT_MARKERS = [
+  'rate_limit',
+  'rate-limit',
+  'ratelimit',
+  'rate limit',
+  'usage_limit',
+  'usage-limit',
+  'usage limit',
+  'quota_exceeded',
+  'quota exceeded',
+  'session limit',
+  'hit your limit',
+  'limit reached',
+];
+
+function asString(value: unknown, max = 2_000): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim().slice(0, max) : undefined;
+}
+
+function collectStrings(value: unknown, out: string[] = [], depth = 0): string[] {
+  if (depth > 4 || value == null) return out;
+  if (typeof value === 'string') {
+    out.push(value);
+    return out;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    out.push(String(value));
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value.slice(0, 20)) collectStrings(entry, out, depth + 1);
+    return out;
+  }
+  if (typeof value === 'object') {
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>).slice(0, 40)) {
+      out.push(key);
+      collectStrings(entry, out, depth + 1);
+    }
+  }
+  return out;
+}
+
+export function detectSessionFailureKind(payload: Record<string, unknown>, status?: 'finished' | 'failed'): SessionFailureKind | null {
+  if (status !== 'failed' && status !== undefined) return null;
+  const haystack = collectStrings(payload).join(' ').toLowerCase();
+  if (RATE_LIMIT_MARKERS.some(marker => haystack.includes(marker))) return 'rate_limit';
+  if (status === 'failed') return 'failed';
+  return null;
+}
+
+function parseHandoffContent(content: string): PendingHandoff | null {
+  try {
+    const parsed = JSON.parse(content) as PendingHandoff;
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (parsed.kind !== 'rate_limit' && parsed.kind !== 'failed') return null;
+    if (!parsed.failedAt || !parsed.host || !parsed.projectRoot || !parsed.externalSessionId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary?: string; changedPaths?: string[] }> {
+  const rows = (await getClient().execute({
+    sql: `SELECT payload FROM memory_session_events
+      WHERE session_id = ? AND type = 'checkpoint'
+      ORDER BY observed_at DESC
+      LIMIT 1`,
+    args: [sessionId],
+  })).rows;
+  if (!rows[0]) return {};
+  try {
+    const payload = JSON.parse(String(rows[0].payload)) as Record<string, unknown>;
+    const summary = asString(payload.summary);
+    const changedPaths = Array.isArray(payload.changedPaths)
+      ? payload.changedPaths.filter((value): value is string => typeof value === 'string').slice(0, 20)
+      : undefined;
+    return { summary, changedPaths };
+  } catch {
+    return {};
+  }
+}
+
+async function findActivePendingHandoff(projectId: string) {
+  void projectId;
+  const conflictKey = normalizeConflictKey(PENDING_HANDOFF_CONFLICT_KEY);
+  const rows = await getClient().execute({
+    sql: `SELECT id, content, tags FROM knowledge_items
+      WHERE status = 'active' AND category = 'state' AND conflict_key = ?
+      ORDER BY updated_at DESC
+      LIMIT 5`,
+    args: [conflictKey],
+  });
+  for (const row of rows.rows) {
+    const handoff = parseHandoffContent(String(row.content));
+    if (!handoff || handoff.consumed) continue;
+    return { id: String(row.id), handoff };
+  }
+  return null;
+}
+
+export function formatPendingHandoffContext(handoff: PendingHandoff): string {
+  const lines = [
+    '# KNOWL - PENDING SESSION HANDOFF',
+    '',
+    'Previous host session ended before a clean finish. Continue from this handoff first.',
+    '',
+    `- Kind: ${handoff.kind}`,
+    `- Urgency: ${handoff.urgency}`,
+    `- Host: ${handoff.host}`,
+    `- Failed at: ${handoff.failedAt}`,
+    `- External session: ${handoff.externalSessionId}`,
+  ];
+  if (handoff.memorySessionId) lines.push(`- Memory session: ${handoff.memorySessionId}`);
+  if (handoff.sessionTitle) lines.push(`- Session title: ${handoff.sessionTitle}`);
+  if (handoff.errorCode) lines.push(`- Error code: ${handoff.errorCode}`);
+  if (handoff.errorMessage) lines.push(`- Error: ${handoff.errorMessage}`);
+  if (handoff.lastCheckpoint) lines.push(`- Last checkpoint: ${handoff.lastCheckpoint}`);
+  if (handoff.changedPaths?.length) lines.push(`- Changed paths: ${handoff.changedPaths.join(', ')}`);
+  lines.push('', 'Do not restart from scratch. Resume the interrupted work using this handoff plus recent project memory.');
+  return truncateText(lines.join('\n'), DEFAULT_CONTEXT_MAX_CHARS);
+}
+
+export async function recordPendingSessionHandoff(
+  projectId: string,
+  input: NormalizedHostHook,
+  options: { memorySessionId?: string } = {},
+): Promise<{ itemId: string; handoff: PendingHandoff } | null> {
+  const kind = detectSessionFailureKind(input.payload, input.status);
+  if (!kind) return null;
+
+  let sessionTitle: string | undefined;
+  let lastCheckpoint: string | undefined;
+  let changedPaths: string[] | undefined;
+  if (options.memorySessionId) {
+    try {
+      const session = await getMemorySession(options.memorySessionId);
+      sessionTitle = session.title;
+    } catch {
+      // Session may already be terminal or missing; handoff still records host failure.
+    }
+    const checkpoint = await loadLatestSessionCheckpoint(options.memorySessionId);
+    lastCheckpoint = checkpoint.summary;
+    changedPaths = checkpoint.changedPaths;
+  }
+
+  const handoff: PendingHandoff = {
+    kind,
+    urgency: kind === 'rate_limit' ? RATE_LIMIT_URGENCY : GENERIC_FAILURE_URGENCY,
+    host: String(input.host),
+    projectRoot: input.projectRoot,
+    externalSessionId: input.externalSessionId,
+    memorySessionId: options.memorySessionId,
+    sessionTitle,
+    errorCode: asString(input.payload.error ?? input.payload.code ?? input.payload.error_code, 200),
+    errorMessage: asString(input.payload.message ?? input.payload.summary ?? input.payload.error_message, 500),
+    lastCheckpoint,
+    changedPaths,
+    failedAt: new Date().toISOString(),
+    consumed: false,
+  };
+
+  const existing = await findActivePendingHandoff(projectId);
+  if (existing) {
+    const updated = await repo.updateKnowledgeItem(existing.id, {
+      title: PENDING_HANDOFF_TITLE,
+      content: JSON.stringify(handoff),
+      tags: ['pending_handoff', kind, handoff.urgency, String(input.host)],
+      source: `host://${input.host}/session-failure`,
+      freshness: 'fresh',
+      confidence: kind === 'rate_limit' ? 1 : 0.9,
+      conflictKey: PENDING_HANDOFF_CONFLICT_KEY,
+      conflictExclusive: true,
+    });
+    await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${kind})`, [
+      { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
+    ]);
+    return { itemId: updated.id, handoff };
+  }
+
+  const created = await repo.createKnowledgeItem(projectId, {
+    category: 'state',
+    title: PENDING_HANDOFF_TITLE,
+    content: JSON.stringify(handoff),
+    tags: ['pending_handoff', kind, handoff.urgency, String(input.host)],
+    source: `host://${input.host}/session-failure`,
+    freshness: 'fresh',
+    confidence: kind === 'rate_limit' ? 1 : 0.9,
+    conflictKey: PENDING_HANDOFF_CONFLICT_KEY,
+    conflictExclusive: true,
+  });
+  await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${kind})`, [
+    { itemId: created.id, action: 'insert', after: created },
+  ]);
+  return { itemId: created.id, handoff };
+}
+
+export async function consumePendingSessionHandoff(
+  projectId: string,
+): Promise<{ itemId: string; handoff: PendingHandoff; context: string } | null> {
+  const existing = await findActivePendingHandoff(projectId);
+  if (!existing) return null;
+
+  const consumed: PendingHandoff = {
+    ...existing.handoff,
+    consumed: true,
+    consumedAt: new Date().toISOString(),
+  };
+  const updated = await repo.updateKnowledgeItem(existing.id, {
+    content: JSON.stringify(consumed),
+    status: 'archived',
+    freshness: 'stale',
+    tags: ['pending_handoff', existing.handoff.kind, existing.handoff.urgency, existing.handoff.host, 'consumed'],
+  });
+  await repo.createKnowledgeCommit(projectId, `Consume pending session handoff (${existing.handoff.kind})`, [
+    { itemId: updated.id, action: 'archive', after: updated },
+  ]);
+
+  return {
+    itemId: updated.id,
+    handoff: existing.handoff,
+    context: formatPendingHandoffContext(existing.handoff),
+  };
+}

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -12,6 +12,14 @@ export const GENERIC_FAILURE_URGENCY = 'high';
 
 export type SessionFailureKind = 'rate_limit' | 'failed';
 
+export type HandoffTaskState = {
+  goal?: string;
+  completed?: string[];
+  nextAction?: string;
+  blocker?: string;
+  artifactRefs?: string[];
+};
+
 export type PendingHandoff = {
   kind: SessionFailureKind;
   urgency: typeof RATE_LIMIT_URGENCY | typeof GENERIC_FAILURE_URGENCY;
@@ -24,6 +32,7 @@ export type PendingHandoff = {
   errorMessage?: string;
   lastCheckpoint?: string;
   changedPaths?: string[];
+  taskState?: HandoffTaskState;
   failedAt: string;
   consumed?: boolean;
   consumedAt?: string;
@@ -91,7 +100,27 @@ function parseHandoffContent(content: string): PendingHandoff | null {
   }
 }
 
-async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary?: string; changedPaths?: string[] }> {
+function stringList(value: unknown, maxItems = 20, maxLength = 2_000): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .slice(0, maxItems)
+    .map(entry => entry.trim().slice(0, maxLength));
+  return values.length ? values : undefined;
+}
+
+function checkpointTaskState(payload: Record<string, unknown>): HandoffTaskState | undefined {
+  const taskState: HandoffTaskState = {
+    goal: asString(payload.goal, 1_000),
+    completed: stringList(payload.completed, 20, 500),
+    nextAction: asString(payload.nextAction, 1_000),
+    blocker: asString(payload.blocker, 1_000),
+    artifactRefs: stringList(payload.artifactRefs, 20, 500),
+  };
+  return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
+}
+
+async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary?: string; changedPaths?: string[]; taskState?: HandoffTaskState }> {
   const rows = (await getClient().execute({
     sql: `SELECT payload FROM memory_session_events
       WHERE session_id = ? AND type = 'checkpoint'
@@ -106,13 +135,48 @@ async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary
     const changedPaths = Array.isArray(payload.changedPaths)
       ? payload.changedPaths.filter((value): value is string => typeof value === 'string').slice(0, 20)
       : undefined;
-    return { summary, changedPaths };
+    return { summary, changedPaths, taskState: checkpointTaskState(payload) };
   } catch {
     return {};
   }
 }
 
-async function findActivePendingHandoff(projectId: string) {
+type HandoffIdentity = Pick<PendingHandoff, 'host' | 'externalSessionId'>;
+
+function handoffScope(identity: HandoffIdentity): Record<string, string> {
+  return {
+    externalSessionId: identity.externalSessionId,
+    host: identity.host,
+  };
+}
+
+function mergeTaskState(existing: HandoffTaskState | undefined, incoming: HandoffTaskState | undefined): HandoffTaskState | undefined {
+  if (!existing) return incoming;
+  if (!incoming) return existing;
+  const taskState: HandoffTaskState = {
+    goal: incoming.goal ?? existing.goal,
+    completed: incoming.completed?.length ? incoming.completed : existing.completed,
+    nextAction: incoming.nextAction ?? existing.nextAction,
+    blocker: incoming.blocker ?? existing.blocker,
+    artifactRefs: incoming.artifactRefs?.length ? incoming.artifactRefs : existing.artifactRefs,
+  };
+  return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
+}
+
+function mergeHandoff(existing: PendingHandoff, incoming: PendingHandoff): PendingHandoff {
+  return {
+    ...incoming,
+    memorySessionId: incoming.memorySessionId ?? existing.memorySessionId,
+    sessionTitle: incoming.sessionTitle ?? existing.sessionTitle,
+    errorCode: incoming.errorCode ?? existing.errorCode,
+    errorMessage: incoming.errorMessage ?? existing.errorMessage,
+    lastCheckpoint: incoming.lastCheckpoint ?? existing.lastCheckpoint,
+    changedPaths: incoming.changedPaths?.length ? incoming.changedPaths : existing.changedPaths,
+    taskState: mergeTaskState(existing.taskState, incoming.taskState),
+  };
+}
+
+async function findActivePendingHandoff(projectId: string, identity?: HandoffIdentity) {
   void projectId;
   const conflictKey = normalizeConflictKey(PENDING_HANDOFF_CONFLICT_KEY);
   const rows = await getClient().execute({
@@ -125,6 +189,7 @@ async function findActivePendingHandoff(projectId: string) {
   for (const row of rows.rows) {
     const handoff = parseHandoffContent(String(row.content));
     if (!handoff || handoff.consumed) continue;
+    if (identity && (handoff.host !== identity.host || handoff.externalSessionId !== identity.externalSessionId)) continue;
     return { id: String(row.id), handoff };
   }
   return null;
@@ -148,6 +213,14 @@ export function formatPendingHandoffContext(handoff: PendingHandoff): string {
   if (handoff.errorMessage) lines.push(`- Error: ${handoff.errorMessage}`);
   if (handoff.lastCheckpoint) lines.push(`- Last checkpoint: ${handoff.lastCheckpoint}`);
   if (handoff.changedPaths?.length) lines.push(`- Changed paths: ${handoff.changedPaths.join(', ')}`);
+  if (handoff.taskState) {
+    lines.push('', '## Task state');
+    if (handoff.taskState.goal) lines.push(`- Goal: ${handoff.taskState.goal}`);
+    if (handoff.taskState.completed?.length) lines.push(`- Completed: ${handoff.taskState.completed.join('; ')}`);
+    if (handoff.taskState.nextAction) lines.push(`- Next action: ${handoff.taskState.nextAction}`);
+    if (handoff.taskState.blocker) lines.push(`- Blocker: ${handoff.taskState.blocker}`);
+    if (handoff.taskState.artifactRefs?.length) lines.push(`- Artifacts: ${handoff.taskState.artifactRefs.join(', ')}`);
+  }
   lines.push('', 'Do not restart from scratch. Resume the interrupted work using this handoff plus recent project memory.');
   return truncateText(lines.join('\n'), DEFAULT_CONTEXT_MAX_CHARS);
 }
@@ -163,6 +236,7 @@ export async function recordPendingSessionHandoff(
   let sessionTitle: string | undefined;
   let lastCheckpoint: string | undefined;
   let changedPaths: string[] | undefined;
+  let taskState: HandoffTaskState | undefined;
   if (options.memorySessionId) {
     try {
       const session = await getMemorySession(options.memorySessionId);
@@ -173,6 +247,7 @@ export async function recordPendingSessionHandoff(
     const checkpoint = await loadLatestSessionCheckpoint(options.memorySessionId);
     lastCheckpoint = checkpoint.summary;
     changedPaths = checkpoint.changedPaths;
+    taskState = checkpoint.taskState;
   }
 
   const handoff: PendingHandoff = {
@@ -187,26 +262,30 @@ export async function recordPendingSessionHandoff(
     errorMessage: asString(input.payload.message ?? input.payload.summary ?? input.payload.error_message, 500),
     lastCheckpoint,
     changedPaths,
+    taskState,
     failedAt: new Date().toISOString(),
     consumed: false,
   };
 
-  const existing = await findActivePendingHandoff(projectId);
+  const identity = handoffScope(handoff);
+  const existing = await findActivePendingHandoff(projectId, handoff);
   if (existing) {
+    const mergedHandoff = mergeHandoff(existing.handoff, handoff);
     const updated = await repo.updateKnowledgeItem(existing.id, {
       title: PENDING_HANDOFF_TITLE,
-      content: JSON.stringify(handoff),
-      tags: ['pending_handoff', kind, handoff.urgency, String(input.host)],
+      content: JSON.stringify(mergedHandoff),
+      tags: ['pending_handoff', kind, mergedHandoff.urgency, String(input.host)],
       source: `host://${input.host}/session-failure`,
       freshness: 'fresh',
       confidence: kind === 'rate_limit' ? 1 : 0.9,
-      conflictKey: PENDING_HANDOFF_CONFLICT_KEY,
+      conflictKey: normalizeConflictKey(PENDING_HANDOFF_CONFLICT_KEY),
+      conflictScope: identity,
       conflictExclusive: true,
     });
     await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${kind})`, [
       { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
     ]);
-    return { itemId: updated.id, handoff };
+    return { itemId: updated.id, handoff: mergedHandoff };
   }
 
   const created = await repo.createKnowledgeItem(projectId, {
@@ -218,6 +297,7 @@ export async function recordPendingSessionHandoff(
     freshness: 'fresh',
     confidence: kind === 'rate_limit' ? 1 : 0.9,
     conflictKey: PENDING_HANDOFF_CONFLICT_KEY,
+    conflictScope: identity,
     conflictExclusive: true,
   });
   await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${kind})`, [

--- a/tests/cli/host-hook.test.ts
+++ b/tests/cli/host-hook.test.ts
@@ -113,6 +113,30 @@ describe('host hook normalization', () => {
     expect(result.payload).not.toHaveProperty('stdout');
   });
 
+  it('keeps structured checkpoint state without retaining arbitrary tool output', () => {
+    const result = normalizeHostHook('generic', 'checkpoint', {
+      sessionId: 'session-structured',
+      turnId: 'turn-structured',
+      cwd: ROOT,
+      summary: 'Checkpoint complete',
+      goal: 'Ship resumable handoffs',
+      completed: ['Added a test'],
+      nextAction: 'Implement the contract',
+      blocker: 'Waiting for a rate-limit reset',
+      artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      stdout: 'discard me',
+    });
+
+    expect(result.payload).toEqual({
+      summary: 'Checkpoint complete',
+      goal: 'Ship resumable handoffs',
+      completed: ['Added a test'],
+      nextAction: 'Implement the contract',
+      blocker: 'Waiting for a rate-limit reset',
+      artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+    });
+  });
+
 
   it('preserves Claude StopFailure rate-limit error codes', () => {
     const result = normalizeHostHook('claude', 'StopFailure', {

--- a/tests/cli/host-hook.test.ts
+++ b/tests/cli/host-hook.test.ts
@@ -113,8 +113,31 @@ describe('host hook normalization', () => {
     expect(result.payload).not.toHaveProperty('stdout');
   });
 
+
+  it('preserves Claude StopFailure rate-limit error codes', () => {
+    const result = normalizeHostHook('claude', 'StopFailure', {
+      session_id: 'session-rate',
+      turn_id: 'turn-rate',
+      cwd: ROOT,
+      error: 'rate_limit',
+      message: 'Claude session limit hit',
+    });
+
+    expect(result).toMatchObject({
+      host: 'claude',
+      event: 'turn-stop',
+      status: 'failed',
+      payload: {
+        status: 'failed',
+        error: 'rate_limit',
+        code: 'rate_limit',
+        message: 'Claude session limit hit',
+      },
+    });
+  });
   it('rejects unsupported hosts and events', () => {
     expect(() => normalizeHostHook('unknown', 'SessionStart', {})).toThrow('Unsupported hook host');
     expect(() => normalizeHostHook('codex', 'UnknownEvent', { session_id: 's', cwd: ROOT })).toThrow('Unsupported codex hook event');
   });
 });
+

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -166,4 +166,77 @@ describe('host lifecycle orchestration', () => {
     expect(event).toEqual({ accepted: true, sessionId: expect.any(String) });
     expect(stop.accepted).toBe(true);
   });
+
+  it('stores a Claude rate-limit handoff and injects it first on the next SessionStart', async () => {
+    const sessionStart = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+    const checkpoint = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'checkpoint',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: 'turn-rate',
+      type: 'checkpoint',
+      payload: { summary: 'Human review gate active', changedPaths: ['src/forge.ts'] },
+    }));
+    const failedStop = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: 'turn-rate',
+      status: 'failed',
+      payload: { status: 'failed', error: 'rate_limit', message: 'Claude session limit hit' },
+    }));
+
+    expect(sessionStart.accepted).toBe(true);
+    expect(checkpoint.accepted).toBe(true);
+    expect(failedStop.accepted).toBe(true);
+    expect(failedStop.handoff?.handoff.kind).toBe('rate_limit');
+    expect(failedStop.handoff?.handoff.lastCheckpoint).toBe('Human review gate active');
+
+    const nextStart = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-resume',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+    const secondStart = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-resume-2',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+
+    expect(String(nextStart.context)).toContain('PENDING SESSION HANDOFF');
+    expect(String(nextStart.context)).toContain('rate_limit');
+    expect(String(nextStart.context)).toContain('Human review gate active');
+    expect(String(nextStart.context)).toContain('Use local memory');
+    expect(String(secondStart.context)).not.toContain('PENDING SESSION HANDOFF');
+  });
+
+  it('records lower-urgency handoffs for non-limit StopFailure events', async () => {
+    await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-generic-fail',
+      externalTurnId: undefined,
+    }));
+    const failedStop = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-generic-fail',
+      externalTurnId: 'turn-fail',
+      status: 'failed',
+      payload: { status: 'failed', error: 'model_error', message: 'provider blew up' },
+    }));
+
+    expect(failedStop.handoff?.handoff.kind).toBe('failed');
+    expect(failedStop.handoff?.handoff.urgency).toBe('high');
+  });
 });

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -101,12 +101,28 @@ describe('host lifecycle orchestration', () => {
       externalTurnId: 'turn-2',
       event: 'checkpoint',
       type: 'checkpoint',
-      payload: { summary: 'Current task state', changedPaths: ['src/auth.ts'] },
+      payload: {
+        summary: 'Current task state',
+        changedPaths: ['src/auth.ts'],
+        goal: 'Ship resumable handoffs',
+        completed: ['Added the regression case'],
+        nextAction: 'Implement the checkpoint contract',
+        blocker: 'None',
+        artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      },
     }));
 
     expect(checkpoint.sessionId).toBe(start.sessionId);
     const rows = await getClient().execute({ sql: 'SELECT payload FROM memory_session_events WHERE session_id = ? AND type = ?', args: [start.sessionId!, 'checkpoint'] });
-    expect(JSON.parse(String(rows.rows[0].payload))).toEqual({ summary: 'Current task state', changedPaths: ['src/auth.ts'] });
+    expect(JSON.parse(String(rows.rows[0].payload))).toEqual({
+      summary: 'Current task state',
+      changedPaths: ['src/auth.ts'],
+      goal: 'Ship resumable handoffs',
+      completed: ['Added the regression case'],
+      nextAction: 'Implement the checkpoint contract',
+      blocker: 'None',
+      artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+    });
   });
 
   it('delivers fallback context once across completed turns without SessionStart', async () => {
@@ -181,7 +197,15 @@ describe('host lifecycle orchestration', () => {
       externalSessionId: 'claude-rate-limit',
       externalTurnId: 'turn-rate',
       type: 'checkpoint',
-      payload: { summary: 'Human review gate active', changedPaths: ['src/forge.ts'] },
+      payload: {
+        summary: 'Human review gate active',
+        changedPaths: ['src/forge.ts'],
+        goal: 'Ship resumable handoffs',
+        completed: ['Captured a structured checkpoint', 'Ran focused tests'],
+        nextAction: 'Persist the pending handoff',
+        blocker: 'Rate limit',
+        artifactRefs: ['src/store/session-handoff.ts', 'tests/store/host-lifecycle.test.ts'],
+      },
     }));
     const failedStop = await handleHostLifecycleEvent(projectId, hook({
       host: 'claude',
@@ -197,6 +221,26 @@ describe('host lifecycle orchestration', () => {
     expect(failedStop.accepted).toBe(true);
     expect(failedStop.handoff?.handoff.kind).toBe('rate_limit');
     expect(failedStop.handoff?.handoff.lastCheckpoint).toBe('Human review gate active');
+    expect(failedStop.handoff?.handoff.taskState).toEqual({
+      goal: 'Ship resumable handoffs',
+      completed: ['Captured a structured checkpoint', 'Ran focused tests'],
+      nextAction: 'Persist the pending handoff',
+      blocker: 'Rate limit',
+      artifactRefs: ['src/store/session-handoff.ts', 'tests/store/host-lifecycle.test.ts'],
+    });
+
+    const repeatedFailure = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-rate-limit',
+      externalTurnId: 'turn-rate',
+      status: 'failed',
+      payload: { status: 'failed', error: 'rate_limit', message: 'Claude session limit hit' },
+    }));
+    expect(repeatedFailure.accepted).toBe(true);
+    const activeHandoffs = await getClient().execute({ sql: "SELECT id, content, conflict_key, conflict_scope FROM knowledge_items WHERE title = 'Pending session handoff' AND status = 'active'" });
+    expect(activeHandoffs.rows).toHaveLength(1);
+    expect(String(activeHandoffs.rows[0].conflict_key)).toBe('pending.session.handoff');
 
     const nextStart = await handleHostLifecycleEvent(projectId, hook({
       host: 'claude',
@@ -216,6 +260,10 @@ describe('host lifecycle orchestration', () => {
     expect(String(nextStart.context)).toContain('PENDING SESSION HANDOFF');
     expect(String(nextStart.context)).toContain('rate_limit');
     expect(String(nextStart.context)).toContain('Human review gate active');
+    expect(String(nextStart.context)).toContain('Ship resumable handoffs');
+    expect(String(nextStart.context)).toContain('Persist the pending handoff');
+    expect(String(nextStart.context)).toContain('Rate limit');
+    expect(String(nextStart.context)).toContain('src/store/session-handoff.ts');
     expect(String(nextStart.context)).toContain('Use local memory');
     expect(String(secondStart.context)).not.toContain('PENDING SESSION HANDOFF');
   });

--- a/tests/store/session-handoff.test.ts
+++ b/tests/store/session-handoff.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { detectSessionFailureKind, formatPendingHandoffContext } from '../../src/store/session-handoff.js';
+
+describe('session handoff helpers', () => {
+  it('detects Claude rate-limit failures from structured error codes', () => {
+    expect(detectSessionFailureKind({ status: 'failed', error: 'rate_limit' }, 'failed')).toBe('rate_limit');
+    expect(detectSessionFailureKind({ status: 'failed', error: { code: 'rate_limit', message: 'hit limit' } }, 'failed')).toBe('rate_limit');
+    expect(detectSessionFailureKind({ status: 'failed', message: 'Session limit reached' }, 'failed')).toBe('rate_limit');
+  });
+
+  it('keeps non-limit failures as generic failed handoffs', () => {
+    expect(detectSessionFailureKind({ status: 'failed', message: 'model crashed' }, 'failed')).toBe('failed');
+    expect(detectSessionFailureKind({ status: 'finished' }, 'finished')).toBeNull();
+  });
+
+  it('formats a resume-first handoff block', () => {
+    const text = formatPendingHandoffContext({
+      kind: 'rate_limit',
+      urgency: 'critical',
+      host: 'claude',
+      projectRoot: 'D:/Code/demo',
+      externalSessionId: 'sess-1',
+      memorySessionId: 'mem-1',
+      sessionTitle: 'Agent session',
+      errorCode: 'rate_limit',
+      lastCheckpoint: 'Review loop gated',
+      changedPaths: ['src/forge.ts'],
+      failedAt: '2026-07-12T00:00:00.000Z',
+    });
+
+    expect(text).toContain('PENDING SESSION HANDOFF');
+    expect(text).toContain('rate_limit');
+    expect(text).toContain('Review loop gated');
+    expect(text).toContain('Do not restart from scratch');
+  });
+});

--- a/tests/store/session-handoff.test.ts
+++ b/tests/store/session-handoff.test.ts
@@ -25,12 +25,22 @@ describe('session handoff helpers', () => {
       errorCode: 'rate_limit',
       lastCheckpoint: 'Review loop gated',
       changedPaths: ['src/forge.ts'],
+      taskState: {
+        goal: 'Ship resumable handoffs',
+        completed: ['Added a regression test'],
+        nextAction: 'Persist task state',
+        blocker: 'Rate limit',
+        artifactRefs: ['tests/store/session-handoff.test.ts'],
+      },
       failedAt: '2026-07-12T00:00:00.000Z',
     });
 
     expect(text).toContain('PENDING SESSION HANDOFF');
     expect(text).toContain('rate_limit');
     expect(text).toContain('Review loop gated');
+    expect(text).toContain('Ship resumable handoffs');
+    expect(text).toContain('Persist task state');
+    expect(text).toContain('tests/store/session-handoff.test.ts');
     expect(text).toContain('Do not restart from scratch');
   });
 });


### PR DESCRIPTION
## Summary
- Preserve structured checkpoint task state (`goal`, `completed`, `nextAction`, `blocker`, `artifactRefs`) through host-hook normalization and session capture.
- Attach that task state to pending session handoffs, merge repeated failure updates, and scope active handoffs by host + external session id.
- Format task state into the next-session resume context so gpt-5.5 can continue after rate limits or failures instead of restarting from scratch.

## Test plan
- [x] `npx vitest run tests/cli/host-hook.test.ts tests/store/host-lifecycle.test.ts tests/store/session-handoff.test.ts`
- [ ] Review handoff formatting for both Claude and Codex failure paths
- [ ] After install/link, verify a failed session injects goal/nextAction/blocker on the next SessionStart