### PR TITLE
feat(session-directory): browsable session inventory (stacked on #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ Knowl exposes exactly 24 MCP tools:
 | `knowl_recent` | Compact recent context when lifecycle bootstrap is unavailable or a refresh is needed |
 | `knowl_state` | Broad active-memory status or hierarchical project summary |
 | `knowl_context` | Compose an explicitly token-budgeted local context pack |
+| `knowl_session_list` | Browse past sessions as an inventory: names, opening asks, promoted knowledge |
 | `knowl_transcript_search` | Search the verbatim session transcripts when memory misses or is ambiguous |
 | `knowl_transcript_read` | Read one transcript entry in full when a snippet cannot settle it |
 | `knowl_task_start` | Start one manual work loop when verified lifecycle hooks are unavailable |

--- a/README.md
+++ b/README.md
@@ -963,6 +963,8 @@ Knowl exposes exactly 24 MCP tools:
 | `knowl_recent` | Compact recent context when lifecycle bootstrap is unavailable or a refresh is needed |
 | `knowl_state` | Broad active-memory status or hierarchical project summary |
 | `knowl_context` | Compose an explicitly token-budgeted local context pack |
+| `knowl_transcript_search` | Search the verbatim session transcripts when memory misses or is ambiguous |
+| `knowl_transcript_read` | Read one transcript entry in full when a snippet cannot settle it |
 | `knowl_task_start` | Start one manual work loop when verified lifecycle hooks are unavailable |
 | `knowl_task_checkpoint` | Checkpoint meaningful manual-loop progress or blockers |
 | `knowl_task_finish` | Finish one manual work loop after verification |

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -13,6 +13,11 @@ export const KNOWL_MCP_TOOL_GROUPS = [
     routing: 'Use recent only without lifecycle bootstrap or for an explicit refresh; state for broad status; context for an explicitly token-budgeted pack.',
   },
   {
+    label: 'Verbatim transcripts',
+    tools: ['knowl_transcript_search', 'knowl_transcript_read'],
+    routing: 'The lossless record under the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
+  },
+  {
     label: 'Manual work loop',
     tools: ['knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish'],
     routing: 'Use only without verified lifecycle hooks: start once, checkpoint meaningful milestones or blockers, and finish once after verification.',
@@ -97,6 +102,7 @@ function renderCompactKnowlGuidance(modeLine: string): string {
     'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
     'Route:',
     '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
+    '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
     '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
     '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
     '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -14,8 +14,8 @@ export const KNOWL_MCP_TOOL_GROUPS = [
   },
   {
     label: 'Verbatim transcripts',
-    tools: ['knowl_transcript_search', 'knowl_transcript_read'],
-    routing: 'The lossless record under the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
+    tools: ['knowl_session_list', 'knowl_transcript_search', 'knowl_transcript_read'],
+    routing: 'The lossless record under the distilled atoms. knowl_session_list browses past sessions as an inventory (names, opening asks, promoted knowledge) to pick one before reading into it. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
   },
   {
     label: 'Manual work loop',
@@ -102,7 +102,7 @@ function renderCompactKnowlGuidance(modeLine: string): string {
     'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
     'Route:',
     '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
-    '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
+    '- verbatim: knowl_session_list to browse/find past sessions; knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to one session; knowl_transcript_read one entry in full; promote what you use.',
     '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
     '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
     '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -321,6 +321,18 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_session_list',
+          description: "Browse the project's past Claude Code sessions as an inventory: best-known name (a user rename beats a generated title), the opening ask, derived status (active / interrupted by a crash handoff / idle), any declared session card, last activity, and what each session promoted into memory. Use to answer 'which session was about X' or to decide between resuming a session and starting a new one - then knowl_transcript_search with sessionId to read into the chosen session. Filters by keywords over intent; for content questions use knowl_transcript_search.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: "Keywords over session names, opening asks, and promoted titles. Omit to list newest first." },
+              limit: { type: 'number', description: 'Maximum sessions returned; defaults to 12.' },
+              projectDir: { type: 'string', description: 'Directory whose sessions to list. Defaults to the current project.' },
+            },
+          },
+        },
+        {
           name: 'knowl_transcript_search',
           description: 'Search the RAW session transcripts - the lossless record of everything actually said, underneath the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Ranked, not grep: BM25 over an incrementally maintained index, fused with semantic similarity when vector search is enabled. ALWAYS follow a useful hit with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice - an unpromoted recovery is a lookup every future session repeats.',
           inputSchema: {
@@ -971,6 +983,20 @@ export function registerTools(
             text: `SCOPE: ${explain ? '`explain`' : 'vector search'} limits this query to the project namespace, so ${skippedNamespaces.join(' and ')} knowledge was NOT searched. A miss here does not mean the knowledge is absent; re-run without it for full scope.`,
           });
         }
+        return { content: blocks };
+      }
+
+      else if (name === 'knowl_session_list') {
+        const { query, limit, projectDir } = args as any;
+        const { listSessionDirectory } = await import('../store/session-directory.js');
+        const result = await listSessionDirectory({
+          projectDir: projectDir ? String(projectDir) : (projectRoot ?? process.cwd()),
+          query: query ? String(query) : undefined,
+          limit: typeof limit === 'number' ? limit : undefined,
+        });
+        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.entries) }];
+        const warming = result.indexComplete ? '' : ' INDEX STILL WARMING - names and openings fill in as it catches up; run again for fuller coverage.';
+        blocks.push({ type: 'text', text: `${result.entries.length} of ${result.total} matching session(s), newest first.${warming} To read into one: knowl_transcript_search with its sessionId.` });
         return { content: blocks };
       }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -321,6 +321,34 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_transcript_search',
+          description: 'Search the RAW session transcripts - the lossless record of everything actually said, underneath the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Ranked, not grep: BM25 over an incrementally maintained index, fused with semantic similarity when vector search is enabled. ALWAYS follow a useful hit with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice - an unpromoted recovery is a lookup every future session repeats.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: 'Content words to recall, not a sentence. Example: "card radius rejected toy".' },
+              limit: { type: 'number', description: 'Maximum hits; defaults to 10. Raise only after a narrow query underdelivers.' },
+              sessionId: { type: 'string', description: 'Restrict to one session, by id or a unique prefix. Use this when a handoff brief names a parent session: ask that transcript first, then re-run without it to widen to the whole archive.' },
+              since: { type: 'string', description: 'ISO timestamp; drop hits older than it.' },
+              projectDir: { type: 'string', description: 'Directory whose transcripts to search. Defaults to the current project.' },
+            },
+            required: ['query'],
+          },
+        },
+        {
+          name: 'knowl_transcript_read',
+          description: 'Read one transcript entry in full, including its tool calls, when a search snippet is not enough to settle the question. Takes the sessionId and line from a knowl_transcript_search locator.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              sessionId: { type: 'string', description: 'Session id, or a unique prefix of it.' },
+              line: { type: 'number', description: '1-indexed line, as returned in the locator.' },
+              projectDir: { type: 'string', description: 'Defaults to the current project.' },
+            },
+            required: ['sessionId', 'line'],
+          },
+        },
+        {
           name: 'knowl_timeline',
           description: 'Inspect immutable assertions for one knowledge item when its history is needed.',
           inputSchema: { type: 'object', properties: { itemId: { type: 'string' } }, required: ['itemId'] },
@@ -944,6 +972,58 @@ export function registerTools(
           });
         }
         return { content: blocks };
