### PR TITLE
Memory quality: session-start drift detection, correction blast radius, tier + provenance

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -37,6 +37,23 @@ export type KnowledgeFreshness =
   | 'stale'
   | 'needs_review';
 
+/**
+ * Standing earned by use, orthogonal to self-reported confidence. Every write starts
+ * `asserted`; repeated confirmed-useful feedback promotes to `verified`; a correction or a
+ * content edit resets, because verified means verified-verbatim. Deliberately absent from
+ * lifecycleHash: verification is this machine's own experience with the item, and an
+ * imported copy has not been used here yet.
+ */
+export type KnowledgeTier = 'asserted' | 'verified';
+
+/**
+ * How the knowledge came to be believed, fixed at write time. `observed` — from execution
+ * or direct inspection; `user_stated` — the human said so; `inferred` — the agent
+ * concluded it. A reflected lesson reads as authoritative once stored, so the class it
+ * was born with is the only record that it was ever a guess.
+ */
+export type KnowledgeProvenance = 'observed' | 'user_stated' | 'inferred';
+
 export type SessionStatus = 'active' | 'finished' | 'failed' | 'abandoned' | 'recovered';
 export type SessionEventType = 'start' | 'command' | 'test' | 'error' | 'git' | 'decision' | 'checkpoint' | 'stop';
 
