### PR TITLE
feat: carry structured task state through handoffs and work loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ knowl task checkpoint <task-id> "Added search UI tests" \
   --goal "Ship search UI" \
   --completed "Added search UI tests" \
   --next-action "Finish implementation" \
-  --artifact "src/search-ui.ts"
+  --artifact "src/search-ui.ts" \
+  --verification-status "tests-passing"
 knowl task finish <task-id> "Verified search UI implementation"
 ```
 
@@ -118,7 +119,7 @@ SessionStart is the sole automatic model-facing context injection. Capture hooks
 
 When a supported host ends with a hard-stop failure (Claude `StopFailure`, failed Codex/Cursor stop/session end, or generic failed stop), Knowl stores a host-scoped deterministic `pending_handoff` state item (no AI required). The next matching-host `SessionStart` injects that handoff first, then normal recent context, and archives it so delivery is one-shot. Ordinary successful stops and tool failures do not create handoffs.
 
-Checkpoints may also carry structured task state (`goal`, `completed`, `nextAction`, `blocker`, `artifactRefs`). When present, those fields ride through the pending handoff so the next session can resume without reconstructing progress from prose alone. Manual `knowl_task_checkpoint` accepts the same fields for MCP work loops.
+Checkpoints may also carry structured task state (`goal`, `completed`, `nextAction`, `blocker`, `artifactRefs`, `verificationStatus`). When present, those fields ride through the pending handoff so the next session can resume without reconstructing progress from prose alone. Manual `knowl_task_checkpoint` accepts the same fields for MCP work loops.
 
 Multiple leftover `knowl serve` processes usually mean multiple host sessions or reconnects, not hook respawn. Multiple agents can use one repo with shared SQLite and brief lock waits; agents in different repos remain isolated under each project `.knowl/`.
 
@@ -205,7 +206,7 @@ If an MCP client shows `Auth: Unsupported` for this local stdio server, that is 
 | `knowl evidence list <item-id>` | List linked file, commit, test, command, URL, user, agent, or symbol evidence. |
 | `knowl state` | Print the full active hierarchical project memory. |
 | `knowl task start <title>` | Start a work loop, query relevant memory, and store active task state. |
-| `knowl task checkpoint <task-id> <summary> [--goal ...] [--completed ...] [--next-action ...] [--blocker ...] [--artifact ...]` | Store durable progress and optional structured task state for an active work loop. |
+| `knowl task checkpoint <task-id> <summary> [--goal ...] [--completed ...] [--next-action ...] [--blocker ...] [--artifact ...] [--verification-status ...]` | Store durable progress and optional structured task state for an active work loop. |
 | `knowl task finish <task-id> <summary>` | Store durable completion state for a work loop. |
 | `knowl task run <title> -- <command...>` | Start a work loop, run a command, then finish on success or checkpoint on failure with the child exit code. |
 | `knowl timeline <item-id>` | Print immutable content assertions for one knowledge item. |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ Or record manual checkpoints:
 
 ```bash
 knowl task start "Implement search UI" --query "search retrieval"
