### PR TITLE
feat(transcript-search): searchable session transcripts as a lossless floor under the atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,8 @@ Knowl exposes exactly 24 MCP tools:
 | `knowl_recent` | Compact recent context when lifecycle bootstrap is unavailable or a refresh is needed |
 | `knowl_state` | Broad active-memory status or hierarchical project summary |
 | `knowl_context` | Compose an explicitly token-budgeted local context pack |
+| `knowl_transcript_search` | Search the verbatim session transcripts when memory misses or is ambiguous |
+| `knowl_transcript_read` | Read one transcript entry in full when a snippet cannot settle it |
 | `knowl_task_start` | Start one manual work loop when verified lifecycle hooks are unavailable |
 | `knowl_task_checkpoint` | Checkpoint meaningful manual-loop progress or blockers |
 | `knowl_task_finish` | Finish one manual work loop after verification |

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -13,6 +13,11 @@ export const KNOWL_MCP_TOOL_GROUPS = [
     routing: 'Use recent only without lifecycle bootstrap or for an explicit refresh; state for broad status; context for an explicitly token-budgeted pack.',
   },
   {
+    label: 'Verbatim transcripts',
+    tools: ['knowl_transcript_search', 'knowl_transcript_read'],
+    routing: 'The lossless record under the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
+  },
+  {
     label: 'Manual work loop',
     tools: ['knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish'],
     routing: 'Use only without verified lifecycle hooks: start once, checkpoint meaningful milestones or blockers, and finish once after verification.',
@@ -97,6 +102,7 @@ function renderCompactKnowlGuidance(modeLine: string): string {
     'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
     'Route:',
     '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
+    '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
     '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
     '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
     '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -321,6 +321,34 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_transcript_search',
+          description: 'Search the RAW session transcripts - the lossless record of everything actually said, underneath the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Ranked, not grep: BM25 over an incrementally maintained index, fused with semantic similarity when vector search is enabled. ALWAYS follow a useful hit with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice - an unpromoted recovery is a lookup every future session repeats.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: 'Content words to recall, not a sentence. Example: "card radius rejected toy".' },
+              limit: { type: 'number', description: 'Maximum hits; defaults to 10. Raise only after a narrow query underdelivers.' },
+              sessionId: { type: 'string', description: 'Restrict to one session, by id or a unique prefix. Use this when a handoff brief names a parent session: ask that transcript first, then re-run without it to widen to the whole archive.' },
+              since: { type: 'string', description: 'ISO timestamp; drop hits older than it.' },
+              projectDir: { type: 'string', description: 'Directory whose transcripts to search. Defaults to the current project.' },
+            },
+            required: ['query'],
+          },
+        },
+        {
+          name: 'knowl_transcript_read',
+          description: 'Read one transcript entry in full, including its tool calls, when a search snippet is not enough to settle the question. Takes the sessionId and line from a knowl_transcript_search locator.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              sessionId: { type: 'string', description: 'Session id, or a unique prefix of it.' },
+              line: { type: 'number', description: '1-indexed line, as returned in the locator.' },
+              projectDir: { type: 'string', description: 'Defaults to the current project.' },
+            },
+            required: ['sessionId', 'line'],
+          },
+        },
+        {
           name: 'knowl_timeline',
           description: 'Inspect immutable assertions for one knowledge item when its history is needed.',
           inputSchema: { type: 'object', properties: { itemId: { type: 'string' } }, required: ['itemId'] },
@@ -944,6 +972,58 @@ export function registerTools(
           });
         }
         return { content: blocks };