+      }
+
+      else if (name === 'knowl_transcript_search') {
+        const { query, limit, since, projectDir, sessionId } = args as any;
+        const { searchTranscripts } = await import('../store/transcript-search.js');
+        const dir = projectDir ? String(projectDir) : (projectRoot ?? process.cwd());
+
+        // Semantic re-ranking is a bonus, not a requirement: vector search is
+        // opt-in, and the lexical ranking is a complete answer without it.
+        let semantic;
+        if (config && projectRoot && isVectorSearchEnabled(config)) {
+          try {
+            const embedder = await createLocalEmbeddingProvider(config, projectRoot);
+            semantic = { model: getVectorSearchConfig(config).model, embed: (texts: string[]) => embedder.embed(texts) };
+          } catch { /* fall back to lexical only */ }
+        }
+
+        const result = await searchTranscripts(String(query), {
+          projectDir: dir,
+          limit: typeof limit === 'number' ? limit : undefined,
+          since: since ? String(since) : undefined,
+          sessionId: sessionId ? String(sessionId) : undefined,
+          semantic,
+        });
+
+        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.hits) }];
+        const ranker = semantic ? 'BM25 + semantic (RRF)' : 'BM25';
+        // The ratchet only compounds if it fires on the result, not just in the
+        // tool description: descriptions are read once, results are read every time.
+        // Say plainly when the index is still warming. A partial index gives
+        // real answers, but "no match" means something different against it,
+        // and a caller told nothing would read absence as proof.
+        const warming = result.indexComplete ? '' : ' INDEX STILL WARMING - it resumes on each call; run the search again for fuller coverage.';
+        if (result.hits.length > 0) {
+          blocks.push({ type: 'text', text: `${ranker} over ${result.indexed} indexed message(s) from ${result.sessions} session(s); index refresh ${result.indexMs}ms.${warming} PROMOTE what you used: call knowl_store (or knowl_update if it corrects an existing item) and cite the hit's locator in the content, so this lookup never has to happen again.` });
+        } else {
+          blocks.push({ type: 'text', text: `No matches across ${result.indexed} indexed message(s) from ${result.sessions} session(s).${warming} Retry with different content words - the index covers user and assistant messages plus tool calls and results.` });
+        }
+        return { content: blocks };
+      }
+
+      else if (name === 'knowl_transcript_read') {
+        const { sessionId, line, projectDir } = args as any;
+        const { readTranscriptEntry, MAX_TRANSCRIPT_ENTRY_CHARS } = await import('../store/transcript-search.js');
+        const entry = await readTranscriptEntry(String(sessionId), Number(line), projectDir ? String(projectDir) : (projectRoot ?? process.cwd()));
+        if (!entry) return { content: [{ type: 'text', text: `No transcript entry at ${sessionId}#L${line}.` }] };
+        // NOT MAX_ITEM_CONTENT_CHARS: that is the 600-char budget for a knowledge
+        // atom's fields, and this tool exists precisely because a ~600-char
+        // snippet was not enough. Capping it there would return the snippet again
+        // under a different name. Bounded at the same size the index stores, so a
+        // pasted megabyte still cannot flood the caller's context.
+        return { content: [{ type: 'text', text: truncateText(entry.text, MAX_TRANSCRIPT_ENTRY_CHARS) }] };
       }
 
       else if (name === 'knowl_timeline') {

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -204,6 +204,50 @@ const SCHEMA_STATEMENTS = [
     FROM knowledge_items
     WHERE NOT EXISTS (SELECT 1 FROM knowledge_items_fts LIMIT 1)
       AND EXISTS (SELECT 1 FROM knowledge_items LIMIT 1);`,
+
+  // Transcript index. Session transcripts are the lossless record underneath the
+  // distilled atoms; these tables make them searchable without re-reading
+  // hundreds of megabytes per query. Rows are derived data and safe to drop --
+  // the source of truth is the .jsonl files on disk.
+  `CREATE TABLE IF NOT EXISTS transcript_files (
+    path TEXT PRIMARY KEY,
+    project_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    -- Transcripts are append-only, so a byte offset is a resume point: the next
+    -- pass reads only what was added rather than the whole file again.
+    bytes_indexed INTEGER NOT NULL DEFAULT 0,
+    lines_indexed INTEGER NOT NULL DEFAULT 0,
+    mtime_ms INTEGER NOT NULL DEFAULT 0,
+    indexed_at TEXT NOT NULL
+  );`,
+  `CREATE TABLE IF NOT EXISTS transcript_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    line INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    ts TEXT,
+    weight REAL NOT NULL,
+    len INTEGER NOT NULL,
+    text TEXT NOT NULL
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_messages_project ON transcript_messages(project_dir);`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_messages_session ON transcript_messages(session_id, line);`,
+  // FTS5 rather than a hand-built inverted index: it ships BM25, and a posting
+  // table written from JavaScript cost ~74 rows per message, which made cold
+  // indexing of a large archive hours of work. External content keeps the text
+  // in transcript_messages instead of storing it twice.
+  `CREATE VIRTUAL TABLE IF NOT EXISTS transcript_fts USING fts5(
+    text,
+    content='transcript_messages',
+    content_rowid='id'
+  );`,
+  // Cached per message so a rerank pays the embedding cost once, not per query.
+  `CREATE TABLE IF NOT EXISTS transcript_embeddings (
+    message_id INTEGER PRIMARY KEY,
+    model TEXT NOT NULL,
+    vector TEXT NOT NULL
+  );`,
 ];
 
 function unwrapJson(value: unknown): unknown {

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -218,7 +218,14 @@ const SCHEMA_STATEMENTS = [
     bytes_indexed INTEGER NOT NULL DEFAULT 0,
     lines_indexed INTEGER NOT NULL DEFAULT 0,
     mtime_ms INTEGER NOT NULL DEFAULT 0,
-    indexed_at TEXT NOT NULL
+    indexed_at TEXT NOT NULL,
+    -- Captured while the indexer streams the file, at zero extra IO: the
+    -- session's own title entries (a user rename beats a generated title), and
+    -- the first real user ask as a one-line descriptor. External tools name
+    -- sessions by filename or first prompt; the transcript already knows better.
+    display_name TEXT,
+    name_kind INTEGER NOT NULL DEFAULT 0,
+    opening TEXT
   );`,
   `CREATE TABLE IF NOT EXISTS transcript_messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -498,6 +505,27 @@ async function ensureMemorySessionColumns(client: Client): Promise<void> {
   if (!columns.includes('promotion_error_code')) await client.execute('ALTER TABLE memory_sessions ADD COLUMN promotion_error_code TEXT;');
 }
 
+async function ensureTranscriptFileColumns(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'transcript_files'))) return;
+  const columns = await tableColumns(client, 'transcript_files');
+  if (!columns.includes('display_name')) {
+    await client.execute('ALTER TABLE transcript_files ADD COLUMN display_name TEXT;');
+  }
+  if (!columns.includes('name_kind')) {
+    await client.execute('ALTER TABLE transcript_files ADD COLUMN name_kind INTEGER NOT NULL DEFAULT 0;');
+  }
+  if (!columns.includes('opening')) {
+    await client.execute('ALTER TABLE transcript_files ADD COLUMN opening TEXT;');
+    // Names and openings are captured while streaming, so rows indexed before
+    // these columns existed would stay nameless forever. The tables are derived
+    // data; resetting the watermarks makes the next pass re-read and fill them.
+    await client.execute("UPDATE transcript_files SET bytes_indexed = 0, lines_indexed = 0, indexed_at = '1970-01-01T00:00:00.000Z';");
+    await client.execute('DELETE FROM transcript_embeddings;');
+    await client.execute('DELETE FROM transcript_messages;');
+    await client.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('delete-all');");
+  }
+}
+
 async function ensureHostSessionBindingColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'host_session_bindings'))) return;
   const columns = await tableColumns(client, 'host_session_bindings');