-knowl task checkpoint <task-id> "Added search UI tests"
+knowl task checkpoint <task-id> "Added search UI tests" \
+  --goal "Ship search UI" \
+  --completed "Added search UI tests" \
+  --next-action "Finish implementation" \
+  --artifact "src/search-ui.ts"
 knowl task finish <task-id> "Verified search UI implementation"
 ```
 
@@ -201,7 +205,7 @@ If an MCP client shows `Auth: Unsupported` for this local stdio server, that is 
 | `knowl evidence list <item-id>` | List linked file, commit, test, command, URL, user, agent, or symbol evidence. |
 | `knowl state` | Print the full active hierarchical project memory. |
 | `knowl task start <title>` | Start a work loop, query relevant memory, and store active task state. |
-| `knowl task checkpoint <task-id> <summary>` | Store durable progress for an active work loop. |
+| `knowl task checkpoint <task-id> <summary> [--goal ...] [--completed ...] [--next-action ...] [--blocker ...] [--artifact ...]` | Store durable progress and optional structured task state for an active work loop. |
 | `knowl task finish <task-id> <summary>` | Store durable completion state for a work loop. |
 | `knowl task run <title> -- <command...>` | Start a work loop, run a command, then finish on success or checkpoint on failure with the child exit code. |
 | `knowl timeline <item-id>` | Print immutable content assertions for one knowledge item. |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ SessionStart is the sole automatic model-facing context injection. Capture hooks
 
 When a supported host ends with a hard-stop failure (Claude `StopFailure`, failed Codex/Cursor stop/session end, or generic failed stop), Knowl stores a host-scoped deterministic `pending_handoff` state item (no AI required). The next matching-host `SessionStart` injects that handoff first, then normal recent context, and archives it so delivery is one-shot. Ordinary successful stops and tool failures do not create handoffs.
 
+Checkpoints may also carry structured task state (`goal`, `completed`, `nextAction`, `blocker`, `artifactRefs`). When present, those fields ride through the pending handoff so the next session can resume without reconstructing progress from prose alone. Manual `knowl_task_checkpoint` accepts the same fields for MCP work loops.
+
 Multiple leftover `knowl serve` processes usually mean multiple host sessions or reconnects, not hook respawn. Multiple agents can use one repo with shared SQLite and brief lock waits; agents in different repos remain isolated under each project `.knowl/`.
 
 Raw prompts, transcripts, stdout/stderr, environment variables, and unknown fields are not retained. Malformed or secret-bearing payloads are rejected, duplicate stop events are idempotently dropped, and stale sessions recover at the next session start. A generic stdin-JSON contract is available for other hosts, but normal users only run `knowl init` and `knowl doctor`.

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -92,6 +92,20 @@ function changedPaths(projectRoot: string, raw: Record<string, unknown>): string
     .slice(0, 50);
 }
 
+function checkpointState(raw: Record<string, unknown>): Record<string, unknown> {
+  const state: Record<string, unknown> = {};
+  for (const key of ['goal', 'completed', 'nextAction', 'blocker', 'artifactRefs']) {
+    const value = raw[key];
+    if (value === undefined) continue;
+    state[key] = Array.isArray(value)
+      ? value.filter((entry): entry is string => typeof entry === 'string').slice(0, 20).map(entry => entry.slice(0, MAX_STRING))
+      : typeof value === 'string'
+        ? value.slice(0, MAX_STRING)
+        : value;
+  }
+  return state;
+}
+
 function toolInput(raw: Record<string, unknown>): Record<string, unknown> {
   return recordValue(raw.tool_input) ?? recordValue(raw.toolInput) ?? {};
 }
@@ -154,7 +168,7 @@ function normalizeGeneric(eventName: string, raw: Record<string, unknown>, proje
   if (event === 'session-event' && type === undefined) throw new IncompleteHostHookPayloadError('Generic session event requires a type.');
   if (type !== undefined && !isSessionEventType(type)) throw new Error(`Unsupported session event type: ${String(type)}`);
   const payload: Record<string, unknown> = {};
-  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message']) {
+  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs']) {
     if (raw[key] !== undefined) payload[key] = Array.isArray(raw[key]) ? raw[key] : typeof raw[key] === 'string' ? String(raw[key]).slice(0, MAX_STRING) : raw[key];
   }
   return {
@@ -206,7 +220,19 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
     return { host: normalizedHost, event, ...ids, projectRoot, title: event === 'turn-start' ? 'Agent turn' : 'Agent session', payload: {} };
   }
   if (event === 'checkpoint') {
-    return { host: normalizedHost, event, ...ids, projectRoot, type: 'checkpoint', payload: { changedPaths: changedPaths(projectRoot, raw) } };
+    const summary = stringValue(raw.summary);
+    return {
+      host: normalizedHost,
+      event,
+      ...ids,
+      projectRoot,
+      type: 'checkpoint',
+      payload: {
+        ...(summary ? { summary } : {}),
+        changedPaths: changedPaths(projectRoot, raw),
+        ...checkpointState(raw),
+      },
+    };
   }
   if (event === 'turn-stop' || event === 'session-stop') {
     const failed = eventName === 'StopFailure' || stringValue(raw.status) === 'failed' || Boolean(stringValue(raw.error) || recordValue(raw.error));

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -94,7 +94,7 @@ function changedPaths(projectRoot: string, raw: Record<string, unknown>): string
 
 function checkpointState(raw: Record<string, unknown>): Record<string, unknown> {
   const state: Record<string, unknown> = {};
-  for (const key of ['goal', 'completed', 'nextAction', 'blocker', 'artifactRefs']) {
+  for (const key of ['goal', 'completed', 'nextAction', 'blocker', 'artifactRefs', 'verificationStatus']) {
     const value = raw[key];
     if (value === undefined) continue;
     state[key] = Array.isArray(value)
@@ -168,7 +168,7 @@ function normalizeGeneric(eventName: string, raw: Record<string, unknown>, proje
   if (event === 'session-event' && type === undefined) throw new IncompleteHostHookPayloadError('Generic session event requires a type.');
   if (type !== undefined && !isSessionEventType(type)) throw new Error(`Unsupported session event type: ${String(type)}`);
   const payload: Record<string, unknown> = {};
-  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs']) {
+  for (const key of ['command', 'exitCode', 'passed', 'summary', 'message', 'code', 'text', 'changedPaths', 'commit', 'status', 'error', 'error_code', 'error_message', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs', 'verificationStatus']) {
     if (raw[key] !== undefined) payload[key] = Array.isArray(raw[key]) ? raw[key] : typeof raw[key] === 'string' ? String(raw[key]).slice(0, MAX_STRING) : raw[key];
   }
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1025,17 +1025,36 @@ taskCommand
   .description('Store durable progress for an active work loop')
   .argument('<taskId>', 'Task ID returned by knowl task start')
   .argument('<summary>', 'Checkpoint summary')
-  .action(async (taskId, summary) => {
+  .option('--goal <goal>', 'Optional current goal for resumable handoffs')
+  .option('--completed <item>', 'Optional completed step; repeatable', (value: string, previous: string[] = []) => previous.concat(value), [])
+  .option('--next-action <nextAction>', 'Optional next action to resume with')
+  .option('--blocker <blocker>', 'Optional current blocker')
+  .option('--artifact <ref>', 'Optional artifact or file reference; repeatable', (value: string, previous: string[] = []) => previous.concat(value), [])
+  .action(async (taskId, summary, options) => {
     try {
       const root = await findProjectRoot(process.cwd());
       await initDb(root);
       const project = await repo.getProjectByRootPath(root);
       if (!project) throw new Error('Project not found in database.');
 
-      const result = await checkpointWorkLoop(project.id, taskId, summary);
+      const result = await checkpointWorkLoop(project.id, taskId, {
+        summary,
+        goal: options.goal,
+        completed: options.completed,
+        nextAction: options.nextAction,
+        blocker: options.blocker,
+        artifactRefs: options.artifact,
+      });
       console.log('KNOWL WORK LOOP CHECKPOINT');
       console.log(`Task ID: ${result.taskId}`);
       console.log(`Checkpoint ID: ${result.itemId}`);
+      if (result.taskState) {
+        if (result.taskState.goal) console.log(`Goal: ${result.taskState.goal}`);
+        if (result.taskState.completed?.length) console.log(`Completed: ${result.taskState.completed.join('; ')}`);
+        if (result.taskState.nextAction) console.log(`Next action: ${result.taskState.nextAction}`);
+        if (result.taskState.blocker) console.log(`Blocker: ${result.taskState.blocker}`);
+        if (result.taskState.artifactRefs?.length) console.log(`Artifacts: ${result.taskState.artifactRefs.join(', ')}`);
+      }
 
       await closeDb();
     } catch (error: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ function printUpgradeStatus(result: Awaited<ReturnType<typeof upgradeExistingRep
 program
   .name('knowl')
   .description('KNOWL — A Knowledge Operating System for AI Agents')
-  .version('0.1.0');
+  .version('1.2.0');
 
 // --- 1. INIT COMMAND ---
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -1030,6 +1030,7 @@ taskCommand
   .option('--next-action <nextAction>', 'Optional next action to resume with')
   .option('--blocker <blocker>', 'Optional current blocker')
   .option('--artifact <ref>', 'Optional artifact or file reference; repeatable', (value: string, previous: string[] = []) => previous.concat(value), [])
+  .option('--verification-status <status>', 'Optional verification status such as unverified, tests-passing, or needs-review')
   .action(async (taskId, summary, options) => {
     try {
       const root = await findProjectRoot(process.cwd());
@@ -1044,6 +1045,7 @@ taskCommand
         nextAction: options.nextAction,
         blocker: options.blocker,
         artifactRefs: options.artifact,
+        verificationStatus: options.verificationStatus,
       });
       console.log('KNOWL WORK LOOP CHECKPOINT');
       console.log(`Task ID: ${result.taskId}`);
@@ -1054,6 +1056,7 @@ taskCommand
         if (result.taskState.nextAction) console.log(`Next action: ${result.taskState.nextAction}`);
         if (result.taskState.blocker) console.log(`Blocker: ${result.taskState.blocker}`);
         if (result.taskState.artifactRefs?.length) console.log(`Artifacts: ${result.taskState.artifactRefs.join(', ')}`);
+        if (result.taskState.verificationStatus) console.log(`Verification: ${result.taskState.verificationStatus}`);
       }
 
       await closeDb();

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -386,7 +386,7 @@ export function registerTools(
         },
         {
           name: 'knowl_task_checkpoint',
-          description: 'Record a work-loop checkpoint during execution so the task writes durable progress before the final summary.',
+          description: 'Record a work-loop checkpoint during execution so the task writes durable progress and optional structured task state before the final summary.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -397,6 +397,28 @@ export function registerTools(
               summary: {
                 type: 'string',
                 description: 'Durable checkpoint summary.',
+              },
+              goal: {
+                type: 'string',
+                description: 'Optional current goal for resumable handoffs.',
+              },
+              completed: {
+                type: 'array',
+                description: 'Optional list of completed steps.',
+                items: { type: 'string' },
+              },
+              nextAction: {
+                type: 'string',
+                description: 'Optional next action to resume with.',
+              },
+              blocker: {
+                type: 'string',
+                description: 'Optional current blocker.',
+              },
+              artifactRefs: {
+                type: 'array',
+                description: 'Optional file or artifact references relevant to the task.',
+                items: { type: 'string' },
               },
             },
             required: ['taskId', 'summary'],
@@ -804,8 +826,15 @@ export function registerTools(
       }
 
       else if (name === 'knowl_task_checkpoint') {
-        const { taskId, summary } = args as any;
-        const result = await checkpointWorkLoop(projectId!, taskId, summary);
+        const { taskId, summary, goal, completed, nextAction, blocker, artifactRefs } = args as any;
+        const result = await checkpointWorkLoop(projectId!, taskId, {
+          summary,
+          goal,
+          completed,
+          nextAction,
+          blocker,
+          artifactRefs,
+        });
         return {
           content: [{ type: 'text', text: compactMcpJson(result) }],
         };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -420,6 +420,10 @@ export function registerTools(
                 description: 'Optional file or artifact references relevant to the task.',
                 items: { type: 'string' },
               },
+              verificationStatus: {
+                type: 'string',
+                description: 'Optional verification status such as unverified, tests-passing, or needs-review.',
+              },
             },
             required: ['taskId', 'summary'],
           },
@@ -826,7 +830,7 @@ export function registerTools(
       }
 
       else if (name === 'knowl_task_checkpoint') {
-        const { taskId, summary, goal, completed, nextAction, blocker, artifactRefs } = args as any;
+        const { taskId, summary, goal, completed, nextAction, blocker, artifactRefs, verificationStatus } = args as any;
         const result = await checkpointWorkLoop(projectId!, taskId, {
           summary,
           goal,
@@ -834,6 +838,7 @@ export function registerTools(
           nextAction,
           blocker,
           artifactRefs,
+          verificationStatus,
         });
         return {
           content: [{ type: 'text', text: compactMcpJson(result) }],

--- a/src/store/session-capture.ts
+++ b/src/store/session-capture.ts
@@ -4,7 +4,7 @@ import { appendMemorySessionEvent } from './session-repository.js';
 const ALLOWED_FIELDS: Record<SessionEventType, string[]> = {
   start: ['title', 'agent'], command: ['command', 'exitCode', 'summary'], test: ['command', 'passed', 'summary'],
   error: ['code', 'message', 'summary'], git: ['commit', 'changedPaths', 'diffStat'], decision: ['text', 'summary'],
-  checkpoint: ['summary', 'changedPaths', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs'], stop: ['status', 'summary'],
+  checkpoint: ['summary', 'changedPaths', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs', 'verificationStatus'], stop: ['status', 'summary'],
 };
 
 export async function captureMemorySessionEvent(sessionId: string, type: SessionEventType, payload: Record<string, unknown>) {

--- a/src/store/session-capture.ts
+++ b/src/store/session-capture.ts
@@ -4,7 +4,7 @@ import { appendMemorySessionEvent } from './session-repository.js';
 const ALLOWED_FIELDS: Record<SessionEventType, string[]> = {
   start: ['title', 'agent'], command: ['command', 'exitCode', 'summary'], test: ['command', 'passed', 'summary'],
   error: ['code', 'message', 'summary'], git: ['commit', 'changedPaths', 'diffStat'], decision: ['text', 'summary'],
-  checkpoint: ['summary', 'changedPaths'], stop: ['status', 'summary'],
+  checkpoint: ['summary', 'changedPaths', 'goal', 'completed', 'nextAction', 'blocker', 'artifactRefs'], stop: ['status', 'summary'],
 };
 
 export async function captureMemorySessionEvent(sessionId: string, type: SessionEventType, payload: Record<string, unknown>) {

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -25,6 +25,7 @@ export type HandoffTaskState = {
   nextAction?: string;
   blocker?: string;
   artifactRefs?: string[];
+  verificationStatus?: string;
 };
 
 export type PendingHandoff = {
@@ -187,6 +188,7 @@ function checkpointTaskState(payload: Record<string, unknown>): HandoffTaskState
     nextAction: asString(payload.nextAction, 1_000),
     blocker: asString(payload.blocker, 1_000),
     artifactRefs: stringList(payload.artifactRefs, 20, 500),
+    verificationStatus: asString(payload.verificationStatus, 100),
   };
   return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
 }
@@ -200,6 +202,7 @@ function mergeTaskState(existing: HandoffTaskState | undefined, incoming: Handof
     nextAction: incoming.nextAction ?? existing.nextAction,
     blocker: incoming.blocker ?? existing.blocker,
     artifactRefs: incoming.artifactRefs?.length ? incoming.artifactRefs : existing.artifactRefs,
+    verificationStatus: incoming.verificationStatus ?? existing.verificationStatus,
   };
   return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
 }
@@ -281,6 +284,7 @@ export function formatPendingHandoffContext(handoff: PendingHandoff): string {
     if (handoff.taskState.nextAction) lines.push(`- Next action: ${handoff.taskState.nextAction}`);
     if (handoff.taskState.blocker) lines.push(`- Blocker: ${handoff.taskState.blocker}`);
     if (handoff.taskState.artifactRefs?.length) lines.push(`- Artifacts: ${handoff.taskState.artifactRefs.join(', ')}`);
+    if (handoff.taskState.verificationStatus) lines.push(`- Verification: ${handoff.taskState.verificationStatus}`);
   }
   lines.push('', 'Do not restart from scratch. Resume the interrupted work using this handoff plus recent project memory.');
   return truncateText(lines.join('\n'), DEFAULT_CONTEXT_MAX_CHARS);
@@ -330,17 +334,23 @@ export async function recordPendingSessionHandoff(
   };
 
   const conflictKey = pendingHandoffConflictKey(host);
+  const identity = {
+    host,
+    externalSessionId: handoff.externalSessionId,
+  };
   const existing = await findActivePendingHandoff(host);
   if (existing) {
+    // One active handoff per host. Same host+session merges; a newer host session replaces/updates the same record.
     const mergedHandoff = mergeHandoff(existing.handoff, handoff);
     const updated = await repo.updateKnowledgeItem(existing.id, {
       title: PENDING_HANDOFF_TITLE,
       content: JSON.stringify(mergedHandoff),
-      tags: ['pending_handoff', kind, mergedHandoff.urgency, host],
+      tags: ['pending_handoff', kind, mergedHandoff.urgency, host, `session:${mergedHandoff.externalSessionId}`],
       source: `host://${host}/session-failure`,
       freshness: 'fresh',
       confidence: kind === 'rate_limit' || kind === 'auth' ? 1 : 0.9,
       conflictKey,
