### PR TITLE
fix(access): stable ordering for same-millisecond access records

### DIFF
--- a/src/store/access-feedback.ts
+++ b/src/store/access-feedback.ts
@@ -88,7 +88,7 @@ export async function recordKnowledgeFeedback(input: Omit<KnowledgeAccessInput, 
 
 export async function listKnowledgeAccess(itemId: string): Promise<KnowledgeAccess[]> {
   const result = await getClient().execute({
-    sql: 'SELECT * FROM knowledge_access WHERE knowledge_item_id = ? ORDER BY retrieved_at ASC, id ASC',
+    sql: 'SELECT * FROM knowledge_access WHERE knowledge_item_id = ? ORDER BY retrieved_at ASC, rowid ASC',
     args: [itemId],
   });
   return result.rows.map(mapAccess);


### PR DESCRIPTION
One line: `ORDER BY retrieved_at ASC, id ASC` → `rowid ASC`. Ids are random hex, so two access records written in the same millisecond come back in coin-flip order; the access-feedback test asserts insertion order and flakes on fast runners — observed on an unrelated PR's CI run ([this failure](https://github.com/dat999zx/knowl/actions/runs/30695537241)). rowid is monotonic and therefore insertion order.