@@ -663,6 +691,7 @@ export async function bootstrapSchema(client: Client): Promise<void> {
   await ensureOwnershipColumns(client);
   await ensureMemorySessionColumns(client);
   await ensureHostSessionBindingColumns(client);
+  await ensureTranscriptFileColumns(client);
   await ensureCodeIndexColumns(client);
   await backfillKnowledgeAssertions(client);
   await repairSkillForeignKeys(client);

--- a/src/store/session-directory.ts
+++ b/src/store/session-directory.ts
@@ -1,0 +1,168 @@
+import { getClient } from './database.js';
+import { ensureTranscriptIndex, sessionFiles } from './transcript-index.js';
+
+// A browsable directory of a project's Claude Code sessions, host-session
+// grained - the unit a person actually thinks in ("the UI session", "the forge
+// session"), not the fine-grained memory sessions the lifecycle hooks create
+// per agent turn.
+//
+// Everything here is derived deterministically from data that already exists:
+// names and opening asks captured by the transcript indexer as it streams,
+// activity figures from the index, and - where lifecycle hooks ran - the
+// knowledge each session actually promoted. No AI provider, no cap on how far
+// back it reaches, and sessions that were never named still appear with their
+// opening ask, which is precisely where the native picker gives up.
+
+export interface SessionDirectoryEntry {
+  sessionId: string;
+  /** Best available name: user rename > agent name > generated title > null. */
+  name: string | null;
+  /** The first real user ask, one line - what the session set out to do. */
+  opening: string | null;
+  /**
+   * Derived at read time from lifecycle data, never stored:
+   * 'interrupted' - an unconsumed crash handoff names this session; there is a
+   *                 blocker waiting to be resumed. Strongest signal, wins.
+   * 'active'      - a live memory session with a recent heartbeat is bound to
+   *                 it, or the transcript was written moments ago.
+   * 'idle'        - everything else; lastActiveAt carries the rest.
+   * Fine-grained working/stalled tiers exist in live monitors, but this is a
+   * recall surface - their precondition (real-time observation) is absent.
+   */
+  status: 'active' | 'interrupted' | 'idle';
+  /** Title of the newest declared session card, when one was stored (tags: session-card + session:<id>). */
+  card: string | null;
+  lastActiveAt: string;
+  sizeBytes: number;
+  messagesIndexed: number;
+  /** Titles of knowledge atoms this session promoted into memory, when lifecycle hooks captured any. */
+  promoted: string[];
+}
+
+/** A heartbeat older than this no longer counts as "working right now". */
+const ACTIVE_HEARTBEAT_MS = 30 * 60 * 1000;
+/** A transcript written this recently is active even without lifecycle hooks. */
+const ACTIVE_MTIME_MS = 10 * 60 * 1000;
+
+export interface SessionDirectoryOptions {
+  projectDir?: string;
+  /** Keyword filter over name + opening. All tokens must match. */
+  query?: string;
+  limit?: number;
+  /** Override transcript roots. Injected by tests so they never mutate HOME. */
+  stores?: string[];
+}
+
+export async function listSessionDirectory(
+  options: SessionDirectoryOptions = {},
+): Promise<{ entries: SessionDirectoryEntry[]; total: number; indexComplete: boolean }> {
+  const { projectDir = process.cwd(), query, limit = 12, stores } = options;
+  const client = getClient();
+
+  // Names and openings are captured by the indexer, so the directory is only as
+  // current as the index. Same budget-bounded call the search path uses.
+  const index = await ensureTranscriptIndex(projectDir, stores);
+  const files = await sessionFiles(projectDir, stores);
+
+  const rows = (await client.execute({
+    sql: `SELECT f.session_id, f.display_name, f.opening,
+                 (SELECT COUNT(*) FROM transcript_messages m WHERE m.session_id = f.session_id AND m.project_dir = ?) AS messages
+          FROM transcript_files f WHERE f.project_dir = ?`,
+    args: [projectDir, projectDir],
+  })).rows;
+  const meta = new Map(rows.map(row => [String(row.session_id), row]));
+
+  // Promoted knowledge per host session, through the lifecycle chain:
+  // host session -> bound memory sessions -> promoted item ids -> item titles.
+  // Best-effort: a project without lifecycle hooks simply has none of this.
+  const promoted = new Map<string, string[]>();
+  try {
+    const promotedRows = (await client.execute(
+      `SELECT b.external_session_id AS sid, i.title AS title
+       FROM host_session_bindings b
+       JOIN memory_sessions s ON s.id = b.memory_session_id
+       JOIN json_each(COALESCE(s.promotion_items, '[]')) p
+       JOIN knowledge_items i ON i.id = p.value
+       WHERE s.promotion_status = 'promoted'`,
+    )).rows;
+    for (const row of promotedRows) {
+      const sid = String(row.sid);
+      const list = promoted.get(sid) ?? [];
+      if (!list.includes(String(row.title))) list.push(String(row.title));
+      promoted.set(sid, list);
+    }
+  } catch { /* older schema or no lifecycle data */ }
+
+  // Lifecycle signals, one query each, mapped by host session id.
+  const activeHeartbeat = new Map<string, number>();
+  try {
+    const hb = (await client.execute(
+      `SELECT b.external_session_id AS sid, MAX(s.last_heartbeat_at) AS beat
+       FROM host_session_bindings b
+       JOIN memory_sessions s ON s.id = b.memory_session_id
+       WHERE s.status = 'active'
+       GROUP BY b.external_session_id`,
+    )).rows;
+    for (const row of hb) activeHeartbeat.set(String(row.sid), Date.parse(String(row.beat)));
+  } catch { /* no lifecycle data */ }
+
+  // Crash handoffs and declared cards both tag themselves session:<id>, so one
+  // scan of active state items covers both. Parsed in JS: tags are JSON text,
+  // and per-session LIKE queries would cost a round trip per session.
+  const interrupted = new Set<string>();
+  const cards = new Map<string, string>();
+  try {
+    const tagged = (await client.execute(
+      `SELECT title, tags, content, updated_at FROM knowledge_items
+       WHERE status = 'active' AND (tags LIKE '%"pending_handoff"%' OR tags LIKE '%"session-card"%')
+       ORDER BY updated_at ASC`,
+    )).rows;
+    for (const row of tagged) {
+      let tags: string[] = [];
+      try { tags = JSON.parse(String(row.tags ?? '[]')); } catch { continue; }
+      // Handoffs written before the session: tag existed carry the id only in
+      // their content JSON; real archives have these, so fall back to it.
+      let sid = tags.find(tag => tag.startsWith('session:'))?.slice('session:'.length);
+      if (!sid) { try { sid = JSON.parse(String(row.content)).externalSessionId; } catch { /* not JSON */ } }
+      if (!sid) continue;
+      if (tags.includes('pending_handoff') && !tags.includes('consumed')) {
+        try { if (JSON.parse(String(row.content)).consumed === true) continue; } catch { /* treat as live */ }
+        interrupted.add(sid);
+      }
+      // Ascending updated_at, so the newest card naturally wins.
+      if (tags.includes('session-card')) cards.set(sid, String(row.title));
+    }
+  } catch { /* no state items */ }
+
+  const now = Date.now();
+  let entries: SessionDirectoryEntry[] = files.map(file => {
+    const row = meta.get(file.sessionId);
+    const beat = activeHeartbeat.get(file.sessionId);
+    const status = interrupted.has(file.sessionId) ? 'interrupted' as const
+      : (beat !== undefined && now - beat < ACTIVE_HEARTBEAT_MS) || now - file.mtimeMs < ACTIVE_MTIME_MS ? 'active' as const
+      : 'idle' as const;
+    return {
+      sessionId: file.sessionId,
+      name: row?.display_name ? String(row.display_name) : null,
+      opening: row?.opening ? String(row.opening) : null,
+      status,
+      card: cards.get(file.sessionId) ?? null,
+      lastActiveAt: new Date(file.mtimeMs).toISOString(),
+      sizeBytes: file.size,
+      messagesIndexed: row ? Number(row.messages) : 0,
+      promoted: (promoted.get(file.sessionId) ?? []).slice(0, 3),
+    };
+  });
+
+  if (query?.trim()) {
+    // Substring AND-match over the intent fields. This filters the INVENTORY
+    // (what a session is about); content questions belong to transcript search.
+    const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+    entries = entries.filter(entry => {
+      const haystack = `${entry.name ?? ''}\n${entry.opening ?? ''}\n${entry.card ?? ''}\n${entry.promoted.join('\n')}`.toLowerCase();
+      return tokens.every(token => haystack.includes(token));
+    });
+  }
+
+  return { entries: entries.slice(0, limit), total: entries.length, indexComplete: index.complete };
+}

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -93,7 +93,8 @@ function isNoise(text: string): boolean {
   const t = text.trimStart();
   if (!t) return true;
   if (t.startsWith('<local-command-caveat>')) return true;
-  if (t.startsWith('<command-name>')) return true;
+  // Slash-command invocations arrive wrapped either way round.
+  if (t.startsWith('<command-name>') || t.startsWith('<command-message>')) return true;
   return /^Caveat: The messages below were generated/.test(t);
 }
 
@@ -167,7 +168,20 @@ async function flush(projectDir: string, pending: PendingMessage[], nextId: { va
   // live session, and a long write transaction starves it into SQLITE_BUSY.
   for (let i = 0; i < statements.length; i += BATCH_STATEMENTS) {
     try {
-      await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+      // Observed repeatedly beside a live serve process writing to the same
+      // database: transient BUSY on commit. Retried with backoff because one
+      // retry proved too thin under sustained neighbour writes; a final
+      // failure is treated like any other batch error below.
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+          break;
+        } catch (error) {
+          const busy = /SQLITE_BUSY|statements in progress/i.test(String((error as Error).message));
+          if (!busy || attempt >= 3) throw error;
+          await new Promise(resolve => setTimeout(resolve, 250 * (attempt + 1)));
+        }
+      }
     } catch (error) {
       // A primary-key collision means another process allocated the same ids -
       // the file lease serializes work per FILE, but ids come from one MAX(id)
@@ -223,7 +237,7 @@ type FileOutcome = { added: number; complete: boolean; reason?: 'budget' | 'leas
 async function indexFile(projectDir: string, file: SessionFile, nextId: { value: number }, deadline: number): Promise<FileOutcome> {
   const client = getClient();
   const row = (await client.execute({
-    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms FROM transcript_files WHERE path = ?',
+    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms, display_name, name_kind, opening FROM transcript_files WHERE path = ?',
     args: [file.path],
   })).rows[0];
 
@@ -237,12 +251,18 @@ async function indexFile(projectDir: string, file: SessionFile, nextId: { value:
   // invisible, which real editing does not do.
   const rewrittenInPlace = row !== undefined
     && startByte === file.size && Number(row.mtime_ms) !== 0 && Number(row.mtime_ms) !== file.mtimeMs;
+  // Carried across incremental passes: a rename entry seen weeks ago must not
+  // be forgotten because later passes only read the appended tail.
+  let name = row?.display_name ? String(row.display_name) : null;
+  let nameKind = row ? Number(row.name_kind) : 0;
+  let opening = row?.opening ? String(row.opening) : null;
 
   // A file that shrank was rewritten rather than appended to, so the offset is
   // meaningless and its rows have to go. Same-size rewrites are caught above.
   if (startByte > file.size || rewrittenInPlace) {
     await purgeBeyond(projectDir, file.sessionId, 0);
-    startByte = 0; lineNo = 0;
+    // The file was rewritten, so metadata read from the old content is void.
+    startByte = 0; lineNo = 0; name = null; nameKind = 0; opening = null;
   }
   if (startByte === file.size) return { added: 0, complete: true };
 
@@ -292,9 +312,18 @@ async function indexFile(projectDir: string, file: SessionFile, nextId: { value:
       if (!line.trim()) continue;
       let entry: any;
       try { entry = JSON.parse(line); } catch { continue; }
+      // The transcript names itself: a user rename (custom-title, mirrored by
+      // agent-name) outranks the generated ai-title, and within a rank the
+      // later entry wins. External tools fall back to filenames or first
+      // prompts; the better source was here all along.
+      if (entry.type === 'custom-title' && typeof entry.customTitle === 'string') { name = entry.customTitle; nameKind = 3; continue; }
+      if (entry.type === 'agent-name' && typeof entry.agentName === 'string' && nameKind <= 2) { name = entry.agentName; nameKind = 2; continue; }
+      if (entry.type === 'ai-title' && typeof entry.aiTitle === 'string' && nameKind <= 1) { name = entry.aiTitle; nameKind = 1; continue; }
       if (entry.type !== 'user' && entry.type !== 'assistant') continue;
       const { text, toolChars } = extractText(entry);
       if (!text || isNoise(text)) continue;
+      // The first real ask, as the session's one-line descriptor.
+      if (opening === null && entry.type === 'user') opening = text.replace(/\s+/g, ' ').slice(0, 240);
       const clipped = text.slice(0, MAX_TEXT_CHARS);
       pending.push({
         sessionId: file.sessionId, line: lineNo, role: entry.type,
@@ -323,11 +352,12 @@ async function indexFile(projectDir: string, file: SessionFile, nextId: { value:
   const doneStamp = new Date().toISOString();
   ownClaims.add(doneStamp);
   await client.execute({
-    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
+    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at, display_name, name_kind, opening)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(path) DO UPDATE SET bytes_indexed = excluded.bytes_indexed,
-            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at`,
-    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp],
+            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at,
+            display_name = excluded.display_name, name_kind = excluded.name_kind, opening = excluded.opening`,
+    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp, name, nameKind, opening],
   });
   return complete ? { added, complete } : { added, complete, reason: 'budget' };
 }

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -1,0 +1,379 @@
+import { createReadStream } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { homedir } from 'node:os';
+import { join, basename, delimiter } from 'node:path';
+import { getClient } from './database.js';
+
+// Incremental index over raw Claude Code session transcripts.
+//
+// The naive approach - stream every file on every query - costs seconds per
+// lookup and gets worse as history grows, which is exactly the wrong shape for
+// something an agent should reach for whenever it is unsure. Transcripts are
+// append-only, so a byte offset is a valid resume point: each pass reads only
+// what was written since the last one, and steady-state indexing is nearly free.
+//
+// Everything here is derived data. The .jsonl files are the source of truth, so
+// these tables can be dropped and rebuilt without losing anything.
+
+const ROLE_WEIGHT: Record<string, number> = { user: 2, assistant: 1 };
+const TOOL_WEIGHT = 0.3;
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'that', 'this', 'with', 'from', 'was', 'were', 'are', 'you', 'your',
+  'not', 'but', 'have', 'has', 'had', 'its', 'it', 'is', 'be', 'to', 'of', 'in', 'on', 'a',
+  'i', 'we', 'they', 'as', 'at', 'by', 'or', 'an', 'if', 'so', 'do', 'does', 'did', 'can',
+]);
+
+export function tokenize(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.toLowerCase().split(/[^a-z0-9_]+/)) {
+    if (raw.length < 2 || raw.length > 40 || STOPWORDS.has(raw)) continue;
+    out.push(raw);
+  }
+  return out;
+}
+
+/** Claude Code encodes the project path by replacing every non-alphanumeric character with '-'. */
+export function encodeProjectDir(dir: string): string {
+  return dir.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Every config root that may hold transcripts. CLAUDE_CONFIG_DIR wins when set;
+ * the default install location is always included. A machine with additional
+ * stores - a second account, a synced archive - names them in
+ * KNOWL_TRANSCRIPT_ROOTS (path-delimiter separated), because which extra roots
+ * exist is a property of one machine, not of this package.
+ */
+export function transcriptStores(): string[] {
+  const roots = new Set<string>();
+  if (process.env.CLAUDE_CONFIG_DIR) roots.add(process.env.CLAUDE_CONFIG_DIR);
+  roots.add(join(homedir(), '.claude'));
+  for (const extra of (process.env.KNOWL_TRANSCRIPT_ROOTS ?? '').split(delimiter)) {
+    if (extra.trim()) roots.add(extra.trim());
+  }
+  return [...roots].map(root => join(root, 'projects'));
+}
+
+export interface SessionFile { sessionId: string; path: string; mtimeMs: number; size: number }
+
+export async function sessionFiles(projectDir: string, stores?: string[]): Promise<SessionFile[]> {
+  const encoded = encodeProjectDir(projectDir);
+  // Two stores can hold the same session id; keep the most recently written copy.
+  const newest = new Map<string, SessionFile>();
+  for (const store of stores ?? transcriptStores()) {
+    let names: string[];
+    try { names = await readdir(join(store, encoded)); } catch { continue; }
+    for (const name of names) {
+      if (!name.endsWith('.jsonl')) continue;
+      const path = join(store, encoded, name);
+      let info;
+      try { info = await stat(path); } catch { continue; }
+      const sessionId = basename(name, '.jsonl');
+      const prev = newest.get(sessionId);
+      // Truncated to whole milliseconds: stat reports a float, the watermark
+      // column stores an integer, and comparing the two must not invent a
+      // rewrite out of the fractional part.
+      const mtimeMs = Math.trunc(info.mtimeMs);
+      if (!prev || prev.mtimeMs < mtimeMs) {
+        newest.set(sessionId, { sessionId, path, mtimeMs, size: info.size });
+      }
+    }
+  }
+  return [...newest.values()].sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/**
+ * Entries that are structurally present but carry no recallable content: the
+ * local-command caveat wrapper, bare slash commands, and the startup handshake.
+ * Indexing them pollutes document frequency and wastes result slots.
+ */
+function isNoise(text: string): boolean {
+  const t = text.trimStart();
+  if (!t) return true;
+  if (t.startsWith('<local-command-caveat>')) return true;
+  if (t.startsWith('<command-name>')) return true;
+  return /^Caveat: The messages below were generated/.test(t);
+}
+
+function extractText(entry: any): { text: string; toolChars: number } {
+  const content = entry?.message?.content;
+  if (typeof content === 'string') return { text: content, toolChars: 0 };
+  if (!Array.isArray(content)) return { text: '', toolChars: 0 };
+  const parts: string[] = [];
+  let toolChars = 0;
+  for (const block of content) {
+    if (block?.type === 'text' && typeof block.text === 'string') { parts.push(block.text); continue; }
+    // Tool traffic is most of the bytes and little of the signal, but a command,
+    // path or error string is sometimes the only place an answer survives. It is
+    // indexed and then weighted down, rather than discarded.
+    if (block?.type === 'tool_use') {
+      const s = JSON.stringify(block.input ?? {});
+      toolChars += s.length; parts.push(s);
+    } else if (block?.type === 'tool_result') {
+      const s = typeof block.content === 'string' ? block.content : JSON.stringify(block.content ?? '');
+      toolChars += s.length; parts.push(s);
+    }
+  }
+  return { text: parts.join('\n'), toolChars };
+}
+
+/** Bounded so one pasted 5MB file cannot dominate the index or a snippet. */
+const MAX_TEXT_CHARS = 20_000;
+
+/**
+ * How long one call may spend indexing. Indexing runs inside a tool call, so
+ * this is really a promise about latency: a first search on a large archive
+ * returns whatever is indexed so far and says the index is still warming,
+ * rather than blocking the caller for minutes.
+ */
+const DEFAULT_INDEX_BUDGET_MS = 8_000;
+
+/** Statements per write transaction. Small on purpose - see flush(). */
+const BATCH_STATEMENTS = 500;
+
+interface PendingMessage {
+  sessionId: string; line: number; role: string; ts: string | null;
+  weight: number; len: number; text: string;
+}
+
+/**
+ * Message ids are assigned here rather than read back from the database. The
+ * obvious shape - INSERT ... RETURNING per message - costs a round trip each,
+ * which on a real archive is tens of thousands of round trips and minutes of
+ * wall clock. Allocating ids from a counter lets a whole batch go out at once.
+ */
+async function flush(projectDir: string, pending: PendingMessage[], nextId: { value: number }): Promise<void> {
+  if (pending.length === 0) return;
+  const client = getClient();
+  const statements: Array<{ sql: string; args: any[] }> = [];
+  for (const message of pending) {
+    const messageId = nextId.value++;
+    statements.push({
+      sql: `INSERT INTO transcript_messages (id, project_dir, session_id, line, role, ts, weight, len, text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [messageId, projectDir, message.sessionId, message.line, message.role, message.ts, message.weight, message.len, message.text],
+    });
+    // FTS5 tokenizes and ranks; nothing here has to build a term index by hand.
+    statements.push({
+      sql: 'INSERT INTO transcript_fts (rowid, text) VALUES (?, ?)',
+      args: [messageId, message.text],
+    });
+  }
+  // libsql runs a batch as one transaction, so the per-statement fsync that
+  // dominates unbatched SQLite writes happens once instead of per row. The
+  // chunk stays small deliberately: this database is also being served to a
+  // live session, and a long write transaction starves it into SQLITE_BUSY.
+  for (let i = 0; i < statements.length; i += BATCH_STATEMENTS) {
+    try {
+      await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+    } catch (error) {
+      // A primary-key collision means another process allocated the same ids -
+      // the file lease serializes work per FILE, but ids come from one MAX(id)
+      // read per pass, so two passes on different files can still clash. The
+      // colliding transaction rolled back, so nothing partial landed from this
+      // chunk; surrender the file and let the next pass resume from a fresh
+      // MAX. Committed earlier chunks sit beyond the watermark and are purged
+      // by whoever claims the file next.
+      if (/SQLITE_CONSTRAINT|UNIQUE/i.test(String((error as Error).message))) throw new IdCollisionError();
+      throw error;
+    }
+  }
+}
+
+class IdCollisionError extends Error {
+  constructor() { super('transcript id collision: concurrent indexer detected'); }
+}
+
+async function nextMessageId(): Promise<number> {
+  const row = (await getClient().execute('SELECT COALESCE(MAX(id), 0) AS max_id FROM transcript_messages')).rows[0];
+  return Number(row.max_id) + 1;
+}
+
+/**
+ * How long one process's claim on a file is honoured. Knowl runs one serve
+ * process per connected session, so two sessions on the same project index
+ * concurrently unless something serializes them - both would read the same
+ * MAX(id) and the same watermark, then collide on primary keys or write the
+ * same messages twice. Longer than an index pass's budget, short enough that a
+ * crashed claimant only stalls a file briefly.
+ */
+const LEASE_MS = 20_000;
+
+/** Claims written by THIS process, so it can resume its own budget-paused files without waiting out the lease. */
+const ownClaims = new Set<string>();
+
+/** Remove indexed rows for a session beyond a line watermark, embeddings included - a purged id can be reallocated, and a stale cached vector would silently attach to the wrong message. */
+async function purgeBeyond(projectDir: string, sessionId: string, afterLine: number): Promise<void> {
+  const client = getClient();
+  const where = 'session_id = ? AND project_dir = ? AND line > ?';
+  const args = [sessionId, projectDir, afterLine];
+  await client.execute({
+    sql: `INSERT INTO transcript_fts(transcript_fts, rowid, text)
+          SELECT 'delete', id, text FROM transcript_messages WHERE ${where}`,
+    args,
+  });
+  await client.execute({ sql: `DELETE FROM transcript_embeddings WHERE message_id IN (SELECT id FROM transcript_messages WHERE ${where})`, args });
+  await client.execute({ sql: `DELETE FROM transcript_messages WHERE ${where}`, args });
+}
+
+type FileOutcome = { added: number; complete: boolean; reason?: 'budget' | 'leased' };
+
+async function indexFile(projectDir: string, file: SessionFile, nextId: { value: number }, deadline: number): Promise<FileOutcome> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms FROM transcript_files WHERE path = ?',
+    args: [file.path],
+  })).rows[0];
+
+  let startByte = row ? Number(row.bytes_indexed) : 0;
+  let lineNo = row ? Number(row.lines_indexed) : 0;
+  const prevStamp = row ? String(row.indexed_at) : null;
+  // A file rewritten to the SAME size slips past the shrink check below, but
+  // not past its own mtime. Only meaningful on a completed row: partial rows
+  // store mtime 0 until their pass finishes. Bounded by filesystem timestamp
+  // granularity - a rewrite within the same tick as the indexed write is
+  // invisible, which real editing does not do.
+  const rewrittenInPlace = row !== undefined
+    && startByte === file.size && Number(row.mtime_ms) !== 0 && Number(row.mtime_ms) !== file.mtimeMs;
+
+  // A file that shrank was rewritten rather than appended to, so the offset is
+  // meaningless and its rows have to go. Same-size rewrites are caught above.
+  if (startByte > file.size || rewrittenInPlace) {
+    await purgeBeyond(projectDir, file.sessionId, 0);
+    startByte = 0; lineNo = 0;
+  }
+  if (startByte === file.size) return { added: 0, complete: true };
+
+  // Another process's fresh claim: leave the file to it. Our own claim from a
+  // budget-paused pass is exempt, or a paused pass could never resume itself.
+  if (prevStamp && !ownClaims.has(prevStamp)) {
+    const stampedAt = Date.parse(prevStamp);
+    if (Number.isFinite(stampedAt) && Date.now() - stampedAt < LEASE_MS) {
+      return { added: 0, complete: false, reason: 'leased' };
+    }
+  }
+
+  // Take the claim with a compare-and-set on the stamp we read, so two
+  // processes arriving together cannot both win. The loser skips the file.
+  const claim = new Date().toISOString();
+  const claimed = row
+    ? await client.execute({ sql: 'UPDATE transcript_files SET indexed_at = ? WHERE path = ? AND indexed_at = ?', args: [claim, file.path, prevStamp] })
+    : await client.execute({
+        sql: 'INSERT OR IGNORE INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at) VALUES (?, ?, ?, 0, 0, 0, ?)',
+        args: [file.path, projectDir, file.sessionId, claim],
+      });
+  if (Number(claimed.rowsAffected) === 0) return { added: 0, complete: false, reason: 'leased' };
+  ownClaims.add(claim);
+
+  // A previous claimant may have died mid-file: batches it committed past the
+  // watermark would be indexed AGAIN from the watermark, as duplicates with
+  // fresh ids. Purge beyond the watermark before resuming so the resume is
+  // idempotent. A no-op on a clean handoff.
+  await purgeBeyond(projectDir, file.sessionId, lineNo);
+
+  const pending: PendingMessage[] = [];
+  let added = 0;
+  // Bytes consumed since startByte, so a run that stops early can record where
+  // it got to. Transcripts are newline-delimited UTF-8, so line length plus one
+  // is exact; the offset is snapped to the real file size on completion anyway.
+  let consumed = 0;
+  let complete = true;
+  try {
+    const rl = createInterface({ input: createReadStream(file.path, { start: startByte }), crlfDelay: Infinity });
+    for await (const line of rl) {
+      lineNo++;
+      consumed += Buffer.byteLength(line, 'utf8') + 1;
+      // Checked per line rather than per file: one 170MB transcript can blow any
+      // budget on its own, and a caller left waiting minutes for a tool call will
+      // give up long before the index is warm.
+      if (Date.now() > deadline) { complete = false; rl.close(); break; }
+      if (!line.trim()) continue;
+      let entry: any;
+      try { entry = JSON.parse(line); } catch { continue; }
+      if (entry.type !== 'user' && entry.type !== 'assistant') continue;
+      const { text, toolChars } = extractText(entry);
+      if (!text || isNoise(text)) continue;
+      const clipped = text.slice(0, MAX_TEXT_CHARS);
+      pending.push({
+        sessionId: file.sessionId, line: lineNo, role: entry.type,
+        ts: typeof entry.timestamp === 'string' ? entry.timestamp : null,
+        weight: (ROLE_WEIGHT[entry.type] ?? 1) * (toolChars > clipped.length / 2 ? TOOL_WEIGHT : 1),
+        len: clipped.length, text: clipped,
+      });
+      added++;
+      if (pending.length >= 500) { await flush(projectDir, pending, nextId); pending.length = 0; }
+    }
+    await flush(projectDir, pending, nextId);
+  } catch (error) {
+    if (error instanceof IdCollisionError) {
+      // Deliberately no watermark write: it still points at the last state this
+      // process knows was fully committed, which is what the next claimant
+      // needs to purge-and-resume correctly.
+      return { added: 0, complete: false, reason: 'leased' };
+    }
+    throw error;
+  }
+
+  // On a complete pass the real file size is authoritative; on a partial one the
+  // running byte count is the resume point, so the next call picks up mid-file
+  // instead of starting the whole transcript again.
+  const bytesIndexed = complete ? file.size : startByte + consumed;
+  const doneStamp = new Date().toISOString();
+  ownClaims.add(doneStamp);
+  await client.execute({
+    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(path) DO UPDATE SET bytes_indexed = excluded.bytes_indexed,
+            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at`,
+    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp],
+  });
+  return complete ? { added, complete } : { added, complete, reason: 'budget' };
+}
+
+export interface IndexResult {
+  filesScanned: number;
+  filesUpdated: number;
+  messagesAdded: number;
+  ms: number;
+  /** False when the budget ran out with work left. The next call resumes. */
+  complete: boolean;
+}
+
+/**
+ * Bring the index up to date. Cheap when nothing changed: a file whose size
+ * matches the stored offset is skipped without being opened.
+ */
+export async function ensureTranscriptIndex(projectDir: string, stores?: string[], budgetMs = DEFAULT_INDEX_BUDGET_MS): Promise<IndexResult> {
+  const started = Date.now();
+  const deadline = started + budgetMs;
+  const files = await sessionFiles(projectDir, stores);
+  const nextId = { value: await nextMessageId() };
+  let filesUpdated = 0;
+  let messagesAdded = 0;
+  let complete = true;
+  // Newest first, so a cold index makes the most recent history searchable
+  // first - that is what a question is most likely to be about.
+  for (const file of files) {
+    if (Date.now() > deadline) { complete = false; break; }
+    const result = await indexFile(projectDir, file, nextId, deadline);
+    if (result.added > 0) { filesUpdated++; messagesAdded += result.added; }
+    if (!result.complete) {
+      complete = false;
+      // Budget exhaustion ends the pass; a lease held by another process only
+      // ends THAT file - the rest of the archive is still ours to index.
+      if (result.reason === 'budget') break;
+    }
+  }
+  return { filesScanned: files.length, filesUpdated, messagesAdded, ms: Date.now() - started, complete };
+}
+
+export async function transcriptIndexStats(projectDir: string): Promise<{ messages: number; avgLen: number; sessions: number }> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT COUNT(*) AS n, COALESCE(AVG(len), 1) AS avg_len, COUNT(DISTINCT session_id) AS sessions FROM transcript_messages WHERE project_dir = ?',
+    args: [projectDir],
+  })).rows[0];
+  return { messages: Number(row.n), avgLen: Number(row.avg_len) || 1, sessions: Number(row.sessions) };
+}

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -1,0 +1,257 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { getClient } from './database.js';
+import { ensureTranscriptIndex, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+
+export { encodeProjectDir, transcriptStores } from './transcript-index.js';
+
+// Ranked search over raw Claude Code session transcripts.
+//
+// Knowl stores distilled atoms. Those are lossy by construction: whatever the
+// writer did not think worth keeping is gone, and there is no fallback. The
+// transcripts are the lossless floor underneath - every word actually
+// exchanged, still on disk. This makes that floor reachable, so a miss in
+// memory becomes a slower lookup rather than amnesia.
+//
+// Consumer is an agent, not a human: no TUI, no pager. What matters is
+// precision ranking, tight snippets, and a locator to cite when promoting a
+// finding back into memory.
+
+export interface TranscriptHit {
+  sessionId: string;
+  line: number;
+  role: string;
+  timestamp?: string;
+  score: number;
+  snippet: string;
+  /** Cite this in the atom when promoting, so the claim keeps its provenance. */
+  locator: string;
+}
+
+/** Supplied by the caller so this module never depends on how embeddings are configured. */
+export interface SemanticReranker {
+  model: string;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface TranscriptSearchOptions {
+  projectDir?: string;
+  limit?: number;
+  since?: string;
+  snippetChars?: number;
+  /**
+   * Restrict to one session, by id or a unique prefix. This is what makes a
+   * handoff brief actionable: a new session is told which session it continues
+   * from, and needs a way to ask that transcript specifically before widening
+   * to the whole archive.
+   */
+  sessionId?: string;
+  /** Override the config roots to scan. Injected by tests so they never mutate HOME. */
+  stores?: string[];
+  /** When present, the top BM25 candidates are re-ranked and the two orders fused. */
+  semantic?: SemanticReranker;
+}
+
+// Reciprocal Rank Fusion. 60 is the value from the original paper and is
+// deliberately large: it flattens the head so neither ranker can dictate the
+// result on its own, which is the point of fusing them.
+const RRF_K = 60;
+
+// How many BM25 candidates get embedded for the semantic pass. Embedding is the
+// expensive half, so recall is bounded by what BM25 surfaces first - a real
+// limitation, and the reason the lexical side is tuned to be good alone.
+const RERANK_DEPTH = 50;
+
+/**
+ * Cap for a full-entry read. Matches the index's own per-message clip, so the
+ * tool returns everything that was searchable and nothing more.
+ */
+export const MAX_TRANSCRIPT_ENTRY_CHARS = 20_000;
+
+interface Scored { messageId: number; score: number }
+
+/**
+ * Rank with FTS5's own BM25, then apply the field weighting it has no way to
+ * express. bm25() returns a negative number where more negative is better, so
+ * it is inverted before the weight is applied.
+ *
+ * A wider candidate window than `depth` is read on purpose: re-weighting can
+ * promote a row FTS5 ranked lower, and a window equal to the final limit would
+ * have already discarded it.
+ */
+async function lexicalRank(projectDir: string, terms: string[], depth: number, sessionId?: string): Promise<Scored[]> {
+  const client = getClient();
+  // Prefix matching, the same convention knowledge search uses. Tokens are
+  // already reduced to [a-z0-9_], so none of FTS5's operators can appear here.
+  const match = terms.map(term => `${term}*`).join(' OR ');
+  const rows = (await client.execute({
+    sql: `SELECT transcript_fts.rowid AS id, bm25(transcript_fts) AS rank, m.weight AS weight
+          FROM transcript_fts
+          JOIN transcript_messages m ON m.id = transcript_fts.rowid
+          WHERE transcript_fts MATCH ? AND m.project_dir = ?
+            ${sessionId ? 'AND m.session_id LIKE ?' : ''}
+          ORDER BY rank ASC
+          LIMIT ?`,
+    args: sessionId
+      ? [match, projectDir, `${sessionId}%`, Math.max(depth * 4, 100)]
+      : [match, projectDir, Math.max(depth * 4, 100)],
+  })).rows;
+
+  return rows
+    .map(row => ({ messageId: Number(row.id), score: -Number(row.rank) * Number(row.weight) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, depth);
+}
+
+function cosine(left: number[], right: number[]): number {
+  let dot = 0, l = 0, r = 0;
+  for (let i = 0; i < left.length; i++) { dot += left[i] * right[i]; l += left[i] * left[i]; r += right[i] * right[i]; }
+  return l === 0 || r === 0 ? 0 : dot / (Math.sqrt(l) * Math.sqrt(r));
+}
+
+/** Vectors for the candidates, embedding only those not already cached. */
+async function candidateVectors(
+  candidates: Array<{ messageId: number; text: string }>,
+  semantic: SemanticReranker,
+): Promise<Map<number, number[]>> {
+  const client = getClient();
+  const vectors = new Map<number, number[]>();
+  if (candidates.length === 0) return vectors;
+
+  const rows = (await client.execute({
+    sql: `SELECT message_id, vector FROM transcript_embeddings WHERE model = ? AND message_id IN (${candidates.map(() => '?').join(',')})`,
+    args: [semantic.model, ...candidates.map(c => c.messageId)],
+  })).rows;
+  for (const row of rows) {
+    try { vectors.set(Number(row.message_id), JSON.parse(String(row.vector))); } catch { /* re-embed below */ }
+  }
+
+  const missing = candidates.filter(c => !vectors.has(c.messageId));
+  if (missing.length > 0) {
+    const embedded = await semantic.embed(missing.map(c => c.text.slice(0, 2_000)));
+    for (let i = 0; i < missing.length; i++) {
+      const vector = embedded[i];
+      if (!vector) continue;
+      vectors.set(missing[i].messageId, vector);
+      await client.execute({
+        sql: 'INSERT OR REPLACE INTO transcript_embeddings (message_id, model, vector) VALUES (?, ?, ?)',
+        args: [missing[i].messageId, semantic.model, JSON.stringify(vector)],
+      });
+    }
+  }
+  return vectors;
+}
+
+function snippetAround(text: string, terms: Set<string>, chars: number): string {
+  const lower = text.toLowerCase();
+  let best = 0, bestCount = -1;
+  const step = Math.max(1, Math.floor(chars / 4));
+  for (let start = 0; start < Math.max(1, lower.length - chars); start += step) {
+    const window = lower.slice(start, start + chars);
+    let count = 0;
+    for (const term of terms) if (window.includes(term)) count++;
+    if (count > bestCount) { bestCount = count; best = start; }
+  }
+  const slice = text.slice(best, best + chars).replace(/\n{3,}/g, '\n\n').trim();
+  return (best > 0 ? '…' : '') + slice + (best + chars < text.length ? '…' : '');
+}
+
+export async function searchTranscripts(
+  query: string,
+  options: TranscriptSearchOptions = {},
+): Promise<{ hits: TranscriptHit[]; indexed: number; sessions: number; indexMs: number; indexComplete: boolean }> {
+  const { projectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId } = options;
+  const terms = [...new Set(tokenize(query))];
+
+  const index = await ensureTranscriptIndex(projectDir, stores);
+  const stats = await transcriptIndexStats(projectDir);
+  const base = { indexed: stats.messages, sessions: stats.sessions, indexMs: index.ms, indexComplete: index.complete };
+  if (terms.length === 0) return { hits: [], ...base };
+
+  const lexical = await lexicalRank(projectDir, terms, semantic ? RERANK_DEPTH : limit * 3, sessionId);
+  if (lexical.length === 0) return { hits: [], ...base };
+
+  const client = getClient();
+  const rows = (await client.execute({
+    sql: `SELECT id, session_id, line, role, ts, text FROM transcript_messages
+          WHERE id IN (${lexical.map(() => '?').join(',')})${since ? ' AND (ts IS NULL OR ts >= ?)' : ''}`,
+    args: since ? [...lexical.map(l => l.messageId), since] : lexical.map(l => l.messageId),
+  })).rows;
+  const byId = new Map(rows.map(row => [Number(row.id), row]));
+
+  let ordered = lexical.filter(entry => byId.has(entry.messageId));
+
+  if (semantic && ordered.length > 1) {
+    const candidates = ordered.map(entry => ({ messageId: entry.messageId, text: String(byId.get(entry.messageId)!.text) }));
+    try {
+      const byMessage = await candidateVectors(candidates, semantic);
+      const [queryVector] = await semantic.embed([query]);
+      if (queryVector && byMessage.size > 0) {
+        const semanticOrder = [...byMessage.entries()]
+          .map(([messageId, vector]) => ({ messageId, score: cosine(queryVector, vector) }))
+          .sort((a, b) => b.score - a.score);
+        // Reciprocal Rank Fusion: combine POSITIONS, not scores. BM25 magnitudes
+        // and cosine similarities are not on a comparable scale, and normalising
+        // them invents a relationship that isn't there.
+        const fused = new Map<number, number>();
+        ordered.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
+        semanticOrder.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
+        ordered = [...fused.entries()]
+          .map(([messageId, score]) => ({ messageId, score }))
+          .sort((a, b) => b.score - a.score);
+      }
+    } catch {
+      // Embeddings are optional and can fail (model not downloaded, provider off).
+      // Lexical order is a complete answer on its own, so degrade rather than error.
+    }
+  }
+
+  const termSet = new Set(terms);
+  const hits = ordered.slice(0, limit).map(entry => {
+    const row = byId.get(entry.messageId)!;
+    return {
+      sessionId: String(row.session_id),
+      line: Number(row.line),
+      role: String(row.role),
+      timestamp: row.ts ? String(row.ts) : undefined,
+      score: Number(entry.score.toFixed(4)),
+      snippet: snippetAround(String(row.text), termSet, snippetChars),
+      locator: `transcript://${row.session_id}#L${row.line}`,
+    };
+  });
+
+  return { hits, ...base };
+}
+
+/** Read one entry in full, straight from the file, for when a snippet cannot settle the question. */
+export async function readTranscriptEntry(
+  sessionId: string,
+  line: number,
+  projectDir = process.cwd(),
+  stores?: string[],
+): Promise<{ text: string; role: string; timestamp?: string } | null> {
+  const files = await sessionFiles(projectDir, stores);
+  const file = files.find(f => f.sessionId === sessionId || f.sessionId.startsWith(sessionId));
+  if (!file) return null;
+  const rl = createInterface({ input: createReadStream(file.path), crlfDelay: Infinity });
+  let lineNo = 0;
+  for await (const raw of rl) {
+    lineNo++;
+    if (lineNo !== line) continue;
+    rl.close();
+    try {
+      const entry = JSON.parse(raw);
+      const content = entry?.message?.content;
+      const text = typeof content === 'string'
+        ? content
+        : Array.isArray(content)
+          ? content.map((b: any) => b?.type === 'text' ? b.text
+              : b?.type === 'tool_use' ? JSON.stringify(b.input ?? {})
+              : b?.type === 'tool_result' ? (typeof b.content === 'string' ? b.content : JSON.stringify(b.content ?? ''))
+              : '').join('\n')
+          : '';
+      return { text, role: entry.type, timestamp: entry.timestamp };
+    } catch { return null; }
+  }
+  return null;
+}

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -16,7 +16,7 @@ import {
 const EXPECTED_TOOLS = [
   'knowl_query',
   'knowl_recent', 'knowl_state', 'knowl_context',
-  'knowl_transcript_search', 'knowl_transcript_read',
+  'knowl_session_list', 'knowl_transcript_search', 'knowl_transcript_read',
   'knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish',
   'knowl_store', 'knowl_ingest_atoms', 'knowl_decide', 'knowl_update',
   'knowl_timeline', 'knowl_evidence_list', 'knowl_conflicts', 'knowl_feedback',
@@ -31,7 +31,7 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
   'Route:',
   '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
-  '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
+  '- verbatim: knowl_session_list to browse/find past sessions; knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to one session; knowl_transcript_read one entry in full; promote what you use.',
   '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
   '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
   '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
@@ -42,10 +42,10 @@ const EXPECTED_CLAUDE_CARD = [
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
 
 describe('canonical Knowl agent guidance', () => {
-  it('defines eight groups and the exact 26-tool inventory', () => {
+  it('defines eight groups and the exact 27-tool inventory', () => {
     expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(8);
     expect(KNOWL_MCP_TOOL_NAMES).toEqual(EXPECTED_TOOLS);
-    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(26);
+    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(27);
     expect(KNOWL_MCP_TOOL_NAMES).not.toContain('knowl_ask');
   });
 
@@ -62,8 +62,8 @@ describe('canonical Knowl agent guidance', () => {
 
   it('keeps both compact renderings bounded and front-loads the required action', () => {
     expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toBe(EXPECTED_CLAUDE_CARD);
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_871);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_922);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_917);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_968);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -84,7 +84,7 @@ describe('canonical Knowl agent guidance', () => {
     const documentedTools = [...readme.matchAll(/^\| \`(knowl_[a-z_]+)\` \|/gm)]
       .map(match => match[1]);
     expect(documentedTools).toEqual([...KNOWL_MCP_TOOL_NAMES]);
-    expect(new Set(documentedTools).size).toBe(26);
+    expect(new Set(documentedTools).size).toBe(27);
     expect(readme).toContain('KNOWL.md');
     expect(readme).toContain('GEMINI.md');
     expect(readme).toContain('agent-reminder claude --json');

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -16,6 +16,7 @@ import {
 const EXPECTED_TOOLS = [
   'knowl_query',
   'knowl_recent', 'knowl_state', 'knowl_context',
+  'knowl_transcript_search', 'knowl_transcript_read',
   'knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish',
   'knowl_store', 'knowl_ingest_atoms', 'knowl_decide', 'knowl_update',
   'knowl_timeline', 'knowl_evidence_list', 'knowl_conflicts', 'knowl_feedback',
@@ -30,6 +31,7 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
   'Route:',
   '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
+  '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
   '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
   '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
   '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
@@ -40,10 +42,10 @@ const EXPECTED_CLAUDE_CARD = [
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
 
 describe('canonical Knowl agent guidance', () => {
-  it('defines seven groups and the exact 24-tool inventory', () => {
-    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(7);
+  it('defines eight groups and the exact 26-tool inventory', () => {
+    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(8);
     expect(KNOWL_MCP_TOOL_NAMES).toEqual(EXPECTED_TOOLS);
-    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(24);
+    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(26);
     expect(KNOWL_MCP_TOOL_NAMES).not.toContain('knowl_ask');
   });
 
@@ -60,8 +62,8 @@ describe('canonical Knowl agent guidance', () => {
 
   it('keeps both compact renderings bounded and front-loads the required action', () => {
     expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toBe(EXPECTED_CLAUDE_CARD);
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_695);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_746);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_871);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_922);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -82,7 +84,7 @@ describe('canonical Knowl agent guidance', () => {
     const documentedTools = [...readme.matchAll(/^\| \`(knowl_[a-z_]+)\` \|/gm)]
       .map(match => match[1]);
     expect(documentedTools).toEqual([...KNOWL_MCP_TOOL_NAMES]);
-    expect(new Set(documentedTools).size).toBe(24);
+    expect(new Set(documentedTools).size).toBe(26);
     expect(readme).toContain('KNOWL.md');
     expect(readme).toContain('GEMINI.md');
     expect(readme).toContain('agent-reminder claude --json');

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(26);
+    expect(new Set(names).size).toBe(27);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(24);
+    expect(new Set(names).size).toBe(26);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/store/session-directory.test.ts
+++ b/tests/store/session-directory.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { encodeProjectDir, ensureTranscriptIndex } from '../../src/store/transcript-index.js';
+import { listSessionDirectory } from '../../src/store/session-directory.js';
+
+const TEST_ROOT = path.resolve('./.knowl-session-directory-test');
+// Injected store, never HOME: mutating HOME/USERPROFILE leaks into other suites.
+const FAKE_STORE = path.join(TEST_ROOT, 'store', 'projects');
+const STORES = [FAKE_STORE];
+const PROJECT_DIR = 'D:\\Code\\DirectoryProject';
+
+const line = (obj: object) => JSON.stringify(obj) + '\n';
+const user = (text: string, ts: string) => line({ type: 'user', timestamp: ts, message: { content: text } });
+const assistant = (text: string, ts: string) => line({ type: 'assistant', timestamp: ts, message: { content: [{ type: 'text', text }] } });
+
+let sessionDir: string;
+let projectId: string;
+
+describe('session directory', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    projectId = (await repo.createProject(TEST_ROOT, 'Session directory test')).id;
+
+    sessionDir = path.join(FAKE_STORE, encodeProjectDir(PROJECT_DIR));
+    await fs.mkdir(sessionDir, { recursive: true });
+
+    // A renamed session: custom-title must beat the generated ai-title.
+    await fs.writeFile(path.join(sessionDir, 'ui-session.jsonl'),
+      line({ type: 'ai-title', sessionId: 'ui-session', aiTitle: 'Generated title about buttons' }) +
+      user('<local-command-caveat>Caveat: local commands</local-command-caveat>', '2026-01-01T00:00:00Z') +
+      user('polish the trial screen meta band and fix the fork stage', '2026-01-01T00:01:00Z') +
+      assistant('Starting on the meta band.', '2026-01-01T00:02:00Z') +
+      line({ type: 'custom-title', sessionId: 'ui-session', customTitle: 'ui-trial-screen' }));
+
+    // Never named: must still appear, described by its opening ask.
+    await fs.writeFile(path.join(sessionDir, 'unnamed.jsonl'),
+      user('investigate the postgres migration ordering bug', '2026-01-02T00:00:00Z') +
+      assistant('Reading the migrations.', '2026-01-02T00:01:00Z'));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('lists sessions newest first with names from the transcript itself', async () => {
+    const { entries, indexComplete } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    expect(indexComplete).toBe(true);
+    expect(entries.length).toBe(2);
+    const ui = entries.find(entry => entry.sessionId === 'ui-session')!;
+    // The user's rename wins over the generated title.
+    expect(ui.name).toBe('ui-trial-screen');
+    expect(ui.opening).toContain('polish the trial screen');
+    // The caveat wrapper is not an opening.
+    expect(ui.opening).not.toContain('local-command-caveat');
+  });
+
+  it('includes unnamed sessions, described by their opening ask', async () => {
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    const unnamed = entries.find(entry => entry.sessionId === 'unnamed')!;
+    expect(unnamed.name).toBeNull();
+    expect(unnamed.opening).toContain('postgres migration ordering');
+  });
+
+  it('answers "which session was about X" with a keyword filter', async () => {
+    const ui = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'trial screen' });
+    expect(ui.entries.map(entry => entry.sessionId)).toEqual(['ui-session']);
+    const pg = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'postgres migration' });
+    expect(pg.entries.map(entry => entry.sessionId)).toEqual(['unnamed']);
+    const none = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'kubernetes' });
+    expect(none.entries).toEqual([]);
+  });
+
+  it('a later rename appended to the transcript updates the name incrementally', async () => {
+    await fs.appendFile(path.join(sessionDir, 'ui-session.jsonl'),
+      line({ type: 'custom-title', sessionId: 'ui-session', customTitle: 'ui-trial-screen-v2' }));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    expect(entries.find(entry => entry.sessionId === 'ui-session')!.name).toBe('ui-trial-screen-v2');
+  });
+
+  it('derives status from lifecycle signals and surfaces declared cards, without storing anything', async () => {
+    const client = getClient();
+    const { storeKnowledgeItemDeduped } = await import('../../src/store/knowledge-writer.js');
+    const now = new Date().toISOString();
+
+    // An unconsumed crash handoff names ui-session -> interrupted, outranking activity.
+    await storeKnowledgeItemDeduped(projectId, {
+      category: 'state', title: 'Rate limit interrupted the ui worksession',
+      content: JSON.stringify({ kind: 'rate_limit', externalSessionId: 'ui-session', consumed: false }),
+      tags: ['pending_handoff', 'rate_limit', 'claude', 'session:ui-session'],
+    } as any, 'test');
+
+    // A live memory session with a fresh heartbeat bound to unnamed -> active.
+    await client.execute({
+      sql: `INSERT INTO memory_sessions (id, title, status, started_at, last_heartbeat_at, expires_at)
+            VALUES ('ms-live', 'Agent turn', 'active', ?, ?, '2099-01-01T00:00:00.000Z')`,
+      args: [now, now],
+    });
+    await client.execute({
+      sql: `INSERT INTO host_session_bindings (host, project_root, external_session_id, external_turn_id, memory_session_id, active, updated_at)
+            VALUES ('claude', ?, 'unnamed', '__session__', 'ms-live', 1, ?)`,
+      args: [PROJECT_DIR.toLowerCase(), now],
+    });
+
+    // A declared card, findable by the keyword filter.
+    await storeKnowledgeItemDeduped(projectId, {
+      category: 'state', title: 'ui-trial-screen: meta band polish, parked at contrast pass',
+      content: 'Session card.', tags: ['session-card', 'session:ui-session'],
+    } as any, 'test');
+
+    // A pre-tag-era handoff: session id only in content JSON. Real archives
+    // have these, so the fallback is load-bearing, not defensive.
+    await storeKnowledgeItemDeduped(projectId, {
+      category: 'state', title: 'Provider outage stranded an unnamed legacy run',
+      content: JSON.stringify({ kind: 'provider_outage', externalSessionId: 'unnamed-legacy', consumed: false }),
+      tags: ['pending_handoff', 'provider_outage', 'claude'],
+    } as any, 'test');
+
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    const ui = entries.find(entry => entry.sessionId === 'ui-session')!;
+    const unnamed = entries.find(entry => entry.sessionId === 'unnamed')!;
+    expect(ui.status).toBe('interrupted');
+    expect(ui.card).toContain('meta band polish');
+    expect(unnamed.status).toBe('active');
+
+    // Cards are part of intent, so the filter can find a session through one.
+    const byCard = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'contrast parked' });
+    expect(byCard.entries.map(entry => entry.sessionId)).toEqual(['ui-session']);
+  });
+
+  it('surfaces knowledge a session promoted, joined through the lifecycle chain', async () => {
+    const client = getClient();
+    // Minimal lifecycle chain: memory session -> binding -> promoted item.
+    const { storeKnowledgeItemDeduped } = await import('../../src/store/knowledge-writer.js');
+    const stored = await storeKnowledgeItemDeduped(projectId, {
+      category: 'decision', title: 'Water shader uses two scrolling layers', content: 'Decided during the ui session.',
+    } as any, 'test');
+    const itemId = stored.item.id;
+    const now = new Date().toISOString();
+    await client.execute({
+      sql: `INSERT INTO memory_sessions (id, title, status, started_at, last_heartbeat_at, expires_at, promotion_status, promotion_items)
+            VALUES ('ms-1', 'Agent turn', 'finished', ?, ?, ?, 'promoted', ?)`,
+      args: [now, now, '2099-01-01T00:00:00Z', JSON.stringify([itemId])],
+    });
+    await client.execute({
+      sql: `INSERT INTO host_session_bindings (host, project_root, external_session_id, external_turn_id, memory_session_id, active, updated_at)
+            VALUES ('claude', ?, 'ui-session', '__session__', 'ms-1', 1, ?)`,
+      args: [PROJECT_DIR.toLowerCase(), now],
+    });
+
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    const ui = entries.find(entry => entry.sessionId === 'ui-session')!;
+    expect(ui.promoted.length).toBeGreaterThan(0);
+    expect(ui.promoted[0]).toContain('Water shader');
+  });
+});

--- a/tests/store/transcript-search.test.ts
+++ b/tests/store/transcript-search.test.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { encodeProjectDir, ensureTranscriptIndex, transcriptIndexStats } from '../../src/store/transcript-index.js';
+import { readTranscriptEntry, searchTranscripts } from '../../src/store/transcript-search.js';
+
+const TEST_ROOT = path.resolve('./.knowl-transcript-search-test');
+// A fake transcript store, injected rather than pointed at via HOME: mutating
+// HOME/USERPROFILE leaks into every other suite sharing the worker, and
+// os.homedir() reads USERPROFILE on Windows.
+const FAKE_STORE = path.join(TEST_ROOT, 'store', 'projects');
+const STORES = [FAKE_STORE];
+const PROJECT_DIR = 'D:\\Code\\FakeProject';
+
+function userLine(text: string, ts: string) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { content: text } }) + '\n';
+}
+function assistantLine(text: string, ts: string) {
+  return JSON.stringify({ type: 'assistant', timestamp: ts, message: { content: [{ type: 'text', text }] } }) + '\n';
+}
+function toolLine(result: string, ts: string) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { content: [{ type: 'tool_result', content: result }] } }) + '\n';
+}
+
+let sessionDir: string;
+
+describe('transcript search', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    await repo.createProject(TEST_ROOT, 'Transcript search test');
+
+    sessionDir = path.join(FAKE_STORE, encodeProjectDir(PROJECT_DIR));
+    await fs.mkdir(sessionDir, { recursive: true });
+
+    await fs.writeFile(path.join(sessionDir, 'session-one.jsonl'),
+      // Noise that must never be indexed.
+      userLine('<local-command-caveat>Caveat: ignore me</local-command-caveat>', '2026-01-01T00:00:00Z') +
+      userLine('<command-name>/rename</command-name>', '2026-01-01T00:01:00Z') +
+      // The target: a decision stated by the user.
+      userLine('the boxed card variant read as an advertisement so we rejected it', '2026-01-02T00:00:00Z') +
+      assistantLine('Understood, dropping the boxed variant.', '2026-01-02T00:01:00Z') +
+      // Distractor sharing one term only.
+      assistantLine('The card padding is sixteen pixels.', '2026-01-02T00:02:00Z'));
+
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'),
+      toolLine('boxed card variant advertisement rejected rejected rejected', '2026-01-03T00:00:00Z') +
+      assistantLine('Unrelated discussion about migrations.', '2026-01-03T00:01:00Z'));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    // Windows keeps a handle on the WAL briefly after close, so removal here can
+    // race and throw EBUSY. beforeAll clears the directory anyway, which is the
+    // guarantee the suite actually needs.
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('encodes a project directory the way Claude Code does', () => {
+    expect(encodeProjectDir('D:\\Code\\FakeProject')).toBe('D--Code-FakeProject');
+  });
+
+  it('ranks the user message that states the decision first', async () => {
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].role).toBe('user');
+    expect(hits[0].snippet).toContain('advertisement');
+    expect(hits[0].locator).toMatch(/^transcript:\/\/session-one#L\d+$/);
+  });
+
+  it('never returns the caveat wrapper or a bare slash command', async () => {
+    const { hits } = await searchTranscripts('rename caveat ignore', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    for (const hit of hits) {
+      expect(hit.snippet).not.toContain('local-command-caveat');
+      expect(hit.snippet).not.toContain('<command-name>');
+    }
+  });
+
+  it('indexes tool output but weights it below real prose', async () => {
+    const { hits } = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    // The tool result repeats the term more often, so an unweighted BM25 would
+    // put it first. The user message must still win.
+    expect(hits[0].sessionId).toBe('session-one');
+    expect(hits.some(hit => hit.sessionId === 'session-two')).toBe(true);
+  });
+
+  it('rewards covering every query term over repeating one', async () => {
+    const { hits } = await searchTranscripts('boxed variant advertisement', { projectDir: PROJECT_DIR, limit: 5, stores: STORES });
+    expect(hits[0].snippet).toContain('boxed');
+    expect(hits[0].snippet).toContain('advertisement');
+  });
+
+  it('returns nothing for a query of only stopwords', async () => {
+    const { hits } = await searchTranscripts('the and for', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits).toEqual([]);
+  });
+
+  it('reads a single entry in full from its locator', async () => {
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    const entry = await readTranscriptEntry(hits[0].sessionId, hits[0].line, PROJECT_DIR, STORES);
+    expect(entry?.role).toBe('user');
+    expect(entry?.text).toContain('rejected it');
+  });
+
+  it('re-indexing an unchanged archive adds nothing and opens no files', async () => {
+    const before = await transcriptIndexStats(PROJECT_DIR);
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(result.messagesAdded).toBe(0);
+    expect(result.filesUpdated).toBe(0);
+    expect((await transcriptIndexStats(PROJECT_DIR)).messages).toBe(before.messages);
+  });
+
+  it('picks up appended messages without reindexing what came before', async () => {
+    const before = await transcriptIndexStats(PROJECT_DIR);
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      userLine('the gradient headline was rejected because it looked like a crypto advert', '2026-01-04T00:00:00Z'));
+
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    // Exactly one new message, not the whole file again.
+    expect(result.messagesAdded).toBe(1);
+    expect((await transcriptIndexStats(PROJECT_DIR)).messages).toBe(before.messages + 1);
+
+    const { hits } = await searchTranscripts('gradient headline crypto', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits[0].snippet).toContain('gradient headline');
+  });
+
+  it('rebuilds a session that was rewritten rather than appended to', async () => {
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'),
+      assistantLine('short', '2026-01-05T00:00:00Z'));
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(result.messagesAdded).toBeGreaterThan(0);
+    // The old tool-result line is gone, so its distinctive terms no longer match.
+    const { hits } = await searchTranscripts('migrations unrelated', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits.every(hit => hit.sessionId !== 'session-two')).toBe(true);
+  });
+
+  it('detects a same-size in-place rewrite by mtime and rebuilds the session', async () => {
+    // Same byte length, different content - invisible to the size check.
+    const before = assistantLine('the animal is a badger', '2026-01-05T01:00:00Z');
+    const after  = assistantLine('the animal is a ferret', '2026-01-05T01:00:00Z');
+    expect(Buffer.byteLength(after)).toBe(Buffer.byteLength(before));
+
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'), before);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect((await searchTranscripts('badger', { projectDir: PROJECT_DIR, stores: STORES })).hits.length).toBeGreaterThan(0);
+
+    // Rewrite the whole file with the one word changed; size is identical.
+    const content = await fs.readFile(path.join(sessionDir, 'session-one.jsonl'), 'utf8');
+    await fs.writeFile(path.join(sessionDir, 'session-one.jsonl'), content.replace('badger', 'ferret'));
+    // Detection is mtime-based, and a rewrite inside the same clock tick is
+    // indistinguishable - real rewrites happen later than that. Model it.
+    const later = new Date(Date.now() + 5_000);
+    await fs.utimes(path.join(sessionDir, 'session-one.jsonl'), later, later);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    expect((await searchTranscripts('badger', { projectDir: PROJECT_DIR, stores: STORES })).hits).toEqual([]);
+    expect((await searchTranscripts('ferret', { projectDir: PROJECT_DIR, stores: STORES })).hits.length).toBeGreaterThan(0);
+  });
+
+  it('stops at the time budget and resumes where it left off', async () => {
+    // Wipe the index so there is real work to interrupt.
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+    await client.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('delete-all')");
+    await client.execute('DELETE FROM transcript_messages');
+    await client.execute('DELETE FROM transcript_files');
+
+    // A zero budget expires on the first line, so the pass must report itself
+    // incomplete rather than quietly returning a half-built index as finished.
+    const first = await ensureTranscriptIndex(PROJECT_DIR, STORES, 0);
+    expect(first.complete).toBe(false);
+
+    // A generous budget finishes the job, and the total is the whole archive -
+    // proving the interrupted pass resumed instead of restarting or duplicating.
+    const second = await ensureTranscriptIndex(PROJECT_DIR, STORES, 60_000);
+    expect(second.complete).toBe(true);
+
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits[0].snippet).toContain('advertisement');
+
+    // No message indexed twice: one locator per line.
+    const all = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 50, stores: STORES });
+    const locators = all.hits.map(hit => hit.locator);
+    expect(new Set(locators).size).toBe(locators.length);
+  });
+
+  it('scopes to one session by id or prefix, which is what makes a handoff brief actionable', async () => {
+    // Own fixture: an earlier test rewrites session-two, so this cannot rely on
+    // the original contents still spanning both sessions.
+    await fs.appendFile(path.join(sessionDir, 'session-two.jsonl'),
+      userLine('a second take on the advertisement question', '2026-01-06T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    const all = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    expect(new Set(all.hits.map(hit => hit.sessionId)).size).toBeGreaterThan(1);
+
+    const scoped = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES, sessionId: 'session-one' });
+    expect(scoped.hits.length).toBeGreaterThan(0);
+    expect(scoped.hits.every(hit => hit.sessionId === 'session-one')).toBe(true);
+
+    // A prefix resolves the same way, so a brief can quote a short id.
+    const byPrefix = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES, sessionId: 'session-o' });
+    expect(byPrefix.hits.map(hit => hit.locator)).toEqual(scoped.hits.map(hit => hit.locator));
+  });
+
+  it('defers to another process\'s fresh lease, then reclaims it once stale', async () => {
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      userLine('the lease canary sentence about phosphorescent umbrellas', '2026-01-07T00:00:00Z'));
+
+    // Simulate a live claim by a DIFFERENT process: a fresh stamp this process
+    // never wrote. The file must be skipped without ending the whole pass.
+    await client.execute({
+      sql: "UPDATE transcript_files SET indexed_at = ? WHERE path LIKE '%session-one%'",
+      args: [new Date().toISOString()],
+    });
+    const deferred = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(deferred.complete).toBe(false);
+    const before = await searchTranscripts('phosphorescent umbrellas', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(before.hits).toEqual([]);
+
+    // Expire the claim: a crashed indexer must not stall the file forever.
+    await client.execute({
+      sql: "UPDATE transcript_files SET indexed_at = ? WHERE path LIKE '%session-one%'",
+      args: [new Date(Date.now() - 60_000).toISOString()],
+    });
+    const reclaimed = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(reclaimed.messagesAdded).toBeGreaterThan(0);
+    const after = await searchTranscripts('phosphorescent umbrellas', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(after.hits[0]?.snippet).toContain('phosphorescent');
+  });
+
+  it('drops cached embeddings when their messages are purged, so a reused id cannot inherit a stale vector', async () => {
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+
+    // Populate the embedding cache via a semantic search over current content.
+    const semantic = { model: 'purge-model', embed: async (texts: string[]) => texts.map(() => [1, 0]) };
+    // Two matching messages: the semantic pass only engages with >1 candidate.
+    await fs.appendFile(path.join(sessionDir, 'session-two.jsonl'),
+      userLine('embedding purge target phrase', '2026-01-08T00:00:00Z') +
+      assistantLine('a second embedding purge target for the ranker', '2026-01-08T00:01:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    await searchTranscripts('embedding purge target', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    const cached = Number((await client.execute("SELECT COUNT(*) n FROM transcript_embeddings WHERE model = 'purge-model'")).rows[0].n);
+    expect(cached).toBeGreaterThan(0);
+
+    // Rewrite the session so its rows are purged. No embedding row may survive
+    // pointing at a message that no longer exists.
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'), assistantLine('tiny', '2026-01-09T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    const orphans = Number((await client.execute(
+      'SELECT COUNT(*) n FROM transcript_embeddings e LEFT JOIN transcript_messages m ON m.id = e.message_id WHERE m.id IS NULL',
+    )).rows[0].n);
+    expect(orphans).toBe(0);
+  });
+
+  it('fuses a semantic ranking with the lexical one when a reranker is supplied', async () => {
+    // A stub embedder: vectors are keyed off a marker word, so the semantic pass
+    // has a defined preference without downloading a model.
+    const semantic = {
+      model: 'stub-model',
+      embed: async (texts: string[]) => texts.map(text => [text.includes('gradient') ? 1 : 0, text.includes('boxed') ? 1 : 0]),
+    };
+    const { hits } = await searchTranscripts('gradient headline crypto', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].snippet).toContain('gradient');
+  });
+
+  it('degrades to lexical ranking when the reranker throws', async () => {
+    const broken = { model: 'broken', embed: async () => { throw new Error('model unavailable'); } };
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES, semantic: broken });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].role).toBe('user');
+  });
+});


### PR DESCRIPTION
> **Stacked on #7** (`feat/transcript-search`) — this branch contains #7's commit plus one more. Review only the top commit here; merge #7 first, after which this shows only the session-directory change.

## What this adds

`knowl_session_list`: a browsable, agent-facing inventory of a project's Claude Code sessions — best-known name, opening ask, activity, and the knowledge each session promoted into memory. It answers "which session was about X?" and "resume or start fresh?", then hands its `sessionId` to `knowl_transcript_search` to read into the chosen session.

## Research before build

Nine shipped tools surveyed first (native `/resume` picker, claude-historian-mcp, claude-session-manager, fork-aware claude-session-mcp, iannuttall/claude-sessions, ClaudeHistoryMCP, tim0120's, raine/claude-history, Session Continuity MCP). Cross-cut findings that shaped this design:

- Everyone enumerates from the transcript store; **nobody reads the transcript's own title entries** — external tools fall back to filenames or first prompts, while a `custom-title` from a user rename is sitting in the file.
- **Deterministic summaries are the norm**; AI summaries are the exception and require a model. This tool is deterministic throughout.
- **Nobody models what a session was for.** The closest attempt is manual session-documentation commands whose own README names forgetting as the failure mode.
- The native picker's issue tracker (anthropics/claude-code #23375, #24435, #25130, #29052, #35698) documents the pain directly: 50-session cap, ~10 enriched, unnamed sessions filtered out entirely.

Skipped deliberately: AI summarization (provider-dependent), regex "decisions/solutions" extraction (knowl's hook-driven candidate promotion already owns that signal), message-level fork trees (solved elsewhere).

## How it works

The transcript indexer from #7 already streams every line; it now also captures — at zero additional IO — the session's title entries (`custom-title` > `agent-name` > `ai-title`, later beats earlier within a rank, carried across incremental passes and reset when a file is rewritten) and the first real user ask as a one-line descriptor. `knowl_session_list` joins that with per-session activity and, through `host_session_bindings → memory_sessions → promotion_items`, the titles of atoms each session promoted — the one enrichment a plain transcript viewer cannot offer. Keyword filter over intent fields only; no session cap; unnamed sessions included.

Schema: three columns on `transcript_files` (unreleased table from #7), with a self-heal that resets watermarks so pre-existing dev indexes refill names on the next pass.

## Status and cards — the gap nobody in the survey fills

Each entry carries a `status`, derived at read time and never stored: `interrupted` when an unconsumed crash handoff names the session (including pre-tag handoffs that carry the id only in content JSON — real archives have these), `active` on a recent bound heartbeat or transcript write, `idle` otherwise. Fine-grained working/stalled tiers from live monitors were considered and rejected — their precondition (real-time observation) is absent in a recall surface.

Sessions can also declare a card — any atom tagged `session-card` + `session:<id>` via the existing `knowl_store`, newest wins — and the directory surfaces it beside the derived status, included in keyword matching. Intent declaration costs zero new tools.

## Measured

Against a 66-session / ~930MB archive: `query: "ui"` returned the owner's main UI-design session and four spawned UI worksessions, correctly named, in one call — the exact question that motivated the feature.

## Testing

7 new tests (rename-beats-generated-title, unnamed-session inclusion, keyword filter, incremental rename pickup, lifecycle-chain enrichment, status derivation incl. legacy content-only handoffs, card surfacing + filtering) plus the four-part guidance contract updated: 27 tools, compact card measured at 1,917/1,968 chars against the 2,000 ceiling — headroom is thinning; worth a thought before the next tool.