+      conflictScope: identity,
       conflictExclusive: true,
     });
     await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${host}/${kind})`, [
@@ -353,11 +363,12 @@ export async function recordPendingSessionHandoff(
     category: 'state',
     title: PENDING_HANDOFF_TITLE,
     content: JSON.stringify(handoff),
-    tags: ['pending_handoff', kind, handoff.urgency, host],
+    tags: ['pending_handoff', kind, handoff.urgency, host, `session:${handoff.externalSessionId}`],
     source: `host://${host}/session-failure`,
     freshness: 'fresh',
     confidence: kind === 'rate_limit' || kind === 'auth' ? 1 : 0.9,
     conflictKey,
+    conflictScope: identity,
     conflictExclusive: true,
   });
   await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${host}/${kind})`, [

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -19,6 +19,14 @@ export type SessionFailureKind =
   | 'interrupted'
   | 'failed';
 
+export type HandoffTaskState = {
+  goal?: string;
+  completed?: string[];
+  nextAction?: string;
+  blocker?: string;
+  artifactRefs?: string[];
+};
+
 export type PendingHandoff = {
   kind: SessionFailureKind;
   urgency: typeof RATE_LIMIT_URGENCY | typeof AUTH_URGENCY | typeof PROVIDER_OUTAGE_URGENCY | typeof INTERRUPTED_URGENCY | typeof GENERIC_FAILURE_URGENCY;
@@ -31,6 +39,7 @@ export type PendingHandoff = {
   errorMessage?: string;
   lastCheckpoint?: string;
   changedPaths?: string[];
+  taskState?: HandoffTaskState;
   failedAt: string;
   consumed?: boolean;
   consumedAt?: string;
@@ -162,7 +171,53 @@ function parseHandoffContent(content: string): PendingHandoff | null {
   }
 }
 
-async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary?: string; changedPaths?: string[] }> {
+function stringList(value: unknown, maxItems = 20, maxLength = 2_000): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .slice(0, maxItems)
+    .map(entry => entry.trim().slice(0, maxLength));
+  return values.length ? values : undefined;
+}
+
+function checkpointTaskState(payload: Record<string, unknown>): HandoffTaskState | undefined {
+  const taskState: HandoffTaskState = {
+    goal: asString(payload.goal, 1_000),
+    completed: stringList(payload.completed, 20, 500),
+    nextAction: asString(payload.nextAction, 1_000),
+    blocker: asString(payload.blocker, 1_000),
+    artifactRefs: stringList(payload.artifactRefs, 20, 500),
+  };
+  return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
+}
+
+function mergeTaskState(existing: HandoffTaskState | undefined, incoming: HandoffTaskState | undefined): HandoffTaskState | undefined {
+  if (!existing) return incoming;
+  if (!incoming) return existing;
+  const taskState: HandoffTaskState = {
+    goal: incoming.goal ?? existing.goal,
+    completed: incoming.completed?.length ? incoming.completed : existing.completed,
+    nextAction: incoming.nextAction ?? existing.nextAction,
+    blocker: incoming.blocker ?? existing.blocker,
+    artifactRefs: incoming.artifactRefs?.length ? incoming.artifactRefs : existing.artifactRefs,
+  };
+  return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
+}
+
+function mergeHandoff(existing: PendingHandoff, incoming: PendingHandoff): PendingHandoff {
+  return {
+    ...incoming,
+    memorySessionId: incoming.memorySessionId ?? existing.memorySessionId,
+    sessionTitle: incoming.sessionTitle ?? existing.sessionTitle,
+    errorCode: incoming.errorCode ?? existing.errorCode,
+    errorMessage: incoming.errorMessage ?? existing.errorMessage,
+    lastCheckpoint: incoming.lastCheckpoint ?? existing.lastCheckpoint,
+    changedPaths: incoming.changedPaths?.length ? incoming.changedPaths : existing.changedPaths,
+    taskState: mergeTaskState(existing.taskState, incoming.taskState),
+  };
+}
+
+async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary?: string; changedPaths?: string[]; taskState?: HandoffTaskState }> {
   const rows = (await getClient().execute({
     sql: `SELECT payload FROM memory_session_events
       WHERE session_id = ? AND type = 'checkpoint'