+      }
+
+      else if (name === 'knowl_transcript_search') {
+        const { query, limit, since, projectDir, sessionId } = args as any;
+        const { searchTranscripts } = await import('../store/transcript-search.js');
+        const dir = projectDir ? String(projectDir) : (projectRoot ?? process.cwd());
+
+        // Semantic re-ranking is a bonus, not a requirement: vector search is
+        // opt-in, and the lexical ranking is a complete answer without it.
+        let semantic;
+        if (config && projectRoot && isVectorSearchEnabled(config)) {
+          try {
+            const embedder = await createLocalEmbeddingProvider(config, projectRoot);
+            semantic = { model: getVectorSearchConfig(config).model, embed: (texts: string[]) => embedder.embed(texts) };
+          } catch { /* fall back to lexical only */ }
+        }
+
+        const result = await searchTranscripts(String(query), {
+          projectDir: dir,
+          limit: typeof limit === 'number' ? limit : undefined,
+          since: since ? String(since) : undefined,
+          sessionId: sessionId ? String(sessionId) : undefined,
+          semantic,
+        });
+
+        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.hits) }];
+        const ranker = semantic ? 'BM25 + semantic (RRF)' : 'BM25';
+        // The ratchet only compounds if it fires on the result, not just in the
+        // tool description: descriptions are read once, results are read every time.
+        // Say plainly when the index is still warming. A partial index gives
+        // real answers, but "no match" means something different against it,
+        // and a caller told nothing would read absence as proof.
+        const warming = result.indexComplete ? '' : ' INDEX STILL WARMING - it resumes on each call; run the search again for fuller coverage.';
+        if (result.hits.length > 0) {
+          blocks.push({ type: 'text', text: `${ranker} over ${result.indexed} indexed message(s) from ${result.sessions} session(s); index refresh ${result.indexMs}ms.${warming} PROMOTE what you used: call knowl_store (or knowl_update if it corrects an existing item) and cite the hit's locator in the content, so this lookup never has to happen again.` });
+        } else {
+          blocks.push({ type: 'text', text: `No matches across ${result.indexed} indexed message(s) from ${result.sessions} session(s).${warming} Retry with different content words - the index covers user and assistant messages plus tool calls and results.` });
+        }
+        return { content: blocks };
+      }
+
+      else if (name === 'knowl_transcript_read') {
+        const { sessionId, line, projectDir } = args as any;
+        const { readTranscriptEntry, MAX_TRANSCRIPT_ENTRY_CHARS } = await import('../store/transcript-search.js');
+        const entry = await readTranscriptEntry(String(sessionId), Number(line), projectDir ? String(projectDir) : (projectRoot ?? process.cwd()));
+        if (!entry) return { content: [{ type: 'text', text: `No transcript entry at ${sessionId}#L${line}.` }] };
+        // NOT MAX_ITEM_CONTENT_CHARS: that is the 600-char budget for a knowledge
+        // atom's fields, and this tool exists precisely because a ~600-char
+        // snippet was not enough. Capping it there would return the snippet again
+        // under a different name. Bounded at the same size the index stores, so a
+        // pasted megabyte still cannot flood the caller's context.
+        return { content: [{ type: 'text', text: truncateText(entry.text, MAX_TRANSCRIPT_ENTRY_CHARS) }] };
       }
 
       else if (name === 'knowl_timeline') {

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -204,6 +204,50 @@ const SCHEMA_STATEMENTS = [
     FROM knowledge_items
     WHERE NOT EXISTS (SELECT 1 FROM knowledge_items_fts LIMIT 1)
       AND EXISTS (SELECT 1 FROM knowledge_items LIMIT 1);`,
+
+  // Transcript index. Session transcripts are the lossless record underneath the
+  // distilled atoms; these tables make them searchable without re-reading
+  // hundreds of megabytes per query. Rows are derived data and safe to drop --
+  // the source of truth is the .jsonl files on disk.
+  `CREATE TABLE IF NOT EXISTS transcript_files (
+    path TEXT PRIMARY KEY,
+    project_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    -- Transcripts are append-only, so a byte offset is a resume point: the next
+    -- pass reads only what was added rather than the whole file again.
+    bytes_indexed INTEGER NOT NULL DEFAULT 0,
+    lines_indexed INTEGER NOT NULL DEFAULT 0,
+    mtime_ms INTEGER NOT NULL DEFAULT 0,
+    indexed_at TEXT NOT NULL
+  );`,
+  `CREATE TABLE IF NOT EXISTS transcript_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    line INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    ts TEXT,
+    weight REAL NOT NULL,
+    len INTEGER NOT NULL,
+    text TEXT NOT NULL
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_messages_project ON transcript_messages(project_dir);`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_messages_session ON transcript_messages(session_id, line);`,
+  // FTS5 rather than a hand-built inverted index: it ships BM25, and a posting
+  // table written from JavaScript cost ~74 rows per message, which made cold
+  // indexing of a large archive hours of work. External content keeps the text
+  // in transcript_messages instead of storing it twice.
+  `CREATE VIRTUAL TABLE IF NOT EXISTS transcript_fts USING fts5(
+    text,
+    content='transcript_messages',
+    content_rowid='id'
+  );`,
+  // Cached per message so a rerank pays the embedding cost once, not per query.
+  `CREATE TABLE IF NOT EXISTS transcript_embeddings (
+    message_id INTEGER PRIMARY KEY,
+    model TEXT NOT NULL,
+    vector TEXT NOT NULL
+  );`,
 ];
 
 function unwrapJson(value: unknown): unknown {

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -1,0 +1,379 @@
+import { createReadStream } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { homedir } from 'node:os';
+import { join, basename, delimiter } from 'node:path';
+import { getClient } from './database.js';
+
+// Incremental index over raw Claude Code session transcripts.
+//
+// The naive approach - stream every file on every query - costs seconds per
+// lookup and gets worse as history grows, which is exactly the wrong shape for
+// something an agent should reach for whenever it is unsure. Transcripts are
+// append-only, so a byte offset is a valid resume point: each pass reads only
+// what was written since the last one, and steady-state indexing is nearly free.
+//
+// Everything here is derived data. The .jsonl files are the source of truth, so
+// these tables can be dropped and rebuilt without losing anything.
+
+const ROLE_WEIGHT: Record<string, number> = { user: 2, assistant: 1 };
+const TOOL_WEIGHT = 0.3;
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'that', 'this', 'with', 'from', 'was', 'were', 'are', 'you', 'your',
+  'not', 'but', 'have', 'has', 'had', 'its', 'it', 'is', 'be', 'to', 'of', 'in', 'on', 'a',
+  'i', 'we', 'they', 'as', 'at', 'by', 'or', 'an', 'if', 'so', 'do', 'does', 'did', 'can',
+]);
+
+export function tokenize(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.toLowerCase().split(/[^a-z0-9_]+/)) {
+    if (raw.length < 2 || raw.length > 40 || STOPWORDS.has(raw)) continue;
+    out.push(raw);
+  }
+  return out;
+}
+
+/** Claude Code encodes the project path by replacing every non-alphanumeric character with '-'. */
+export function encodeProjectDir(dir: string): string {
+  return dir.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Every config root that may hold transcripts. CLAUDE_CONFIG_DIR wins when set;
+ * the default install location is always included. A machine with additional
+ * stores - a second account, a synced archive - names them in
+ * KNOWL_TRANSCRIPT_ROOTS (path-delimiter separated), because which extra roots
+ * exist is a property of one machine, not of this package.
+ */
+export function transcriptStores(): string[] {
+  const roots = new Set<string>();
+  if (process.env.CLAUDE_CONFIG_DIR) roots.add(process.env.CLAUDE_CONFIG_DIR);
+  roots.add(join(homedir(), '.claude'));
+  for (const extra of (process.env.KNOWL_TRANSCRIPT_ROOTS ?? '').split(delimiter)) {
+    if (extra.trim()) roots.add(extra.trim());
+  }
+  return [...roots].map(root => join(root, 'projects'));
+}
+
+export interface SessionFile { sessionId: string; path: string; mtimeMs: number; size: number }
+
+export async function sessionFiles(projectDir: string, stores?: string[]): Promise<SessionFile[]> {
+  const encoded = encodeProjectDir(projectDir);
+  // Two stores can hold the same session id; keep the most recently written copy.
+  const newest = new Map<string, SessionFile>();
+  for (const store of stores ?? transcriptStores()) {
+    let names: string[];
+    try { names = await readdir(join(store, encoded)); } catch { continue; }
+    for (const name of names) {
+      if (!name.endsWith('.jsonl')) continue;
+      const path = join(store, encoded, name);
+      let info;
+      try { info = await stat(path); } catch { continue; }
+      const sessionId = basename(name, '.jsonl');
+      const prev = newest.get(sessionId);
+      // Truncated to whole milliseconds: stat reports a float, the watermark
+      // column stores an integer, and comparing the two must not invent a
+      // rewrite out of the fractional part.
+      const mtimeMs = Math.trunc(info.mtimeMs);
+      if (!prev || prev.mtimeMs < mtimeMs) {
+        newest.set(sessionId, { sessionId, path, mtimeMs, size: info.size });
+      }
+    }
+  }
+  return [...newest.values()].sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/**
+ * Entries that are structurally present but carry no recallable content: the
+ * local-command caveat wrapper, bare slash commands, and the startup handshake.
+ * Indexing them pollutes document frequency and wastes result slots.
+ */
+function isNoise(text: string): boolean {
+  const t = text.trimStart();
+  if (!t) return true;
+  if (t.startsWith('<local-command-caveat>')) return true;
+  if (t.startsWith('<command-name>')) return true;
+  return /^Caveat: The messages below were generated/.test(t);
+}
+
+function extractText(entry: any): { text: string; toolChars: number } {
+  const content = entry?.message?.content;
+  if (typeof content === 'string') return { text: content, toolChars: 0 };
+  if (!Array.isArray(content)) return { text: '', toolChars: 0 };
+  const parts: string[] = [];
+  let toolChars = 0;
+  for (const block of content) {
+    if (block?.type === 'text' && typeof block.text === 'string') { parts.push(block.text); continue; }
+    // Tool traffic is most of the bytes and little of the signal, but a command,
+    // path or error string is sometimes the only place an answer survives. It is
+    // indexed and then weighted down, rather than discarded.
+    if (block?.type === 'tool_use') {
+      const s = JSON.stringify(block.input ?? {});
+      toolChars += s.length; parts.push(s);
+    } else if (block?.type === 'tool_result') {
+      const s = typeof block.content === 'string' ? block.content : JSON.stringify(block.content ?? '');
+      toolChars += s.length; parts.push(s);
+    }
+  }
+  return { text: parts.join('\n'), toolChars };
+}
+
+/** Bounded so one pasted 5MB file cannot dominate the index or a snippet. */
+const MAX_TEXT_CHARS = 20_000;
+
+/**
+ * How long one call may spend indexing. Indexing runs inside a tool call, so
+ * this is really a promise about latency: a first search on a large archive
+ * returns whatever is indexed so far and says the index is still warming,
+ * rather than blocking the caller for minutes.
+ */
+const DEFAULT_INDEX_BUDGET_MS = 8_000;
+
+/** Statements per write transaction. Small on purpose - see flush(). */
+const BATCH_STATEMENTS = 500;
+
+interface PendingMessage {
+  sessionId: string; line: number; role: string; ts: string | null;
+  weight: number; len: number; text: string;
+}
+
+/**
+ * Message ids are assigned here rather than read back from the database. The
+ * obvious shape - INSERT ... RETURNING per message - costs a round trip each,
+ * which on a real archive is tens of thousands of round trips and minutes of
+ * wall clock. Allocating ids from a counter lets a whole batch go out at once.
+ */
+async function flush(projectDir: string, pending: PendingMessage[], nextId: { value: number }): Promise<void> {
+  if (pending.length === 0) return;
+  const client = getClient();
+  const statements: Array<{ sql: string; args: any[] }> = [];
+  for (const message of pending) {
+    const messageId = nextId.value++;
+    statements.push({
+      sql: `INSERT INTO transcript_messages (id, project_dir, session_id, line, role, ts, weight, len, text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [messageId, projectDir, message.sessionId, message.line, message.role, message.ts, message.weight, message.len, message.text],
+    });
+    // FTS5 tokenizes and ranks; nothing here has to build a term index by hand.
+    statements.push({
+      sql: 'INSERT INTO transcript_fts (rowid, text) VALUES (?, ?)',
+      args: [messageId, message.text],
+    });
+  }
+  // libsql runs a batch as one transaction, so the per-statement fsync that
+  // dominates unbatched SQLite writes happens once instead of per row. The
+  // chunk stays small deliberately: this database is also being served to a
+  // live session, and a long write transaction starves it into SQLITE_BUSY.
+  for (let i = 0; i < statements.length; i += BATCH_STATEMENTS) {
+    try {
+      await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+    } catch (error) {
+      // A primary-key collision means another process allocated the same ids -
+      // the file lease serializes work per FILE, but ids come from one MAX(id)
+      // read per pass, so two passes on different files can still clash. The
+      // colliding transaction rolled back, so nothing partial landed from this
+      // chunk; surrender the file and let the next pass resume from a fresh
+      // MAX. Committed earlier chunks sit beyond the watermark and are purged
+      // by whoever claims the file next.
+      if (/SQLITE_CONSTRAINT|UNIQUE/i.test(String((error as Error).message))) throw new IdCollisionError();
+      throw error;
+    }
+  }
+}
+
+class IdCollisionError extends Error {
+  constructor() { super('transcript id collision: concurrent indexer detected'); }
+}
+
+async function nextMessageId(): Promise<number> {
+  const row = (await getClient().execute('SELECT COALESCE(MAX(id), 0) AS max_id FROM transcript_messages')).rows[0];
+  return Number(row.max_id) + 1;
+}
+
+/**
+ * How long one process's claim on a file is honoured. Knowl runs one serve
+ * process per connected session, so two sessions on the same project index
+ * concurrently unless something serializes them - both would read the same
+ * MAX(id) and the same watermark, then collide on primary keys or write the
+ * same messages twice. Longer than an index pass's budget, short enough that a
+ * crashed claimant only stalls a file briefly.
+ */
+const LEASE_MS = 20_000;
+
+/** Claims written by THIS process, so it can resume its own budget-paused files without waiting out the lease. */
+const ownClaims = new Set<string>();
+
+/** Remove indexed rows for a session beyond a line watermark, embeddings included - a purged id can be reallocated, and a stale cached vector would silently attach to the wrong message. */
+async function purgeBeyond(projectDir: string, sessionId: string, afterLine: number): Promise<void> {
+  const client = getClient();
+  const where = 'session_id = ? AND project_dir = ? AND line > ?';
+  const args = [sessionId, projectDir, afterLine];
+  await client.execute({
+    sql: `INSERT INTO transcript_fts(transcript_fts, rowid, text)
+          SELECT 'delete', id, text FROM transcript_messages WHERE ${where}`,
+    args,
+  });
+  await client.execute({ sql: `DELETE FROM transcript_embeddings WHERE message_id IN (SELECT id FROM transcript_messages WHERE ${where})`, args });
+  await client.execute({ sql: `DELETE FROM transcript_messages WHERE ${where}`, args });
+}
+
+type FileOutcome = { added: number; complete: boolean; reason?: 'budget' | 'leased' };
+
+async function indexFile(projectDir: string, file: SessionFile, nextId: { value: number }, deadline: number): Promise<FileOutcome> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms FROM transcript_files WHERE path = ?',
+    args: [file.path],
+  })).rows[0];
+
+  let startByte = row ? Number(row.bytes_indexed) : 0;
+  let lineNo = row ? Number(row.lines_indexed) : 0;
+  const prevStamp = row ? String(row.indexed_at) : null;
+  // A file rewritten to the SAME size slips past the shrink check below, but
+  // not past its own mtime. Only meaningful on a completed row: partial rows
+  // store mtime 0 until their pass finishes. Bounded by filesystem timestamp
+  // granularity - a rewrite within the same tick as the indexed write is
+  // invisible, which real editing does not do.
+  const rewrittenInPlace = row !== undefined
+    && startByte === file.size && Number(row.mtime_ms) !== 0 && Number(row.mtime_ms) !== file.mtimeMs;
+
+  // A file that shrank was rewritten rather than appended to, so the offset is
+  // meaningless and its rows have to go. Same-size rewrites are caught above.
+  if (startByte > file.size || rewrittenInPlace) {
+    await purgeBeyond(projectDir, file.sessionId, 0);
+    startByte = 0; lineNo = 0;
+  }
+  if (startByte === file.size) return { added: 0, complete: true };
+
+  // Another process's fresh claim: leave the file to it. Our own claim from a
+  // budget-paused pass is exempt, or a paused pass could never resume itself.
+  if (prevStamp && !ownClaims.has(prevStamp)) {
+    const stampedAt = Date.parse(prevStamp);
+    if (Number.isFinite(stampedAt) && Date.now() - stampedAt < LEASE_MS) {
+      return { added: 0, complete: false, reason: 'leased' };
+    }
+  }
+
+  // Take the claim with a compare-and-set on the stamp we read, so two
+  // processes arriving together cannot both win. The loser skips the file.
+  const claim = new Date().toISOString();
+  const claimed = row
+    ? await client.execute({ sql: 'UPDATE transcript_files SET indexed_at = ? WHERE path = ? AND indexed_at = ?', args: [claim, file.path, prevStamp] })
+    : await client.execute({
+        sql: 'INSERT OR IGNORE INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at) VALUES (?, ?, ?, 0, 0, 0, ?)',
+        args: [file.path, projectDir, file.sessionId, claim],
+      });
+  if (Number(claimed.rowsAffected) === 0) return { added: 0, complete: false, reason: 'leased' };
+  ownClaims.add(claim);
+
+  // A previous claimant may have died mid-file: batches it committed past the
+  // watermark would be indexed AGAIN from the watermark, as duplicates with
+  // fresh ids. Purge beyond the watermark before resuming so the resume is
+  // idempotent. A no-op on a clean handoff.
+  await purgeBeyond(projectDir, file.sessionId, lineNo);
+
+  const pending: PendingMessage[] = [];
+  let added = 0;
+  // Bytes consumed since startByte, so a run that stops early can record where
+  // it got to. Transcripts are newline-delimited UTF-8, so line length plus one
+  // is exact; the offset is snapped to the real file size on completion anyway.
+  let consumed = 0;
+  let complete = true;
+  try {
+    const rl = createInterface({ input: createReadStream(file.path, { start: startByte }), crlfDelay: Infinity });
+    for await (const line of rl) {
+      lineNo++;
+      consumed += Buffer.byteLength(line, 'utf8') + 1;
+      // Checked per line rather than per file: one 170MB transcript can blow any
+      // budget on its own, and a caller left waiting minutes for a tool call will
+      // give up long before the index is warm.
+      if (Date.now() > deadline) { complete = false; rl.close(); break; }
+      if (!line.trim()) continue;
+      let entry: any;
+      try { entry = JSON.parse(line); } catch { continue; }
+      if (entry.type !== 'user' && entry.type !== 'assistant') continue;
+      const { text, toolChars } = extractText(entry);
+      if (!text || isNoise(text)) continue;
+      const clipped = text.slice(0, MAX_TEXT_CHARS);
+      pending.push({
+        sessionId: file.sessionId, line: lineNo, role: entry.type,
+        ts: typeof entry.timestamp === 'string' ? entry.timestamp : null,
+        weight: (ROLE_WEIGHT[entry.type] ?? 1) * (toolChars > clipped.length / 2 ? TOOL_WEIGHT : 1),
+        len: clipped.length, text: clipped,
+      });
+      added++;
+      if (pending.length >= 500) { await flush(projectDir, pending, nextId); pending.length = 0; }
+    }
+    await flush(projectDir, pending, nextId);
+  } catch (error) {
+    if (error instanceof IdCollisionError) {
+      // Deliberately no watermark write: it still points at the last state this
+      // process knows was fully committed, which is what the next claimant
+      // needs to purge-and-resume correctly.
+      return { added: 0, complete: false, reason: 'leased' };
+    }
+    throw error;
+  }
+
+  // On a complete pass the real file size is authoritative; on a partial one the
+  // running byte count is the resume point, so the next call picks up mid-file
+  // instead of starting the whole transcript again.
+  const bytesIndexed = complete ? file.size : startByte + consumed;
+  const doneStamp = new Date().toISOString();
+  ownClaims.add(doneStamp);
+  await client.execute({
+    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(path) DO UPDATE SET bytes_indexed = excluded.bytes_indexed,
+            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at`,
+    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp],
+  });
+  return complete ? { added, complete } : { added, complete, reason: 'budget' };
+}
+
+export interface IndexResult {
+  filesScanned: number;
+  filesUpdated: number;
+  messagesAdded: number;
+  ms: number;
+  /** False when the budget ran out with work left. The next call resumes. */
+  complete: boolean;
+}
+
+/**
+ * Bring the index up to date. Cheap when nothing changed: a file whose size
+ * matches the stored offset is skipped without being opened.
+ */
+export async function ensureTranscriptIndex(projectDir: string, stores?: string[], budgetMs = DEFAULT_INDEX_BUDGET_MS): Promise<IndexResult> {
+  const started = Date.now();
+  const deadline = started + budgetMs;
+  const files = await sessionFiles(projectDir, stores);
+  const nextId = { value: await nextMessageId() };
+  let filesUpdated = 0;
+  let messagesAdded = 0;
+  let complete = true;
+  // Newest first, so a cold index makes the most recent history searchable
+  // first - that is what a question is most likely to be about.
+  for (const file of files) {
+    if (Date.now() > deadline) { complete = false; break; }
+    const result = await indexFile(projectDir, file, nextId, deadline);
+    if (result.added > 0) { filesUpdated++; messagesAdded += result.added; }
+    if (!result.complete) {
+      complete = false;
+      // Budget exhaustion ends the pass; a lease held by another process only
+      // ends THAT file - the rest of the archive is still ours to index.
+      if (result.reason === 'budget') break;
+    }
+  }
+  return { filesScanned: files.length, filesUpdated, messagesAdded, ms: Date.now() - started, complete };
+}
+
+export async function transcriptIndexStats(projectDir: string): Promise<{ messages: number; avgLen: number; sessions: number }> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT COUNT(*) AS n, COALESCE(AVG(len), 1) AS avg_len, COUNT(DISTINCT session_id) AS sessions FROM transcript_messages WHERE project_dir = ?',
+    args: [projectDir],
+  })).rows[0];
+  return { messages: Number(row.n), avgLen: Number(row.avg_len) || 1, sessions: Number(row.sessions) };
+}

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -1,0 +1,257 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { getClient } from './database.js';
+import { ensureTranscriptIndex, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+
+export { encodeProjectDir, transcriptStores } from './transcript-index.js';
+
+// Ranked search over raw Claude Code session transcripts.
+//
+// Knowl stores distilled atoms. Those are lossy by construction: whatever the
+// writer did not think worth keeping is gone, and there is no fallback. The
+// transcripts are the lossless floor underneath - every word actually
+// exchanged, still on disk. This makes that floor reachable, so a miss in
+// memory becomes a slower lookup rather than amnesia.
+//
+// Consumer is an agent, not a human: no TUI, no pager. What matters is
+// precision ranking, tight snippets, and a locator to cite when promoting a
+// finding back into memory.
+
+export interface TranscriptHit {
+  sessionId: string;
+  line: number;
+  role: string;
+  timestamp?: string;
+  score: number;
+  snippet: string;
+  /** Cite this in the atom when promoting, so the claim keeps its provenance. */
+  locator: string;
+}
+
+/** Supplied by the caller so this module never depends on how embeddings are configured. */
+export interface SemanticReranker {
+  model: string;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface TranscriptSearchOptions {
+  projectDir?: string;
+  limit?: number;
+  since?: string;
+  snippetChars?: number;
+  /**
+   * Restrict to one session, by id or a unique prefix. This is what makes a
+   * handoff brief actionable: a new session is told which session it continues
+   * from, and needs a way to ask that transcript specifically before widening
+   * to the whole archive.
+   */
+  sessionId?: string;
+  /** Override the config roots to scan. Injected by tests so they never mutate HOME. */
+  stores?: string[];
+  /** When present, the top BM25 candidates are re-ranked and the two orders fused. */
+  semantic?: SemanticReranker;
+}
+
+// Reciprocal Rank Fusion. 60 is the value from the original paper and is
+// deliberately large: it flattens the head so neither ranker can dictate the
+// result on its own, which is the point of fusing them.
+const RRF_K = 60;
+
+// How many BM25 candidates get embedded for the semantic pass. Embedding is the
+// expensive half, so recall is bounded by what BM25 surfaces first - a real
+// limitation, and the reason the lexical side is tuned to be good alone.
+const RERANK_DEPTH = 50;
+
+/**
+ * Cap for a full-entry read. Matches the index's own per-message clip, so the
+ * tool returns everything that was searchable and nothing more.
+ */
+export const MAX_TRANSCRIPT_ENTRY_CHARS = 20_000;
+
+interface Scored { messageId: number; score: number }
+
+/**
+ * Rank with FTS5's own BM25, then apply the field weighting it has no way to
+ * express. bm25() returns a negative number where more negative is better, so
+ * it is inverted before the weight is applied.
+ *
+ * A wider candidate window than `depth` is read on purpose: re-weighting can
+ * promote a row FTS5 ranked lower, and a window equal to the final limit would
+ * have already discarded it.
+ */
+async function lexicalRank(projectDir: string, terms: string[], depth: number, sessionId?: string): Promise<Scored[]> {
+  const client = getClient();
+  // Prefix matching, the same convention knowledge search uses. Tokens are
+  // already reduced to [a-z0-9_], so none of FTS5's operators can appear here.
+  const match = terms.map(term => `${term}*`).join(' OR ');
+  const rows = (await client.execute({
+    sql: `SELECT transcript_fts.rowid AS id, bm25(transcript_fts) AS rank, m.weight AS weight
+          FROM transcript_fts
+          JOIN transcript_messages m ON m.id = transcript_fts.rowid
+          WHERE transcript_fts MATCH ? AND m.project_dir = ?
+            ${sessionId ? 'AND m.session_id LIKE ?' : ''}
+          ORDER BY rank ASC
+          LIMIT ?`,
+    args: sessionId
+      ? [match, projectDir, `${sessionId}%`, Math.max(depth * 4, 100)]
+      : [match, projectDir, Math.max(depth * 4, 100)],
+  })).rows;
+
+  return rows
+    .map(row => ({ messageId: Number(row.id), score: -Number(row.rank) * Number(row.weight) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, depth);
+}
+
+function cosine(left: number[], right: number[]): number {
+  let dot = 0, l = 0, r = 0;
+  for (let i = 0; i < left.length; i++) { dot += left[i] * right[i]; l += left[i] * left[i]; r += right[i] * right[i]; }
+  return l === 0 || r === 0 ? 0 : dot / (Math.sqrt(l) * Math.sqrt(r));
+}
+
+/** Vectors for the candidates, embedding only those not already cached. */
+async function candidateVectors(
+  candidates: Array<{ messageId: number; text: string }>,
+  semantic: SemanticReranker,
+): Promise<Map<number, number[]>> {
+  const client = getClient();
+  const vectors = new Map<number, number[]>();
+  if (candidates.length === 0) return vectors;
+
+  const rows = (await client.execute({
+    sql: `SELECT message_id, vector FROM transcript_embeddings WHERE model = ? AND message_id IN (${candidates.map(() => '?').join(',')})`,
+    args: [semantic.model, ...candidates.map(c => c.messageId)],
+  })).rows;
+  for (const row of rows) {
+    try { vectors.set(Number(row.message_id), JSON.parse(String(row.vector))); } catch { /* re-embed below */ }
+  }
+
+  const missing = candidates.filter(c => !vectors.has(c.messageId));
+  if (missing.length > 0) {
+    const embedded = await semantic.embed(missing.map(c => c.text.slice(0, 2_000)));
+    for (let i = 0; i < missing.length; i++) {
+      const vector = embedded[i];
+      if (!vector) continue;
+      vectors.set(missing[i].messageId, vector);
+      await client.execute({
+        sql: 'INSERT OR REPLACE INTO transcript_embeddings (message_id, model, vector) VALUES (?, ?, ?)',
+        args: [missing[i].messageId, semantic.model, JSON.stringify(vector)],
+      });
+    }
+  }
+  return vectors;
+}
+
+function snippetAround(text: string, terms: Set<string>, chars: number): string {
+  const lower = text.toLowerCase();
+  let best = 0, bestCount = -1;
+  const step = Math.max(1, Math.floor(chars / 4));
+  for (let start = 0; start < Math.max(1, lower.length - chars); start += step) {
+    const window = lower.slice(start, start + chars);
+    let count = 0;
+    for (const term of terms) if (window.includes(term)) count++;
+    if (count > bestCount) { bestCount = count; best = start; }
+  }
+  const slice = text.slice(best, best + chars).replace(/\n{3,}/g, '\n\n').trim();
+  return (best > 0 ? '…' : '') + slice + (best + chars < text.length ? '…' : '');
+}
+
+export async function searchTranscripts(
+  query: string,
+  options: TranscriptSearchOptions = {},
+): Promise<{ hits: TranscriptHit[]; indexed: number; sessions: number; indexMs: number; indexComplete: boolean }> {
+  const { projectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId } = options;
+  const terms = [...new Set(tokenize(query))];
+
+  const index = await ensureTranscriptIndex(projectDir, stores);
+  const stats = await transcriptIndexStats(projectDir);
+  const base = { indexed: stats.messages, sessions: stats.sessions, indexMs: index.ms, indexComplete: index.complete };
+  if (terms.length === 0) return { hits: [], ...base };
+
+  const lexical = await lexicalRank(projectDir, terms, semantic ? RERANK_DEPTH : limit * 3, sessionId);
+  if (lexical.length === 0) return { hits: [], ...base };
+
+  const client = getClient();
+  const rows = (await client.execute({
+    sql: `SELECT id, session_id, line, role, ts, text FROM transcript_messages
+          WHERE id IN (${lexical.map(() => '?').join(',')})${since ? ' AND (ts IS NULL OR ts >= ?)' : ''}`,
+    args: since ? [...lexical.map(l => l.messageId), since] : lexical.map(l => l.messageId),
+  })).rows;
+  const byId = new Map(rows.map(row => [Number(row.id), row]));
+
+  let ordered = lexical.filter(entry => byId.has(entry.messageId));
+
+  if (semantic && ordered.length > 1) {
+    const candidates = ordered.map(entry => ({ messageId: entry.messageId, text: String(byId.get(entry.messageId)!.text) }));
+    try {
+      const byMessage = await candidateVectors(candidates, semantic);
+      const [queryVector] = await semantic.embed([query]);
+      if (queryVector && byMessage.size > 0) {
+        const semanticOrder = [...byMessage.entries()]
+          .map(([messageId, vector]) => ({ messageId, score: cosine(queryVector, vector) }))
+          .sort((a, b) => b.score - a.score);
+        // Reciprocal Rank Fusion: combine POSITIONS, not scores. BM25 magnitudes
+        // and cosine similarities are not on a comparable scale, and normalising
+        // them invents a relationship that isn't there.
+        const fused = new Map<number, number>();
+        ordered.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
+        semanticOrder.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
+        ordered = [...fused.entries()]
+          .map(([messageId, score]) => ({ messageId, score }))
+          .sort((a, b) => b.score - a.score);
+      }
+    } catch {
+      // Embeddings are optional and can fail (model not downloaded, provider off).
+      // Lexical order is a complete answer on its own, so degrade rather than error.
+    }
+  }
+
+  const termSet = new Set(terms);
+  const hits = ordered.slice(0, limit).map(entry => {
+    const row = byId.get(entry.messageId)!;
+    return {
+      sessionId: String(row.session_id),
+      line: Number(row.line),
+      role: String(row.role),
+      timestamp: row.ts ? String(row.ts) : undefined,
+      score: Number(entry.score.toFixed(4)),
+      snippet: snippetAround(String(row.text), termSet, snippetChars),
+      locator: `transcript://${row.session_id}#L${row.line}`,
+    };
+  });
+
+  return { hits, ...base };
+}
+
+/** Read one entry in full, straight from the file, for when a snippet cannot settle the question. */
+export async function readTranscriptEntry(
+  sessionId: string,
+  line: number,
+  projectDir = process.cwd(),
+  stores?: string[],
+): Promise<{ text: string; role: string; timestamp?: string } | null> {
+  const files = await sessionFiles(projectDir, stores);
+  const file = files.find(f => f.sessionId === sessionId || f.sessionId.startsWith(sessionId));
+  if (!file) return null;
+  const rl = createInterface({ input: createReadStream(file.path), crlfDelay: Infinity });
+  let lineNo = 0;
+  for await (const raw of rl) {
+    lineNo++;
+    if (lineNo !== line) continue;
+    rl.close();
+    try {
+      const entry = JSON.parse(raw);
+      const content = entry?.message?.content;
+      const text = typeof content === 'string'
+        ? content
+        : Array.isArray(content)
+          ? content.map((b: any) => b?.type === 'text' ? b.text
+              : b?.type === 'tool_use' ? JSON.stringify(b.input ?? {})
+              : b?.type === 'tool_result' ? (typeof b.content === 'string' ? b.content : JSON.stringify(b.content ?? ''))
+              : '').join('\n')
+          : '';
+      return { text, role: entry.type, timestamp: entry.timestamp };
+    } catch { return null; }
+  }
+  return null;
+}

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -16,6 +16,7 @@ import {
 const EXPECTED_TOOLS = [
   'knowl_query',
   'knowl_recent', 'knowl_state', 'knowl_context',
+  'knowl_transcript_search', 'knowl_transcript_read',
   'knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish',
   'knowl_store', 'knowl_ingest_atoms', 'knowl_decide', 'knowl_update',
   'knowl_timeline', 'knowl_evidence_list', 'knowl_conflicts', 'knowl_feedback',
@@ -30,6 +31,7 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
   'Route:',
   '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
+  '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
   '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
   '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
   '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
@@ -40,10 +42,10 @@ const EXPECTED_CLAUDE_CARD = [
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
 
 describe('canonical Knowl agent guidance', () => {
-  it('defines seven groups and the exact 24-tool inventory', () => {
-    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(7);
+  it('defines eight groups and the exact 26-tool inventory', () => {
+    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(8);
     expect(KNOWL_MCP_TOOL_NAMES).toEqual(EXPECTED_TOOLS);
-    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(24);
+    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(26);
     expect(KNOWL_MCP_TOOL_NAMES).not.toContain('knowl_ask');
   });
 
@@ -60,8 +62,8 @@ describe('canonical Knowl agent guidance', () => {
 
   it('keeps both compact renderings bounded and front-loads the required action', () => {
     expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toBe(EXPECTED_CLAUDE_CARD);
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_695);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_746);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_871);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_922);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -82,7 +84,7 @@ describe('canonical Knowl agent guidance', () => {
     const documentedTools = [...readme.matchAll(/^\| \`(knowl_[a-z_]+)\` \|/gm)]
       .map(match => match[1]);
     expect(documentedTools).toEqual([...KNOWL_MCP_TOOL_NAMES]);
-    expect(new Set(documentedTools).size).toBe(24);
+    expect(new Set(documentedTools).size).toBe(26);
     expect(readme).toContain('KNOWL.md');
     expect(readme).toContain('GEMINI.md');
     expect(readme).toContain('agent-reminder claude --json');

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(24);
+    expect(new Set(names).size).toBe(26);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/store/transcript-search.test.ts
+++ b/tests/store/transcript-search.test.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { encodeProjectDir, ensureTranscriptIndex, transcriptIndexStats } from '../../src/store/transcript-index.js';
+import { readTranscriptEntry, searchTranscripts } from '../../src/store/transcript-search.js';
+
+const TEST_ROOT = path.resolve('./.knowl-transcript-search-test');
+// A fake transcript store, injected rather than pointed at via HOME: mutating
+// HOME/USERPROFILE leaks into every other suite sharing the worker, and
+// os.homedir() reads USERPROFILE on Windows.
+const FAKE_STORE = path.join(TEST_ROOT, 'store', 'projects');
+const STORES = [FAKE_STORE];
+const PROJECT_DIR = 'D:\\Code\\FakeProject';
+
+function userLine(text: string, ts: string) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { content: text } }) + '\n';
+}
+function assistantLine(text: string, ts: string) {
+  return JSON.stringify({ type: 'assistant', timestamp: ts, message: { content: [{ type: 'text', text }] } }) + '\n';
+}
+function toolLine(result: string, ts: string) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { content: [{ type: 'tool_result', content: result }] } }) + '\n';
+}
+
+let sessionDir: string;
+
+describe('transcript search', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    await repo.createProject(TEST_ROOT, 'Transcript search test');
+
+    sessionDir = path.join(FAKE_STORE, encodeProjectDir(PROJECT_DIR));
+    await fs.mkdir(sessionDir, { recursive: true });
+
+    await fs.writeFile(path.join(sessionDir, 'session-one.jsonl'),
+      // Noise that must never be indexed.
+      userLine('<local-command-caveat>Caveat: ignore me</local-command-caveat>', '2026-01-01T00:00:00Z') +
+      userLine('<command-name>/rename</command-name>', '2026-01-01T00:01:00Z') +
+      // The target: a decision stated by the user.
+      userLine('the boxed card variant read as an advertisement so we rejected it', '2026-01-02T00:00:00Z') +
+      assistantLine('Understood, dropping the boxed variant.', '2026-01-02T00:01:00Z') +
+      // Distractor sharing one term only.
+      assistantLine('The card padding is sixteen pixels.', '2026-01-02T00:02:00Z'));
+
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'),
+      toolLine('boxed card variant advertisement rejected rejected rejected', '2026-01-03T00:00:00Z') +
+      assistantLine('Unrelated discussion about migrations.', '2026-01-03T00:01:00Z'));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    // Windows keeps a handle on the WAL briefly after close, so removal here can
+    // race and throw EBUSY. beforeAll clears the directory anyway, which is the
+    // guarantee the suite actually needs.
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('encodes a project directory the way Claude Code does', () => {
+    expect(encodeProjectDir('D:\\Code\\FakeProject')).toBe('D--Code-FakeProject');
+  });
+
+  it('ranks the user message that states the decision first', async () => {
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].role).toBe('user');
+    expect(hits[0].snippet).toContain('advertisement');
+    expect(hits[0].locator).toMatch(/^transcript:\/\/session-one#L\d+$/);
+  });
+
+  it('never returns the caveat wrapper or a bare slash command', async () => {
+    const { hits } = await searchTranscripts('rename caveat ignore', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    for (const hit of hits) {
+      expect(hit.snippet).not.toContain('local-command-caveat');
+      expect(hit.snippet).not.toContain('<command-name>');
+    }
+  });
+
+  it('indexes tool output but weights it below real prose', async () => {
+    const { hits } = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    // The tool result repeats the term more often, so an unweighted BM25 would
+    // put it first. The user message must still win.
+    expect(hits[0].sessionId).toBe('session-one');
+    expect(hits.some(hit => hit.sessionId === 'session-two')).toBe(true);
+  });
+
+  it('rewards covering every query term over repeating one', async () => {
+    const { hits } = await searchTranscripts('boxed variant advertisement', { projectDir: PROJECT_DIR, limit: 5, stores: STORES });
+    expect(hits[0].snippet).toContain('boxed');
+    expect(hits[0].snippet).toContain('advertisement');
+  });
+
+  it('returns nothing for a query of only stopwords', async () => {
+    const { hits } = await searchTranscripts('the and for', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits).toEqual([]);
+  });
+
+  it('reads a single entry in full from its locator', async () => {
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    const entry = await readTranscriptEntry(hits[0].sessionId, hits[0].line, PROJECT_DIR, STORES);
+    expect(entry?.role).toBe('user');
+    expect(entry?.text).toContain('rejected it');
+  });
+
+  it('re-indexing an unchanged archive adds nothing and opens no files', async () => {
+    const before = await transcriptIndexStats(PROJECT_DIR);
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(result.messagesAdded).toBe(0);
+    expect(result.filesUpdated).toBe(0);
+    expect((await transcriptIndexStats(PROJECT_DIR)).messages).toBe(before.messages);
+  });
+
+  it('picks up appended messages without reindexing what came before', async () => {
+    const before = await transcriptIndexStats(PROJECT_DIR);
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      userLine('the gradient headline was rejected because it looked like a crypto advert', '2026-01-04T00:00:00Z'));
+
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    // Exactly one new message, not the whole file again.
+    expect(result.messagesAdded).toBe(1);
+    expect((await transcriptIndexStats(PROJECT_DIR)).messages).toBe(before.messages + 1);
+
+    const { hits } = await searchTranscripts('gradient headline crypto', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits[0].snippet).toContain('gradient headline');
+  });
+
+  it('rebuilds a session that was rewritten rather than appended to', async () => {
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'),
+      assistantLine('short', '2026-01-05T00:00:00Z'));
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(result.messagesAdded).toBeGreaterThan(0);
+    // The old tool-result line is gone, so its distinctive terms no longer match.
+    const { hits } = await searchTranscripts('migrations unrelated', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits.every(hit => hit.sessionId !== 'session-two')).toBe(true);
+  });
+
+  it('detects a same-size in-place rewrite by mtime and rebuilds the session', async () => {
+    // Same byte length, different content - invisible to the size check.
+    const before = assistantLine('the animal is a badger', '2026-01-05T01:00:00Z');
+    const after  = assistantLine('the animal is a ferret', '2026-01-05T01:00:00Z');
+    expect(Buffer.byteLength(after)).toBe(Buffer.byteLength(before));
+
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'), before);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect((await searchTranscripts('badger', { projectDir: PROJECT_DIR, stores: STORES })).hits.length).toBeGreaterThan(0);
+
+    // Rewrite the whole file with the one word changed; size is identical.
+    const content = await fs.readFile(path.join(sessionDir, 'session-one.jsonl'), 'utf8');
+    await fs.writeFile(path.join(sessionDir, 'session-one.jsonl'), content.replace('badger', 'ferret'));
+    // Detection is mtime-based, and a rewrite inside the same clock tick is
+    // indistinguishable - real rewrites happen later than that. Model it.
+    const later = new Date(Date.now() + 5_000);
+    await fs.utimes(path.join(sessionDir, 'session-one.jsonl'), later, later);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    expect((await searchTranscripts('badger', { projectDir: PROJECT_DIR, stores: STORES })).hits).toEqual([]);
+    expect((await searchTranscripts('ferret', { projectDir: PROJECT_DIR, stores: STORES })).hits.length).toBeGreaterThan(0);
+  });
+
+  it('stops at the time budget and resumes where it left off', async () => {
+    // Wipe the index so there is real work to interrupt.
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+    await client.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('delete-all')");
+    await client.execute('DELETE FROM transcript_messages');
+    await client.execute('DELETE FROM transcript_files');
+
+    // A zero budget expires on the first line, so the pass must report itself
+    // incomplete rather than quietly returning a half-built index as finished.
+    const first = await ensureTranscriptIndex(PROJECT_DIR, STORES, 0);
+    expect(first.complete).toBe(false);
+
+    // A generous budget finishes the job, and the total is the whole archive -
+    // proving the interrupted pass resumed instead of restarting or duplicating.
+    const second = await ensureTranscriptIndex(PROJECT_DIR, STORES, 60_000);
+    expect(second.complete).toBe(true);
+
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits[0].snippet).toContain('advertisement');
+
+    // No message indexed twice: one locator per line.
+    const all = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 50, stores: STORES });
+    const locators = all.hits.map(hit => hit.locator);
+    expect(new Set(locators).size).toBe(locators.length);
+  });
+
+  it('scopes to one session by id or prefix, which is what makes a handoff brief actionable', async () => {
+    // Own fixture: an earlier test rewrites session-two, so this cannot rely on
+    // the original contents still spanning both sessions.
+    await fs.appendFile(path.join(sessionDir, 'session-two.jsonl'),
+      userLine('a second take on the advertisement question', '2026-01-06T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    const all = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    expect(new Set(all.hits.map(hit => hit.sessionId)).size).toBeGreaterThan(1);
+
+    const scoped = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES, sessionId: 'session-one' });
+    expect(scoped.hits.length).toBeGreaterThan(0);
+    expect(scoped.hits.every(hit => hit.sessionId === 'session-one')).toBe(true);
+
+    // A prefix resolves the same way, so a brief can quote a short id.
+    const byPrefix = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES, sessionId: 'session-o' });
+    expect(byPrefix.hits.map(hit => hit.locator)).toEqual(scoped.hits.map(hit => hit.locator));
+  });
+
+  it('defers to another process\'s fresh lease, then reclaims it once stale', async () => {
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      userLine('the lease canary sentence about phosphorescent umbrellas', '2026-01-07T00:00:00Z'));
+
+    // Simulate a live claim by a DIFFERENT process: a fresh stamp this process
+    // never wrote. The file must be skipped without ending the whole pass.
+    await client.execute({
+      sql: "UPDATE transcript_files SET indexed_at = ? WHERE path LIKE '%session-one%'",
+      args: [new Date().toISOString()],
+    });
+    const deferred = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(deferred.complete).toBe(false);
+    const before = await searchTranscripts('phosphorescent umbrellas', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(before.hits).toEqual([]);
+
+    // Expire the claim: a crashed indexer must not stall the file forever.
+    await client.execute({
+      sql: "UPDATE transcript_files SET indexed_at = ? WHERE path LIKE '%session-one%'",
+      args: [new Date(Date.now() - 60_000).toISOString()],
+    });
+    const reclaimed = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(reclaimed.messagesAdded).toBeGreaterThan(0);
+    const after = await searchTranscripts('phosphorescent umbrellas', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(after.hits[0]?.snippet).toContain('phosphorescent');
+  });
+
+  it('drops cached embeddings when their messages are purged, so a reused id cannot inherit a stale vector', async () => {
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+
+    // Populate the embedding cache via a semantic search over current content.
+    const semantic = { model: 'purge-model', embed: async (texts: string[]) => texts.map(() => [1, 0]) };
+    // Two matching messages: the semantic pass only engages with >1 candidate.
+    await fs.appendFile(path.join(sessionDir, 'session-two.jsonl'),
+      userLine('embedding purge target phrase', '2026-01-08T00:00:00Z') +
+      assistantLine('a second embedding purge target for the ranker', '2026-01-08T00:01:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    await searchTranscripts('embedding purge target', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    const cached = Number((await client.execute("SELECT COUNT(*) n FROM transcript_embeddings WHERE model = 'purge-model'")).rows[0].n);
+    expect(cached).toBeGreaterThan(0);
+
+    // Rewrite the session so its rows are purged. No embedding row may survive
+    // pointing at a message that no longer exists.
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'), assistantLine('tiny', '2026-01-09T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    const orphans = Number((await client.execute(
+      'SELECT COUNT(*) n FROM transcript_embeddings e LEFT JOIN transcript_messages m ON m.id = e.message_id WHERE m.id IS NULL',
+    )).rows[0].n);
+    expect(orphans).toBe(0);
+  });
+
+  it('fuses a semantic ranking with the lexical one when a reranker is supplied', async () => {
+    // A stub embedder: vectors are keyed off a marker word, so the semantic pass
+    // has a defined preference without downloading a model.
+    const semantic = {
+      model: 'stub-model',
+      embed: async (texts: string[]) => texts.map(text => [text.includes('gradient') ? 1 : 0, text.includes('boxed') ? 1 : 0]),
+    };
+    const { hits } = await searchTranscripts('gradient headline crypto', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].snippet).toContain('gradient');
+  });
+
+  it('degrades to lexical ranking when the reranker throws', async () => {
+    const broken = { model: 'broken', embed: async () => { throw new Error('model unavailable'); } };
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES, semantic: broken });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].role).toBe('user');
+  });
+});


### PR DESCRIPTION
## What this adds

Two MCP tools — `knowl_transcript_search` and `knowl_transcript_read` — that make raw Claude Code session transcripts searchable from Knowl.

## Why

Knowl stores distilled atoms. That is lossy by construction: whatever the writer did not judge salient is gone, and there is no fallback — the documented weakness of extract-and-store memory systems. The `.jsonl` transcripts are the lossless record underneath, and they were unreachable. This turns a memory miss into a slower lookup instead of amnesia.

It also closes a gap in promotion. `candidate-promotion.ts` promotes hook-captured session events; a fact recovered by reading history had no path back into memory, so the same lookup repeated every session. Each hit carries a `transcript://<sessionId>#L<line>` locator, and the **result** — not only the tool description — instructs the caller to promote what it used. Descriptions are read once; results are read every time.

## Design notes

**FTS5, not a hand-rolled index.** The first implementation built its own postings table at ~74 rows per message. Measured: three 8s passes covered 14MB of a 930MB archive, so a cold index would have taken ~30 minutes. FTS5 ships BM25, is already used here for `knowledge_items`, and with `content='transcript_messages'` avoids storing text twice. The same budget then covered 12–15k messages per pass — roughly 20× faster.

**Field weighting on top of BM25.** `bm25()` returns negative-is-better; it is inverted and multiplied by a stored weight — user 2.0, assistant 1.0, and 0.3 for a message more than half tool output, so a pasted file cannot win on volume. The candidate window is 4× the requested depth because re-weighting can promote a row FTS5 ranked lower.

**`sessionId` scoping.** A handoff brief that names a parent session needs a way to ask that transcript specifically before widening to the whole archive. Accepts a full id or a unique prefix.

**Incremental by byte offset.** Transcripts are append-only, so `transcript_files.bytes_indexed` is a valid resume point.

**Bounded latency.** Indexing runs inside a tool call, so it has an 8s budget and resumes mid-file. A partial index reports `INDEX STILL WARMING` in the result, because a caller told nothing would read "no matches" as proof of absence.

**Small write batches.** Long write transactions starve a concurrently served session into `SQLITE_BUSY`. Hit in practice, not anticipated.

**Concurrent serve processes are serialized per file.** Knowl runs one serve process per connected session, so two sessions on one project index concurrently. A per-file lease (compare-and-set on the watermark stamp, 20s expiry) keeps them off each other's files; a cross-file id collision aborts that file's pass and defers to the next one, and a claimant purges any rows a crashed predecessor committed past the watermark, embeddings included — a purged id can be reallocated, and a stale cached vector would otherwise attach to the wrong message.

**Optional hybrid ranking.** When vector search is enabled, top candidates are re-ranked and the two orders fused by Reciprocal Rank Fusion (k=60), combining *positions* rather than scores, since bm25 magnitudes and cosine similarities are not on a comparable scale. Vectors are cached per message. A disabled provider or missing model degrades to lexical ranking rather than failing.

## Limitations, stated rather than glossed

- **Semantic recall is bounded by the lexical pass** — only the top 50 BM25 candidates are embedded. Embedding an entire archive was not worth the cost, which is why the lexical side is tuned to stand alone.
- **In-place edits at identical file size go undetected.** A file that *shrinks* is treated as rewritten and rebuilt; one edited without changing size is not. Append-only is an assumption, not something enforced.
- **Old-format archives that interleave subagent turns** (`isSidechain` entries inside the parent transcript) would have those indexed as ordinary parent-session messages. Verified absent in a current-format 66-session archive; disclosed rather than special-cased.
- **Index storage is not reclaimed** when transcripts are deleted from disk; rows for a vanished session persist until that session is rebuilt.
- **The compact guidance card grew** to 1,871 / 1,922 chars (468 / 481 tokens) against its 2,000-char and 500-token ceilings. Still inside both, with less headroom than before — worth knowing before the next tool is added.

## Testing

16 tests in `tests/store/transcript-search.test.ts`: ranking order, noise exclusion, tool-output weighting, `sessionId` scoping by id and prefix, incremental append, rewrite-triggered rebuild, budget interruption with resume and no double-indexing, lease deferral and stale-lease reclaim, embedding purge on rebuild, RRF fusion with a stub embedder, and graceful degradation when the embedder throws.

Registered in the canonical inventory, so the guidance contract tests, README table, and `tools/list` all stay aligned.

Verified end-to-end over the real MCP stdio protocol against a 66-session / ~930MB archive: 53,744 messages indexed across five passes, then **21–29 ms per query** once warm.

Note for reviewers: the full suite is load-sensitive on a busy machine — `query-command`, `workspace-query` and `foreign-item-refusal` can time out under a 135-file parallel run and pass in isolation. Verified identical behaviour on pristine `main`.