@@ -80,6 +97,8 @@ export interface KnowledgeItem {
   visibility?: string | null;
   freshness: KnowledgeFreshness;
   confidence: number;
+  tier: KnowledgeTier;
+  provenance?: KnowledgeProvenance | null;
   conflictKey?: string | null;
   conflictScope?: Record<string, unknown> | null;
   conflictExclusive?: boolean;
@@ -272,6 +291,7 @@ export interface KnowledgeAtom {
   sourceCommit?: string | null;
   affectedPaths?: string[] | null;
   confidence?: number;
+  provenance?: KnowledgeProvenance | null;
   conflictKey?: string | null;
   conflictScope?: Record<string, unknown> | null;
   conflictExclusive?: boolean;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -98,6 +98,8 @@ export interface KnowledgeItem {
   freshness: KnowledgeFreshness;
   confidence: number;
   tier: KnowledgeTier;
+  /** When `tier` was last set; confirmations before it belong to a superseded standing. */
+  tierSince?: string | null;
   provenance?: KnowledgeProvenance | null;
   conflictKey?: string | null;
   conflictScope?: Record<string, unknown> | null;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -26,6 +26,7 @@ import { createSkillPackage, listSkillPackages, readSkillPackage, runSkillPackag
 import { KnowledgeValidationError } from '../core/knowledge-validation.js';
 import { isEvidenceStale, listEvidenceForItem } from '../store/evidence-repository.js';
 import { recordKnowledgeFeedback } from '../store/access-feedback.js';
+import { flagCorrectionSiblingsBestEffort } from '../store/blast-radius.js';
 import { finishMemorySession } from '../store/session-repository.js';
 import { finalizeMemorySession } from '../store/session-finalizer.js';
 import { configuredNamespaces, namespaceDescriptor, queryLayeredKnowledge, withNamespaceDatabase } from '../store/namespaces.js';
@@ -976,7 +977,19 @@ export function registerTools(
         const owner = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
         try { await assertOwnedItem(itemId, owner); } catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
         const feedback = await recordKnowledgeFeedback({ itemId, used, useful, causedCorrection });
-        return { content: [{ type: 'text', text: `Recorded feedback for ${itemId}:\n\n${JSON.stringify(feedback, null, 2)}` }] };
+        // A correction implicates the corrected item's batch, not just the item: the
+        // pass that produced one wrong atom usually produced more. Explicit
+        // causedCorrection is the unambiguous signal; a routine supersede is not.
+        let blast: Awaited<ReturnType<typeof flagCorrectionSiblingsBestEffort>> = null;
+        if (causedCorrection === true) {
+          const { getKnowledgeItem } = await import('../store/repository.js');
+          const corrected = await getKnowledgeItem(itemId);
+          blast = await flagCorrectionSiblingsBestEffort(projectId!, itemId, `"${corrected?.title ?? itemId}" (correction feedback)`);
+        }
+        const blastNote = blast && blast.flaggedIds.length > 0
+          ? `\n\nBlast radius: ${blast.flaggedIds.length} sibling item(s) marked needs_review${blast.capped ? ' (capped)' : ''}.`
+          : '';
+        return { content: [{ type: 'text', text: `Recorded feedback for ${itemId}:\n\n${JSON.stringify(feedback, null, 2)}${blastNote}` }] };
       }
 
       else if (name === 'knowl_session_finish') {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -218,6 +218,11 @@ export function registerTools(
                     sourceCommit: { type: 'string' },
                     affectedPaths: { type: 'array', items: { type: 'string' } },
                     confidence: { type: 'number' },
+                    provenance: {
+                      type: 'string',
+                      enum: ['observed', 'user_stated', 'inferred'],
+                      description: 'How this came to be believed: observed (execution or direct inspection), user_stated (the human said so), or inferred (concluded without direct evidence). Inferred items rank lower until confirmed by use.',
+                    },
                     steps: { type: 'array', items: { type: 'string' } },
                     supersedes: { type: 'string', description: 'Id of an active item this atom replaces; it is marked superseded (retired but still queryable), not deleted.' },
                   },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -27,6 +27,7 @@ import { KnowledgeValidationError } from '../core/knowledge-validation.js';
 import { isEvidenceStale, listEvidenceForItem } from '../store/evidence-repository.js';
 import { recordKnowledgeFeedback } from '../store/access-feedback.js';
 import { flagCorrectionSiblingsBestEffort } from '../store/blast-radius.js';
+import { applyFeedbackToTierBestEffort } from '../store/tier.js';
 import { finishMemorySession } from '../store/session-repository.js';
 import { finalizeMemorySession } from '../store/session-finalizer.js';
 import { configuredNamespaces, namespaceDescriptor, queryLayeredKnowledge, withNamespaceDatabase } from '../store/namespaces.js';
@@ -176,6 +177,11 @@ export function registerTools(
               confidence: {
                 type: 'number',
                 description: 'Optional confidence from 0.0 to 1.0.',
+              },
+              provenance: {
+                type: 'string',
+                enum: ['observed', 'user_stated', 'inferred'],
+                description: 'How this came to be believed: observed (execution or direct inspection), user_stated (the human said so), or inferred (concluded without direct evidence). Inferred items rank lower until confirmed by use.',
               },
               conflictKey: { type: 'string', description: 'Optional normalized semantic identity key.' },
               conflictScope: { type: 'object', description: 'Optional scope for the conflict key.' },
@@ -679,7 +685,7 @@ export function registerTools(
       }
 
       else if (name === 'knowl_store') {
-        const { category, title, content, reasoning, alternatives, tags, source, sourceCommit, affectedPaths, confidence, steps, conflictKey, conflictScope, conflictExclusive, supersedes, namespace = 'project' } = args as any;
+        const { category, title, content, reasoning, alternatives, tags, source, sourceCommit, affectedPaths, confidence, provenance, steps, conflictKey, conflictScope, conflictExclusive, supersedes, namespace = 'project' } = args as any;
 
         if (!KNOWLEDGE_CATEGORIES.includes(category)) {
           throw new Error(`Invalid knowledge category: ${category}`);
@@ -698,6 +704,7 @@ export function registerTools(
             sourceCommit,
             affectedPaths,
             confidence,
+            provenance,
             conflictKey,
             conflictScope,
             conflictExclusive,
@@ -977,6 +984,9 @@ export function registerTools(
         const owner = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
         try { await assertOwnedItem(itemId, owner); } catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
         const feedback = await recordKnowledgeFeedback({ itemId, used, useful, causedCorrection });
+        // Standing is the deliberate consequence of feedback, applied here rather than
+        // inside telemetry recording, which still never alters retrieval by itself.
+        const tierChange = await applyFeedbackToTierBestEffort(projectId!, itemId, { useful, causedCorrection });
         // A correction implicates the corrected item's batch, not just the item: the
         // pass that produced one wrong atom usually produced more. Explicit
         // causedCorrection is the unambiguous signal; a routine supersede is not.
@@ -986,10 +996,13 @@ export function registerTools(
           const corrected = await getKnowledgeItem(itemId);
           blast = await flagCorrectionSiblingsBestEffort(projectId!, itemId, `"${corrected?.title ?? itemId}" (correction feedback)`);
         }
+        const tierNote = tierChange
+          ? `\n\nStanding: item ${tierChange.reason} to ${tierChange.tier}.`
+          : '';
         const blastNote = blast && blast.flaggedIds.length > 0
           ? `\n\nBlast radius: ${blast.flaggedIds.length} sibling item(s) marked needs_review${blast.capped ? ' (capped)' : ''}.`
           : '';
-        return { content: [{ type: 'text', text: `Recorded feedback for ${itemId}:\n\n${JSON.stringify(feedback, null, 2)}${blastNote}` }] };
+        return { content: [{ type: 'text', text: `Recorded feedback for ${itemId}:\n\n${JSON.stringify(feedback, null, 2)}${tierNote}${blastNote}` }] };
       }
 
       else if (name === 'knowl_session_finish') {

--- a/src/store/agent-query.ts
+++ b/src/store/agent-query.ts
@@ -18,6 +18,13 @@ const MMR_SIMILARITY_WEIGHT = 0.8;
 // freshness re-rank keeps current-truth above near-identical stale siblings.
 const VECTOR_PRIMARY_WEIGHT = 1;
 const BM25_FALLBACK_WEIGHT = 0.35;
+// Standing terms. Sized below the freshness re-rank on both paths: an item's earned
+// standing breaks ties between near-equals but must never outrank being current — and an
+// inferred item is discounted, never buried, because it may still be the only answer.
+const TIER_VERIFIED_BOOST_VECTOR = 0.015;
+const TIER_VERIFIED_BOOST_LEXICAL = 0.004;
+const PROVENANCE_INFERRED_PENALTY_VECTOR = -0.01;
+const PROVENANCE_INFERRED_PENALTY_LEXICAL = -0.003;
 
 function queryTokens(query?: string): string[] {
   return [...new Set((query ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(token => token.length > 1))];
@@ -224,6 +231,12 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
       const recency = normalizedRecencyScore(result.item, timestamps) * RECENCY_BOOST;
       const confidence = result.item.confidence * CONFIDENCE_BOOST;
       const exactIdentifier = exactIdentifierScore(result.item, options.query);
+      const standing = (result.item.tier === 'verified'
+        ? (usingVector ? TIER_VERIFIED_BOOST_VECTOR : TIER_VERIFIED_BOOST_LEXICAL)
+        : 0)
+        + (result.item.provenance === 'inferred'
+          ? (usingVector ? PROVENANCE_INFERRED_PENALTY_VECTOR : PROVENANCE_INFERRED_PENALTY_LEXICAL)
+          : 0);
       let rank: number;
       let text: number;
       let freshness: number;
@@ -243,7 +256,7 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
         text = Math.min(textMatchScore(result.item, tokens), 20) * 0.01;
         freshness = freshnessScore(result.item);
       }
-      const contributions = { rank, text, category, recency, confidence, freshness, exactIdentifier };
+      const contributions = { rank, text, category, recency, confidence, freshness, exactIdentifier, standing };
       return {
         result,
         score: Object.values(contributions).reduce((sum, value) => sum + value, 0),

--- a/src/store/blast-radius.ts
+++ b/src/store/blast-radius.ts
@@ -1,0 +1,134 @@
+import { getClient } from './database.js';
+import * as repo from './repository.js';
+import type { CommitChange } from '../core/types.js';
+
+/**
+ * A correction never implicates only itself. The extraction pass, session promotion, or
+ * ingest batch that produced one wrong item usually produced more, and the correction is
+ * the one moment the system knows where to look. Siblings — items born in the same insert
+ * commit, carrying the same source label, or citing the same evidence — are flipped to
+ * needs_review, pointing review at the batch instead of pretending the defect was a
+ * one-off.
+ *
+ * Deliberately conservative: only active, currently-fresh items are touched, the total is
+ * capped, and nothing recurses — a flip is a freshness update, not a correction, so it
+ * cannot implicate a further ring of siblings.
+ */
+
+export const MAX_BLAST_RADIUS = 12;
+
+export type BlastRadiusResult = {
+  flaggedIds: string[];
+  /** True when more siblings matched than the cap allowed; the rest were left untouched. */
+  capped: boolean;
+};
+
+async function siblingsFromInsertCommits(itemId: string): Promise<string[]> {
+  // The changes column is JSON; the id scan is a LIKE because nothing indexes into it.
+  // Bounded by how often one id appears in commits, which is small by construction.
+  const rows = (await getClient().execute({
+    sql: 'SELECT changes FROM knowledge_commits WHERE changes LIKE ?',
+    args: [`%${itemId}%`],
+  })).rows;
+
+  const siblings = new Set<string>();
+  for (const row of rows) {
+    let changes: CommitChange[];
+    try {
+      changes = JSON.parse(String(row.changes));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(changes)) continue;
+    // Only the commit that INSERTED the corrected item defines its batch. The commit
+    // superseding it also mentions its id, and treating that as a batch would flag the
+    // replacement that just corrected it.
+    const insertedHere = changes.some(change => change?.itemId === itemId && change.action === 'insert');
+    if (!insertedHere) continue;
+    for (const change of changes) {
+      if (change?.itemId && change.itemId !== itemId && change.action === 'insert') {
+        siblings.add(change.itemId);
+      }
+    }
+  }
+  return [...siblings];
+}
+
+async function siblingsFromSource(itemId: string): Promise<string[]> {
+  const rows = (await getClient().execute({
+    sql: `SELECT other.id FROM knowledge_items corrected
+          JOIN knowledge_items other ON other.source = corrected.source AND other.id != corrected.id
+          WHERE corrected.id = ? AND corrected.source IS NOT NULL AND corrected.source != ''`,
+    args: [itemId],
+  })).rows;
+  return rows.map(row => String(row.id));
+}
+
+async function siblingsFromSharedEvidence(itemId: string): Promise<string[]> {
+  const rows = (await getClient().execute({
+    sql: `SELECT DISTINCT other.knowledge_item_id AS id
+          FROM knowledge_evidence own
+          JOIN knowledge_evidence other ON other.evidence_id = own.evidence_id
+          WHERE own.knowledge_item_id = ? AND other.knowledge_item_id != ?`,
+    args: [itemId, itemId],
+  })).rows;
+  return rows.map(row => String(row.id));
+}
+
+export async function flagCorrectionSiblings(
+  projectId: string,
+  correctedItemId: string,
+  reason: string,
+): Promise<BlastRadiusResult> {
+  const groups = await Promise.all([
+    siblingsFromInsertCommits(correctedItemId),
+    siblingsFromSource(correctedItemId),
+    siblingsFromSharedEvidence(correctedItemId),
+  ]);
+  const candidateIds = [...new Set(groups.flat())];
+  if (candidateIds.length === 0) return { flaggedIds: [], capped: false };
+
+  // Only items still standing on their original claim are worth flagging: an inactive
+  // item is already out of retrieval's default path, and one already stale or flagged
+  // has nothing further to learn from this correction.
+  const eligible: { id: string; item: Awaited<ReturnType<typeof repo.getKnowledgeItem>> }[] = [];
+  for (const id of candidateIds) {
+    const item = await repo.getKnowledgeItem(id);
+    if (item && item.status === 'active' && item.freshness === 'fresh') {
+      eligible.push({ id, item });
+    }
+  }
+  if (eligible.length === 0) return { flaggedIds: [], capped: false };
+
+  const capped = eligible.length > MAX_BLAST_RADIUS;
+  const toFlag = eligible.slice(0, MAX_BLAST_RADIUS);
+
+  const changes: CommitChange[] = [];
+  for (const { id, item } of toFlag) {
+    const updated = await repo.updateKnowledgeItem(id, { freshness: 'needs_review' });
+    changes.push({ itemId: id, action: 'update', before: item, after: updated });
+  }
+  await repo.createKnowledgeCommit(
+    projectId,
+    `Correction blast radius: ${changes.length} sibling(s) of ${reason}`,
+    changes,
+  );
+
+  return { flaggedIds: toFlag.map(entry => entry.id), capped };
+}
+
+/**
+ * The write that triggers a blast radius must never fail because of it: flagging siblings
+ * is advisory review pressure, not part of the correction's own contract.
+ */
+export async function flagCorrectionSiblingsBestEffort(
+  projectId: string,
+  correctedItemId: string,
+  reason: string,
+): Promise<BlastRadiusResult | null> {
+  try {
+    return await flagCorrectionSiblings(projectId, correctedItemId, reason);
+  } catch {
+    return null;
+  }
+}

--- a/src/store/blast-radius.ts
+++ b/src/store/blast-radius.ts
@@ -17,6 +17,13 @@ import type { CommitChange } from '../core/types.js';
 
 export const MAX_BLAST_RADIUS = 12;
 
+/**
+ * Upper bound on candidate ids considered before eligibility. Far above MAX_BLAST_RADIUS so
+ * the cap, not this limit, is what decides the outcome in any realistic batch; it exists so
+ * a pathologically wide source label cannot build an unbounded `IN (...)` list.
+ */
+const CANDIDATE_SCAN_LIMIT = 500;
+
 export type BlastRadiusResult = {
   flaggedIds: string[];
   /** True when more siblings matched than the cap allowed; the rest were left untouched. */
@@ -55,11 +62,16 @@ async function siblingsFromInsertCommits(itemId: string): Promise<string[]> {
 }
 
 async function siblingsFromSource(itemId: string): Promise<string[]> {
+  // `source` is a free-form label, so one value can cover an arbitrarily large batch.
+  // Bounded here rather than after loading: the cap decides how many are flagged, and a
+  // batch wider than the scan limit is already past every threshold this function has.
   const rows = (await getClient().execute({
     sql: `SELECT other.id FROM knowledge_items corrected
           JOIN knowledge_items other ON other.source = corrected.source AND other.id != corrected.id
-          WHERE corrected.id = ? AND corrected.source IS NOT NULL AND corrected.source != ''`,
-    args: [itemId],
+          WHERE corrected.id = ? AND corrected.source IS NOT NULL AND corrected.source != ''
+            AND other.status = 'active' AND other.freshness = 'fresh'
+          LIMIT ?`,
+    args: [itemId, CANDIDATE_SCAN_LIMIT],
   })).rows;
   return rows.map(row => String(row.id));
 }
@@ -69,8 +81,33 @@ async function siblingsFromSharedEvidence(itemId: string): Promise<string[]> {
     sql: `SELECT DISTINCT other.knowledge_item_id AS id
           FROM knowledge_evidence own
           JOIN knowledge_evidence other ON other.evidence_id = own.evidence_id
-          WHERE own.knowledge_item_id = ? AND other.knowledge_item_id != ?`,
-    args: [itemId, itemId],
+          JOIN knowledge_items item ON item.id = other.knowledge_item_id
+          WHERE own.knowledge_item_id = ? AND other.knowledge_item_id != ?
+            AND item.status = 'active' AND item.freshness = 'fresh'
+          LIMIT ?`,
+    args: [itemId, itemId, CANDIDATE_SCAN_LIMIT],
+  })).rows;
+  return rows.map(row => String(row.id));
+}
+
+/**
+ * Eligibility in one round trip. Only items still standing on their original claim are
+ * worth flagging: an inactive item is already out of retrieval's default path, and one
+ * already stale or flagged has nothing further to learn from this correction.
+ *
+ * Filtered in SQL rather than by loading each candidate, because the candidate set is
+ * bounded by how wide a batch was, not by the cap — a shared source label across hundreds
+ * of atoms made a single correction pay hundreds of sequential round trips inside one
+ * MCP call. One row over the cap is fetched so the caller can still report the overflow.
+ */
+async function eligibleSiblings(candidateIds: string[]): Promise<string[]> {
+  const scanned = candidateIds.slice(0, CANDIDATE_SCAN_LIMIT);
+  const placeholders = scanned.map(() => '?').join(', ');
+  const rows = (await getClient().execute({
+    sql: `SELECT id FROM knowledge_items
+          WHERE id IN (${placeholders}) AND status = 'active' AND freshness = 'fresh'
+          LIMIT ?`,
+    args: [...scanned, MAX_BLAST_RADIUS + 1],
   })).rows;
   return rows.map(row => String(row.id));
 }
@@ -88,23 +125,18 @@ export async function flagCorrectionSiblings(
   const candidateIds = [...new Set(groups.flat())];
   if (candidateIds.length === 0) return { flaggedIds: [], capped: false };
 
-  // Only items still standing on their original claim are worth flagging: an inactive
-  // item is already out of retrieval's default path, and one already stale or flagged
-  // has nothing further to learn from this correction.
-  const eligible: { id: string; item: Awaited<ReturnType<typeof repo.getKnowledgeItem>> }[] = [];
-  for (const id of candidateIds) {
-    const item = await repo.getKnowledgeItem(id);
-    if (item && item.status === 'active' && item.freshness === 'fresh') {
-      eligible.push({ id, item });
-    }
-  }
+  const eligible = await eligibleSiblings(candidateIds);
   if (eligible.length === 0) return { flaggedIds: [], capped: false };
 
   const capped = eligible.length > MAX_BLAST_RADIUS;
   const toFlag = eligible.slice(0, MAX_BLAST_RADIUS);
 
+  // Full rows are loaded only for what is actually flagged — at most the cap — because the
+  // commit records each item's before state.
   const changes: CommitChange[] = [];
-  for (const { id, item } of toFlag) {
+  for (const id of toFlag) {
+    const item = await repo.getKnowledgeItem(id);
+    if (!item) continue;
     const updated = await repo.updateKnowledgeItem(id, { freshness: 'needs_review' });
     changes.push({ itemId: id, action: 'update', before: item, after: updated });
   }
@@ -114,7 +146,7 @@ export async function flagCorrectionSiblings(
     changes,
   );
 
-  return { flaggedIds: toFlag.map(entry => entry.id), capped };
+  return { flaggedIds: changes.map(change => change.itemId), capped };
 }
 
 /**

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -27,6 +27,8 @@ const SCHEMA_STATEMENTS = [
     content_hash TEXT,
     freshness TEXT NOT NULL DEFAULT 'fresh',
     confidence REAL NOT NULL DEFAULT 1.0,
+    tier TEXT NOT NULL DEFAULT 'asserted',
+    provenance TEXT,
     conflict_key TEXT, conflict_scope TEXT, conflict_exclusive INTEGER NOT NULL DEFAULT 0,
     superseded_by_id TEXT,
     version INTEGER NOT NULL DEFAULT 1,
@@ -329,6 +331,22 @@ async function repairSkillForeignKeys(client: Client): Promise<void> {
   await client.execute('PRAGMA foreign_keys = ON;');
 }
 
+/**
+ * Tier (standing earned by use) and provenance (how the knowledge came to be believed).
+ * Existing rows get tier 'asserted' -- nothing has confirmed them here -- and provenance
+ * NULL, which is what a row written before the class existed means.
+ */
+async function ensureQualityColumns(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'knowledge_items'))) return;
+  const columns = await tableColumns(client, 'knowledge_items');
+  if (!columns.includes('tier')) {
+    await client.execute("ALTER TABLE knowledge_items ADD COLUMN tier TEXT NOT NULL DEFAULT 'asserted';");
+  }
+  if (!columns.includes('provenance')) {
+    await client.execute('ALTER TABLE knowledge_items ADD COLUMN provenance TEXT;');
+  }
+}
+
 async function ensureFreshnessColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'knowledge_items'))) {
     return;
@@ -590,6 +608,7 @@ export async function bootstrapSchema(client: Client): Promise<void> {
   await migrateLegacyProjectSchema(client);
   await executeAll(client, SCHEMA_STATEMENTS);
   await ensureFreshnessColumns(client);
+  await ensureQualityColumns(client);
   await ensureConflictColumns(client);
   await ensureOwnershipColumns(client);
   await ensureMemorySessionColumns(client);

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -151,6 +151,14 @@ const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS code_symbols (locator TEXT PRIMARY KEY, file_path TEXT NOT NULL REFERENCES code_files(path) ON DELETE CASCADE, qualified_name TEXT NOT NULL, kind TEXT NOT NULL, start_line INTEGER NOT NULL, end_line INTEGER NOT NULL, signature TEXT, signature_hash TEXT);`,
   `CREATE TABLE IF NOT EXISTS code_symbol_edges (from_locator TEXT NOT NULL, to_locator TEXT NOT NULL, kind TEXT NOT NULL, PRIMARY KEY (from_locator, to_locator, kind));`,
 
+  // Last git commit the automatic drift check ran against, per project root. Git history is
+  // the thing that moves here, so a knowledge-commit rowid watermark cannot track it.
+  `CREATE TABLE IF NOT EXISTS drift_state (
+    project_root TEXT PRIMARY KEY,
+    last_checked_commit TEXT NOT NULL,
+    checked_at TEXT NOT NULL
+  );`,
+
   `CREATE INDEX IF NOT EXISTS idx_ki_cat_status ON knowledge_items(category, status);`,
   `CREATE INDEX IF NOT EXISTS idx_ki_status ON knowledge_items(status);`,
   `CREATE INDEX IF NOT EXISTS idx_ki_updated ON knowledge_items(updated_at);`,

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -28,6 +28,7 @@ const SCHEMA_STATEMENTS = [
     freshness TEXT NOT NULL DEFAULT 'fresh',
     confidence REAL NOT NULL DEFAULT 1.0,
     tier TEXT NOT NULL DEFAULT 'asserted',
+    tier_since TEXT,
     provenance TEXT,
     conflict_key TEXT, conflict_scope TEXT, conflict_exclusive INTEGER NOT NULL DEFAULT 0,
     superseded_by_id TEXT,
@@ -341,6 +342,11 @@ async function ensureQualityColumns(client: Client): Promise<void> {
   const columns = await tableColumns(client, 'knowledge_items');
   if (!columns.includes('tier')) {
     await client.execute("ALTER TABLE knowledge_items ADD COLUMN tier TEXT NOT NULL DEFAULT 'asserted';");
+  }
+  if (!columns.includes('tier_since')) {
+    // Left NULL rather than backfilled to now: an existing row has never had its standing
+    // reset, so every confirmation it already carries still belongs to its current tier.
+    await client.execute('ALTER TABLE knowledge_items ADD COLUMN tier_since TEXT;');
   }
   if (!columns.includes('provenance')) {
     await client.execute('ALTER TABLE knowledge_items ADD COLUMN provenance TEXT;');

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -1,0 +1,97 @@
+import { getClient } from './database.js';
+import { checkKnowledgeDrift, getCurrentGitCommit, listChangedFilesSince } from './drift.js';
+
+export type AutoDriftResult = {
+  /** False on the run that only learns the baseline; nothing was compared. */
+  checked: boolean;
+  /** Items flipped to needs_review by this run. */
+  flagged: number;
+  /** The watermark the diff ran from; absent when nothing was compared. */
+  sinceCommit?: string;
+};
+
+/**
+ * The drift check that `pr check` runs by hand, run automatically at session start.
+ *
+ * `checkKnowledgeDrift` has existed since the pr command shipped, but its only caller was a
+ * command someone had to remember to type — so in practice knowledge went stale exactly as if
+ * the check did not exist. The session boundary is the right chokepoint: it is the moment
+ * before an agent starts relying on memory, and it is already where lifecycle work happens.
+ *
+ * The watermark is the last git commit a check ran against, keyed by project root. rowid-style
+ * head tracking (change-watermark.ts) does not work here: the thing that moves is the git
+ * history, not the knowledge log.
+ */
+export async function runAutoDriftCheck(projectId: string, projectRoot: string): Promise<AutoDriftResult | null> {
+  const current = getCurrentGitCommit(projectRoot);
+  if (!current) return null; // not a git repository: nothing to diff against
+
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT last_checked_commit FROM drift_state WHERE project_root = ?',
+    args: [projectRoot],
+  })).rows[0];
+  const watermark = row ? String(row.last_checked_commit) : null;
+
+  if (watermark === current) return { checked: true, flagged: 0, sinceCommit: watermark };
+
+  // First run learns the baseline and flags nothing. Diffing from the repository's root
+  // commit would flip most of the store to needs_review in one silent wall — the same
+  // reason the embedding backfill was never made automatic.
+  if (!watermark) {
+    await writeWatermark(projectRoot, current);
+    return { checked: false, flagged: 0 };
+  }
+
+  let changedFiles: string[];
+  try {
+    changedFiles = listChangedFilesSince(projectRoot, watermark, current);
+  } catch {
+    // The watermark commit no longer exists — rebase, aggressive gc, a rewritten branch.
+    // Re-baseline rather than guess: a storm of wrong needs_review flags costs more trust
+    // than one missed window, and the next real change is caught from the new baseline.
+    await writeWatermark(projectRoot, current);
+    return { checked: false, flagged: 0 };
+  }
+
+  let flagged = 0;
+  if (changedFiles.length > 0) {
+    const result = await checkKnowledgeDrift(projectId, {
+      sinceCommit: watermark,
+      currentCommit: current,
+      changedFiles,
+      apply: true,
+    });
+    flagged = result.updatedCount;
+  }
+
+  await writeWatermark(projectRoot, current);
+  return { checked: true, flagged, sinceCommit: watermark };
+}
+
+/** Hooks must never fail the host: any error reads as "no drift information this session". */
+export async function runAutoDriftCheckBestEffort(projectId: string, projectRoot: string): Promise<AutoDriftResult | null> {
+  try {
+    return await runAutoDriftCheck(projectId, projectRoot);
+  } catch {
+    return null;
+  }
+}
+
+async function writeWatermark(projectRoot: string, commit: string): Promise<void> {
+  await getClient().execute({
+    sql: `INSERT INTO drift_state (project_root, last_checked_commit, checked_at) VALUES (?, ?, ?)
+          ON CONFLICT(project_root) DO UPDATE SET last_checked_commit = excluded.last_checked_commit, checked_at = excluded.checked_at`,
+    args: [projectRoot, commit, new Date().toISOString()],
+  });
+}
+
+/**
+ * The one-line session-start warning. Rendered here so the hook path and any future
+ * surface (doctor, status) say it the same way.
+ */
+export function describeAutoDrift(result: AutoDriftResult | null): string | undefined {
+  if (!result || result.flagged === 0) return undefined;
+  const shortCommit = result.sinceCommit ? result.sinceCommit.slice(0, 7) : 'last check';
+  return `DRIFT: ${result.flagged} knowledge item(s) touch files changed since ${shortCommit} and were marked needs_review — verify before relying on them.`;
+}

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -4,23 +4,39 @@ import { checkKnowledgeDrift, getCurrentGitCommit, listChangedFilesSince } from 
 export type AutoDriftResult = {
   /** False on the run that only learns the baseline; nothing was compared. */
   checked: boolean;
-  /** Items flipped to needs_review by this run. */
-  flagged: number;
+  /** Items whose files changed since the watermark. Detection only — nothing is flipped. */
+  candidateCount: number;
+  /** Up to the first few candidate titles, for the session-start warning. */
+  candidateTitles: string[];
   /** The watermark the diff ran from; absent when nothing was compared. */
   sinceCommit?: string;
 };
 
+const WARNING_TITLE_LIMIT = 3;
+
 /**
- * The drift check that `pr check` runs by hand, run automatically at session start.
+ * The drift check that `pr check` runs by hand, run automatically at session start —
+ * as DETECTION ONLY.
  *
- * `checkKnowledgeDrift` has existed since the pr command shipped, but its only caller was a
- * command someone had to remember to type — so in practice knowledge went stale exactly as if
- * the check did not exist. The session boundary is the right chokepoint: it is the moment
- * before an agent starts relying on memory, and it is already where lifecycle work happens.
+ * `checkKnowledgeDrift` has existed since the pr command shipped, but its only caller was
+ * a command someone had to remember to type, so in practice knowledge went stale exactly
+ * as if the check did not exist. The session boundary is the right chokepoint: it is the
+ * moment before an agent starts relying on memory.
  *
- * The watermark is the last git commit a check ran against, keyed by project root. rowid-style
- * head tracking (change-watermark.ts) does not work here: the thing that moves is the git
- * history, not the knowledge log.
+ * Why detection does not auto-apply: measured on a real, documentation-heavy repository,
+ * one commit window matched 36 of 301 atoms and fifteen windows matched a third of the
+ * store — atoms annotate hot files, hot files change every day, and an automatic flip
+ * would hold those atoms at needs_review permanently. Run by hand after a PR, that flag
+ * volume is a review worklist; applied silently at every session start, it is corpus-wide
+ * ranking damage and a warning that cries wolf. So the automatic path names what moved
+ * and the exact command to review it, and flipping freshness stays a deliberate act.
+ *
+ * The watermark is the last git commit a check ran against, keyed by project root.
+ * rowid-style head tracking (change-watermark.ts) does not work here: the thing that
+ * moves is the git history, not the knowledge log. It advances even when candidates go
+ * unreviewed — the warning carries the pinned `pr check --since` command for acting
+ * later, and repeating the same warning forever would punish exactly the sessions that
+ * cannot deal with it yet.
  */
 export async function runAutoDriftCheck(projectId: string, projectRoot: string): Promise<AutoDriftResult | null> {
   const current = getCurrentGitCommit(projectRoot);
@@ -33,14 +49,13 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
   })).rows[0];
   const watermark = row ? String(row.last_checked_commit) : null;
 
-  if (watermark === current) return { checked: true, flagged: 0, sinceCommit: watermark };
+  if (watermark === current) return { checked: true, candidateCount: 0, candidateTitles: [], sinceCommit: watermark };
 
-  // First run learns the baseline and flags nothing. Diffing from the repository's root
-  // commit would flip most of the store to needs_review in one silent wall — the same
-  // reason the embedding backfill was never made automatic.
+  // First run learns the baseline and reports nothing: diffing from the repository's
+  // root commit would announce most of the store as drift candidates in one wall.
   if (!watermark) {
     await writeWatermark(projectRoot, current);
-    return { checked: false, flagged: 0 };
+    return { checked: false, candidateCount: 0, candidateTitles: [] };
   }
 
   let changedFiles: string[];
@@ -48,25 +63,26 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
     changedFiles = listChangedFilesSince(projectRoot, watermark, current);
   } catch {
     // The watermark commit no longer exists — rebase, aggressive gc, a rewritten branch.
-    // Re-baseline rather than guess: a storm of wrong needs_review flags costs more trust
-    // than one missed window, and the next real change is caught from the new baseline.
+    // Re-baseline rather than guess; the next real change is caught from the new baseline.
     await writeWatermark(projectRoot, current);
-    return { checked: false, flagged: 0 };
+    return { checked: false, candidateCount: 0, candidateTitles: [] };
   }
 
-  let flagged = 0;
+  let candidateCount = 0;
+  let candidateTitles: string[] = [];
   if (changedFiles.length > 0) {
     const result = await checkKnowledgeDrift(projectId, {
       sinceCommit: watermark,
       currentCommit: current,
       changedFiles,
-      apply: true,
+      apply: false,
     });
-    flagged = result.updatedCount;
+    candidateCount = result.candidates.length;
+    candidateTitles = result.candidates.slice(0, WARNING_TITLE_LIMIT).map(candidate => candidate.title);
   }
 
   await writeWatermark(projectRoot, current);
-  return { checked: true, flagged, sinceCommit: watermark };
+  return { checked: true, candidateCount, candidateTitles, sinceCommit: watermark };
 }
 
 /** Hooks must never fail the host: any error reads as "no drift information this session". */
@@ -87,11 +103,15 @@ async function writeWatermark(projectRoot: string, commit: string): Promise<void
 }
 
 /**
- * The one-line session-start warning. Rendered here so the hook path and any future
- * surface (doctor, status) say it the same way.
+ * The session-start warning. Rendered here so the hook path and any future surface
+ * (doctor, status) say it the same way. Carries the pinned review command because the
+ * watermark has already advanced: this line is the only record of the window.
  */
 export function describeAutoDrift(result: AutoDriftResult | null): string | undefined {
-  if (!result || result.flagged === 0) return undefined;
-  const shortCommit = result.sinceCommit ? result.sinceCommit.slice(0, 7) : 'last check';
-  return `DRIFT: ${result.flagged} knowledge item(s) touch files changed since ${shortCommit} and were marked needs_review — verify before relying on them.`;
+  if (!result || result.candidateCount === 0) return undefined;
+  const names = result.candidateTitles.length > 0
+    ? ` (${result.candidateTitles.map(title => `"${title}"`).join(', ')}${result.candidateCount > result.candidateTitles.length ? ', …' : ''})`
+    : '';
+  const since = result.sinceCommit ? ` --since ${result.sinceCommit.slice(0, 12)}` : '';
+  return `DRIFT: ${result.candidateCount} knowledge item(s) reference files changed since the last session${names}. Verify before relying on them; review and apply with \`knowl pr check${since}\`.`;
 }

--- a/src/store/host-lifecycle.ts
+++ b/src/store/host-lifecycle.ts
@@ -35,6 +35,7 @@ import {
 import { bootstrapAgentSession } from './context-bootstrap.js';
 import { consumePendingSessionHandoff, recordPendingSessionHandoff } from './session-handoff.js';
 import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
+import { describeAutoDrift, runAutoDriftCheckBestEffort, type AutoDriftResult } from './drift-auto.js';
 
 // Emit the mid-turn continuation reminder after this many consecutive non-Knowl
 // tool calls; any Knowl tool call resets the counter to zero.
@@ -52,6 +53,7 @@ export type HostLifecycleResult = {
   handoff?: Awaited<ReturnType<typeof recordPendingSessionHandoff>>;
   hostOutput?: Record<string, unknown>;
   changes?: ChangeSummary;
+  drift?: AutoDriftResult;
 };
 
 function bindingKey(input: NormalizedHostHook, scope: 'session' | 'turn'): HostSessionKey {
@@ -293,15 +295,23 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     const recovered = await recoverAbandonedSessions();
     const purgedEventCount = await purgeExpiredSessionEvents();
     await closeInactiveHostSessionBindings();
+    // Before context composition, so the freshness it flips is what the composed
+    // context reflects rather than news the next session hears first.
+    const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
     const started = await bootstrapWithHandoff(projectId, input, 'session', true);
+    const driftLine = describeAutoDrift(drift);
+    const context = driftLine
+      ? (started.context ? `${driftLine}\n\n${started.context}` : driftLine)
+      : started.context;
     return {
       accepted: true,
       sessionId: started.session.id,
-      context: started.context,
+      context,
       contextTruncated: started.truncated,
       recoveredCount: recovered.length,
       purgedEventCount,
-      hostOutput: hostContextOutput(input, started.context),
+      hostOutput: hostContextOutput(input, context),
+      ...(drift ? { drift } : {}),
     };
   }
 

--- a/src/store/host-lifecycle.ts
+++ b/src/store/host-lifecycle.ts
@@ -298,15 +298,22 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // Detection only: names what moved and the command to review it, mutating nothing.
     const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
     const started = await bootstrapWithHandoff(projectId, input, 'session', true);
-    const driftLine = describeAutoDrift(drift);
-    const context = driftLine
-      ? (started.context ? `${driftLine}\n\n${started.context}` : driftLine)
-      : started.context;
+    // The warning is charged against the cap first — the same rule the subagent card
+    // follows. Prepending it to an already-budgeted block pushed the session past the size
+    // the host was promised, and the warning is the part that must survive: the watermark
+    // has already advanced, so this line is the only record of the window.
+    const warning = truncateText(describeAutoDrift(drift) ?? '', DEFAULT_CONTEXT_MAX_CHARS);
+    const recentBudget = warning
+      ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - warning.length - 2)
+      : DEFAULT_CONTEXT_MAX_CHARS;
+    const recent = started.context ? truncateText(started.context, recentBudget) : undefined;
+    const context = warning ? (recent ? `${warning}\n\n${recent}` : warning) : recent;
     return {
       accepted: true,
       sessionId: started.session.id,
       context,
-      contextTruncated: started.truncated,
+      contextTruncated: started.truncated
+        || Boolean(started.context && started.context.length > recentBudget),
       recoveredCount: recovered.length,
       purgedEventCount,
       hostOutput: hostContextOutput(input, context),

--- a/src/store/host-lifecycle.ts
+++ b/src/store/host-lifecycle.ts
@@ -295,8 +295,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     const recovered = await recoverAbandonedSessions();
     const purgedEventCount = await purgeExpiredSessionEvents();
     await closeInactiveHostSessionBindings();
-    // Before context composition, so the freshness it flips is what the composed
-    // context reflects rather than news the next session hears first.
+    // Detection only: names what moved and the command to review it, mutating nothing.
     const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
     const started = await bootstrapWithHandoff(projectId, input, 'session', true);
     const driftLine = describeAutoDrift(drift);

--- a/src/store/knowledge-actions.ts
+++ b/src/store/knowledge-actions.ts
@@ -177,5 +177,13 @@ export async function updateKnowledgeItemWithCommit(
     },
   ]);
 
+  // Demotion to deprecated/rejected says "this was wrong", which implicates the batch
+  // that produced it — unlike a supersede, which as often means "this is outdated" and
+  // must not flag siblings on every routine state refresh.
+  if ((updates.status === 'deprecated' || updates.status === 'rejected') && beforeItem.status === 'active') {
+    const { flagCorrectionSiblingsBestEffort } = await import('./blast-radius.js');
+    await flagCorrectionSiblingsBestEffort(projectId, id, `"${beforeItem.title}" (${updates.status})`);
+  }
+
   return updated;
 }

--- a/src/store/knowledge-writer.ts
+++ b/src/store/knowledge-writer.ts
@@ -1,4 +1,4 @@
-import { CommitChange, EvidenceInput, KnowledgeCategory, KnowledgeItem, KnowledgeWriteValidationOptions } from '../core/types.js';
+import { CommitChange, EvidenceInput, KnowledgeCategory, KnowledgeItem, KnowledgeProvenance, KnowledgeWriteValidationOptions } from '../core/types.js';
 import { searchKnowledgeItems } from './search.js';
 import * as repo from './repository.js';
 import { checkKnowledgeConflict } from './conflicts.js';
@@ -25,6 +25,7 @@ export interface StoreKnowledgeInput {
   sourceCommit?: string | null;
   affectedPaths?: string[] | null;
   confidence?: number;
+  provenance?: KnowledgeProvenance | null;
   steps?: string[];
   evidence?: EvidenceInput[];
   /** Explicitly mark this active item id superseded by the new write. */
@@ -303,6 +304,7 @@ export async function storeKnowledgeItemDeduped(
       sourceCommit: input.sourceCommit,
       affectedPaths: input.affectedPaths,
       confidence: input.confidence,
+      provenance: input.provenance,
       conflictKey: input.conflictKey,
       conflictScope: input.conflictScope,
       conflictExclusive: input.conflictExclusive,
@@ -379,6 +381,7 @@ export async function storeKnowledgeAtomsDeduped(
         sourceCommit: atom.sourceCommit,
         affectedPaths: atom.affectedPaths,
         confidence: atom.confidence,
+        provenance: atom.provenance,
       },
       atom.steps,
       undefined,

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -88,6 +88,7 @@ export function mapRowToKnowledgeItem(row: typeof schema.knowledgeItems.$inferSe
     status: row.status as KnowledgeStatus,
     freshness: (row.freshness || DEFAULT_FRESHNESS) as KnowledgeFreshness,
     tier: (row.tier || 'asserted') as KnowledgeTier,
+    tierSince: (row.tierSince ?? null) as string | null,
     provenance: (row.provenance ?? null) as KnowledgeProvenance | null,
     alternatives: row.alternatives as string[] | null,
     tags: row.tags as string[] | null,
@@ -173,6 +174,7 @@ export async function createKnowledgeItem(
     freshness,
     confidence: item.confidence ?? 1.0,
     tier: 'asserted' as const, // standing is earned by use, never granted at birth
+    tierSince: now, // the climb to verified starts here, not at some inherited history
     provenance: item.provenance ?? null,
     conflictKey: item.conflictKey ? normalizeConflictKey(item.conflictKey) : null, conflictScope: normalizeConflictScope(item.conflictScope), conflictExclusive: item.conflictExclusive ?? false,
     supersededById: null,
@@ -337,6 +339,10 @@ export async function updateKnowledgeItem(
       visibility: updates.visibility !== undefined ? updates.visibility : current[0].visibility,
     };
 
+    const tierIsSetExplicitly = updates.tier !== undefined;
+    const tierIsReset = !tierIsSetExplicitly
+      && (updates.content !== undefined || updates.title !== undefined);
+
     const dbUpdates = {
       ...updates,
       ...(updates.affectedPaths !== undefined ? { affectedPaths } : {}),
@@ -344,8 +350,12 @@ export async function updateKnowledgeItem(
       ...(updates.lifecycleHash === undefined ? { lifecycleHash: hashKnowledgeLifecycle(lifecycle) } : {}),
       // Verified means verified-verbatim: standing earned by use does not survive the
       // words changing. An explicit tier in `updates` (an import replaying a peer) wins.
-      ...(updates.tier === undefined && (updates.content !== undefined || updates.title !== undefined)
-        ? { tier: 'asserted' as const }
+      ...(tierIsReset ? { tier: 'asserted' as const } : {}),
+      // Whenever the tier is set, stamp when it began. Confirmations are counted from this
+      // moment, so a reset restarts the climb rather than inheriting the events that
+      // confirmed wording this edit just replaced — or the standing a correction just voided.
+      ...((tierIsSetExplicitly || tierIsReset) && updates.tierSince === undefined
+        ? { tierSince: now }
         : {}),
       version: nextVersion,
       updatedAt: now,

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -14,6 +14,8 @@ import {
   CommitChange,
   KnowledgeCategory,
   KnowledgeFreshness,
+  KnowledgeTier,
+  KnowledgeProvenance,
   KnowledgeStatus,
   KnowledgeWriteValidationOptions,
 } from '../core/types.js';
@@ -85,6 +87,8 @@ export function mapRowToKnowledgeItem(row: typeof schema.knowledgeItems.$inferSe
     category: row.category as KnowledgeCategory,
     status: row.status as KnowledgeStatus,
     freshness: (row.freshness || DEFAULT_FRESHNESS) as KnowledgeFreshness,
+    tier: (row.tier || 'asserted') as KnowledgeTier,
+    provenance: (row.provenance ?? null) as KnowledgeProvenance | null,
     alternatives: row.alternatives as string[] | null,
     tags: row.tags as string[] | null,
     affectedPaths: row.affectedPaths as string[] | null,
@@ -114,6 +118,7 @@ export async function createKnowledgeItem(
     contentHash?: string | null;
     freshness?: KnowledgeFreshness;
     confidence?: number;
+    provenance?: KnowledgeProvenance | null;
     conflictKey?: string | null;
     conflictScope?: Record<string, unknown> | null;
     conflictExclusive?: boolean;
@@ -167,6 +172,8 @@ export async function createKnowledgeItem(
     }),
     freshness,
     confidence: item.confidence ?? 1.0,
+    tier: 'asserted' as const, // standing is earned by use, never granted at birth
+    provenance: item.provenance ?? null,
     conflictKey: item.conflictKey ? normalizeConflictKey(item.conflictKey) : null, conflictScope: normalizeConflictScope(item.conflictScope), conflictExclusive: item.conflictExclusive ?? false,
     supersededById: null,
     version: 1,
@@ -335,6 +342,11 @@ export async function updateKnowledgeItem(
       ...(updates.affectedPaths !== undefined ? { affectedPaths } : {}),
       ...(shouldRefreshHash ? { contentHash: hashKnowledgeContent(merged) } : {}),
       ...(updates.lifecycleHash === undefined ? { lifecycleHash: hashKnowledgeLifecycle(lifecycle) } : {}),
+      // Verified means verified-verbatim: standing earned by use does not survive the
+      // words changing. An explicit tier in `updates` (an import replaying a peer) wins.
+      ...(updates.tier === undefined && (updates.content !== undefined || updates.title !== undefined)
+        ? { tier: 'asserted' as const }
+        : {}),
       version: nextVersion,
       updatedAt: now,
     };

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -27,6 +27,13 @@ export const knowledgeItems = sqliteTable('knowledge_items', {
   confidence: real('confidence').notNull().default(1.0),
   /** Standing earned by confirmed use: 'asserted' | 'verified'. Not part of lifecycleHash. */
   tier: text('tier').notNull().default('asserted'),
+  /**
+   * When the current tier was established. Confirmations are counted from here, so a reset
+   * genuinely restarts the climb instead of inheriting the history that a correction or a
+   * rewording just invalidated. NULL on rows predating the column: they have never had
+   * standing reset, so their whole history is still theirs to count.
+   */
+  tierSince: text('tier_since'),
   /** 'observed' | 'user_stated' | 'inferred'; NULL on rows written before the column existed. */
   provenance: text('provenance'),
   conflictKey: text('conflict_key'), conflictScope: text('conflict_scope', { mode: 'json' }), conflictExclusive: integer('conflict_exclusive', { mode: 'boolean' }).notNull().default(false),

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -25,6 +25,10 @@ export const knowledgeItems = sqliteTable('knowledge_items', {
   visibility: text('visibility').notNull().default('repo'),
   freshness: text('freshness').notNull().default('fresh'), // 'fresh', 'stale', 'needs_review'
   confidence: real('confidence').notNull().default(1.0),
+  /** Standing earned by confirmed use: 'asserted' | 'verified'. Not part of lifecycleHash. */
+  tier: text('tier').notNull().default('asserted'),
+  /** 'observed' | 'user_stated' | 'inferred'; NULL on rows written before the column existed. */
+  provenance: text('provenance'),
   conflictKey: text('conflict_key'), conflictScope: text('conflict_scope', { mode: 'json' }), conflictExclusive: integer('conflict_exclusive', { mode: 'boolean' }).notNull().default(false),
   supersededById: text('superseded_by_id'),
   version: integer('version').notNull().default(1),

--- a/src/store/tier.ts
+++ b/src/store/tier.ts
@@ -45,10 +45,17 @@ export async function applyFeedbackToTier(
 
   if (feedback.useful !== true || item.tier === 'verified') return null;
 
+  // Counted from when the current tier began, not from the item's whole history. An
+  // unbounded count made both resets cosmetic: a correction or a rewording dropped the
+  // item to asserted, and the very next confirmation re-promoted it on the strength of
+  // events that had confirmed a claim the item no longer makes.
+  // NULL tier_since means a row written before the column existed: it has never been
+  // reset, so its full history still belongs to its current standing.
   const row = (await getClient().execute({
     sql: `SELECT COUNT(*) AS confirmations FROM knowledge_access
-          WHERE knowledge_item_id = ? AND surface = 'feedback' AND useful = 1`,
-    args: [itemId],
+          WHERE knowledge_item_id = ? AND surface = 'feedback' AND useful = 1
+            AND retrieved_at > COALESCE(?, '')`,
+    args: [itemId, item.tierSince ?? null],
   })).rows[0];
   if (Number(row?.confirmations ?? 0) < VERIFY_THRESHOLD) return null;
 

--- a/src/store/tier.ts
+++ b/src/store/tier.ts
@@ -1,0 +1,73 @@
+import { getClient } from './database.js';
+import * as repo from './repository.js';
+
+/**
+ * Confirmed-useful feedback events required before an asserted item is promoted. One use
+ * can be a coincidence of phrasing; two independent confirmations are the item earning
+ * its place. Kept deliberately low because feedback is rare — agents report it after
+ * actually using a result, not on every retrieval.
+ */
+export const VERIFY_THRESHOLD = 2;
+
+export type TierChange = {
+  itemId: string;
+  tier: 'asserted' | 'verified';
+  reason: 'promoted' | 'demoted';
+};
+
+/**
+ * The one place feedback changes an item's standing. Telemetry recording stays in
+ * access-feedback.ts and still never alters retrieval by itself; standing is a separate,
+ * deliberate consequence applied here, so the boundary between "we log what happened"
+ * and "what happened has weight" is a function call you can find.
+ *
+ * Promotion needs VERIFY_THRESHOLD confirmed-useful events. A correction demotes
+ * immediately and unconditionally: one proof of wrongness outweighs any history of
+ * usefulness — the poisoning literature's core finding is confidence accumulating
+ * without ground truth, and this is the ground-truth valve.
+ */
+export async function applyFeedbackToTier(
+  projectId: string,
+  itemId: string,
+  feedback: { useful?: boolean; causedCorrection?: boolean },
+): Promise<TierChange | null> {
+  const item = await repo.getKnowledgeItem(itemId);
+  if (!item || item.status !== 'active') return null;
+
+  if (feedback.causedCorrection === true) {
+    if (item.tier === 'asserted') return null;
+    const updated = await repo.updateKnowledgeItem(itemId, { tier: 'asserted' });
+    await repo.createKnowledgeCommit(projectId, `Demote to asserted: ${item.title}`, [
+      { itemId, action: 'update', before: item, after: updated },
+    ]);
+    return { itemId, tier: 'asserted', reason: 'demoted' };
+  }
+
+  if (feedback.useful !== true || item.tier === 'verified') return null;
+
+  const row = (await getClient().execute({
+    sql: `SELECT COUNT(*) AS confirmations FROM knowledge_access
+          WHERE knowledge_item_id = ? AND surface = 'feedback' AND useful = 1`,
+    args: [itemId],
+  })).rows[0];
+  if (Number(row?.confirmations ?? 0) < VERIFY_THRESHOLD) return null;
+
+  const updated = await repo.updateKnowledgeItem(itemId, { tier: 'verified' });
+  await repo.createKnowledgeCommit(projectId, `Promote to verified: ${item.title}`, [
+    { itemId, action: 'update', before: item, after: updated },
+  ]);
+  return { itemId, tier: 'verified', reason: 'promoted' };
+}
+
+/** Feedback recording must never fail because standing could not be updated. */
+export async function applyFeedbackToTierBestEffort(
+  projectId: string,
+  itemId: string,
+  feedback: { useful?: boolean; causedCorrection?: boolean },
+): Promise<TierChange | null> {
+  try {
+    return await applyFeedbackToTier(projectId, itemId, feedback);
+  } catch {
+    return null;
+  }
+}

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -257,6 +257,35 @@ describe('MCP Server Layer', () => {
 
     const gcPreviewTool = res.result.tools.find((t: any) => t.name === 'knowl_gc_preview');
     expect(gcPreviewTool.description).toContain('Preview knowledge garbage collection');
+
+    // The batch path is where extraction and session promotion write, which is exactly the
+    // population provenance exists to classify. Advertising it only on the single-atom tool
+    // left the class unreachable from the tool the guidance calls preferred.
+    const provenanceEnum = ['observed', 'user_stated', 'inferred'];
+    expect(storeTool.inputSchema.properties.provenance.enum).toEqual(provenanceEnum);
+    expect(ingestAtomsTool.inputSchema.properties.atoms.items.properties.provenance.enum)
+      .toEqual(provenanceEnum);
+  });
+
+  it('persists provenance written through the batch atom path', async () => {
+    const res = await runRpcRequest('tools/call', {
+      name: 'knowl_ingest_atoms',
+      arguments: {
+        atoms: [{
+          category: 'fact',
+          title: 'Batch provenance atom',
+          content: 'Concluded from a single log line, not observed directly.',
+          provenance: 'inferred',
+        }],
+        commitMessage: 'Batch with provenance',
+      },
+    });
+    expect(res.error).toBeUndefined();
+
+    const storedId = /stored ([a-f0-9]+):/.exec(res.result.content[0].text)?.[1];
+    expect(storedId).toBeDefined();
+    const item = await repo.getKnowledgeItem(storedId!);
+    expect(item?.provenance).toBe('inferred');
   });
 
   it('should list resources', async () => {

--- a/tests/store/blast-radius.test.ts
+++ b/tests/store/blast-radius.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
 import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
-import { flagCorrectionSiblings } from '../../src/store/blast-radius.js';
+import { flagCorrectionSiblings, MAX_BLAST_RADIUS } from '../../src/store/blast-radius.js';
 import { updateKnowledgeItemWithCommit } from '../../src/store/knowledge-actions.js';
 import { storeKnowledgeAtomsDeduped, storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
 import * as repo from '../../src/store/repository.js';
@@ -114,6 +114,43 @@ describe('correction blast radius', () => {
     )).rows;
     expect(commits).toHaveLength(1);
     expect(String(commits[0].message)).toContain('"Commit trail one" (rejected)');
+  });
+
+  it('flags at most MAX_BLAST_RADIUS siblings and reports the overflow', async () => {
+    const corrected = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Corrected member', content: 'The wrong one.', source: 'wide-batch',
+    });
+    const siblings = [];
+    for (let i = 0; i < MAX_BLAST_RADIUS + 5; i++) {
+      siblings.push(await repo.createKnowledgeItem(projectId, {
+        category: 'fact', title: `Wide batch member ${i}`, content: `Member number ${i}.`,
+        source: 'wide-batch',
+      }));
+    }
+
+    const result = await flagCorrectionSiblings(projectId, corrected.id, 'test');
+
+    expect(result.flaggedIds).toHaveLength(MAX_BLAST_RADIUS);
+    expect(result.capped).toBe(true);
+    const flagged = new Set(result.flaggedIds);
+    for (const sibling of siblings) {
+      expect(await freshnessOf(sibling.id)).toBe(flagged.has(sibling.id) ? 'needs_review' : 'fresh');
+    }
+    // The correction's own subject is never part of its own blast radius.
+    expect(flagged.has(corrected.id)).toBe(false);
+  });
+
+  it('leaves capped false when every sibling fits', async () => {
+    const corrected = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Small batch member', content: 'The wrong one.', source: 'small-batch',
+    });
+    await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'The only sibling', content: 'The other one.', source: 'small-batch',
+    });
+
+    const result = await flagCorrectionSiblings(projectId, corrected.id, 'test');
+    expect(result.flaggedIds).toHaveLength(1);
+    expect(result.capped).toBe(false);
   });
 
   it('a routine supersede flags nothing', async () => {

--- a/tests/store/blast-radius.test.ts
+++ b/tests/store/blast-radius.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
+import { flagCorrectionSiblings } from '../../src/store/blast-radius.js';
+import { updateKnowledgeItemWithCommit } from '../../src/store/knowledge-actions.js';
+import { storeKnowledgeAtomsDeduped, storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import * as repo from '../../src/store/repository.js';
+
+const ROOT = path.resolve('.knowl-blast-radius-test');
+
+const freshnessOf = async (id: string): Promise<string> => {
+  const row = (await getClient().execute({
+    sql: 'SELECT freshness FROM knowledge_items WHERE id = ?',
+    args: [id],
+  })).rows[0];
+  return String(row.freshness);
+};
+
+describe('correction blast radius', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'Blast radius test')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_evidence`);
+    await db.run(sql`DELETE FROM evidence`);
+    await db.run(sql`DELETE FROM knowledge_commits`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('flags batch siblings when one member is demoted', async () => {
+    const batch = await storeKnowledgeAtomsDeduped(projectId, [
+      { category: 'fact', title: 'Extracted fact alpha', content: 'From ingest batch one, page 3.' },
+      { category: 'fact', title: 'Extracted fact beta', content: 'From ingest batch one, page 7.' },
+      { category: 'fact', title: 'Extracted fact gamma', content: 'From ingest batch one, page 9.' },
+    ]);
+    const [alpha, beta, gamma] = batch.itemIds;
+
+    await updateKnowledgeItemWithCommit(projectId, alpha, { status: 'rejected' }, { projectRoot: ROOT });
+
+    expect(await freshnessOf(beta)).toBe('needs_review');
+    expect(await freshnessOf(gamma)).toBe('needs_review');
+  });
+
+  it('does not flag the replacement that performed the correction', async () => {
+    const wrong = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Cache TTL', content: 'The cache TTL is 60 seconds.',
+    });
+    const correction = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Cache TTL corrected', content: 'The cache TTL is 300 seconds.',
+      supersedes: wrong.item.id,
+    });
+
+    const result = await flagCorrectionSiblings(projectId, wrong.item.id, 'test');
+    expect(result.flaggedIds).not.toContain(correction.item.id);
+    expect(await freshnessOf(correction.item.id)).toBe('fresh');
+  });
+
+  it('flags same-source and shared-evidence siblings, skipping ineligible ones', async () => {
+    const corrected = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Corrected claim', content: 'Wrong reading of the spec.', source: 'spec-ingest-7',
+    });
+    const sourceSibling = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Source sibling', content: 'Another reading of the spec.', source: 'spec-ingest-7',
+    });
+    const alreadyFlagged = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Already under review', content: 'Same source, already flagged.',
+      source: 'spec-ingest-7', freshness: 'needs_review',
+    });
+    const unrelated = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Unrelated', content: 'Different source entirely.', source: 'other-source',
+    });
+
+    const evidenceSibling = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Evidence sibling', content: 'Cites the same test run.',
+    });
+    const { attachEvidenceToKnowledge } = await import('../../src/store/evidence-repository.js');
+    const shared = { type: 'test' as const, locator: 'test://spec-suite#run-42', observedAt: new Date().toISOString() };
+    await attachEvidenceToKnowledge(corrected.id, [shared]);
+    await attachEvidenceToKnowledge(evidenceSibling.id, [shared]);
+
+    const result = await flagCorrectionSiblings(projectId, corrected.id, '"Corrected claim" (rejected)');
+
+    expect(result.flaggedIds.sort()).toEqual([sourceSibling.id, evidenceSibling.id].sort());
+    expect(await freshnessOf(sourceSibling.id)).toBe('needs_review');
+    expect(await freshnessOf(evidenceSibling.id)).toBe('needs_review');
+    expect(await freshnessOf(unrelated.id)).toBe('fresh');
+    // Already-flagged stays flagged without being re-counted.
+    expect(await freshnessOf(alreadyFlagged.id)).toBe('needs_review');
+  });
+
+  it('records the flips as one knowledge commit naming the correction', async () => {
+    const batch = await storeKnowledgeAtomsDeduped(projectId, [
+      { category: 'fact', title: 'Commit trail one', content: 'First of the batch.' },
+      { category: 'fact', title: 'Commit trail two', content: 'Second of the batch.' },
+    ]);
+    await flagCorrectionSiblings(projectId, batch.itemIds[0], '"Commit trail one" (rejected)');
+
+    const commits = (await getClient().execute(
+      "SELECT message FROM knowledge_commits WHERE message LIKE 'Correction blast radius%'",
+    )).rows;
+    expect(commits).toHaveLength(1);
+    expect(String(commits[0].message)).toContain('"Commit trail one" (rejected)');
+  });
+
+  it('a routine supersede flags nothing', async () => {
+    const batch = await storeKnowledgeAtomsDeduped(projectId, [
+      { category: 'state', title: 'Sprint status', content: 'Sprint one is underway.' },
+      { category: 'state', title: 'Deploy status', content: 'Deploy pipeline is green.' },
+    ]);
+    await updateKnowledgeItemWithCommit(projectId, batch.itemIds[0], { status: 'superseded' }, { projectRoot: ROOT });
+
+    expect(await freshnessOf(batch.itemIds[1])).toBe('fresh');
+  });
+});

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -1,0 +1,155 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { describeAutoDrift, runAutoDriftCheck } from '../../src/store/drift-auto.js';
+import { handleHostLifecycleEvent } from '../../src/store/host-lifecycle.js';
+import * as repo from '../../src/store/repository.js';
+
+const ROOT = path.resolve('.knowl-drift-auto-test');
+
+const git = (args: string) => execSync(`git ${args}`, { cwd: ROOT, encoding: 'utf-8' });
+
+const commitFile = async (relPath: string, content: string, message: string): Promise<string> => {
+  const filePath = path.join(ROOT, relPath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+  git(`add ${relPath}`);
+  git(`commit -m "${message}"`);
+  return git('rev-parse HEAD').trim();
+};
+
+const hook = (input: Partial<NormalizedHostHook>): NormalizedHostHook => ({
+  host: 'generic',
+  event: 'session-start',
+  externalSessionId: 'drift-session',
+  externalTurnId: undefined,
+  projectRoot: ROOT,
+  payload: {},
+  ...input,
+});
+
+describe('automatic drift check', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    git('init');
+    git('config user.email test@example.com');
+    git('config user.name Test');
+    await commitFile('src/billing.ts', 'export const rate = 1;\n', 'add billing');
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'Drift auto test')).id;
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('learns the baseline on first run and flags nothing', async () => {
+    const first = await runAutoDriftCheck(projectId, ROOT);
+    expect(first).toEqual({ checked: false, flagged: 0 });
+
+    const second = await runAutoDriftCheck(projectId, ROOT);
+    expect(second?.checked).toBe(true);
+    expect(second?.flagged).toBe(0);
+  });
+
+  it('flags knowledge whose paths changed since the watermark, then advances it', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'architecture',
+      title: 'Billing module',
+      content: 'Billing rates live in src/billing.ts.',
+      affectedPaths: ['src/billing.ts'],
+    });
+    const bystander = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Unrelated fact',
+      content: 'Nothing to do with billing paths.',
+    });
+
+    await commitFile('src/billing.ts', 'export const rate = 2;\n', 'change billing');
+    const result = await runAutoDriftCheck(projectId, ROOT);
+    expect(result?.checked).toBe(true);
+    expect(result?.flagged).toBe(1);
+
+    const rows = await getClient().execute({
+      sql: 'SELECT id, freshness FROM knowledge_items WHERE id IN (?, ?)',
+      args: [item.id, bystander.id],
+    });
+    const freshnessById = new Map(rows.rows.map(row => [String(row.id), String(row.freshness)]));
+    expect(freshnessById.get(item.id)).toBe('needs_review');
+    expect(freshnessById.get(bystander.id)).toBe('fresh');
+
+    // Watermark advanced: the same change is not reported twice.
+    const repeat = await runAutoDriftCheck(projectId, ROOT);
+    expect(repeat?.flagged).toBe(0);
+  });
+
+  it('re-baselines quietly when the watermark commit no longer resolves', async () => {
+    await getClient().execute({
+      sql: 'UPDATE drift_state SET last_checked_commit = ? WHERE project_root = ?',
+      args: ['0000000000000000000000000000000000000000', ROOT],
+    });
+    const result = await runAutoDriftCheck(projectId, ROOT);
+    expect(result).toEqual({ checked: false, flagged: 0 });
+  });
+
+  it('returns null outside a git repository', async () => {
+    // In the system temp dir, not the repo tree: rev-parse walks up, so a bare
+    // directory inside this repository would resolve to this repository's HEAD.
+    const bare = path.join(os.tmpdir(), 'knowl-drift-auto-nogit-test');
+    await fs.rm(bare, { recursive: true, force: true });
+    await fs.mkdir(bare, { recursive: true });
+    try {
+      expect(await runAutoDriftCheck(projectId, bare)).toBeNull();
+    } finally {
+      await fs.rm(bare, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('renders the warning only when something was flagged', () => {
+    expect(describeAutoDrift(null)).toBeUndefined();
+    expect(describeAutoDrift({ checked: true, flagged: 0, sinceCommit: 'abc' })).toBeUndefined();
+    expect(describeAutoDrift({ checked: true, flagged: 2, sinceCommit: 'abcdef0123456789' }))
+      .toContain('2 knowledge item(s)');
+  });
+
+  it('leads the session-start context with the drift warning', async () => {
+    const flagged = await repo.createKnowledgeItem(projectId, {
+      category: 'architecture',
+      title: 'Rate limits',
+      content: 'Limits are configured in src/limits.ts.',
+      affectedPaths: ['src/limits.ts'],
+    });
+    await commitFile('src/limits.ts', 'export const limit = 10;\n', 'add limits');
+    await runAutoDriftCheck(projectId, ROOT); // advance watermark past the file's creation
+    // The advance itself flagged the item (its file changed); reset so the lifecycle
+    // event is what flips it — drift skips items already at needs_review.
+    await getClient().execute({
+      sql: "UPDATE knowledge_items SET freshness = 'fresh' WHERE id = ?",
+      args: [flagged.id],
+    });
+    await commitFile('src/limits.ts', 'export const limit = 20;\n', 'raise limits');
+
+    const result = await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: `drift-session-${Date.now()}`,
+      title: 'Agent session',
+    }));
+
+    expect(result.accepted).toBe(true);
+    expect(result.drift?.flagged).toBe(1);
+    expect(result.context).toMatch(/^DRIFT: 1 knowledge item/);
+
+    const row = (await getClient().execute({
+      sql: 'SELECT freshness FROM knowledge_items WHERE id = ?',
+      args: [flagged.id],
+    })).rows[0];
+    expect(String(row.freshness)).toBe('needs_review');
+  });
+});

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
+import { DEFAULT_CONTEXT_MAX_CHARS } from '../../src/core/token-budget.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { describeAutoDrift, runAutoDriftCheck } from '../../src/store/drift-auto.js';
 import { handleHostLifecycleEvent } from '../../src/store/host-lifecycle.js';
@@ -124,6 +125,40 @@ describe('automatic drift check', () => {
     expect(warning).toContain('"Billing module"');
     expect(warning).toContain('…');
     expect(warning).toContain('knowl pr check --since abcdef012345');
+  });
+
+  it('charges the drift warning against the context budget instead of overflowing it', async () => {
+    // Enough recent knowledge to fill the budget on its own, so a warning appended after
+    // budgeting would push the total over the cap the host was promised.
+    // Recent context is 3 items (each content-capped) plus 8 commit lines, so the budget is
+    // filled from both ends.
+    for (let i = 0; i < 3; i++) {
+      await repo.createKnowledgeItem(projectId, {
+        category: 'fact',
+        title: `Bulky context item ${i} about the payments subsystem`,
+        content: `Filler paragraph ${i} describing the payments subsystem at length. `.repeat(30),
+        affectedPaths: ['src/bulky.ts'],
+      });
+    }
+    for (let i = 0; i < 8; i++) {
+      await repo.createKnowledgeCommit(
+        projectId,
+        `Bulky commit ${i}: ${`a long commit message segment ${i} `.repeat(8)}`,
+        [],
+      );
+    }
+    await commitFile('src/bulky.ts', 'export const a = 1;\n', 'add bulky');
+    await runAutoDriftCheck(projectId, ROOT); // advance the watermark past creation
+    await commitFile('src/bulky.ts', 'export const a = 2;\n', 'change bulky');
+
+    const result = await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: `drift-budget-${Date.now()}`,
+      title: 'Agent session',
+    }));
+
+    expect(result.drift?.candidateCount).toBeGreaterThan(0);
+    expect(result.context).toMatch(/^DRIFT: /);
+    expect(result.context!.length).toBeLessThanOrEqual(DEFAULT_CONTEXT_MAX_CHARS);
   });
 
   it('leads the session-start context with the drift warning', async () => {

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -51,16 +51,16 @@ describe('automatic drift check', () => {
     await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('learns the baseline on first run and flags nothing', async () => {
+  it('learns the baseline on first run and reports nothing', async () => {
     const first = await runAutoDriftCheck(projectId, ROOT);
-    expect(first).toEqual({ checked: false, flagged: 0 });
+    expect(first).toEqual({ checked: false, candidateCount: 0, candidateTitles: [] });
 
     const second = await runAutoDriftCheck(projectId, ROOT);
     expect(second?.checked).toBe(true);
-    expect(second?.flagged).toBe(0);
+    expect(second?.candidateCount).toBe(0);
   });
 
-  it('flags knowledge whose paths changed since the watermark, then advances it', async () => {
+  it('detects candidates without mutating them, then advances the watermark', async () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'architecture',
       title: 'Billing module',
@@ -76,19 +76,19 @@ describe('automatic drift check', () => {
     await commitFile('src/billing.ts', 'export const rate = 2;\n', 'change billing');
     const result = await runAutoDriftCheck(projectId, ROOT);
     expect(result?.checked).toBe(true);
-    expect(result?.flagged).toBe(1);
+    expect(result?.candidateCount).toBe(1);
+    expect(result?.candidateTitles).toEqual(['Billing module']);
 
+    // Detection only: freshness is untouched on both candidate and bystander.
     const rows = await getClient().execute({
       sql: 'SELECT id, freshness FROM knowledge_items WHERE id IN (?, ?)',
       args: [item.id, bystander.id],
     });
-    const freshnessById = new Map(rows.rows.map(row => [String(row.id), String(row.freshness)]));
-    expect(freshnessById.get(item.id)).toBe('needs_review');
-    expect(freshnessById.get(bystander.id)).toBe('fresh');
+    for (const row of rows.rows) expect(String(row.freshness)).toBe('fresh');
 
-    // Watermark advanced: the same change is not reported twice.
+    // Watermark advanced: the same window is not reported twice.
     const repeat = await runAutoDriftCheck(projectId, ROOT);
-    expect(repeat?.flagged).toBe(0);
+    expect(repeat?.candidateCount).toBe(0);
   });
 
   it('re-baselines quietly when the watermark commit no longer resolves', async () => {
@@ -97,7 +97,7 @@ describe('automatic drift check', () => {
       args: ['0000000000000000000000000000000000000000', ROOT],
     });
     const result = await runAutoDriftCheck(projectId, ROOT);
-    expect(result).toEqual({ checked: false, flagged: 0 });
+    expect(result).toEqual({ checked: false, candidateCount: 0, candidateTitles: [] });
   });
 
   it('returns null outside a git repository', async () => {
@@ -113,11 +113,17 @@ describe('automatic drift check', () => {
     }
   });
 
-  it('renders the warning only when something was flagged', () => {
+  it('renders the warning with the pinned review command, only when something matched', () => {
     expect(describeAutoDrift(null)).toBeUndefined();
-    expect(describeAutoDrift({ checked: true, flagged: 0, sinceCommit: 'abc' })).toBeUndefined();
-    expect(describeAutoDrift({ checked: true, flagged: 2, sinceCommit: 'abcdef0123456789' }))
-      .toContain('2 knowledge item(s)');
+    expect(describeAutoDrift({ checked: true, candidateCount: 0, candidateTitles: [], sinceCommit: 'abc' })).toBeUndefined();
+    const warning = describeAutoDrift({
+      checked: true, candidateCount: 4, candidateTitles: ['Billing module', 'Rate limits'],
+      sinceCommit: 'abcdef0123456789',
+    });
+    expect(warning).toContain('4 knowledge item(s)');
+    expect(warning).toContain('"Billing module"');
+    expect(warning).toContain('…');
+    expect(warning).toContain('knowl pr check --since abcdef012345');
   });
 
   it('leads the session-start context with the drift warning', async () => {
@@ -129,12 +135,6 @@ describe('automatic drift check', () => {
     });
     await commitFile('src/limits.ts', 'export const limit = 10;\n', 'add limits');
     await runAutoDriftCheck(projectId, ROOT); // advance watermark past the file's creation
-    // The advance itself flagged the item (its file changed); reset so the lifecycle
-    // event is what flips it — drift skips items already at needs_review.
-    await getClient().execute({
-      sql: "UPDATE knowledge_items SET freshness = 'fresh' WHERE id = ?",
-      args: [flagged.id],
-    });
     await commitFile('src/limits.ts', 'export const limit = 20;\n', 'raise limits');
 
     const result = await handleHostLifecycleEvent(projectId, hook({
@@ -143,13 +143,14 @@ describe('automatic drift check', () => {
     }));
 
     expect(result.accepted).toBe(true);
-    expect(result.drift?.flagged).toBe(1);
+    expect(result.drift?.candidateCount).toBe(1);
     expect(result.context).toMatch(/^DRIFT: 1 knowledge item/);
 
+    // Still detection only, even through the lifecycle path.
     const row = (await getClient().execute({
       sql: 'SELECT freshness FROM knowledge_items WHERE id = ?',
       args: [flagged.id],
     })).rows[0];
-    expect(String(row.freshness)).toBe('needs_review');
+    expect(String(row.freshness)).toBe('fresh');
   });
 });

--- a/tests/store/tier.test.ts
+++ b/tests/store/tier.test.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
+import { scoreCandidates } from '../../src/store/agent-query.js';
+import { recordKnowledgeFeedback } from '../../src/store/access-feedback.js';
+import { applyFeedbackToTier } from '../../src/store/tier.js';
+import * as repo from '../../src/store/repository.js';
+import type { KnowledgeItem } from '../../src/core/types.js';
+
+const ROOT = path.resolve('.knowl-tier-test');
+
+describe('evidence tier and provenance', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'Tier test')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_access`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('every write starts asserted, carrying its provenance class', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Observed fact', content: 'Seen in a test run.', provenance: 'observed',
+    });
+    expect(item.tier).toBe('asserted');
+    expect(item.provenance).toBe('observed');
+
+    const legacy = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Unclassified fact', content: 'Written with no class.',
+    });
+    expect(legacy.provenance).toBeNull();
+  });
+
+  it('promotes only at the confirmation threshold, then demotes on correction', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Useful fact', content: 'Confirmed by use twice.',
+    });
+
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    const promoted = await applyFeedbackToTier(projectId, item.id, { useful: true });
+    expect(promoted).toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
+
+    const demoted = await applyFeedbackToTier(projectId, item.id, { causedCorrection: true });
+    expect(demoted).toEqual({ itemId: item.id, tier: 'asserted', reason: 'demoted' });
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  it('a content edit resets verified to asserted — verified means verified-verbatim', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Edited fact', content: 'Original wording.',
+    });
+    await repo.updateKnowledgeItem(item.id, { tier: 'verified' });
+
+    const touched = await repo.updateKnowledgeItem(item.id, { content: 'Reworded claim.' });
+    expect(touched.tier).toBe('asserted');
+
+    // A non-content update leaves earned standing alone.
+    await repo.updateKnowledgeItem(item.id, { tier: 'verified' });
+    const statusOnly = await repo.updateKnowledgeItem(item.id, { freshness: 'stale' });
+    expect(statusOnly.tier).toBe('verified');
+  });
+
+  it('ranks verified above asserted and observed above inferred, all else equal', () => {
+    const base = (id: string, overrides: Partial<KnowledgeItem>): { item: KnowledgeItem; bm25Rank: number } => ({
+      item: {
+        id, category: 'fact', status: 'active', title: 'Same claim', content: 'Same content.',
+        freshness: 'fresh', confidence: 1, tier: 'asserted', provenance: null,
+        version: 1, createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:00:00.000Z',
+      } as KnowledgeItem,
+      bm25Rank: 1,
+    });
+
+    const tierRanked = scoreCandidates([
+      base('asserted-item', {}),
+      { ...base('verified-item', {}), item: { ...base('verified-item', {}).item, tier: 'verified' } },
+    ], { limit: 2, usingVector: false });
+    expect(tierRanked[0].item.id).toBe('verified-item');
+
+    const provenanceRanked = scoreCandidates([
+      { ...base('inferred-item', {}), item: { ...base('inferred-item', {}).item, provenance: 'inferred' } },
+      { ...base('observed-item', {}), item: { ...base('observed-item', {}).item, provenance: 'observed' } },
+    ], { limit: 2, usingVector: false });
+    expect(provenanceRanked[0].item.id).toBe('observed-item');
+  });
+
+  it('round-trips tier and provenance through the row mapping', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'constraint', title: 'Inferred limit', content: 'Concluded from one log line.', provenance: 'inferred',
+    });
+    await repo.updateKnowledgeItem(item.id, { tier: 'verified' });
+
+    const row = (await getClient().execute({
+      sql: 'SELECT tier, provenance FROM knowledge_items WHERE id = ?',
+      args: [item.id],
+    })).rows[0];
+    expect(String(row.tier)).toBe('verified');
+    expect(String(row.provenance)).toBe('inferred');
+
+    const mapped = await repo.getKnowledgeItem(item.id);
+    expect(mapped?.tier).toBe('verified');
+    expect(mapped?.provenance).toBe('inferred');
+  });
+});

--- a/tests/store/tier.test.ts
+++ b/tests/store/tier.test.ts
@@ -5,7 +5,7 @@ import { sql } from 'drizzle-orm';
 import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
 import { scoreCandidates } from '../../src/store/agent-query.js';
 import { recordKnowledgeFeedback } from '../../src/store/access-feedback.js';
-import { applyFeedbackToTier } from '../../src/store/tier.js';
+import { applyFeedbackToTier, VERIFY_THRESHOLD } from '../../src/store/tier.js';
 import * as repo from '../../src/store/repository.js';
 import type { KnowledgeItem } from '../../src/core/types.js';
 
@@ -77,6 +77,70 @@ describe('evidence tier and provenance', () => {
     await repo.updateKnowledgeItem(item.id, { tier: 'verified' });
     const statusOnly = await repo.updateKnowledgeItem(item.id, { freshness: 'stale' });
     expect(statusOnly.tier).toBe('verified');
+  });
+
+  it('a content edit restarts the confirmation count — old useful events do not re-promote', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Reworded fact', content: 'Original wording.',
+    });
+    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
+      await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+      await applyFeedbackToTier(projectId, item.id, { useful: true });
+    }
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
+
+    await repo.updateKnowledgeItem(item.id, { content: 'A materially different claim.' });
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    // One confirmation of the NEW wording is below the threshold. The pre-edit events
+    // confirmed words that no longer exist and must not count toward this promotion.
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    // A full threshold of post-edit confirmations does promote again.
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true }))
+      .toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
+  });
+
+  it('a correction restarts the confirmation count — one useful event does not undo it', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Corrected fact', content: 'A claim proven wrong.',
+    });
+    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
+      await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+      await applyFeedbackToTier(projectId, item.id, { useful: true });
+    }
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
+
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, causedCorrection: true });
+    await applyFeedbackToTier(projectId, item.id, { causedCorrection: true });
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    // Proof of wrongness must cost more than a single subsequent confirmation.
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  it('counts the full history of a row written before tier_since existed', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Legacy row', content: 'Written before the column existed.',
+    });
+    // Exactly what the migration leaves behind: standing has never been reset here, so the
+    // confirmations the row already carries still belong to its current tier.
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET tier_since = NULL WHERE id = ?',
+      args: [item.id],
+    });
+    expect((await repo.getKnowledgeItem(item.id))?.tierSince).toBeNull();
+
+    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
+      await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    }
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true }))
+      .toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
   });
 
   it('ranks verified above asserted and observed above inferred, all else equal', () => {


### PR DESCRIPTION
## Memory quality machinery: drift detection at session start, correction blast radius, earned standing

Four changes on one theme: the quality primitives knowl already has (pr check, feedback telemetry, evidence links) are commands someone must remember to run — and the reason knowl exists is that "remember to run it" doesn't survive real work. I tested each mechanism against my real corpora (three linked repos, ~530 atoms, live git history) before opening this, and one measurement reshaped the design — details below.

### 1. The pr-check drift sweep runs automatically at session start — as detection only

`checkKnowledgeDrift` had exactly one caller: a command typed by hand. The session boundary is the right chokepoint (the moment before an agent relies on memory), so a watermarked check now runs there and leads the session context with what moved.

**Why it detects instead of auto-applying:** measured on my documentation-heavy repo, one commit window matched 36 of 301 atoms; fifteen windows matched a third of the store. Atoms annotate hot files, hot files change daily — an automatic freshness flip would hold those atoms at needs_review permanently. So the warning names the count, the top titles, and the exact pinned `knowl pr check --since <commit>` command; flipping freshness stays deliberate. First run learns the baseline silently; a vanished watermark (rebase/gc) re-baselines quietly.

### 2. A correction flags the batch that produced it

A wrong memory is a class, not an instance: the extraction pass or session promotion that produced one bad atom usually produced more, and the correction is the one moment the system knows where to look. Siblings of a corrected item (same insert commit, same source label, shared evidence) flip to needs_review, capped at 12, recorded as one knowledge commit so the existing change cards announce them.

Triggers are only the two unambiguous signals: `knowl_feedback` with `causedCorrection`, and demotion to deprecated/rejected. A routine supersede deliberately does not fire — state atoms supersede weekly, and firing there would be a flag storm. The insert commit defines the batch, so the replacement that performed a correction is never flagged. On my history: 4 real corrections, max source fan-out 6, so no storm risk observed.

### 3. `tier`: standing earned by use, orthogonal to self-reported confidence

Every write starts `asserted`; two confirmed-useful `knowl_feedback` events promote to `verified`; one `causedCorrection` demotes immediately; a content edit resets — verified means verified-verbatim. Ranking gains a bounded `standing` term sized below the freshness re-rank: earned standing breaks ties, never outranks being current. Tier is deliberately absent from `lifecycleHash`: verification is one machine's own experience with an item, and an imported copy hasn't been used there yet.

Honest numbers from my corpora: 19 feedback events (all in one repo), 2 items would be verified today, 10 causedCorrection events. The value scales with feedback adoption — this probably wants a companion guidance nudge.

### 4. `provenance`: how the knowledge came to be believed, fixed at write time

`observed` / `user_stated` / `inferred` on `knowl_store`; NULL on legacy rows means exactly "written before the class existed". Inferred items get a small ranking discount (never buried — an inferred item may be the only answer). The memory-poisoning literature's finding is the motivation: a reflected "lesson" reads as authoritative once stored, and the class it was born with is the only record it was ever a guess. Currently infrastructure — inert until writers pass it. Known gap: `synthesize` output doesn't yet inherit the lowest input class.

### Notes

- Telemetry recording itself still never alters retrieval; standing is applied as a separate, findable consequence in the feedback handler.
- 16 new tests; full suite green locally (one env note: CLI integration tests silently run a stale `dist/` — the version assertion is the only tell; worth a build step in CI if there isn't one).
- Schema: two additive columns + one new table (`drift_state`), all `IF NOT EXISTS`/column-guard style, no migration needed.
- Two judgment calls I'd especially like eyes on: no blast radius on routine supersede (measured flag-storm risk vs missed corrections), and `VERIFY_THRESHOLD = 2` (at real-world feedback rates, higher values would make promotion decorative).