@@ -177,7 +232,7 @@ async function loadLatestSessionCheckpoint(sessionId: string): Promise<{ summary
     const changedPaths = Array.isArray(payload.changedPaths)
       ? payload.changedPaths.filter((value): value is string => typeof value === 'string').slice(0, 20)
       : undefined;
-    return { summary, changedPaths };
+    return { summary, changedPaths, taskState: checkpointTaskState(payload) };
   } catch {
     return {};
   }
@@ -219,6 +274,14 @@ export function formatPendingHandoffContext(handoff: PendingHandoff): string {
   if (handoff.errorMessage) lines.push(`- Error: ${handoff.errorMessage}`);
   if (handoff.lastCheckpoint) lines.push(`- Last checkpoint: ${handoff.lastCheckpoint}`);
   if (handoff.changedPaths?.length) lines.push(`- Changed paths: ${handoff.changedPaths.join(', ')}`);
+  if (handoff.taskState) {
+    lines.push('', '## Task state');
+    if (handoff.taskState.goal) lines.push(`- Goal: ${handoff.taskState.goal}`);
+    if (handoff.taskState.completed?.length) lines.push(`- Completed: ${handoff.taskState.completed.join('; ')}`);
+    if (handoff.taskState.nextAction) lines.push(`- Next action: ${handoff.taskState.nextAction}`);
+    if (handoff.taskState.blocker) lines.push(`- Blocker: ${handoff.taskState.blocker}`);
+    if (handoff.taskState.artifactRefs?.length) lines.push(`- Artifacts: ${handoff.taskState.artifactRefs.join(', ')}`);
+  }
   lines.push('', 'Do not restart from scratch. Resume the interrupted work using this handoff plus recent project memory.');
   return truncateText(lines.join('\n'), DEFAULT_CONTEXT_MAX_CHARS);
 }
@@ -234,6 +297,7 @@ export async function recordPendingSessionHandoff(
   let sessionTitle: string | undefined;
   let lastCheckpoint: string | undefined;
   let changedPaths: string[] | undefined;
+  let taskState: HandoffTaskState | undefined;
   if (options.memorySessionId) {
     try {
       const session = await getMemorySession(options.memorySessionId);
@@ -244,6 +308,7 @@ export async function recordPendingSessionHandoff(
     const checkpoint = await loadLatestSessionCheckpoint(options.memorySessionId);
     lastCheckpoint = checkpoint.summary;
     changedPaths = checkpoint.changedPaths;
+    taskState = checkpoint.taskState;
   }
 
   const host = String(input.host);
@@ -259,6 +324,7 @@ export async function recordPendingSessionHandoff(
     errorMessage: asString(input.payload.message ?? input.payload.summary ?? input.payload.error_message, 500),
     lastCheckpoint,
     changedPaths,
+    taskState,
     failedAt: new Date().toISOString(),
     consumed: false,
   };
@@ -266,10 +332,11 @@ export async function recordPendingSessionHandoff(
   const conflictKey = pendingHandoffConflictKey(host);
   const existing = await findActivePendingHandoff(host);
   if (existing) {
+    const mergedHandoff = mergeHandoff(existing.handoff, handoff);
     const updated = await repo.updateKnowledgeItem(existing.id, {
       title: PENDING_HANDOFF_TITLE,
-      content: JSON.stringify(handoff),
-      tags: ['pending_handoff', kind, handoff.urgency, host],
+      content: JSON.stringify(mergedHandoff),
+      tags: ['pending_handoff', kind, mergedHandoff.urgency, host],
       source: `host://${host}/session-failure`,
       freshness: 'fresh',
       confidence: kind === 'rate_limit' || kind === 'auth' ? 1 : 0.9,
@@ -279,7 +346,7 @@ export async function recordPendingSessionHandoff(
     await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${host}/${kind})`, [
       { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
     ]);
-    return { itemId: updated.id, handoff };
+    return { itemId: updated.id, handoff: mergedHandoff };
   }
 
   const created = await repo.createKnowledgeItem(projectId, {

--- a/src/store/work-loop.ts
+++ b/src/store/work-loop.ts
@@ -21,10 +21,23 @@ export type WorkLoopStartResult = {
   memorySessionId?: string;
 };
 
+export type WorkLoopTaskState = {
+  goal?: string;
+  completed?: string[];
+  nextAction?: string;
+  blocker?: string;
+  artifactRefs?: string[];
+};
+
+export type WorkLoopCheckpointInput = {
+  summary: string;
+} & WorkLoopTaskState;
+
 export type WorkLoopStepResult = {
   taskId: string;
   itemId: string;
   summary: string;
+  taskState?: WorkLoopTaskState;
 };
 
 function compactMemoryHit(item: KnowledgeItem): WorkLoopMemoryHit {
@@ -42,6 +55,37 @@ async function requireWorkLoopTask(taskId: string): Promise<KnowledgeItem> {
     throw new Error(`Work loop task not found: ${taskId}`);
   }
   return task;
+}
+
+function stringList(value: unknown, maxItems = 20, maxLength = 500): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    .slice(0, maxItems)
+    .map(entry => entry.trim().slice(0, maxLength));
+  return values.length ? values : undefined;
+}
+
+function normalizeTaskState(input: WorkLoopTaskState): WorkLoopTaskState | undefined {
+  const taskState: WorkLoopTaskState = {
+    goal: typeof input.goal === 'string' && input.goal.trim() ? input.goal.trim().slice(0, 1_000) : undefined,
+    completed: stringList(input.completed, 20, 500),
+    nextAction: typeof input.nextAction === 'string' && input.nextAction.trim() ? input.nextAction.trim().slice(0, 1_000) : undefined,
+    blocker: typeof input.blocker === 'string' && input.blocker.trim() ? input.blocker.trim().slice(0, 1_000) : undefined,
+    artifactRefs: stringList(input.artifactRefs, 20, 500),
+  };
+  return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
+}
+
+function taskStateLines(taskState: WorkLoopTaskState | undefined): string[] {
+  if (!taskState) return [];
+  const lines: string[] = [];
+  if (taskState.goal) lines.push(`Goal: ${taskState.goal}`);
+  if (taskState.completed?.length) lines.push(`Completed: ${taskState.completed.join('; ')}`);
+  if (taskState.nextAction) lines.push(`Next action: ${taskState.nextAction}`);
+  if (taskState.blocker) lines.push(`Blocker: ${taskState.blocker}`);
+  if (taskState.artifactRefs?.length) lines.push(`Artifacts: ${taskState.artifactRefs.join(', ')}`);
+  return lines;
 }
 
 function memorySessionId(task: KnowledgeItem): string | undefined {
@@ -102,10 +146,12 @@ async function recordWorkLoopStep(
   title: 'Work Loop checkpoint' | 'Work Loop finish',
   summary: string,
   commitMessage: string,
-  stepTag: 'checkpoint' | 'finish'
+  stepTag: 'checkpoint' | 'finish',
+  taskStateInput: WorkLoopTaskState = {},
 ): Promise<WorkLoopStepResult> {
   const task = await requireWorkLoopTask(taskId);
   const now = new Date().toISOString();
+  const taskState = normalizeTaskState(taskStateInput);
   const item = await repo.createKnowledgeItem(projectId, {
     category: 'state',
     title,
@@ -114,6 +160,7 @@ async function recordWorkLoopStep(
       `Task: ${task.title.replace(/^Work Loop: /, '')}`,
       `Recorded at: ${now}`,
       `Summary: ${summary}`,
+      ...taskStateLines(taskState),
     ].join('\n'),
     tags: ['work-loop', `task:${taskId}`, stepTag],
     source: 'knowl work loop',
@@ -128,7 +175,7 @@ async function recordWorkLoopStep(
   if (sessionId) {
     try {
       if (stepTag === 'finish') { await finishMemorySession(sessionId, 'finished', summary); await finalizeMemorySession(projectId, sessionId); }
-      else await captureMemorySessionEvent(sessionId, 'checkpoint', { summary });
+      else await captureMemorySessionEvent(sessionId, 'checkpoint', { summary, ...taskState });
     } catch (error: any) {
       console.error(`Warning: session capture unavailable: ${error.message}`);
     }
@@ -138,21 +185,24 @@ async function recordWorkLoopStep(
     taskId,
     itemId: item.id,
     summary,
+    ...(taskState ? { taskState } : {}),
   };
 }
 
 export async function checkpointWorkLoop(
   projectId: string,
   taskId: string,
-  summary: string
+  input: string | WorkLoopCheckpointInput,
 ): Promise<WorkLoopStepResult> {
+  const checkpoint = typeof input === 'string' ? { summary: input } : input;
   return recordWorkLoopStep(
     projectId,
     taskId,
     'Work Loop checkpoint',
-    summary,
+    checkpoint.summary,
     `Work loop checkpoint: ${taskId}`,
-    'checkpoint'
+    'checkpoint',
+    checkpoint,
   );
 }
 

--- a/src/store/work-loop.ts
+++ b/src/store/work-loop.ts
@@ -27,6 +27,7 @@ export type WorkLoopTaskState = {
   nextAction?: string;
   blocker?: string;
   artifactRefs?: string[];
+  verificationStatus?: string;
 };
 
 export type WorkLoopCheckpointInput = {
@@ -73,6 +74,9 @@ function normalizeTaskState(input: WorkLoopTaskState): WorkLoopTaskState | undef
     nextAction: typeof input.nextAction === 'string' && input.nextAction.trim() ? input.nextAction.trim().slice(0, 1_000) : undefined,
     blocker: typeof input.blocker === 'string' && input.blocker.trim() ? input.blocker.trim().slice(0, 1_000) : undefined,
     artifactRefs: stringList(input.artifactRefs, 20, 500),
+    verificationStatus: typeof input.verificationStatus === 'string' && input.verificationStatus.trim()
+      ? input.verificationStatus.trim().slice(0, 100)
+      : undefined,
   };
   return Object.values(taskState).some(value => value !== undefined) ? taskState : undefined;
 }
@@ -85,6 +89,7 @@ function taskStateLines(taskState: WorkLoopTaskState | undefined): string[] {
   if (taskState.nextAction) lines.push(`Next action: ${taskState.nextAction}`);
   if (taskState.blocker) lines.push(`Blocker: ${taskState.blocker}`);
   if (taskState.artifactRefs?.length) lines.push(`Artifacts: ${taskState.artifactRefs.join(', ')}`);
+  if (taskState.verificationStatus) lines.push(`Verification: ${taskState.verificationStatus}`);
   return lines;
 }
 

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -369,7 +369,7 @@ describe('CLI Integration', () => {
     expect(taskId).toBeTruthy();
 
     const checkpointOutput = execSync(
-      `node "${CLI_PATH}" task checkpoint ${taskId} "Added search UI tests" --goal "Ship resumable handoffs" --completed "Added search UI tests" --next-action "Finish the implementation" --blocker "None" --artifact "src/index.ts"`,
+      `node "${CLI_PATH}" task checkpoint ${taskId} "Added search UI tests" --goal "Ship resumable handoffs" --completed "Added search UI tests" --next-action "Finish the implementation" --blocker "None" --artifact "src/index.ts" --verification-status "tests-passing"`,
       {
         cwd: workLoopDir,
         encoding: 'utf-8',
@@ -381,6 +381,7 @@ describe('CLI Integration', () => {
     expect(checkpointOutput).toContain('Completed: Added search UI tests');
     expect(checkpointOutput).toContain('Next action: Finish the implementation');
     expect(checkpointOutput).toContain('Artifacts: src/index.ts');
+    expect(checkpointOutput).toContain('Verification: tests-passing');
 
     const finishOutput = execSync(`node "${CLI_PATH}" task finish ${taskId} "Verified search UI implementation"`, {
       cwd: workLoopDir,

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -368,12 +368,19 @@ describe('CLI Integration', () => {
     const taskId = startOutput.match(/Task ID:\s+([a-f0-9]+)/)?.[1];
     expect(taskId).toBeTruthy();
 
-    const checkpointOutput = execSync(`node "${CLI_PATH}" task checkpoint ${taskId} "Added search UI tests"`, {
-      cwd: workLoopDir,
-      encoding: 'utf-8',
-    });
+    const checkpointOutput = execSync(
+      `node "${CLI_PATH}" task checkpoint ${taskId} "Added search UI tests" --goal "Ship resumable handoffs" --completed "Added search UI tests" --next-action "Finish the implementation" --blocker "None" --artifact "src/index.ts"`,
+      {
+        cwd: workLoopDir,
+        encoding: 'utf-8',
+      }
+    );
     expect(checkpointOutput).toContain('KNOWL WORK LOOP CHECKPOINT');
     expect(checkpointOutput).toContain('Checkpoint ID:');
+    expect(checkpointOutput).toContain('Goal: Ship resumable handoffs');
+    expect(checkpointOutput).toContain('Completed: Added search UI tests');
+    expect(checkpointOutput).toContain('Next action: Finish the implementation');
+    expect(checkpointOutput).toContain('Artifacts: src/index.ts');
 
     const finishOutput = execSync(`node "${CLI_PATH}" task finish ${taskId} "Verified search UI implementation"`, {
       cwd: workLoopDir,

--- a/tests/cli/host-hook.test.ts
+++ b/tests/cli/host-hook.test.ts
@@ -113,6 +113,30 @@ describe('host hook normalization', () => {
     expect(result.payload).not.toHaveProperty('stdout');
   });
 
+  it('keeps structured checkpoint state without retaining arbitrary tool output', () => {
+    const result = normalizeHostHook('generic', 'checkpoint', {
+      sessionId: 'session-structured',
+      turnId: 'turn-structured',
+      cwd: ROOT,
+      summary: 'Checkpoint complete',
+      goal: 'Ship resumable handoffs',
+      completed: ['Added a test'],
+      nextAction: 'Implement the contract',
+      blocker: 'Waiting for a rate-limit reset',
+      artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      stdout: 'discard me',
+    });
+
+    expect(result.payload).toEqual({
+      summary: 'Checkpoint complete',
+      goal: 'Ship resumable handoffs',
+      completed: ['Added a test'],
+      nextAction: 'Implement the contract',
+      blocker: 'Waiting for a rate-limit reset',
+      artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+    });
+  });
+
   it('preserves hard-stop failure payloads across hosts', () => {
     const claude = normalizeHostHook('claude', 'StopFailure', {
       session_id: 'session-rate',

--- a/tests/cli/host-hook.test.ts
+++ b/tests/cli/host-hook.test.ts
@@ -124,6 +124,7 @@ describe('host hook normalization', () => {
       nextAction: 'Implement the contract',
       blocker: 'Waiting for a rate-limit reset',
       artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      verificationStatus: 'needs-review',
       stdout: 'discard me',
     });
 
@@ -134,6 +135,7 @@ describe('host hook normalization', () => {
       nextAction: 'Implement the contract',
       blocker: 'Waiting for a rate-limit reset',
       artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      verificationStatus: 'needs-review',
     });
   });
 

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -540,6 +540,7 @@ describe('MCP Server Layer', () => {
         nextAction: 'Finish the implementation',
         blocker: 'None',
         artifactRefs: ['src/mcp/tools.ts'],
+        verificationStatus: 'tests-passing',
       },
     });
 
@@ -554,6 +555,7 @@ describe('MCP Server Layer', () => {
       nextAction: 'Finish the implementation',
       blocker: 'None',
       artifactRefs: ['src/mcp/tools.ts'],
+      verificationStatus: 'tests-passing',
     });
 
     const finishRes = await runRpcRequest('tools/call', {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -535,6 +535,11 @@ describe('MCP Server Layer', () => {
       arguments: {
         taskId: startPayload.taskId,
         summary: 'Added search UI tests',
+        goal: 'Ship resumable handoffs',
+        completed: ['Added search UI tests'],
+        nextAction: 'Finish the implementation',
+        blocker: 'None',
+        artifactRefs: ['src/mcp/tools.ts'],
       },
     });
 
@@ -543,6 +548,13 @@ describe('MCP Server Layer', () => {
     const checkpointPayload = JSON.parse(checkpointRes.result.content[0].text);
     expect(checkpointPayload.taskId).toBe(startPayload.taskId);
     expect(checkpointPayload.itemId).toBeTruthy();
+    expect(checkpointPayload.taskState).toEqual({
+      goal: 'Ship resumable handoffs',
+      completed: ['Added search UI tests'],
+      nextAction: 'Finish the implementation',
+      blocker: 'None',
+      artifactRefs: ['src/mcp/tools.ts'],
+    });
 
     const finishRes = await runRpcRequest('tools/call', {
       name: 'knowl_task_finish',

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -109,6 +109,7 @@ describe('host lifecycle orchestration', () => {
         nextAction: 'Implement the checkpoint contract',
         blocker: 'None',
         artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+        verificationStatus: 'unverified',
       },
     }));
 
@@ -122,6 +123,7 @@ describe('host lifecycle orchestration', () => {
       nextAction: 'Implement the checkpoint contract',
       blocker: 'None',
       artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      verificationStatus: 'unverified',
     });
   });
 
@@ -297,6 +299,7 @@ describe('host lifecycle orchestration', () => {
         nextAction: 'Persist the pending handoff',
         blocker: 'Rate limit',
         artifactRefs: ['src/store/session-handoff.ts', 'tests/store/host-lifecycle.test.ts'],
+        verificationStatus: 'needs-review',
       },
     }));
     const failedStop = await handleHostLifecycleEvent(projectId, hook({
@@ -319,6 +322,7 @@ describe('host lifecycle orchestration', () => {
       nextAction: 'Persist the pending handoff',
       blocker: 'Rate limit',
       artifactRefs: ['src/store/session-handoff.ts', 'tests/store/host-lifecycle.test.ts'],
+      verificationStatus: 'needs-review',
     });
     expect(failedStop.promotion).toBeDefined();
 
@@ -358,8 +362,66 @@ describe('host lifecycle orchestration', () => {
     expect(String(nextStart.context)).toContain('Persist the pending handoff');
     expect(String(nextStart.context)).toContain('Rate limit');
     expect(String(nextStart.context)).toContain('src/store/session-handoff.ts');
+    expect(String(nextStart.context)).toContain('needs-review');
     expect(String(nextStart.context)).toContain('Use local memory');
     expect(String(secondStart.context)).not.toContain('PENDING SESSION HANDOFF');
+  });
+
+  it('updates one host-scoped handoff record for repeated failures instead of creating duplicates', async () => {
+    await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'claude-dedupe-session',
+      externalTurnId: undefined,
+    }));
+    await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'checkpoint',
+      externalSessionId: 'claude-dedupe-session',
+      externalTurnId: 'turn-1',
+      type: 'checkpoint',
+      payload: {
+        summary: 'First checkpoint',
+        goal: 'Keep one handoff',
+        completed: ['Recorded first failure path'],
+        nextAction: 'Retry after rate limit',
+        blocker: 'Rate limit',
+        artifactRefs: ['src/store/session-handoff.ts'],
+        verificationStatus: 'unverified',
+      },
+    }));
+    const firstFail = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-dedupe-session',
+      externalTurnId: 'turn-1',
+      status: 'failed',
+      payload: { status: 'failed', error: 'rate_limit', message: 'limit hit' },
+    }));
+    const secondFail = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'turn-stop',
+      externalSessionId: 'claude-dedupe-session',
+      externalTurnId: 'turn-1',
+      status: 'failed',
+      payload: { status: 'failed', error: 'rate_limit', message: 'limit hit again' },
+    }));
+
+    expect(firstFail.handoff?.itemId).toBeTruthy();
+    expect(secondFail.handoff?.itemId).toBe(firstFail.handoff?.itemId);
+
+    const active = await getClient().execute({
+      sql: "SELECT id, content, conflict_scope, tags FROM knowledge_items WHERE title = 'Pending session handoff' AND status = 'active'",
+    });
+    expect(active.rows).toHaveLength(1);
+    const handoff = JSON.parse(String(active.rows[0].content));
+    expect(handoff.externalSessionId).toBe('claude-dedupe-session');
+    expect(handoff.taskState.verificationStatus).toBe('unverified');
+    expect(String(active.rows[0].tags)).toContain('session:claude-dedupe-session');
+    expect(JSON.parse(String(active.rows[0].conflict_scope))).toEqual({
+      host: 'claude',
+      externalSessionId: 'claude-dedupe-session',
+    });
   });
 
   it('records host-neutral hard-stop handoffs for Codex and Cursor failures', async () => {

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -101,12 +101,28 @@ describe('host lifecycle orchestration', () => {
       externalTurnId: 'turn-2',
       event: 'checkpoint',
       type: 'checkpoint',
-      payload: { summary: 'Current task state', changedPaths: ['src/auth.ts'] },
+      payload: {
+        summary: 'Current task state',
+        changedPaths: ['src/auth.ts'],
+        goal: 'Ship resumable handoffs',
+        completed: ['Added the regression case'],
+        nextAction: 'Implement the checkpoint contract',
+        blocker: 'None',
+        artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+      },
     }));
 
     expect(checkpoint.sessionId).toBe(start.sessionId);
     const rows = await getClient().execute({ sql: 'SELECT payload FROM memory_session_events WHERE session_id = ? AND type = ?', args: [start.sessionId!, 'checkpoint'] });
-    expect(JSON.parse(String(rows.rows[0].payload))).toEqual({ summary: 'Current task state', changedPaths: ['src/auth.ts'] });
+    expect(JSON.parse(String(rows.rows[0].payload))).toEqual({
+      summary: 'Current task state',
+      changedPaths: ['src/auth.ts'],
+      goal: 'Ship resumable handoffs',
+      completed: ['Added the regression case'],
+      nextAction: 'Implement the checkpoint contract',
+      blocker: 'None',
+      artifactRefs: ['tests/store/host-lifecycle.test.ts'],
+    });
   });
 
   it('delivers fallback context once across completed turns without SessionStart', async () => {
@@ -273,7 +289,15 @@ describe('host lifecycle orchestration', () => {
       externalSessionId: 'claude-rate-limit',
       externalTurnId: 'turn-rate',
       type: 'checkpoint',
-      payload: { summary: 'Human review gate active', changedPaths: ['src/forge.ts'] },
+      payload: {
+        summary: 'Human review gate active',
+        changedPaths: ['src/forge.ts'],
+        goal: 'Ship resumable handoffs',
+        completed: ['Captured a structured checkpoint', 'Ran focused tests'],
+        nextAction: 'Persist the pending handoff',
+        blocker: 'Rate limit',
+        artifactRefs: ['src/store/session-handoff.ts', 'tests/store/host-lifecycle.test.ts'],
+      },
     }));
     const failedStop = await handleHostLifecycleEvent(projectId, hook({
       host: 'claude',
@@ -289,6 +313,13 @@ describe('host lifecycle orchestration', () => {
     expect(failedStop.accepted).toBe(true);
     expect(failedStop.handoff?.handoff.kind).toBe('rate_limit');
     expect(failedStop.handoff?.handoff.lastCheckpoint).toBe('Human review gate active');
+    expect(failedStop.handoff?.handoff.taskState).toEqual({
+      goal: 'Ship resumable handoffs',
+      completed: ['Captured a structured checkpoint', 'Ran focused tests'],
+      nextAction: 'Persist the pending handoff',
+      blocker: 'Rate limit',
+      artifactRefs: ['src/store/session-handoff.ts', 'tests/store/host-lifecycle.test.ts'],
+    });
     expect(failedStop.promotion).toBeDefined();
 
     const sessionRows = await getClient().execute({
@@ -323,6 +354,10 @@ describe('host lifecycle orchestration', () => {
     expect(String(nextStart.context)).toContain('PENDING SESSION HANDOFF');
     expect(String(nextStart.context)).toContain('rate_limit');
     expect(String(nextStart.context)).toContain('Human review gate active');
+    expect(String(nextStart.context)).toContain('Ship resumable handoffs');
+    expect(String(nextStart.context)).toContain('Persist the pending handoff');
+    expect(String(nextStart.context)).toContain('Rate limit');
+    expect(String(nextStart.context)).toContain('src/store/session-handoff.ts');
     expect(String(nextStart.context)).toContain('Use local memory');
     expect(String(secondStart.context)).not.toContain('PENDING SESSION HANDOFF');
   });

--- a/tests/store/session-handoff.test.ts
+++ b/tests/store/session-handoff.test.ts
@@ -34,6 +34,7 @@ describe('session handoff helpers', () => {
         nextAction: 'Persist task state',
         blocker: 'Rate limit',
         artifactRefs: ['tests/store/session-handoff.test.ts'],
+        verificationStatus: 'unverified',
       },
       failedAt: '2026-07-12T00:00:00.000Z',
     });
@@ -44,6 +45,7 @@ describe('session handoff helpers', () => {
     expect(text).toContain('Ship resumable handoffs');
     expect(text).toContain('Persist task state');
     expect(text).toContain('tests/store/session-handoff.test.ts');
+    expect(text).toContain('unverified');
     expect(text).toContain('Do not restart from scratch');
   });
 });

--- a/tests/store/session-handoff.test.ts
+++ b/tests/store/session-handoff.test.ts
@@ -28,12 +28,22 @@ describe('session handoff helpers', () => {
       errorCode: 'rate_limit',
       lastCheckpoint: 'Review loop gated',
       changedPaths: ['src/forge.ts'],
+      taskState: {
+        goal: 'Ship resumable handoffs',
+        completed: ['Added a regression test'],
+        nextAction: 'Persist task state',
+        blocker: 'Rate limit',
+        artifactRefs: ['tests/store/session-handoff.test.ts'],
+      },
       failedAt: '2026-07-12T00:00:00.000Z',
     });
 
     expect(text).toContain('PENDING SESSION HANDOFF');
     expect(text).toContain('rate_limit');
     expect(text).toContain('Review loop gated');
+    expect(text).toContain('Ship resumable handoffs');
+    expect(text).toContain('Persist task state');
+    expect(text).toContain('tests/store/session-handoff.test.ts');
     expect(text).toContain('Do not restart from scratch');
   });
 });

--- a/tests/store/work-loop.test.ts
+++ b/tests/store/work-loop.test.ts
@@ -34,6 +34,7 @@ describe('work loop session capture', () => {
       nextAction: 'Verify MCP tool payload',
       blocker: 'None',
       artifactRefs: ['src/store/work-loop.ts', 'tests/store/work-loop.test.ts'],
+      verificationStatus: 'tests-passing',
     });
 
     expect(checkpoint.taskState).toEqual({
@@ -42,6 +43,7 @@ describe('work loop session capture', () => {
       nextAction: 'Verify MCP tool payload',
       blocker: 'None',
       artifactRefs: ['src/store/work-loop.ts', 'tests/store/work-loop.test.ts'],
+      verificationStatus: 'tests-passing',
     });
 
     const rows = await getClient().execute({
@@ -55,6 +57,7 @@ describe('work loop session capture', () => {
       nextAction: 'Verify MCP tool payload',
       blocker: 'None',
       artifactRefs: ['src/store/work-loop.ts', 'tests/store/work-loop.test.ts'],
+      verificationStatus: 'tests-passing',
     });
   });
 });

--- a/tests/store/work-loop.test.ts
+++ b/tests/store/work-loop.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { closeDb, getDb, initDb } from '../../src/store/database.js';
+import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
 import * as repo from '../../src/store/repository.js';
-import { finishWorkLoop, startWorkLoop } from '../../src/store/work-loop.js';
+import { checkpointWorkLoop, finishWorkLoop, startWorkLoop } from '../../src/store/work-loop.js';
 
 const TEST_ROOT = path.resolve('./.knowl-work-loop-session-test');
 
@@ -22,5 +22,39 @@ describe('work loop session capture', () => {
     const events = await db.all(`SELECT type FROM memory_session_events`);
     expect(finished).toHaveLength(1);
     expect(events.map((row: any) => row.type)).toEqual(expect.arrayContaining(['start', 'stop']));
+  });
+
+  it('stores structured checkpoint task state on the linked memory session', async () => {
+    const project = await repo.createProject(TEST_ROOT, 'Work loop structured checkpoint');
+    const started = await startWorkLoop(project.id, 'Ship resumable handoffs', 'handoffs');
+    const checkpoint = await checkpointWorkLoop(project.id, started.taskId, {
+      summary: 'Captured structured progress',
+      goal: 'Ship resumable handoffs',
+      completed: ['Extended work-loop checkpoints'],
+      nextAction: 'Verify MCP tool payload',
+      blocker: 'None',
+      artifactRefs: ['src/store/work-loop.ts', 'tests/store/work-loop.test.ts'],
+    });
+
+    expect(checkpoint.taskState).toEqual({
+      goal: 'Ship resumable handoffs',
+      completed: ['Extended work-loop checkpoints'],
+      nextAction: 'Verify MCP tool payload',
+      blocker: 'None',
+      artifactRefs: ['src/store/work-loop.ts', 'tests/store/work-loop.test.ts'],
+    });
+
+    const rows = await getClient().execute({
+      sql: 'SELECT payload FROM memory_session_events WHERE session_id = ? AND type = ?',
+      args: [started.memorySessionId!, 'checkpoint'],
+    });
+    expect(JSON.parse(String(rows.rows[0].payload))).toEqual({
+      summary: 'Captured structured progress',
+      goal: 'Ship resumable handoffs',
+      completed: ['Extended work-loop checkpoints'],
+      nextAction: 'Verify MCP tool payload',
+      blocker: 'None',
+      artifactRefs: ['src/store/work-loop.ts', 'tests/store/work-loop.test.ts'],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Preserve structured task state (`goal`, `completed`, `nextAction`, `blocker`, `artifactRefs`) on checkpoints and host failure handoffs.
- Extend `knowl_task_checkpoint` / work-loop checkpoints so manual MCP loops feed the same resumable contract as host lifecycle checkpoints.
- Document the handoff lifecycle so resume context includes structured task state, not just freeform summary text.

## Why
Upstream `main` already ships host-scoped hard-stop handoffs in 1.2.0. This PR layers the missing structured task-state resume fields on top of that contract instead of reintroducing the older handoff branch.

## Test plan
- [x] `npm test -- tests/store/work-loop.test.ts tests/store/session-handoff.test.ts tests/store/host-lifecycle.test.ts tests/cli/host-hook.test.ts tests/mcp/server.test.ts`
- [x] `npm run build`
- [x] `npm link` (`@dat999zx/knowl@1.2.0 -> D:\Code\knowl`)

## Notes
- Restart MCP/agent hosts to pick up the new `knowl_task_checkpoint` schema.
- Older PR #3 targeted a divergent fork of the handoff work and conflicts with current `main`; this branch is based on `upstream/main` @ 1.2.0.