### PR TITLE
feat(transcript-search): rank the whole archive semantically, not BM25's top 50 (stacked on #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ Knowl exposes exactly 24 MCP tools:
 | `knowl_recent` | Compact recent context when lifecycle bootstrap is unavailable or a refresh is needed |
 | `knowl_state` | Broad active-memory status or hierarchical project summary |
 | `knowl_context` | Compose an explicitly token-budgeted local context pack |
+| `knowl_session_list` | Browse past sessions as an inventory: names, opening asks, promoted knowledge |
 | `knowl_transcript_search` | Search the verbatim session transcripts when memory misses or is ambiguous |
 | `knowl_transcript_read` | Read one transcript entry in full when a snippet cannot settle it |
 | `knowl_task_start` | Start one manual work loop when verified lifecycle hooks are unavailable |

--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ Knowl exposes exactly 24 MCP tools:
 | `knowl_session_list` | Browse past sessions as an inventory: names, opening asks, promoted knowledge |
 | `knowl_transcript_search` | Search the verbatim session transcripts when memory misses or is ambiguous |
 | `knowl_transcript_read` | Read one transcript entry in full when a snippet cannot settle it |
+| `knowl_handoff` | Park the current workstream; the next session in this project receives it once |
 | `knowl_task_start` | Start one manual work loop when verified lifecycle hooks are unavailable |
 | `knowl_task_checkpoint` | Checkpoint meaningful manual-loop progress or blockers |
 | `knowl_task_finish` | Finish one manual work loop after verification |

--- a/README.md
+++ b/README.md
@@ -963,6 +963,8 @@ Knowl exposes exactly 24 MCP tools:
 | `knowl_recent` | Compact recent context when lifecycle bootstrap is unavailable or a refresh is needed |
 | `knowl_state` | Broad active-memory status or hierarchical project summary |
 | `knowl_context` | Compose an explicitly token-budgeted local context pack |
+| `knowl_transcript_search` | Search the verbatim session transcripts when memory misses or is ambiguous |
+| `knowl_transcript_read` | Read one transcript entry in full when a snippet cannot settle it |
 | `knowl_task_start` | Start one manual work loop when verified lifecycle hooks are unavailable |
 | `knowl_task_checkpoint` | Checkpoint meaningful manual-loop progress or blockers |
 | `knowl_task_finish` | Finish one manual work loop after verification |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "2.11.1",
+  "version": "3.0.0-fork.1",
   "description": "A Knowledge Operating System for AI Agents",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "3.0.0-fork.1",
+  "version": "3.0.0-fork.2",
   "description": "A Knowledge Operating System for AI Agents",
   "main": "dist/index.js",
   "type": "module",

--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -6,31 +6,48 @@ import { KnowledgeEmbedder } from '../store/vector-index.js';
 /**
  * Chosen by measurement on a real corpus, not by leaderboard rank.
  *
- * Against 346 project atoms with 17 queries phrased the way someone
- * half-remembers a thing, all-MiniLM-L6-v2 returned the correct atom first
- * only 29% of the time (MRR 0.465); bge-small doubles that to 59% (MRR 0.662)
- * for roughly 2x the embedding cost. MTEB rank would have picked
- * all-MiniLM-L12-v2, which measured SLOWER and LESS accurate here, and
- * bge-base, whose q8 export returns degenerate rankings (18% at every k,
- * under both mean and CLS pooling) - so neither leaderboards nor model size
- * predicted this outcome.
+ * Scored against project atoms with 17 queries phrased the way someone
+ * half-remembers a thing. Every row below is from ONE session on ONE corpus
+ * snapshot, because the baseline moves: bge-small scored MRR 0.662 one day and
+ * 0.621 the next on a corpus that had grown by ~16 atoms, which is larger than
+ * some of the gaps being judged.
  *
- * It also raises the input ceiling from 256 word-pieces to 512. The old model
- * silently truncated: transcript messages are stored up to 20,000 characters,
- * so long messages were being ranked on their first paragraph alone.
+ *   granite-embedding-small-english-r2  @1 59%  @3 94%  MRR 0.750  <- chosen
+ *   bge-small-en-v1.5                   @1 53%  @3 65%  MRR 0.621
+ *   granite-embedding-97m-multilingual-r2  @1 47%  @3 76%  MRR 0.643
+ *   all-MiniLM-L6-v2                    @1 29%  @3 53%  MRR 0.465
  *
- * Mean pooling is deliberate. BGE documents CLS pooling, but CLS measured
- * slightly worse here (MRR 0.640 vs 0.662), and the number from this corpus
- * outranks the number from the model card.
+ * Granite's English model finds the right atom in the top three 94% of the
+ * time against bge-small's 65% - five more queries out of seventeen - for
+ * about 1.3x the embedding cost. Its multilingual sibling of triple the size
+ * is NOT better here: it carries 200+ languages of capacity through an
+ * all-English corpus and lands inside the noise floor.
+ *
+ * Neither leaderboards nor parameter count predicted any of this. MTEB rank
+ * would have picked all-MiniLM-L12-v2, which measured slower AND less accurate,
+ * and bge-base's q8 export returns degenerate rankings (18% at every k).
  *
  * Changing this is safe: embeddings are keyed by provider+model and searched
  * with that as a filter, so vectors written by a previous model become
  * ineligible rather than being compared across model spaces.
  */
-const DEFAULT_LOCAL_EMBEDDING_MODEL = 'Xenova/bge-small-en-v1.5';
+const DEFAULT_LOCAL_EMBEDDING_MODEL = 'onnx-community/granite-embedding-small-english-r2-ONNX';
 const DEFAULT_LOCAL_EMBEDDING_DTYPE = 'q8';
 
-type TransformersPipeline = (texts: string[], options: { pooling: 'mean'; normalize: boolean }) => Promise<{
+/**
+ * Pooling is part of the model, not a preference.
+ *
+ * Granite is trained for CLS. Run it with mean - the setting its predecessor
+ * wanted - and the SAME weights on the SAME corpus score MRR 0.337 instead of
+ * 0.750. That is a worse result than the model this replaces, from a model that
+ * beats it, produced by one wrong string. So it travels with the model default
+ * rather than being assumed, and config can override it per model.
+ */
+const DEFAULT_LOCAL_EMBEDDING_POOLING: PoolingMode = 'cls';
+
+export type PoolingMode = 'mean' | 'cls';
+
+type TransformersPipeline = (texts: string[], options: { pooling: PoolingMode; normalize: boolean }) => Promise<{
   data: Float32Array | number[];
   dims: number[];
 }>;
@@ -58,6 +75,22 @@ export function isVectorSearchEnabled(config: ProjectConfig): boolean {
   return config.search?.vector?.enabled === true;
 }
 
+/**
+ * The pooling a model was trained for, unless config says otherwise.
+ *
+ * A config that names a model but not its pooling is the common case, and
+ * silently applying the wrong one costs more accuracy than the model choice
+ * gained. So the mapping is explicit and the default follows the family: BGE
+ * and MiniLM are trained for mean, Granite and E5 for CLS. An unrecognised
+ * model keeps mean, which is what the majority of small sentence encoders on
+ * the hub expect.
+ */
+function poolingFor(model: string | undefined, configured: string | undefined): PoolingMode {
+  if (configured === 'cls' || configured === 'mean') return configured;
+  if (!model) return DEFAULT_LOCAL_EMBEDDING_POOLING;
+  return /granite|e5-|gte-multilingual/i.test(model) ? 'cls' : 'mean';
+}
+
 export function getVectorSearchConfig(config: ProjectConfig) {
   const vector = config.search?.vector;
   return {
@@ -65,6 +98,7 @@ export function getVectorSearchConfig(config: ProjectConfig) {
     provider: vector?.provider || 'local',
     model: vector?.model || DEFAULT_LOCAL_EMBEDDING_MODEL,
     dtype: vector?.dtype || DEFAULT_LOCAL_EMBEDDING_DTYPE,
+    pooling: poolingFor(vector?.model, vector?.pooling),
     cacheDir: vector?.cacheDir,
   };
 }
@@ -107,18 +141,26 @@ export async function createLocalEmbeddingProvider(
   return {
     provider: 'local',
     model: vector.model,
+    // One text per forward pass, whatever the caller hands over.
+    //
+    // Two reasons, both measured. A batch pads every sequence to its longest
+    // member, and real corpora are not uniform: on a real transcript queue
+    // (median 169 chars, max 2,000) batches of 16 ran at 198 ms/doc against
+    // 42 ms/doc one at a time. Batching here was 4.7x SLOWER than not batching.
+    //
+    // And a long-context model makes it fatal rather than slow. Granite R2
+    // builds a global attention mask sized by the longest sequence in the
+    // batch, so passing all 363 knowledge atoms in one call - which
+    // reindexKnowledgeEmbeddings did - asked onnxruntime for a 52 GB buffer and
+    // killed the process. Enforced here rather than at each call site, because
+    // every caller that batches is one model change away from that crash.
     embed: async (texts: string[]) => {
-      const output = await localPipeline!(texts, {
-        pooling: 'mean',
-        normalize: true,
-      });
-      const dimensions = output.dims[1];
-      const data = Array.from(output.data);
-
-      return texts.map((_, index) => {
-        const start = index * dimensions;
-        return data.slice(start, start + dimensions);
-      });
+      const vectors: number[][] = [];
+      for (const text of texts) {
+        const output = await localPipeline!([text], { pooling: vector.pooling, normalize: true });
+        vectors.push(Array.from(output.data).slice(0, output.dims[output.dims.length - 1]));
+      }
+      return vectors;
     },
   };
 }

--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -3,7 +3,31 @@ import fsPromises from 'node:fs/promises';
 import { ProjectConfig } from '../core/types.js';
 import { KnowledgeEmbedder } from '../store/vector-index.js';
 
-const DEFAULT_LOCAL_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
+/**
+ * Chosen by measurement on a real corpus, not by leaderboard rank.
+ *
+ * Against 346 project atoms with 17 queries phrased the way someone
+ * half-remembers a thing, all-MiniLM-L6-v2 returned the correct atom first
+ * only 29% of the time (MRR 0.465); bge-small doubles that to 59% (MRR 0.662)
+ * for roughly 2x the embedding cost. MTEB rank would have picked
+ * all-MiniLM-L12-v2, which measured SLOWER and LESS accurate here, and
+ * bge-base, whose q8 export returns degenerate rankings (18% at every k,
+ * under both mean and CLS pooling) - so neither leaderboards nor model size
+ * predicted this outcome.
+ *
+ * It also raises the input ceiling from 256 word-pieces to 512. The old model
+ * silently truncated: transcript messages are stored up to 20,000 characters,
+ * so long messages were being ranked on their first paragraph alone.
+ *
+ * Mean pooling is deliberate. BGE documents CLS pooling, but CLS measured
+ * slightly worse here (MRR 0.640 vs 0.662), and the number from this corpus
+ * outranks the number from the model card.
+ *
+ * Changing this is safe: embeddings are keyed by provider+model and searched
+ * with that as a filter, so vectors written by a previous model become
+ * ineligible rather than being compared across model spaces.
+ */
+const DEFAULT_LOCAL_EMBEDDING_MODEL = 'Xenova/bge-small-en-v1.5';
 const DEFAULT_LOCAL_EMBEDDING_DTYPE = 'q8';
 
 type TransformersPipeline = (texts: string[], options: { pooling: 'mean'; normalize: boolean }) => Promise<{

--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -4,34 +4,36 @@ import { ProjectConfig } from '../core/types.js';
 import { KnowledgeEmbedder } from '../store/vector-index.js';
 
 /**
- * Chosen by measurement on a real corpus, not by leaderboard rank.
+ * Chosen by measurement, on the corpus this actually searches.
  *
- * Scored against project atoms with 17 queries phrased the way someone
- * half-remembers a thing. Every row below is from ONE session on ONE corpus
- * snapshot, because the baseline moves: bge-small scored MRR 0.662 one day and
- * 0.621 the next on a corpus that had grown by ~16 atoms, which is larger than
- * some of the gaps being judged.
+ * The candidate list is the part that matters. An earlier pass tested five
+ * models recalled from memory - all 2021-2023 - and reported a confident
+ * winner. Enumerating the registry found 537 plausible ONNX candidates, and the
+ * model below beat that "winner" by 72%. A search engine ranks by accumulated
+ * popularity, which accumulates with age, so it structurally cannot surface a
+ * recent release. Rigor downstream cannot repair a biased candidate list.
  *
- *   granite-embedding-small-english-r2  @1 59%  @3 94%  MRR 0.750  <- chosen
- *   bge-small-en-v1.5                   @1 53%  @3 65%  MRR 0.621
- *   granite-embedding-97m-multilingual-r2  @1 47%  @3 76%  MRR 0.643
- *   all-MiniLM-L6-v2                    @1 29%  @3 53%  MRR 0.465
+ * Measured over the REAL 60k-message transcript archive, 20 known-item queries
+ * phrased in words the target message does not use:
  *
- * Granite's English model finds the right atom in the top three 94% of the
- * time against bge-small's 65% - five more queries out of seventeen - for
- * about 1.3x the embedding cost. Its multilingual sibling of triple the size
- * is NOT better here: it carries 200+ languages of capacity through an
- * all-English corpus and lands inside the noise floor.
+ *   ranker                        @1    @3    @10   MRR
+ *   BM25 alone                    5%    15%   15%   0.092
+ *   semantic alone (this model)   5%    30%   45%   0.230
+ *   BM25 + semantic, RRF fused    5%    35%   65%   0.227   <- what ships
  *
- * Neither leaderboards nor parameter count predicted any of this. MTEB rank
- * would have picked all-MiniLM-L12-v2, which measured slower AND less accurate,
- * and bge-base's q8 export returns degenerate rankings (18% at every k).
+ * recall@10 is the metric that matters here, not @1: the consumer is an agent
+ * that reads every returned snippet, not a human clicking the first link.
+ *
+ * On a curated 363-atom corpus the same models score far higher (0.493 for the
+ * previous pick) - a proxy corpus flatters everything, so decisions get made on
+ * the real one.
  *
  * Changing this is safe: embeddings are keyed by provider+model and searched
  * with that as a filter, so vectors written by a previous model become
- * ineligible rather than being compared across model spaces.
+ * ineligible rather than being compared across model spaces. It is not FREE -
+ * re-embedding 60k messages took ~2.5 hours locally.
  */
-const DEFAULT_LOCAL_EMBEDDING_MODEL = 'onnx-community/granite-embedding-small-english-r2-ONNX';
+const DEFAULT_LOCAL_EMBEDDING_MODEL = 'Snowflake/snowflake-arctic-embed-m-v2.0';
 const DEFAULT_LOCAL_EMBEDDING_DTYPE = 'q8';
 
 /**
@@ -44,6 +46,23 @@ const DEFAULT_LOCAL_EMBEDDING_DTYPE = 'q8';
  * rather than being assumed, and config can override it per model.
  */
 const DEFAULT_LOCAL_EMBEDDING_POOLING: PoolingMode = 'cls';
+
+/**
+ * Retrieval models are trained ASYMMETRICALLY: the query gets an instruction
+ * prefix the document does not. Arctic wants `query: `, E5 wants `query: `,
+ * Nomic wants `search_query: ` against `search_document: `. Omitting it is the
+ * same class of silent mistake as the wrong pooling - the model still returns
+ * vectors, they are just measurably worse, and nothing reports a problem.
+ *
+ * Keyed by model family, overridable in config for a model this does not know.
+ */
+const QUERY_PREFIXES: Array<[RegExp, string]> = [
+  [/arctic-embed-\w*-v2/i, 'query: '],
+  [/arctic-embed/i, 'Represent this sentence for searching relevant passages: '],
+  [/\be5-|multilingual-e5/i, 'query: '],
+  [/nomic-embed|modernbert-embed/i, 'search_query: '],
+  [/bge-\w+-en|mxbai-embed/i, 'Represent this sentence for searching relevant passages: '],
+];
 
 export type PoolingMode = 'mean' | 'cls';
 
@@ -88,7 +107,14 @@ export function isVectorSearchEnabled(config: ProjectConfig): boolean {
 function poolingFor(model: string | undefined, configured: string | undefined): PoolingMode {
   if (configured === 'cls' || configured === 'mean') return configured;
   if (!model) return DEFAULT_LOCAL_EMBEDDING_POOLING;
-  return /granite|e5-|gte-multilingual/i.test(model) ? 'cls' : 'mean';
+  return /granite|e5-|gte-|arctic|mxbai|bge-\w+-en/i.test(model) ? 'cls' : 'mean';
+}
+
+/** The instruction a query carries and a document does not. Empty for symmetric models. */
+function queryPrefixFor(model: string | undefined, configured: string | undefined): string {
+  if (typeof configured === 'string') return configured;
+  if (!model) return '';
+  return QUERY_PREFIXES.find(([pattern]) => pattern.test(model))?.[1] ?? '';
 }
 
 export function getVectorSearchConfig(config: ProjectConfig) {
@@ -99,6 +125,7 @@ export function getVectorSearchConfig(config: ProjectConfig) {
     model: vector?.model || DEFAULT_LOCAL_EMBEDDING_MODEL,
     dtype: vector?.dtype || DEFAULT_LOCAL_EMBEDDING_DTYPE,
     pooling: poolingFor(vector?.model, vector?.pooling),
+    queryPrefix: queryPrefixFor(vector?.model, vector?.queryPrefix),
     cacheDir: vector?.cacheDir,
   };
 }
@@ -161,6 +188,15 @@ export async function createLocalEmbeddingProvider(
         vectors.push(Array.from(output.data).slice(0, output.dims[output.dims.length - 1]));
       }
       return vectors;
+    },
+    /**
+     * A QUERY, not a document. Separate entry point rather than a flag, because
+     * the asymmetry is invisible at the call site otherwise and every caller
+     * that forgets it silently loses accuracy instead of failing.
+     */
+    embedQuery: async (text: string) => {
+      const output = await localPipeline!([vector.queryPrefix + text], { pooling: vector.pooling, normalize: true });
+      return Array.from(output.data).slice(0, output.dims[output.dims.length - 1]);
     },
   };
 }

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -8,6 +8,7 @@ export type ConfigKey =
   | 'search.vector.model'
   | 'search.vector.dtype'
   | 'search.vector.pooling'
+  | 'search.vector.queryPrefix'
   | 'search.vector.cacheDir'
   | 'ai.provider'
   | 'ai.model'
@@ -72,6 +73,7 @@ export const CONFIG_FIELDS: ConfigField[] = [
   // copied from whatever the last model wanted. Set it only for a model the
   // family mapping does not recognise.
   { key: 'search.vector.pooling', category: 'Search', type: 'enum', values: VECTOR_POOLINGS, parse: enumValue(VECTOR_POOLINGS) },
+  { key: 'search.vector.queryPrefix', category: 'Search', type: 'string', parse: String },
   { key: 'search.vector.cacheDir', category: 'Search', type: 'string', parse: String },
   { key: 'security.rejectSecrets', category: 'Security', type: 'boolean', parse: booleanValue, defaultValue: DEFAULT_CONFIG.security.rejectSecrets },
   { key: 'security.secretPatterns', category: 'Security', type: 'list', parse: stringList, defaultValue: DEFAULT_CONFIG.security.secretPatterns },

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -7,6 +7,7 @@ export type ConfigKey =
   | 'search.vector.provider'
   | 'search.vector.model'
   | 'search.vector.dtype'
+  | 'search.vector.pooling'
   | 'search.vector.cacheDir'
   | 'ai.provider'
   | 'ai.model'
@@ -59,6 +60,7 @@ const stringList = (raw: string) => raw.split(',').map(value => value.trim()).fi
 
 const VECTOR_PROVIDERS = ['local'] as const;
 const VECTOR_DTYPES = ['q4', 'q8', 'fp16', 'fp32'] as const;
+const VECTOR_POOLINGS = ['mean', 'cls'] as const;
 const AI_PROVIDERS = ['openai', 'anthropic', 'ollama', 'custom'] as const;
 
 export const CONFIG_FIELDS: ConfigField[] = [
@@ -66,6 +68,10 @@ export const CONFIG_FIELDS: ConfigField[] = [
   { key: 'search.vector.provider', category: 'Search', type: 'enum', values: VECTOR_PROVIDERS, parse: enumValue(VECTOR_PROVIDERS), defaultValue: DEFAULT_CONFIG.search?.vector?.provider },
   { key: 'search.vector.model', category: 'Search', type: 'string', parse: String, defaultValue: DEFAULT_CONFIG.search?.vector?.model },
   { key: 'search.vector.dtype', category: 'Search', type: 'enum', values: VECTOR_DTYPES, parse: enumValue(VECTOR_DTYPES), defaultValue: DEFAULT_CONFIG.search?.vector?.dtype },
+  // Left unset by default: the model's own family default is better than a value
+  // copied from whatever the last model wanted. Set it only for a model the
+  // family mapping does not recognise.
+  { key: 'search.vector.pooling', category: 'Search', type: 'enum', values: VECTOR_POOLINGS, parse: enumValue(VECTOR_POOLINGS) },
   { key: 'search.vector.cacheDir', category: 'Search', type: 'string', parse: String },
   { key: 'security.rejectSecrets', category: 'Security', type: 'boolean', parse: booleanValue, defaultValue: DEFAULT_CONFIG.security.rejectSecrets },
   { key: 'security.secretPatterns', category: 'Security', type: 'list', parse: stringList, defaultValue: DEFAULT_CONFIG.security.secretPatterns },

--- a/src/cli/doctor-fix.ts
+++ b/src/cli/doctor-fix.ts
@@ -4,6 +4,7 @@ import { installKnowlGitignoreEntry } from '../core/gitignore.js';
 import { closeDb, initDb } from '../store/database.js';
 import { getProjectByRootPath } from '../store/repository.js';
 import { recoverAbandonedSessions } from '../store/session-repository.js';
+import { repairUnnormalizedConflictKeys } from '../store/conflicts.js';
 import { reindexKnowledgeEmbeddings } from '../store/vector-index.js';
 import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../ai/embeddings.js';
 import { runAgentInitFlow } from './init-flow.js';
@@ -38,6 +39,15 @@ async function runRemedy(projectRoot: string, remedy: DoctorRemedy): Promise<voi
       await initDb(projectRoot);
       try {
         await recoverAbandonedSessions();
+      } finally {
+        await closeDb();
+      }
+      return;
+
+    case 'conflict-key-normalize':
+      await initDb(projectRoot);
+      try {
+        await repairUnnormalizedConflictKeys();
       } finally {
         await closeDb();
       }

--- a/src/cli/doctor-remedy.ts
+++ b/src/cli/doctor-remedy.ts
@@ -10,12 +10,17 @@
  * knowledge store and the MCP tool-surface checks deliberately have none: they need a person
  * or a new build, and pretending otherwise would let a sweep report a repo healthy when it
  * is not.
+ *
+ * The one integrity error that DOES get a remedy is an unnormalized conflict key: the repair
+ * is `normalizeConflictKey` applied to a column, which is deterministic, and leaving it means
+ * leaving rows permanently unreachable by every lookup.
  */
 export type DoctorRemedy =
   | { kind: 'guidance' }
   | { kind: 'gitignore' }
   | { kind: 'session-recover' }
   | { kind: 'reindex-vectors' }
+  | { kind: 'conflict-key-normalize' }
   /** Re-run a host's registration. Only ever emitted for a host the repo already uses. */
   | { kind: 'host-init'; host: string };
 

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -100,6 +100,19 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         // is cleared either by retiring the item or by changing the security setting.
         : 'run `knowl audit` to list the records, then retire an item with `knowl supersede <itemId> <replacementId>` or adjust security settings with `knowl config`',
     });
+
+    // Broken out of the integrity roll-up because, unlike the other integrity errors, this
+    // one has a deterministic repair. Left alone the rows stay unreachable by every conflict
+    // lookup, which reads as "no conflict" and lets the same identity be claimed again.
+    const unnormalizedKeys = integrity.findings.filter(finding => finding.code === 'unnormalized-conflict-key').length;
+    checks.push({
+      status: unnormalizedKeys > 0 ? 'FAIL' : 'OK',
+      message: unnormalizedKeys === 0
+        ? 'Conflict keys are in storage shape'
+        : `${unnormalizedKeys} conflict key(s) are not in storage shape and match no lookup`,
+      fix: unnormalizedKeys === 0 ? undefined : 'run `knowl doctor --fix` to normalize them',
+      remedy: unnormalizedKeys === 0 ? undefined : { kind: 'conflict-key-normalize' },
+    });
     try {
       await (getDb() as any).all(sql`SELECT 1 FROM knowledge_embeddings LIMIT 1`);
       checks.push({ status: 'OK', message: 'Database schema includes knowledge_embeddings' });

--- a/src/cli/query-command.ts
+++ b/src/cli/query-command.ts
@@ -2,6 +2,7 @@ import type { KnowledgeItem } from '../core/types.js';
 import { loadConfig } from '../core/config.js';
 import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../ai/embeddings.js';
 import { rankKnowledge, type RankOptions } from '../store/agent-query.js';
+import { embedSearchQuery } from '../store/vector-index.js';
 import { queryKnowledgeBase } from '../store/queries.js';
 import { queryFederated, type FederatedResult } from '../workspace/federated-query.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
@@ -57,7 +58,7 @@ export async function runCliQuery(input: {
   if (input.query && config && isVectorSearchEnabled(config)) {
     try {
       const embedder = await createLocalEmbeddingProvider(config, input.projectRoot);
-      const [embedding] = await embedder.embed([input.query]);
+      const embedding = await embedSearchQuery(embedder, input.query);
       vector = {
         enabled: true,
         provider: embedder.provider,

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -13,6 +13,11 @@ export const KNOWL_MCP_TOOL_GROUPS = [
     routing: 'Use recent only without lifecycle bootstrap or for an explicit refresh; state for broad status; context for an explicitly token-budgeted pack.',
   },
   {
+    label: 'Verbatim transcripts',
+    tools: ['knowl_transcript_search', 'knowl_transcript_read'],
+    routing: 'The lossless record under the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
+  },
+  {
     label: 'Manual work loop',
     tools: ['knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish'],
     routing: 'Use only without verified lifecycle hooks: start once, checkpoint meaningful milestones or blockers, and finish once after verification.',
@@ -97,6 +102,7 @@ function renderCompactKnowlGuidance(modeLine: string): string {
     'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
     'Route:',
     '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
+    '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
     '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
     '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
     '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -14,8 +14,8 @@ export const KNOWL_MCP_TOOL_GROUPS = [
   },
   {
     label: 'Verbatim transcripts',
-    tools: ['knowl_transcript_search', 'knowl_transcript_read'],
-    routing: 'The lossless record under the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
+    tools: ['knowl_session_list', 'knowl_transcript_search', 'knowl_transcript_read'],
+    routing: 'The lossless record under the distilled atoms. knowl_session_list browses past sessions as an inventory (names, opening asks, promoted knowledge) to pick one before reading into it. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
   },
   {
     label: 'Manual work loop',
@@ -102,7 +102,7 @@ function renderCompactKnowlGuidance(modeLine: string): string {
     'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
     'Route:',
     '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
-    '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
+    '- verbatim: knowl_session_list to browse/find past sessions; knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to one session; knowl_transcript_read one entry in full; promote what you use.',
     '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
     '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
     '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -18,6 +18,11 @@ export const KNOWL_MCP_TOOL_GROUPS = [
     routing: 'The lossless record under the distilled atoms. knowl_session_list browses past sessions as an inventory (names, opening asks, promoted knowledge) to pick one before reading into it. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Scope with sessionId when a handoff names a parent session, then widen. Read one entry in full only when a snippet cannot settle it. Promote what you used with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice.',
   },
   {
+    label: 'Session handoff',
+    tools: ['knowl_handoff'],
+    routing: 'Write a baton before deliberately leaving a workstream - goal, what is done, the next action, any blocker, and whether the work was verified. The next session started in this project receives it once at startup and it is then archived, so it is a one-shot pass, not a durable note. One baton per project at a time: writing another replaces it. Durable facts still belong in knowl_store.',
+  },
+  {
     label: 'Manual work loop',
     tools: ['knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish'],
     routing: 'Use only without verified lifecycle hooks: start once, checkpoint meaningful milestones or blockers, and finish once after verification.',
@@ -97,16 +102,17 @@ export const KNOWL_HOST_NEUTRAL_MODE_LINE = 'Mode: verified hooks, when active, 
 function renderCompactKnowlGuidance(modeLine: string): string {
   return [
     'KNOWL WORKFLOW - for project work.',
-    'Start: use a relevant active lifecycle hit; else call knowl_query with 2-6 keywords before repository files or commands. A knowl_task_start hit counts in manual mode. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are unavailable, stop and tell the user.',
+    'Start: use a relevant active lifecycle hit; else call knowl_query with 2-6 keywords before files or commands. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are unavailable, stop and tell the user.',
     modeLine,
-    'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
+    'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones/blockers, knowl_task_finish once after verification.',
     'Route:',
     '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
     '- verbatim: knowl_session_list to browse/find past sessions; knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to one session; knowl_transcript_read one entry in full; promote what you use.',
+    '- handoff: knowl_handoff when parking a workstream; the next session in this project receives it once, then it is archived.',
     '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
     '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
     '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
-    '- special: knowl_ingest only for explicit raw-source ingestion, never silent chat; knowl_synthesize only for an explicit scope; knowl_session_finish only for an explicitly owned manual session; knowl_gc_preview before maintenance; knowl_gc_apply only after preview and explicit approval.',
+    '- special: knowl_ingest only on explicit request, never silent chat; knowl_synthesize only for a stated scope; knowl_session_finish only for an owned manual session; knowl_gc_preview then knowl_gc_apply, only after approval.',
     'During work, store or update verified durable findings; never store raw transcripts, secrets, or routine command noise.',
   ].join('\n');
 }

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -23,6 +23,11 @@ export const KNOWL_MCP_TOOL_GROUPS = [
     routing: 'Write a baton before deliberately leaving a workstream - goal, what is done, the next action, any blocker, and whether the work was verified. The next session started in this project receives it once at startup and it is then archived, so it is a one-shot pass, not a durable note. One baton per project at a time: writing another replaces it. Durable facts still belong in knowl_store.',
   },
   {
+    label: 'Parked workstreams',
+    tools: ['knowl_park', 'knowl_resume'],
+    routing: 'Park work the user means to come back to, or a session ending mid-workstream: knowl_park mints a short key and returns a paste-ready instruction line to hand them verbatim, since a key reworded is a key lost. knowl_resume takes that key in any later session and returns the brief. Unlike the handoff baton, which the next session in this project consumes once, a key is held by the user, is not spent by resuming, and works any number of sessions later. Call knowl_resume as soon as a user supplies a key; with no key it lists what is parked here.',
+  },
+  {
     label: 'Manual work loop',
     tools: ['knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish'],
     routing: 'Use only without verified lifecycle hooks: start once, checkpoint meaningful milestones or blockers, and finish once after verification.',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -240,6 +240,8 @@ export interface ProjectConfig {
       dtype?: 'q4' | 'q8' | 'fp32' | 'fp16';
       /** Overrides the pooling the model's family is trained for. Wrong pooling costs more accuracy than a wrong model. */
       pooling?: 'mean' | 'cls';
+      /** Instruction prefix applied to QUERIES only. Defaults to the model family's. */
+      queryPrefix?: string;
       cacheDir?: string;
     };
   };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -238,6 +238,8 @@ export interface ProjectConfig {
       provider?: 'local';
       model?: string;
       dtype?: 'q4' | 'q8' | 'fp32' | 'fp16';
+      /** Overrides the pooling the model's family is trained for. Wrong pooling costs more accuracy than a wrong model. */
+      pooling?: 'mean' | 'cls';
       cacheDir?: string;
     };
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ import { recordKnownRepo } from './cli/repo-registry.js';
 import { discoverRepos } from './cli/repo-discovery.js';
 import { applyDoctorRemedies } from './cli/doctor-fix.js';
 import { formatSweepReport, sweepRepos } from './cli/upgrade-all.js';
-import { createLocalEmbeddingProvider, isVectorSearchEnabled } from './ai/embeddings.js';
+import { createLocalEmbeddingProvider, getVectorSearchConfig, isVectorSearchEnabled } from './ai/embeddings.js';
 import { getConfigValue, resetAllConfig, resetConfigValue, setConfigValue } from './cli/config/service.js';
 import { runConfigUi } from './cli/config/ui.js';
 import { DEFAULT_DIVERGENCE_POLICY, DIVERGENCE_POLICIES } from './store/import-policy.js';
@@ -1031,10 +1031,12 @@ program
   .command('reindex')
   .description('Rebuild derived search indexes')
   .option('--vectors', 'Rebuild optional vector embeddings')
+  .option('--transcripts', 'Embed session transcripts so semantic search covers the whole archive')
+  .option('--budget <minutes>', 'Stop after this long; rerun to continue where it stopped', '30')
   .action(async (options) => {
     try {
-      if (!options.vectors) {
-        throw new Error('Nothing to reindex. Pass --vectors to rebuild vector embeddings.');
+      if (!options.vectors && !options.transcripts) {
+        throw new Error('Nothing to reindex. Pass --vectors to rebuild vector embeddings, or --transcripts to embed session transcripts.');
       }
 
       const root = await findProjectRoot(process.cwd());
@@ -1057,8 +1059,79 @@ program
             : `Downloading local embedding model ${model} (first run)...`,
         ),
       });
-      const result = await reindexKnowledgeEmbeddings(project.id, embedder);
-      console.log(`Indexed ${result.indexed} vector embedding(s).`);
+      if (options.vectors) {
+        const result = await reindexKnowledgeEmbeddings(project.id, embedder);
+        console.log(`Indexed ${result.indexed} vector embedding(s).`);
+      }
+
+      if (options.transcripts) {
+        const { ensureTranscriptIndex } = await import('./store/transcript-index.js');
+        const { embedTranscripts, transcriptVectorStats } = await import('./store/transcript-vectors.js');
+        const model = getVectorSearchConfig(config).model;
+
+        // Only indexed messages can be embedded, and the search-time index pass
+        // is capped at seconds. Give it real time here, or a first run embeds
+        // the handful of messages that happened to be indexed already.
+        console.log('Indexing transcripts...');
+        try {
+          const index = await ensureTranscriptIndex(root, undefined, 10 * 60_000);
+          console.log(`  ${index.messagesAdded} new message(s) across ${index.filesScanned} session file(s)${index.complete ? '' : ` - ${index.filesPending} file(s) still pending`}.`);
+        } catch (error: any) {
+          // Live sessions write to this database while this runs, so a ten-minute
+          // indexing pass can lose a lock race. Everything already indexed is still
+          // embeddable, and both passes resume, so the run continues on what it has
+          // rather than discarding an hour of embedding over a contended write.
+          console.log(`  Indexing stopped early (${error.message}). Continuing with what is already indexed; rerun to pick up the rest.`);
+        }
+
+        const before = await transcriptVectorStats(root, model);
+        console.log(`Embedding ${before.total - before.embedded} of ${before.total} message(s) with ${model}...`);
+        // Progress matters here in a way it does not elsewhere: this is a job
+        // measured in tens of minutes, and a silent terminal is indistinguishable
+        // from a hung one.
+        let lastReport = Date.now();
+        const deadline = Date.now() + Math.max(1, Number(options.budget) || 30) * 60_000;
+        // A run measured in tens of minutes shares this database with live
+        // sessions, so it has to survive a lost lock race rather than end on
+        // one. Embedding is resumable - the work left is "messages with no
+        // vector" - so resuming is just calling it again.
+        for (let stall = 0; Date.now() < deadline; ) {
+          try {
+            const pass = await embedTranscripts(root, embedder, {
+              budgetMs: deadline - Date.now(),
+              onProgress: (embedded, remaining) => {
+                if (Date.now() - lastReport < 5_000) return;
+                lastReport = Date.now();
+                console.log(`  ${embedded} embedded this pass, ${remaining} to go`);
+              },
+            });
+            if (pass.complete) break;
+            // Out of budget rather than out of work.
+            if (Date.now() >= deadline) break;
+          } catch (error: any) {
+            // Reconnect, do not just wait. SQLITE_BUSY_SNAPSHOT means THIS
+            // connection is pinned to a read snapshot older than the current WAL
+            // head, so its writes can never commit again - measured directly: a
+            // fresh process wrote this same database in 71ms while the long-lived
+            // backfill had been failing on it for fourteen minutes straight.
+            // Backing off waits for a condition that only a reconnect clears.
+            // Cheap here: the embedding model lives in this process, not in the
+            // connection, so reopening costs a file handle and nothing else.
+            const wait = Math.min(30_000, 2_000 * 2 ** stall++);
+            if (Date.now() + wait >= deadline) { console.log(`  Still failing (${error.message}) and out of budget.`); break; }
+            console.log(`  Database conflict (${error.message}); reconnecting and resuming in ${wait / 1000}s.`);
+            await new Promise(resolve => setTimeout(resolve, wait));
+            try { await closeDb(); } catch { /* already gone; reopening is what matters */ }
+            await initDb(root);
+          }
+        }
+
+        const done = await transcriptVectorStats(root, model);
+        console.log(done.embedded >= done.total
+          ? `Embedded ${done.embedded} of ${done.total} message(s). Semantic search now covers the whole archive.`
+          : `Embedded ${done.embedded} of ${done.total} message(s); ${done.total - done.embedded} left. Run the same command again to continue.`);
+      }
+
       await closeDb();
     } catch (error: any) {
       console.error(`Error reindexing: ${error.message}`);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1063,8 +1063,7 @@ export function registerTools(
               '',
               'Resuming does not consume it; the same key works again later.',
               point.brief.sessionId ? '' : 'No sessionId was recorded, so the resuming session cannot read this conversation for detail — pass one next time.',
-            ].filter(Boolean).join('
-'),
+            ].filter(Boolean).join('\n'),
           }],
         };
       }
@@ -1077,9 +1076,7 @@ export function registerTools(
           const points = await listResumePoints(projectDir ? String(projectDir) : (projectRoot ?? process.cwd()));
           if (points.length === 0) return { content: [{ type: 'text', text: 'No parked workstreams in this project.' }] };
           const lines = points.map(p => `  ${p.key}  ${p.brief.goal}${p.resumeCount ? ` (resumed ${p.resumeCount}x)` : ''}`);
-          return { content: [{ type: 'text', text: `Parked workstreams, newest first:
-${lines.join('
-')}` }] };
+          return { content: [{ type: 'text', text: `Parked workstreams, newest first:\n${lines.join('\n')}` }] };
         }
 
         const point = await readResumePoint(String(key));
@@ -1087,11 +1084,7 @@ ${lines.join('
           // A wrong key must not read as "no such work" -- it is far more often a
           // typo, and the recoverable next step is to show what does exist.
           const points = await listResumePoints(projectRoot ?? process.cwd());
-          const known = points.length ? `
-
-Keys parked in this project:
-${points.map(p => `  ${p.key}  ${p.brief.goal}`).join('
-')}` : '';
+          const known = points.length ? `\n\nKeys parked in this project:\n${points.map(p => `  ${p.key}  ${p.brief.goal}`).join('\n')}` : '';
           return {
             isError: true,
             content: [{ type: 'text', text: `No parked work under key "${key}". Check the key with the user rather than guessing what they meant.${known}` }],

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -321,6 +321,18 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_session_list',
+          description: "Browse the project's past Claude Code sessions as an inventory: best-known name (a user rename beats a generated title), the opening ask, derived status (active / interrupted by a crash handoff / idle), any declared session card, last activity, and what each session promoted into memory. Use to answer 'which session was about X' or to decide between resuming a session and starting a new one - then knowl_transcript_search with sessionId to read into the chosen session. Filters by keywords over intent; for content questions use knowl_transcript_search.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: "Keywords over session names, opening asks, and promoted titles. Omit to list newest first." },
+              limit: { type: 'number', description: 'Maximum sessions returned; defaults to 12.' },
+              projectDir: { type: 'string', description: 'Directory whose sessions to list. Defaults to the current project.' },
+            },
+          },
+        },
+        {
           name: 'knowl_transcript_search',
           description: 'Search the RAW session transcripts - the lossless record of everything actually said, underneath the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Ranked, not grep: BM25 over an incrementally maintained index, fused with semantic similarity when vector search is enabled. ALWAYS follow a useful hit with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice - an unpromoted recovery is a lookup every future session repeats.',
           inputSchema: {
@@ -971,6 +983,20 @@ export function registerTools(
             text: `SCOPE: ${explain ? '`explain`' : 'vector search'} limits this query to the project namespace, so ${skippedNamespaces.join(' and ')} knowledge was NOT searched. A miss here does not mean the knowledge is absent; re-run without it for full scope.`,
           });
         }
+        return { content: blocks };
+      }
+
+      else if (name === 'knowl_session_list') {
+        const { query, limit, projectDir } = args as any;
+        const { listSessionDirectory } = await import('../store/session-directory.js');
+        const result = await listSessionDirectory({
+          projectDir: projectDir ? String(projectDir) : (projectRoot ?? process.cwd()),
+          query: query ? String(query) : undefined,
+          limit: typeof limit === 'number' ? limit : undefined,
+        });
+        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.entries) }];
+        const warming = result.indexComplete ? '' : ' INDEX STILL WARMING - names and openings fill in as it catches up; run again for fuller coverage.';
+        blocks.push({ type: 'text', text: `${result.entries.length} of ${result.total} matching session(s), newest first.${warming} To read into one: knowl_transcript_search with its sessionId.` });
         return { content: blocks };
       }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1043,16 +1043,28 @@ export function registerTools(
           artifactRefs: Array.isArray(artifactRefs) ? artifactRefs.map(String) : undefined,
           sessionId: sessionId ? String(sessionId) : undefined,
         });
-        // The key is the entire product of this call, so it is stated on its own
-        // line and told to the user verbatim -- a key paraphrased is a key lost.
+        // What the user gets back is a ready-to-paste INSTRUCTION, not just the
+        // key. A bare token relies on the receiving model being curious enough to
+        // look it up; a sentence naming the tool leaves nothing to disposition,
+        // and still works in a session where knowl's tool descriptions were never
+        // read. The key alone remains valid for anyone who prefers to type six
+        // characters.
+        const resumeLine = `Continue the parked workstream with key ${point.key} — use the knowl memory MCP (knowl_resume).`;
         return {
           content: [{
             type: 'text',
-            text: `Parked. Give the user this key exactly, on its own line:
-
-    ${point.key}
-
-Pasting it into any future session resumes this work. It is not consumed by being used.${point.brief.sessionId ? '' : ' No sessionId was recorded, so the resuming session cannot read this conversation for detail - pass one next time.'}`,
+            text: [
+              'Parked. Give the user BOTH of these verbatim — do not paraphrase, a key reworded is a key lost:',
+              '',
+              '  To resume, paste this into a new session:',
+              `    ${resumeLine}`,
+              '',
+              `  Key on its own, if they prefer: ${point.key}`,
+              '',
+              'Resuming does not consume it; the same key works again later.',
+              point.brief.sessionId ? '' : 'No sessionId was recorded, so the resuming session cannot read this conversation for detail — pass one next time.',
+            ].filter(Boolean).join('
+'),
           }],
         };
       }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1060,7 +1060,14 @@ export function registerTools(
           semantic,
         });
 
-        const ranker = semantic ? 'BM25 + semantic (RRF)' : 'BM25';
+        // Semantic coverage is reported as a fraction for the same reason index coverage is:
+        // "BM25 + semantic" over 2% of the archive is a different claim from the same words
+        // over all of it, and only one of them justifies trusting a near-miss result.
+        const ranker = !semantic
+          ? 'BM25'
+          : result.vectorsEmbedded >= result.indexed
+            ? 'BM25 + semantic over the full archive (RRF)'
+            : `BM25 over everything + semantic over ${result.vectorsEmbedded}/${result.indexed} embedded message(s) (RRF); run \`knowl reindex --transcripts\` to embed the rest`;
 
         // Zero hits against a partially-indexed archive is not an answer, and prose saying so
         // was not enough: an empty list plus a footer still reads as absence, which is the one

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -321,6 +321,34 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_transcript_search',
+          description: 'Search the RAW session transcripts - the lossless record of everything actually said, underneath the distilled atoms. Use only after knowl_query misses or returns something stale, ambiguous, or lower-confidence than the question needs, and use it instead of guessing about a past decision. Ranked, not grep: BM25 over an incrementally maintained index, fused with semantic similarity when vector search is enabled. ALWAYS follow a useful hit with knowl_store or knowl_update citing the returned locator, so the same lookup is never paid for twice - an unpromoted recovery is a lookup every future session repeats.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: 'Content words to recall, not a sentence. Example: "card radius rejected toy".' },
+              limit: { type: 'number', description: 'Maximum hits; defaults to 10. Raise only after a narrow query underdelivers.' },
+              sessionId: { type: 'string', description: 'Restrict to one session, by id or a unique prefix. Use this when a handoff brief names a parent session: ask that transcript first, then re-run without it to widen to the whole archive.' },
+              since: { type: 'string', description: 'ISO timestamp; drop hits older than it.' },
+              projectDir: { type: 'string', description: 'Directory whose transcripts to search. Defaults to the current project.' },
+            },
+            required: ['query'],
+          },
+        },
+        {
+          name: 'knowl_transcript_read',
+          description: 'Read one transcript entry in full, including its tool calls, when a search snippet is not enough to settle the question. Takes the sessionId and line from a knowl_transcript_search locator.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              sessionId: { type: 'string', description: 'Session id, or a unique prefix of it.' },
+              line: { type: 'number', description: '1-indexed line, as returned in the locator.' },
+              projectDir: { type: 'string', description: 'Defaults to the current project.' },
+            },
+            required: ['sessionId', 'line'],
+          },
+        },
+        {
           name: 'knowl_timeline',
           description: 'Inspect immutable assertions for one knowledge item when its history is needed.',
           inputSchema: { type: 'object', properties: { itemId: { type: 'string' } }, required: ['itemId'] },
@@ -944,6 +972,58 @@ export function registerTools(
           });
         }
         return { content: blocks };
+      }
+
+      else if (name === 'knowl_transcript_search') {
+        const { query, limit, since, projectDir, sessionId } = args as any;
+        const { searchTranscripts } = await import('../store/transcript-search.js');
+        const dir = projectDir ? String(projectDir) : (projectRoot ?? process.cwd());
+
+        // Semantic re-ranking is a bonus, not a requirement: vector search is
+        // opt-in, and the lexical ranking is a complete answer without it.
+        let semantic;
+        if (config && projectRoot && isVectorSearchEnabled(config)) {
+          try {
+            const embedder = await createLocalEmbeddingProvider(config, projectRoot);
+            semantic = { model: getVectorSearchConfig(config).model, embed: (texts: string[]) => embedder.embed(texts) };
+          } catch { /* fall back to lexical only */ }
+        }
+
+        const result = await searchTranscripts(String(query), {
+          projectDir: dir,
+          limit: typeof limit === 'number' ? limit : undefined,
+          since: since ? String(since) : undefined,
+          sessionId: sessionId ? String(sessionId) : undefined,
+          semantic,
+        });
+
+        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.hits) }];
+        const ranker = semantic ? 'BM25 + semantic (RRF)' : 'BM25';
+        // The ratchet only compounds if it fires on the result, not just in the
+        // tool description: descriptions are read once, results are read every time.
+        // Say plainly when the index is still warming. A partial index gives
+        // real answers, but "no match" means something different against it,
+        // and a caller told nothing would read absence as proof.
+        const warming = result.indexComplete ? '' : ' INDEX STILL WARMING - it resumes on each call; run the search again for fuller coverage.';
+        if (result.hits.length > 0) {
+          blocks.push({ type: 'text', text: `${ranker} over ${result.indexed} indexed message(s) from ${result.sessions} session(s); index refresh ${result.indexMs}ms.${warming} PROMOTE what you used: call knowl_store (or knowl_update if it corrects an existing item) and cite the hit's locator in the content, so this lookup never has to happen again.` });
+        } else {
+          blocks.push({ type: 'text', text: `No matches across ${result.indexed} indexed message(s) from ${result.sessions} session(s).${warming} Retry with different content words - the index covers user and assistant messages plus tool calls and results.` });
+        }
+        return { content: blocks };
+      }
+
+      else if (name === 'knowl_transcript_read') {
+        const { sessionId, line, projectDir } = args as any;
+        const { readTranscriptEntry, MAX_TRANSCRIPT_ENTRY_CHARS } = await import('../store/transcript-search.js');
+        const entry = await readTranscriptEntry(String(sessionId), Number(line), projectDir ? String(projectDir) : (projectRoot ?? process.cwd()));
+        if (!entry) return { content: [{ type: 'text', text: `No transcript entry at ${sessionId}#L${line}.` }] };
+        // NOT MAX_ITEM_CONTENT_CHARS: that is the 600-char budget for a knowledge
+        // atom's fields, and this tool exists precisely because a ~600-char
+        // snippet was not enough. Capping it there would return the snippet again
+        // under a different name. Bounded at the same size the index stores, so a
+        // pasted megabyte still cannot flood the caller's context.
+        return { content: [{ type: 'text', text: truncateText(entry.text, MAX_TRANSCRIPT_ENTRY_CHARS) }] };
       }
 
       else if (name === 'knowl_timeline') {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -881,7 +881,7 @@ export function registerTools(
         let vector;
         if (config && projectRoot && query && isVectorSearchEnabled(config)) {
           const embedder = await createLocalEmbeddingProvider(config, projectRoot);
-          const [embedding] = await embedder.embed([query]);
+          const embedding = await embedSearchQuery(embedder, query);
           const vectorConfig = getVectorSearchConfig(config);
           vector = {
             enabled: true,
@@ -1048,7 +1048,11 @@ export function registerTools(
         if (config && projectRoot && isVectorSearchEnabled(config)) {
           try {
             const embedder = await createLocalEmbeddingProvider(config, projectRoot);
-            semantic = { model: getVectorSearchConfig(config).model, embed: (texts: string[]) => embedder.embed(texts) };
+            semantic = {
+              model: getVectorSearchConfig(config).model,
+              embed: (texts: string[]) => embedder.embed(texts),
+              embedQuery: embedder.embedQuery ? (text: string) => embedder.embedQuery!(text) : undefined,
+            };
           } catch { /* fall back to lexical only */ }
         }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -321,6 +321,23 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_handoff',
+          description: "Park the current workstream for the next session in this project. Use when the user is deliberately moving to another session and wants work continued - not for durable facts, which belong in knowl_store. The next session started in this project receives it once at startup, then it is archived. One baton per project: writing another replaces it.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              goal: { type: 'string', description: 'What this workstream is trying to achieve, in one line.' },
+              nextAction: { type: 'string', description: 'The single next thing the receiving session should do.' },
+              completed: { type: 'array', items: { type: 'string' }, description: 'What is already done, so the next session does not redo it.' },
+              blocker: { type: 'string', description: 'What is in the way, if anything.' },
+              verificationStatus: { type: 'string', description: 'What has and has not been verified - say plainly if something is untested.' },
+              artifactRefs: { type: 'array', items: { type: 'string' }, description: 'Files, branches, PRs, or locators the next session needs.' },
+              sessionId: { type: 'string', description: "This session's id, when known. Identifies the baton's origin." },
+            },
+            required: ['goal', 'nextAction'],
+          },
+        },
+        {
           name: 'knowl_session_list',
           description: "Browse the project's past Claude Code sessions as an inventory: best-known name (a user rename beats a generated title), the opening ask, derived status (active / interrupted by a crash handoff / idle), any declared session card, last activity, and what each session promoted into memory. Use to answer 'which session was about X' or to decide between resuming a session and starting a new one - then knowl_transcript_search with sessionId to read into the chosen session. Filters by keywords over intent; for content questions use knowl_transcript_search.",
           inputSchema: {
@@ -986,6 +1003,26 @@ export function registerTools(
         return { content: blocks };
       }
 
+      else if (name === 'knowl_handoff') {
+        if (!projectId || !projectRoot) return { content: [{ type: 'text', text: 'No initialized Knowl project; cannot park a handoff.' }] };
+        const { goal, nextAction, completed, blocker, verificationStatus, artifactRefs, sessionId } = args as any;
+        const { recordDeliberateHandoff } = await import('../store/session-handoff.js');
+        const result = await recordDeliberateHandoff(projectId, {
+          host: 'claude',
+          projectRoot,
+          externalSessionId: sessionId ? String(sessionId) : 'unknown',
+          taskState: {
+            goal: String(goal),
+            nextAction: String(nextAction),
+            completed: Array.isArray(completed) ? completed.map(String) : undefined,
+            blocker: blocker ? String(blocker) : undefined,
+            verificationStatus: verificationStatus ? String(verificationStatus) : undefined,
+            artifactRefs: Array.isArray(artifactRefs) ? artifactRefs.map(String) : undefined,
+          },
+        });
+        return { content: [{ type: 'text', text: `Handoff parked (${result.itemId}). The next session started in this project receives it once, then it is archived. It is a one-shot pass - anything worth keeping belongs in knowl_store.` }] };
+      }
+
       else if (name === 'knowl_session_list') {
         const { query, limit, projectDir } = args as any;
         const { listSessionDirectory } = await import('../store/session-directory.js');
@@ -1023,18 +1060,31 @@ export function registerTools(
           semantic,
         });
 
-        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.hits) }];
         const ranker = semantic ? 'BM25 + semantic (RRF)' : 'BM25';
-        // The ratchet only compounds if it fires on the result, not just in the
-        // tool description: descriptions are read once, results are read every time.
-        // Say plainly when the index is still warming. A partial index gives
-        // real answers, but "no match" means something different against it,
-        // and a caller told nothing would read absence as proof.
-        const warming = result.indexComplete ? '' : ' INDEX STILL WARMING - it resumes on each call; run the search again for fuller coverage.';
+
+        // Zero hits against a partially-indexed archive is not an answer, and prose saying so
+        // was not enough: an empty list plus a footer still reads as absence, which is the one
+        // inference a partial index cannot support. So it fails instead of returning, and the
+        // caller has to re-run rather than conclude. Coverage travels as numbers either way.
+        if (result.inconclusive) {
+          const searched = result.filesScanned - result.filesPending;
+          return {
+            isError: true,
+            content: [{
+              type: 'text',
+              text: `SEARCH INCONCLUSIVE - not a "no matches" result. Only ${searched} of ${result.filesScanned} session file(s) were searchable this pass (${result.filesPending} still indexing after ${result.indexMs}ms), so this query cannot tell "absent from the archive" from "not indexed yet". Run the same search again - indexing resumes on every call and newest sessions are covered first. Do NOT report this as nothing found.`,
+            }],
+          };
+        }
+
+        const blocks: CallToolResult['content'] = [{ type: 'text', text: compactMcpJson(result.hits) }];
+        const coverage = result.indexComplete
+          ? 'index complete'
+          : `PARTIAL INDEX: ${result.filesScanned - result.filesPending}/${result.filesScanned} session file(s) searchable, ${result.filesPending} still indexing - re-run for the rest`;
         if (result.hits.length > 0) {
-          blocks.push({ type: 'text', text: `${ranker} over ${result.indexed} indexed message(s) from ${result.sessions} session(s); index refresh ${result.indexMs}ms.${warming} PROMOTE what you used: call knowl_store (or knowl_update if it corrects an existing item) and cite the hit's locator in the content, so this lookup never has to happen again.` });
+          blocks.push({ type: 'text', text: `${ranker} over ${result.indexed} indexed message(s) from ${result.sessions} session(s); index refresh ${result.indexMs}ms; ${coverage}. PROMOTE what you used: call knowl_store (or knowl_update if it corrects an existing item) and cite the hit's locator in the content, so this lookup never has to happen again.` });
         } else {
-          blocks.push({ type: 'text', text: `No matches across ${result.indexed} indexed message(s) from ${result.sessions} session(s).${warming} Retry with different content words - the index covers user and assistant messages plus tool calls and results.` });
+          blocks.push({ type: 'text', text: `No matches across ${result.indexed} indexed message(s) from ${result.sessions} session(s); ${coverage}. Retry with different content words - the index covers user and assistant messages plus tool calls and results.` });
         }
         return { content: blocks };
       }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -17,6 +17,7 @@ import { getRecentContext } from '../store/recent-context.js';
 import { storeKnowledgeItemDeduped, storeKnowledgeAtomsDeduped } from '../store/knowledge-writer.js';
 import { recordDecisionDirect, updateKnowledgeItemWithCommit } from '../store/knowledge-actions.js';
 import { isVectorSearchEnabled, createLocalEmbeddingProvider, getVectorSearchConfig } from '../ai/embeddings.js';
+import { embedSearchQuery } from '../store/vector-index.js';
 import { queryKnowledgeForAgent, queryKnowledgeForAgentExplained } from '../store/agent-query.js';
 import { previewKnowledgeGc, applyKnowledgeGc } from '../store/gc.js';
 import { checkpointWorkLoop, finishWorkLoop, startWorkLoop } from '../store/work-loop.js';

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -338,6 +338,34 @@ export function registerTools(
           },
         },
         {
+          name: 'knowl_park',
+          description: "Park this workstream under a short KEY the user keeps, and hand them the key. Use when the user says they want to come back to THIS work later, or wants to hold several threads at once. Unlike knowl_handoff (one baton per project, auto-delivered to whoever starts next, then archived), a parked point is addressable, survives being picked up, and many can exist side by side. Keep the brief short and pass sessionId - the resuming session reads the transcript for detail rather than trusting a long summary.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              goal: { type: 'string', description: 'What this workstream is trying to achieve, in one line.' },
+              nextAction: { type: 'string', description: 'The single next thing to do on resuming.' },
+              completed: { type: 'array', items: { type: 'string' }, description: 'What is already done, so it is not redone.' },
+              blocker: { type: 'string', description: 'What is in the way, if anything.' },
+              verificationStatus: { type: 'string', description: 'What has and has not been verified - say plainly if something is untested.' },
+              artifactRefs: { type: 'array', items: { type: 'string' }, description: 'Files, branches, PRs, or locators needed to continue.' },
+              sessionId: { type: 'string', description: "This session's id. The resuming session searches its transcript for anything the brief omits." },
+            },
+            required: ['goal', 'nextAction'],
+          },
+        },
+        {
+          name: 'knowl_resume',
+          description: "Restore a parked workstream from its key. CALL THIS IMMEDIATELY, before anything else, whenever the user's message is (or contains) a short opaque token of about six letters and digits - for example `k7x2qm`, `knowl:k7x2qm`, or `resume k7x2qm`. A bare token like that is not a question; it is a resume key, and the user expects the work to continue without being asked what it refers to. Pass the token exactly as given. With no key, lists the workstreams parked in this project.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              key: { type: 'string', description: 'The key the user pasted. Any surrounding punctuation or `knowl:` prefix is fine.' },
+              projectDir: { type: 'string', description: 'Project whose parked work to list when no key is given. Defaults to the current project.' },
+            },
+          },
+        },
+        {
           name: 'knowl_session_list',
           description: "Browse the project's past Claude Code sessions as an inventory: best-known name (a user rename beats a generated title), the opening ask, derived status (active / interrupted by a crash handoff / idle), any declared session card, last activity, and what each session promoted into memory. Use to answer 'which session was about X' or to decide between resuming a session and starting a new one - then knowl_transcript_search with sessionId to read into the chosen session. Filters by keywords over intent; for content questions use knowl_transcript_search.",
           inputSchema: {
@@ -1001,6 +1029,64 @@ export function registerTools(
           });
         }
         return { content: blocks };
+      }
+
+      else if (name === 'knowl_park') {
+        const { goal, nextAction, completed, blocker, verificationStatus, artifactRefs, sessionId } = args as any;
+        const { createResumePoint } = await import('../store/resume-points.js');
+        const point = await createResumePoint(projectRoot ?? process.cwd(), {
+          goal: String(goal),
+          nextAction: String(nextAction),
+          completed: Array.isArray(completed) ? completed.map(String) : undefined,
+          blocker: blocker ? String(blocker) : undefined,
+          verificationStatus: verificationStatus ? String(verificationStatus) : undefined,
+          artifactRefs: Array.isArray(artifactRefs) ? artifactRefs.map(String) : undefined,
+          sessionId: sessionId ? String(sessionId) : undefined,
+        });
+        // The key is the entire product of this call, so it is stated on its own
+        // line and told to the user verbatim -- a key paraphrased is a key lost.
+        return {
+          content: [{
+            type: 'text',
+            text: `Parked. Give the user this key exactly, on its own line:
+
+    ${point.key}
+
+Pasting it into any future session resumes this work. It is not consumed by being used.${point.brief.sessionId ? '' : ' No sessionId was recorded, so the resuming session cannot read this conversation for detail - pass one next time.'}`,
+          }],
+        };
+      }
+
+      else if (name === 'knowl_resume') {
+        const { key, projectDir } = args as any;
+        const { readResumePoint, listResumePoints, formatResumeBrief } = await import('../store/resume-points.js');
+
+        if (!key) {
+          const points = await listResumePoints(projectDir ? String(projectDir) : (projectRoot ?? process.cwd()));
+          if (points.length === 0) return { content: [{ type: 'text', text: 'No parked workstreams in this project.' }] };
+          const lines = points.map(p => `  ${p.key}  ${p.brief.goal}${p.resumeCount ? ` (resumed ${p.resumeCount}x)` : ''}`);
+          return { content: [{ type: 'text', text: `Parked workstreams, newest first:
+${lines.join('
+')}` }] };
+        }
+
+        const point = await readResumePoint(String(key));
+        if (!point) {
+          // A wrong key must not read as "no such work" -- it is far more often a
+          // typo, and the recoverable next step is to show what does exist.
+          const points = await listResumePoints(projectRoot ?? process.cwd());
+          const known = points.length ? `
+
+Keys parked in this project:
+${points.map(p => `  ${p.key}  ${p.brief.goal}`).join('
+')}` : '';
+          return {
+            isError: true,
+            content: [{ type: 'text', text: `No parked work under key "${key}". Check the key with the user rather than guessing what they meant.${known}` }],
+          };
+        }
+
+        return { content: [{ type: 'text', text: formatResumeBrief(point) }] };
       }
 
       else if (name === 'knowl_handoff') {

--- a/src/store/access-feedback.ts
+++ b/src/store/access-feedback.ts
@@ -124,20 +124,38 @@ export async function getKnowledgeAccessReport(): Promise<{
   };
 }
 
-export type KnowledgeAccessSummary = { retrievalCount: number; lastRetrievedAt: string };
+export type KnowledgeAccessSummary = {
+  retrievalCount: number;
+  lastRetrievedAt: string;
+  /** Times explicitly marked useful. Direct evidence of worth, unlike a retrieval count. */
+  usefulCount: number;
+  /** Times explicitly marked NOT useful — evidence the row is noise in results it wins. */
+  notUsefulCount: number;
+};
 
 // Per-item retrieval frequency and recency — used by GC to protect hot memory
-// from decay and to collect only genuinely cold items.
+// from decay and to collect only genuinely cold items. Retrieval counts still exclude
+// feedback rows (a verdict is not a retrieval), but the verdicts themselves are now
+// summarised alongside, because retrieval volume on its own cannot tell a load-bearing
+// item from one that keeps polluting result sets.
 export async function getAccessSummary(): Promise<Map<string, KnowledgeAccessSummary>> {
   const rows = (await getClient().execute(`
-    SELECT knowledge_item_id, COUNT(*) AS retrieval_count, MAX(retrieved_at) AS last_retrieved_at
-    FROM knowledge_access WHERE surface != 'feedback' GROUP BY knowledge_item_id
+    SELECT knowledge_item_id,
+      SUM(CASE WHEN surface != 'feedback' THEN 1 ELSE 0 END) AS retrieval_count,
+      MAX(CASE WHEN surface != 'feedback' THEN retrieved_at END) AS last_retrieved_at,
+      SUM(CASE WHEN useful = 1 THEN 1 ELSE 0 END) AS useful_count,
+      SUM(CASE WHEN useful = 0 THEN 1 ELSE 0 END) AS not_useful_count
+    FROM knowledge_access GROUP BY knowledge_item_id
   `)).rows;
   const summary = new Map<string, KnowledgeAccessSummary>();
   for (const row of rows) {
     summary.set(String(row.knowledge_item_id), {
       retrievalCount: Number(row.retrieval_count),
-      lastRetrievedAt: String(row.last_retrieved_at),
+      // A row with feedback but no retrievals has no last-retrieved instant; the epoch keeps
+      // it unambiguously cold rather than accidentally recent via an empty string.
+      lastRetrievedAt: row.last_retrieved_at === null ? new Date(0).toISOString() : String(row.last_retrieved_at),
+      usefulCount: Number(row.useful_count),
+      notUsefulCount: Number(row.not_useful_count),
     });
   }
   return summary;

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -540,6 +540,64 @@ async function ensureTranscriptEmbeddingFormat(client: Client): Promise<void> {
   await client.execute("DELETE FROM transcript_embeddings WHERE typeof(vector) = 'text';");
 }
 
+/**
+ * Collapse the spellings of one directory into the single key it should always
+ * have had. Databases written before project_dir was normalized hold the same
+ * archive several times over - one copy per way a caller happened to spell the
+ * path - and the embeddings attach to only one of them, so searches issued with
+ * a different spelling silently score against a set that has no vectors.
+ *
+ * Where a normalized copy already exists the variants are duplicates and go.
+ * Where none does, the rows are simply relabelled, so nothing has to be
+ * re-indexed for a difference that was only ever cosmetic.
+ */
+async function ensureNormalizedProjectDirs(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'transcript_messages'))) return;
+  const { normalizeProjectDir } = await import('./transcript-index.js');
+
+  const dirs = (await client.execute('SELECT DISTINCT project_dir FROM transcript_messages')).rows
+    .map(row => String(row.project_dir))
+    .filter(dir => dir !== normalizeProjectDir(dir));
+
+  for (const variant of dirs) {
+    const canonical = normalizeProjectDir(variant);
+    const existing = Number((await client.execute({
+      sql: 'SELECT COUNT(*) AS n FROM transcript_messages WHERE project_dir = ?',
+      args: [canonical],
+    })).rows[0].n);
+
+    if (existing > 0) {
+      await client.execute({
+        sql: `INSERT INTO transcript_fts(transcript_fts, rowid, text)
+              SELECT 'delete', id, text FROM transcript_messages WHERE project_dir = ?`,
+        args: [variant],
+      });
+      await client.execute({
+        sql: 'DELETE FROM transcript_embeddings WHERE message_id IN (SELECT id FROM transcript_messages WHERE project_dir = ?)',
+        args: [variant],
+      });
+      await client.execute({ sql: 'DELETE FROM transcript_messages WHERE project_dir = ?', args: [variant] });
+    } else {
+      await client.execute({ sql: 'UPDATE transcript_messages SET project_dir = ? WHERE project_dir = ?', args: [canonical, variant] });
+    }
+  }
+
+  if (await tableExists(client, 'transcript_files')) {
+    const fileDirs = (await client.execute('SELECT DISTINCT project_dir FROM transcript_files')).rows
+      .map(row => String(row.project_dir))
+      .filter(dir => dir !== normalizeProjectDir(dir));
+    for (const variant of fileDirs) {
+      // One row per path, so relabelling cannot collide. A path whose messages
+      // were just deleted as duplicates keeps its watermark, because the
+      // surviving copy of those messages is already indexed.
+      await client.execute({
+        sql: 'UPDATE OR REPLACE transcript_files SET project_dir = ? WHERE project_dir = ?',
+        args: [normalizeProjectDir(variant), variant],
+      });
+    }
+  }
+}
+
 async function ensureHostSessionBindingColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'host_session_bindings'))) return;
   const columns = await tableColumns(client, 'host_session_bindings');
@@ -707,6 +765,7 @@ export async function bootstrapSchema(client: Client): Promise<void> {
   await ensureHostSessionBindingColumns(client);
   await ensureTranscriptFileColumns(client);
   await ensureTranscriptEmbeddingFormat(client);
+  await ensureNormalizedProjectDirs(client);
   await ensureCodeIndexColumns(client);
   await backfillKnowledgeAssertions(client);
   await repairSkillForeignKeys(client);

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -204,6 +204,50 @@ const SCHEMA_STATEMENTS = [
     FROM knowledge_items
     WHERE NOT EXISTS (SELECT 1 FROM knowledge_items_fts LIMIT 1)
       AND EXISTS (SELECT 1 FROM knowledge_items LIMIT 1);`,
+
+  // Transcript index. Session transcripts are the lossless record underneath the
+  // distilled atoms; these tables make them searchable without re-reading
+  // hundreds of megabytes per query. Rows are derived data and safe to drop --
+  // the source of truth is the .jsonl files on disk.
+  `CREATE TABLE IF NOT EXISTS transcript_files (
+    path TEXT PRIMARY KEY,
+    project_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    -- Transcripts are append-only, so a byte offset is a resume point: the next
+    -- pass reads only what was added rather than the whole file again.
+    bytes_indexed INTEGER NOT NULL DEFAULT 0,
+    lines_indexed INTEGER NOT NULL DEFAULT 0,
+    mtime_ms INTEGER NOT NULL DEFAULT 0,
+    indexed_at TEXT NOT NULL
+  );`,
+  `CREATE TABLE IF NOT EXISTS transcript_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    line INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    ts TEXT,
+    weight REAL NOT NULL,
+    len INTEGER NOT NULL,
+    text TEXT NOT NULL
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_messages_project ON transcript_messages(project_dir);`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_messages_session ON transcript_messages(session_id, line);`,
+  // FTS5 rather than a hand-built inverted index: it ships BM25, and a posting
+  // table written from JavaScript cost ~74 rows per message, which made cold
+  // indexing of a large archive hours of work. External content keeps the text
+  // in transcript_messages instead of storing it twice.
+  `CREATE VIRTUAL TABLE IF NOT EXISTS transcript_fts USING fts5(
+    text,
+    content='transcript_messages',
+    content_rowid='id'
+  );`,
+  // Cached per message so a rerank pays the embedding cost once, not per query.
+  `CREATE TABLE IF NOT EXISTS transcript_embeddings (
+    message_id INTEGER PRIMARY KEY,
+    model TEXT NOT NULL,
+    vector TEXT NOT NULL
+  );`,
 ];
 
 function unwrapJson(value: unknown): unknown {

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -218,7 +218,14 @@ const SCHEMA_STATEMENTS = [
     bytes_indexed INTEGER NOT NULL DEFAULT 0,
     lines_indexed INTEGER NOT NULL DEFAULT 0,
     mtime_ms INTEGER NOT NULL DEFAULT 0,
-    indexed_at TEXT NOT NULL
+    indexed_at TEXT NOT NULL,
+    -- Captured while the indexer streams the file, at zero extra IO: the
+    -- session's own title entries (a user rename beats a generated title), and
+    -- the first real user ask as a one-line descriptor. External tools name
+    -- sessions by filename or first prompt; the transcript already knows better.
+    display_name TEXT,
+    name_kind INTEGER NOT NULL DEFAULT 0,
+    opening TEXT
   );`,
   `CREATE TABLE IF NOT EXISTS transcript_messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -498,6 +505,27 @@ async function ensureMemorySessionColumns(client: Client): Promise<void> {
   if (!columns.includes('promotion_error_code')) await client.execute('ALTER TABLE memory_sessions ADD COLUMN promotion_error_code TEXT;');
 }
 
+async function ensureTranscriptFileColumns(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'transcript_files'))) return;
+  const columns = await tableColumns(client, 'transcript_files');
+  if (!columns.includes('display_name')) {
+    await client.execute('ALTER TABLE transcript_files ADD COLUMN display_name TEXT;');
+  }
+  if (!columns.includes('name_kind')) {
+    await client.execute('ALTER TABLE transcript_files ADD COLUMN name_kind INTEGER NOT NULL DEFAULT 0;');
+  }
+  if (!columns.includes('opening')) {
+    await client.execute('ALTER TABLE transcript_files ADD COLUMN opening TEXT;');
+    // Names and openings are captured while streaming, so rows indexed before
+    // these columns existed would stay nameless forever. The tables are derived
+    // data; resetting the watermarks makes the next pass re-read and fill them.
+    await client.execute("UPDATE transcript_files SET bytes_indexed = 0, lines_indexed = 0, indexed_at = '1970-01-01T00:00:00.000Z';");
+    await client.execute('DELETE FROM transcript_embeddings;');
+    await client.execute('DELETE FROM transcript_messages;');
+    await client.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('delete-all');");
+  }
+}
+
 async function ensureHostSessionBindingColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'host_session_bindings'))) return;
   const columns = await tableColumns(client, 'host_session_bindings');
@@ -663,6 +691,7 @@ export async function bootstrapSchema(client: Client): Promise<void> {
   await ensureOwnershipColumns(client);
   await ensureMemorySessionColumns(client);
   await ensureHostSessionBindingColumns(client);
+  await ensureTranscriptFileColumns(client);
   await ensureCodeIndexColumns(client);
   await backfillKnowledgeAssertions(client);
   await repairSkillForeignKeys(client);

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -250,6 +250,19 @@ const SCHEMA_STATEMENTS = [
     content='transcript_messages',
     content_rowid='id'
   );`,
+  // A named, resumable parking spot for a workstream. Distinct from the one-shot
+  // session handoff: many can exist at once, each addressed by a short key the
+  // user keeps, and resuming does not consume it.
+  `CREATE TABLE IF NOT EXISTS resume_points (
+    key TEXT PRIMARY KEY,
+    project_dir TEXT NOT NULL,
+    brief TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    last_resumed_at TEXT,
+    resume_count INTEGER NOT NULL DEFAULT 0
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_resume_points_project ON resume_points(project_dir, created_at);`,
+
   // One int8-quantized vector per message, so a query can score the whole
   // archive rather than re-ranking what keyword search already found. Stored as
   // a BLOB: a JSON array of 384 floats is ~8x the bytes and has to be parsed

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -1,6 +1,7 @@
 import { Client } from '@libsql/client';
 import { DEFAULT_FRESHNESS, hashKnowledgeContent, normalizeAffectedPaths } from './freshness.js';
 import { assertSchemaSupported, stampSchemaVersion } from './schema-version.js';
+import { normalizeProjectDir } from './project-dir.js';
 
 const BASE_STATEMENTS = [
   // Must come first: journal_mode = WAL (and everything after it) takes locks, and a
@@ -553,7 +554,6 @@ async function ensureTranscriptEmbeddingFormat(client: Client): Promise<void> {
  */
 async function ensureNormalizedProjectDirs(client: Client): Promise<void> {
   if (!(await tableExists(client, 'transcript_messages'))) return;
-  const { normalizeProjectDir } = await import('./transcript-index.js');
 
   const dirs = (await client.execute('SELECT DISTINCT project_dir FROM transcript_messages')).rows
     .map(row => String(row.project_dir))

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -249,11 +249,14 @@ const SCHEMA_STATEMENTS = [
     content='transcript_messages',
     content_rowid='id'
   );`,
-  // Cached per message so a rerank pays the embedding cost once, not per query.
+  // One int8-quantized vector per message, so a query can score the whole
+  // archive rather than re-ranking what keyword search already found. Stored as
+  // a BLOB: a JSON array of 384 floats is ~8x the bytes and has to be parsed
+  // before it can be compared.
   `CREATE TABLE IF NOT EXISTS transcript_embeddings (
     message_id INTEGER PRIMARY KEY,
     model TEXT NOT NULL,
-    vector TEXT NOT NULL
+    vector BLOB NOT NULL
   );`,
 ];
 
@@ -526,6 +529,17 @@ async function ensureTranscriptFileColumns(client: Client): Promise<void> {
   }
 }
 
+/**
+ * Earlier builds cached vectors as JSON text in this column. They are a derived
+ * cache of at most a few hundred re-ranked candidates, so they are dropped
+ * rather than converted - the next embedding pass rewrites them quantized, and
+ * leaving them would mean carrying a reader for a format nothing writes.
+ */
+async function ensureTranscriptEmbeddingFormat(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'transcript_embeddings'))) return;
+  await client.execute("DELETE FROM transcript_embeddings WHERE typeof(vector) = 'text';");
+}
+
 async function ensureHostSessionBindingColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'host_session_bindings'))) return;
   const columns = await tableColumns(client, 'host_session_bindings');
@@ -692,6 +706,7 @@ export async function bootstrapSchema(client: Client): Promise<void> {
   await ensureMemorySessionColumns(client);
   await ensureHostSessionBindingColumns(client);
   await ensureTranscriptFileColumns(client);
+  await ensureTranscriptEmbeddingFormat(client);
   await ensureCodeIndexColumns(client);
   await backfillKnowledgeAssertions(client);
   await repairSkillForeignKeys(client);

--- a/src/store/conflicts.ts
+++ b/src/store/conflicts.ts
@@ -2,6 +2,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import * as schema from './schema.js';
 import { mapRowToKnowledgeItem } from './repository.js';
 import { localStore, type StoreHandle } from './store-handle.js';
+import { getClient } from './database.js';
 
 export function normalizeConflictKey(value: string): string {
   return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '.').replace(/^\.+|\.+$/g, '');
@@ -10,6 +11,96 @@ export function normalizeConflictKey(value: string): string {
 export function normalizeConflictScope(scope?: Record<string, unknown> | null): Record<string, unknown> | null {
   if (!scope || Object.keys(scope).length === 0) return null;
   return Object.fromEntries(Object.keys(scope).sort().map(key => [key, scope[key]]));
+}
+
+/**
+ * Conflict identity in storage shape. EVERY write path must route through this.
+ *
+ * Create and update used to normalize independently, and update simply forgot: it spread
+ * its `updates` object into the row verbatim. A key written raw (`a-b:c` rather than
+ * `a.b.c`) stops matching every lookup, which all run on the normalized form — so the row
+ * becomes permanently invisible to the conflict check that was supposed to keep it unique
+ * and to the reader that was supposed to retire it. Two call sites each having to remember
+ * is what made that possible, so there is now one.
+ *
+ * `undefined` means "leave this column alone" and is preserved as an absent key, so a
+ * partial update never clears identity it did not mention.
+ */
+export function normalizeConflictFields(
+  input: { conflictKey?: string | null; conflictScope?: Record<string, unknown> | null },
+): { conflictKey?: string | null; conflictScope?: Record<string, unknown> | null } {
+  const fields: { conflictKey?: string | null; conflictScope?: Record<string, unknown> | null } = {};
+  if (input.conflictKey !== undefined) {
+    fields.conflictKey = input.conflictKey ? normalizeConflictKey(input.conflictKey) : null;
+  }
+  if (input.conflictScope !== undefined) {
+    fields.conflictScope = normalizeConflictScope(input.conflictScope);
+  }
+  return fields;
+}
+
+/** True when a stored key is already in storage shape. The doctor invariant. */
+export function isNormalizedConflictKey(value: string): boolean {
+  return normalizeConflictKey(value) === value;
+}
+
+/**
+ * Put every stored conflict key back into storage shape.
+ *
+ * Rows written raw were invisible to the exclusivity check, so the same identity could be
+ * claimed more than once. Normalizing them makes those duplicates visible for the first
+ * time — so the repair also has to settle them, or it would leave the store asserting two
+ * active rows for an identity declared exclusive. Newest wins and the rest are archived,
+ * which is the invariant those rows escaped rather than a new policy.
+ */
+export async function repairUnnormalizedConflictKeys(): Promise<{ repaired: number; archived: number }> {
+  const client = getClient();
+  const rows = (await client.execute(
+    `SELECT id, conflict_key, conflict_scope, conflict_exclusive, status, updated_at
+     FROM knowledge_items WHERE conflict_key IS NOT NULL`,
+  )).rows;
+
+  const now = new Date().toISOString();
+  let repaired = 0;
+
+  for (const row of rows) {
+    const stored = String(row.conflict_key);
+    const normalized = normalizeConflictKey(stored);
+    if (normalized === stored) continue;
+    // `updated_at` is deliberately untouched. Repairing a column's spelling is not an edit to
+    // what the row says: bumping it would make every repaired row look touched today, which
+    // both destroys the recency the duplicate settlement below sorts on and resets the
+    // staleness clock that decides when the row can be collected.
+    await client.execute({
+      sql: 'UPDATE knowledge_items SET conflict_key = ? WHERE id = ?',
+      args: [normalized, String(row.id)],
+    });
+    repaired++;
+  }
+
+  if (repaired === 0) return { repaired: 0, archived: 0 };
+
+  // Re-read: identities that were split across raw and normalized spellings are only now
+  // comparable, and only the post-repair values say which rows actually collide.
+  const settled = (await client.execute(
+    `SELECT id, conflict_key, conflict_scope, updated_at FROM knowledge_items
+     WHERE conflict_key IS NOT NULL AND conflict_exclusive = 1 AND status = 'active'
+     ORDER BY updated_at DESC`,
+  )).rows;
+
+  const seen = new Set<string>();
+  let archived = 0;
+  for (const row of settled) {
+    const identity = `${String(row.conflict_key)}\0${row.conflict_scope === null ? '' : String(row.conflict_scope)}`;
+    if (!seen.has(identity)) { seen.add(identity); continue; }
+    await client.execute({
+      sql: `UPDATE knowledge_items SET status = 'archived', freshness = 'stale', updated_at = ? WHERE id = ?`,
+      args: [now, String(row.id)],
+    });
+    archived++;
+  }
+
+  return { repaired, archived };
 }
 
 export async function checkKnowledgeConflict(

--- a/src/store/connection-pool.ts
+++ b/src/store/connection-pool.ts
@@ -29,8 +29,37 @@ export async function acquireClient(dbPath: string, options: { readOnly?: boolea
   const existing = clients.get(key);
   if (existing) return existing;
 
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const client = await openClient(dbPath, readOnly);
+      clients.set(key, client);
+      return client;
+    } catch (error) {
+      // Opening runs bootstrap, which migrates and creates tables - real writes,
+      // against a database other live sessions are also writing to. A lock lost
+      // here is transient and the whole command dies on it, so it is retried
+      // rather than surfaced. Not folded into busy_timeout: some statements
+      // (schema changes among them) return BUSY without ever consulting the
+      // busy handler, so waiting longer inside SQLite would not have helped.
+      const busy = /SQLITE_BUSY|database is locked|statements in progress/i.test(String((error as Error).message));
+      if (!busy || attempt >= 4) throw error;
+      await new Promise(resolve => setTimeout(resolve, 250 * 2 ** attempt));
+    }
+  }
+}
+
+async function openClient(dbPath: string, readOnly: boolean): Promise<Client> {
   const client = createClient({ url: `file:${path.resolve(dbPath)}` });
   try {
+    // Wait for a lock instead of failing on it. Knowl runs one process per
+    // connected session plus whatever the user starts from a terminal, so
+    // concurrent writers to one database are the normal case, not an edge one -
+    // and SQLite's default busy handler gives up instantly. Without this, a
+    // long job beside a live session dies on "database is locked" the first
+    // time the two overlap, which is how a transcript backfill lost its whole
+    // pass. Individual hot paths retry on BUSY as well; this makes every OTHER
+    // statement survive too, including the ones nobody thought to wrap.
+    await client.execute('PRAGMA busy_timeout = 10000;');
     // A read-only open skips bootstrap, and the version guard lives inside bootstrap --
     // so without this it would skip the guard too, which is exactly backwards for the
     // case the guard matters most: reading a database someone else's Knowl wrote.
@@ -52,7 +81,6 @@ export async function acquireClient(dbPath: string, options: { readOnly?: boolea
     await client.close();
     throw error;
   }
-  clients.set(key, client);
   return client;
 }
 

--- a/src/store/freshness.ts
+++ b/src/store/freshness.ts
@@ -72,6 +72,20 @@ export function hashKnowledgeLifecycle(input: {
     .digest('hex');
 }
 
+/**
+ * A tag counts as provenance only when it is written as a path.
+ *
+ * Tags are topic labels far more often than locations, and `pathMatches` treats a bare
+ * word as a directory prefix — so a single commit under `content/` matched every atom
+ * tagged `content`, including pure strategy notes with no file provenance at all, and
+ * `pr check` flipped all of them to needs_review. Requiring a separator or an extension
+ * keeps `src/store/freshness.ts`-style tags working and stops a topic name from
+ * standing in for a top-level directory.
+ */
+function tagLooksLikePath(tag: string): boolean {
+  return tag.includes('/') || /\.[A-Za-z0-9]+$/.test(tag);
+}
+
 function pathMatches(knownPath: string, changedPath: string): boolean {
   const known = normalizePathForKnowledge(knownPath);
   const changed = normalizePathForKnowledge(changedPath);
@@ -97,6 +111,7 @@ export function knowledgeMentionsChangedPath(item: {
   }
 
   for (const tag of item.tags || []) {
+    if (!tagLooksLikePath(tag)) continue;
     if (normalizedChanged.some(changedPath => pathMatches(tag, changedPath))) {
       return true;
     }

--- a/src/store/gc.ts
+++ b/src/store/gc.ts
@@ -48,9 +48,45 @@ const HOT_RECENT_DAYS = 21;
 export function isHot(itemId: string, access: Map<string, KnowledgeAccessSummary>, now: Date): boolean {
   const a = access.get(itemId);
   if (!a) return false;
+  // Explicit feedback outranks retrieval volume in both directions. Retrieval alone is weak
+  // evidence of worth: an item that keeps surfacing in results it does not belong in gets
+  // retrieved BECAUSE it is noise, and counting that as heat let the worst rows earn the
+  // strongest protection from collection. A row somebody actually used is hot regardless of
+  // count; a row somebody marked not-useful no longer coasts on being retrieved often.
+  if (a.usefulCount > 0) return true;
+  if (a.notUsefulCount > 0) return false;
   if (a.retrievalCount >= HOT_RETRIEVAL_COUNT) return true;
   return daysSince(a.lastRetrievedAt, now) <= HOT_RECENT_DAYS;
 }
+/**
+ * A one-shot record is delivered to the NEXT session that starts. Once days of sessions have
+ * begun without it being claimed, nothing is ever going to claim it.
+ */
+const SPENT_ONE_SHOT_DAYS = 7;
+
+function isOneShotRecord(item: KnowledgeItem): boolean {
+  return item.category === 'state' && (item.tags ?? []).includes('pending_handoff');
+}
+
+/** When the one-shot became pending. Its own record beats the row's mtime, which any touch moves. */
+function oneShotPendingSince(item: KnowledgeItem): string {
+  try {
+    const parsed = JSON.parse(item.content) as { failedAt?: unknown };
+    if (typeof parsed.failedAt === 'string') return parsed.failedAt;
+  } catch {
+    // Not JSON or not this shape; the row's own timestamp is the honest fallback.
+  }
+  return item.updatedAt;
+}
+
+function oneShotIsConsumed(item: KnowledgeItem): boolean {
+  try {
+    return (JSON.parse(item.content) as { consumed?: unknown }).consumed === true;
+  } catch {
+    return false;
+  }
+}
+
 const PROTECTED_CATEGORIES = new Set<KnowledgeCategory>([
   'decision',
   'constraint',
@@ -119,6 +155,18 @@ function buildCandidates(items: KnowledgeItem[], options: KnowledgeGcOptions, ac
     bestByDuplicateKey.set(key, currentBest ? preferredDuplicate(currentBest, item) : item);
   }
 
+  // Only one one-shot may be pending per identity — that is exactly what its exclusive
+  // conflict key declares. Any older one is therefore already spent. Identity comes from the
+  // conflict key rather than the title because every handoff shares the same title, which is
+  // also why the duplicate rule above never catches them: same title, different JSON body.
+  const newestOneShot = new Map<string, KnowledgeItem>();
+  for (const item of items) {
+    if (item.status !== 'active' || !isOneShotRecord(item)) continue;
+    const identity = item.conflictKey ?? item.title;
+    const incumbent = newestOneShot.get(identity);
+    if (!incumbent || item.updatedAt > incumbent.updatedAt) newestOneShot.set(identity, item);
+  }
+
   for (const item of items) {
     const beforeBytes = Buffer.byteLength(item.content, 'utf8');
 
@@ -141,6 +189,36 @@ function buildCandidates(items: KnowledgeItem[], options: KnowledgeGcOptions, ac
           afterBytes: 0,
         });
         continue;
+      }
+
+      // Checked before the age clock and deliberately outside the hotness guard. A record
+      // that carries its own liveness signal is garbage the moment that signal fires, not
+      // sixty days later — and hotness makes age worse here rather than safer, because a
+      // spent handoff gets retrieved precisely BECAUSE it pollutes unrelated result sets.
+      if (isOneShotRecord(item)) {
+        const identity = item.conflictKey ?? item.title;
+        const newest = newestOneShot.get(identity);
+        const pendingDays = daysSince(oneShotPendingSince(item), now);
+        const spentReason = oneShotIsConsumed(item)
+          ? 'One-shot handoff already consumed'
+          : newest && newest.id !== item.id
+            ? `Superseded by a newer pending handoff for the same identity (${newest.id})`
+            : pendingDays >= SPENT_ONE_SHOT_DAYS
+              ? `One-shot handoff unclaimed for ${pendingDays} days; no session will claim it now`
+              : null;
+        if (spentReason) {
+          candidates.push({
+            itemId: item.id,
+            action: 'archive',
+            title: item.title,
+            category: item.category,
+            status: item.status,
+            reason: spentReason,
+            beforeBytes,
+            afterBytes: beforeBytes,
+          });
+          continue;
+        }
       }
 
       if (

--- a/src/store/host-lifecycle.ts
+++ b/src/store/host-lifecycle.ts
@@ -38,6 +38,7 @@ import {
 } from './host-session-bindings.js';
 import { bootstrapAgentSession } from './context-bootstrap.js';
 import { consumePendingSessionHandoff, recordPendingSessionHandoff } from './session-handoff.js';
+import { ensureTranscriptIndex } from './transcript-index.js';
 import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
 import { describeAutoDrift, runAutoDriftCheckBestEffort, type AutoDriftResult } from './drift-auto.js';
 
@@ -117,6 +118,29 @@ async function startBoundSession(projectId: string, input: NormalizedHostHook, s
     title: input.title ?? (scope === 'session' ? 'Agent session' : 'Agent turn'),
     includeContext,
   });
+}
+
+/**
+ * Ceiling, not a tax. Indexing is cheap once warm — a file whose size matches the stored
+ * offset is skipped without being opened — so this is only fully spent when there is real
+ * new transcript to absorb.
+ */
+const SESSION_START_INDEX_BUDGET_MS = 2_500;
+
+/**
+ * Bring the transcript index forward at session start rather than on first search.
+ *
+ * Warming lazily put the entire cost on the one call whose answer it corrupts: a search
+ * against a partially-indexed archive cannot distinguish "absent" from "not indexed yet",
+ * and the first search of a session was reliably the one that ran against the least
+ * coverage. Paying here means that search meets a warm index instead.
+ */
+async function warmTranscriptIndex(projectRoot: string): Promise<void> {
+  try {
+    await ensureTranscriptIndex(projectRoot, undefined, SESSION_START_INDEX_BUDGET_MS);
+  } catch {
+    // An optimisation only. A cold index degrades search; a throwing hook breaks the session.
+  }
 }
 
 async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext: boolean) {
@@ -301,6 +325,10 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     await closeInactiveHostSessionBindings();
     // Detection only: names what moved and the command to review it, mutating nothing.
     const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
+    // Deliberately here and not inside bootstrapWithHandoff: 'session' scope is also what a
+    // turn-start fallback and a SubagentStart use, and fan-out multiplies whatever a subagent
+    // costs. One warm per real session start is the whole point.
+    await warmTranscriptIndex(input.projectRoot);
     const started = await bootstrapWithHandoff(projectId, input, 'session', true);
     // The warning is charged against the cap first — the same rule the subagent card
     // follows. Prepending it to an already-budgeted block pushed the session past the size

--- a/src/store/integrity.ts
+++ b/src/store/integrity.ts
@@ -2,9 +2,10 @@ import { sql } from 'drizzle-orm';
 import { KnowledgeWriteValidationOptions } from '../core/types.js';
 import { KnowledgeValidationError, validateKnowledgeWrite } from '../core/knowledge-validation.js';
 import { getDb } from './database.js';
+import { isNormalizedConflictKey, normalizeConflictKey } from './conflicts.js';
 
 export type IntegrityFinding = {
-  code: 'secret' | 'dangling-reference' | 'missing-index-row' | 'invalid-json' | 'invalid-status';
+  code: 'secret' | 'dangling-reference' | 'missing-index-row' | 'invalid-json' | 'invalid-status' | 'unnormalized-conflict-key';
   severity: 'error' | 'warning';
   itemId?: string;
   detail: string;
@@ -31,9 +32,22 @@ export async function auditKnowledgeStore(
 ): Promise<IntegrityReport> {
   const db = getDb() as any;
   const findings: IntegrityFinding[] = [];
-  const rows = await db.all(sql`SELECT id, title, content, reasoning, source, alternatives, tags, affected_paths, status FROM knowledge_items`);
+  const rows = await db.all(sql`SELECT id, title, content, reasoning, source, alternatives, tags, affected_paths, status, conflict_key FROM knowledge_items`);
 
   for (const row of rows) {
+    // Every lookup matches on the normalized form, so a key that is not already in that
+    // form matches nothing — the row is unreachable by the conflict check meant to keep it
+    // unique and by the reader meant to retire it. Cheap to assert, and it is the invariant
+    // that would have caught the update path writing keys raw.
+    if (row.conflict_key !== null && row.conflict_key !== undefined && !isNormalizedConflictKey(String(row.conflict_key))) {
+      findings.push({
+        code: 'unnormalized-conflict-key',
+        severity: 'error',
+        itemId: String(row.id),
+        detail: `Conflict key "${row.conflict_key}" is not in storage shape (expected "${normalizeConflictKey(String(row.conflict_key))}"); the row is invisible to every conflict lookup.`,
+      });
+    }
+
     const alternatives = parseStringArray(row.alternatives);
     const tags = parseStringArray(row.tags);
     const affectedPaths = parseStringArray(row.affected_paths);

--- a/src/store/project-dir.ts
+++ b/src/store/project-dir.ts
@@ -1,0 +1,31 @@
+/**
+ * One directory, one key.
+ *
+ * project_dir is an opaque string in every transcript query, so each spelling of
+ * the same path becomes a separate archive. On Windows that is not hypothetical:
+ * `D:\Code\x`, `d:\Code\x` and `d:/Code/x` all reach the same folder and all
+ * arrived here, depending on whether the caller was the CLI (path.resolve), the
+ * MCP server (its configured root) or a script.
+ *
+ * Measured on a real database before this existed: 59,358 messages indexed three
+ * times over under three spellings, with every embedding attached to just one of
+ * them - so semantic search from the MCP server scored against a set that had no
+ * vectors at all and silently returned lexical results. The duplicates also
+ * tripled the storage.
+ *
+ * Purely lexical, and deliberately NOT path.resolve. This value is also what
+ * encodeProjectDir turns into a transcript directory name, so it has to stay the
+ * path Claude Code encoded - and resolve() rewrites a Windows-shaped path on a
+ * POSIX host into cwd + the literal string, because backslashes are not
+ * separators there. That pointed the whole index at a directory that does not
+ * exist and failed 22 tests on Linux while passing on Windows. Only the two
+ * things that actually vary are canonicalized: the case of the drive letter, and
+ * which slash was typed.
+ *
+ * This lives alone, with no imports, because the schema bootstrap needs it to
+ * migrate old rows and everything else in the store imports the bootstrap.
+ */
+export function normalizeProjectDir(dir: string): string {
+  if (!/^[a-zA-Z]:/.test(dir)) return dir;
+  return dir[0].toUpperCase() + dir.slice(1).replace(/\//g, '\\').replace(/[\\]+$/, '');
+}

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -4,7 +4,7 @@ import { getDb, withClientTransaction } from './database.js';
 import type { DbConnection } from './database.js';
 import * as schema from './schema.js';
 import { recordTombstone } from './tombstones.js';
-import { normalizeConflictKey, normalizeConflictScope } from './conflicts.js';
+import { normalizeConflictFields } from './conflicts.js';
 import {
   Project,
   KnowledgeItem,
@@ -176,7 +176,9 @@ export async function createKnowledgeItem(
     tier: 'asserted' as const, // standing is earned by use, never granted at birth
     tierSince: now, // the climb to verified starts here, not at some inherited history
     provenance: item.provenance ?? null,
-    conflictKey: item.conflictKey ? normalizeConflictKey(item.conflictKey) : null, conflictScope: normalizeConflictScope(item.conflictScope), conflictExclusive: item.conflictExclusive ?? false,
+    conflictKey: null, conflictScope: null, // replaced below; the boundary owns both columns
+    ...normalizeConflictFields({ conflictKey: item.conflictKey ?? null, conflictScope: item.conflictScope ?? null }),
+    conflictExclusive: item.conflictExclusive ?? false,
     supersededById: null,
     version: 1,
     createdAt: now,
@@ -343,8 +345,13 @@ export async function updateKnowledgeItem(
     const tierIsReset = !tierIsSetExplicitly
       && (updates.content !== undefined || updates.title !== undefined);
 
+    // Identity goes through the boundary here too. Spreading `updates` verbatim is exactly
+    // how raw keys used to reach the column, and a raw key is unreachable forever after.
+    const conflictFields = normalizeConflictFields(updates);
+
     const dbUpdates = {
       ...updates,
+      ...conflictFields,
       ...(updates.affectedPaths !== undefined ? { affectedPaths } : {}),
       ...(shouldRefreshHash ? { contentHash: hashKnowledgeContent(merged) } : {}),
       ...(updates.lifecycleHash === undefined ? { lifecycleHash: hashKnowledgeLifecycle(lifecycle) } : {}),
@@ -373,7 +380,7 @@ export async function updateKnowledgeItem(
       await exec.update(schema.knowledgeAssertions).set({ validTo: now, replacedAt: now }).where(eq(schema.knowledgeAssertions.id, openAssertions[0].id));
       await exec.insert(schema.knowledgeAssertions).values({
         id: generateId(), knowledgeItemId: id, content: merged.content, validFrom: now, validTo: null,
-        recordedAt: now, replacedAt: null, confidence: updates.confidence ?? current[0].confidence, sourceEvidenceId: null, conflictKey: updates.conflictKey ?? current[0].conflictKey, conflictScope: updates.conflictScope ?? current[0].conflictScope, conflictExclusive: updates.conflictExclusive ?? current[0].conflictExclusive,
+        recordedAt: now, replacedAt: null, confidence: updates.confidence ?? current[0].confidence, sourceEvidenceId: null, conflictKey: conflictFields.conflictKey ?? current[0].conflictKey, conflictScope: conflictFields.conflictScope ?? current[0].conflictScope, conflictExclusive: updates.conflictExclusive ?? current[0].conflictExclusive,
       });
     }
 

--- a/src/store/resume-points.ts
+++ b/src/store/resume-points.ts
@@ -1,0 +1,193 @@
+import { getClient } from './database.js';
+import { normalizeProjectDir } from './project-dir.js';
+
+// A named, re-usable resume point: park a workstream, get a short key, and hand
+// that key to any future session to pick the work up exactly where it stopped.
+//
+// The existing session handoff is a one-shot baton - one per project, delivered
+// automatically to whoever starts next, then archived. That is the right shape
+// for "I am stopping, someone continue", and the wrong shape for "I have three
+// workstreams parked and I want THAT one now". This is the second shape:
+// addressable, persistent, and resumable more than once.
+//
+// The brief is deliberately THIN and carries the session id. Semantic transcript
+// search covers the whole archive, so the resuming agent can read the original
+// conversation for any detail the brief left out. A fat brief goes stale the
+// moment the work moves; a pointer into a searchable transcript does not.
+
+export interface ResumeBrief {
+  goal: string;
+  nextAction: string;
+  completed?: string[];
+  blocker?: string;
+  verificationStatus?: string;
+  artifactRefs?: string[];
+  sessionId?: string;
+}
+
+export interface ResumePoint {
+  key: string;
+  projectDir: string;
+  brief: ResumeBrief;
+  createdAt: string;
+  lastResumedAt: string | null;
+  resumeCount: number;
+}
+
+/**
+ * Keys are typed by a human, so the alphabet omits everything that gets
+ * misread: no 0/O, no 1/I/L. Six characters from a 30-symbol alphabet is ~729
+ * million combinations, which is far past any plausible number of parked
+ * workstreams while staying short enough to retype from a screenshot.
+ */
+const ALPHABET = 'abcdefghjkmnpqrstuvwxyz23456789';
+
+function mintKey(): string {
+  let key = '';
+  for (let i = 0; i < 6; i++) key += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+  return key;
+}
+
+/**
+ * Accepts what a person actually pastes: bare, prefixed, spaced, or shouted.
+ *
+ * Separators go first, then each label is stripped on its own — `knowl:x`,
+ * `resume x` and `knowl/resume/x` are all things a user will type, and a single
+ * pattern expecting both labels together silently mangles the first two.
+ */
+export function normalizeKey(raw: string): string {
+  let key = raw.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  for (const label of ['knowl', 'resume']) {
+    if (key.startsWith(label) && key.length > label.length) key = key.slice(label.length);
+  }
+  return key;
+}
+
+export async function createResumePoint(projectDir: string, brief: ResumeBrief): Promise<ResumePoint> {
+  const client = getClient();
+  const dir = normalizeProjectDir(projectDir);
+  const createdAt = new Date().toISOString();
+
+  // Retry on the astronomically unlikely collision rather than pretend it cannot happen.
+  for (let attempt = 0; ; attempt++) {
+    const key = mintKey();
+    try {
+      await client.execute({
+        sql: `INSERT INTO resume_points (key, project_dir, brief, created_at, last_resumed_at, resume_count)
+              VALUES (?, ?, ?, ?, NULL, 0)`,
+        args: [key, dir, JSON.stringify(brief), createdAt],
+      });
+      return { key, projectDir: dir, brief, createdAt, lastResumedAt: null, resumeCount: 0 };
+    } catch (error) {
+      if (attempt >= 4 || !/UNIQUE|CONSTRAINT/i.test(String((error as Error).message))) throw error;
+    }
+  }
+}
+
+/**
+ * Look up a key and record that it was used.
+ *
+ * Deliberately NOT consumed: the same workstream can be picked up on Monday,
+ * parked again, and picked up on Wednesday. A one-shot key would make resuming
+ * twice an error, which is not how work behaves.
+ *
+ * The project is not part of the lookup. A key is unique on its own, and someone
+ * pasting one into the wrong directory means to go to the work, not to be told
+ * it does not exist here.
+ */
+export async function readResumePoint(rawKey: string): Promise<ResumePoint | null> {
+  const client = getClient();
+  const key = normalizeKey(rawKey);
+  if (!key) return null;
+
+  const row = (await client.execute({
+    sql: 'SELECT key, project_dir, brief, created_at, last_resumed_at, resume_count FROM resume_points WHERE key = ?',
+    args: [key],
+  })).rows[0];
+  if (!row) return null;
+
+  await client.execute({
+    sql: 'UPDATE resume_points SET last_resumed_at = ?, resume_count = resume_count + 1 WHERE key = ?',
+    args: [new Date().toISOString(), key],
+  });
+
+  let brief: ResumeBrief;
+  try { brief = JSON.parse(String(row.brief)); } catch { return null; }
+
+  return {
+    key,
+    projectDir: String(row.project_dir),
+    brief,
+    createdAt: String(row.created_at),
+    lastResumedAt: row.last_resumed_at ? String(row.last_resumed_at) : null,
+    resumeCount: Number(row.resume_count),
+  };
+}
+
+/** Parked workstreams for a project, newest first — for "what did I leave open?". */
+export async function listResumePoints(projectDir: string, limit = 20): Promise<ResumePoint[]> {
+  const rows = (await getClient().execute({
+    sql: `SELECT key, project_dir, brief, created_at, last_resumed_at, resume_count
+          FROM resume_points WHERE project_dir = ? ORDER BY created_at DESC LIMIT ?`,
+    args: [normalizeProjectDir(projectDir), limit],
+  })).rows;
+
+  return rows.flatMap(row => {
+    try {
+      return [{
+        key: String(row.key),
+        projectDir: String(row.project_dir),
+        brief: JSON.parse(String(row.brief)) as ResumeBrief,
+        createdAt: String(row.created_at),
+        lastResumedAt: row.last_resumed_at ? String(row.last_resumed_at) : null,
+        resumeCount: Number(row.resume_count),
+      }];
+    } catch {
+      return [];
+    }
+  });
+}
+
+/**
+ * What the resuming session reads. Written as an instruction to that session
+ * rather than as a record, because it arrives as the first thing in a context
+ * that knows nothing: it has to say what the work is, what to do next, and
+ * where to look for everything it does not contain.
+ */
+export function formatResumeBrief(point: ResumePoint): string {
+  const { brief } = point;
+  const lines = [
+    `# RESUMING PARKED WORK — key ${point.key}`,
+    '',
+    `Parked ${point.createdAt}${point.resumeCount > 0 ? ` · resumed ${point.resumeCount} time(s) before` : ''}.`,
+    `Project: ${point.projectDir}`,
+    '',
+    `## Goal`,
+    brief.goal,
+    '',
+    `## Do this next`,
+    brief.nextAction,
+  ];
+
+  if (brief.completed?.length) {
+    lines.push('', '## Already done — do not redo', ...brief.completed.map(item => `- ${item}`));
+  }
+  if (brief.blocker) lines.push('', '## Blocker', brief.blocker);
+  if (brief.verificationStatus) lines.push('', '## Verification state', brief.verificationStatus);
+  if (brief.artifactRefs?.length) {
+    lines.push('', '## Artifacts', ...brief.artifactRefs.map(ref => `- ${ref}`));
+  }
+
+  if (brief.sessionId) {
+    lines.push(
+      '',
+      '## Where the detail lives',
+      `The originating session is \`${brief.sessionId}\`. This brief is deliberately short — for anything`,
+      `it does not answer, call knowl_transcript_search with sessionId "${brief.sessionId}" and read the`,
+      `original conversation rather than guessing at what was decided.`,
+    );
+  }
+
+  lines.push('', 'Pick the work up from here. Do not restate this brief back to the user; just continue.');
+  return lines.join('\n');
+}

--- a/src/store/resume-points.ts
+++ b/src/store/resume-points.ts
@@ -35,17 +35,40 @@ export interface ResumePoint {
 }
 
 /**
- * Keys are typed by a human, so the alphabet omits everything that gets
- * misread: no 0/O, no 1/I/L. Six characters from a 30-symbol alphabet is ~729
- * million combinations, which is far past any plausible number of parked
- * workstreams while staying short enough to retype from a screenshot.
+ * The key is MINTED, never chosen, and always contains a digit.
+ *
+ * Both properties exist to stop a key from reading as an instruction. A key the
+ * user picks would be something like `fix-login-bug`, and a fresh session
+ * receiving that has no reason to treat it as a lookup - it would simply start
+ * fixing a login bug. An opaque token has no competing interpretation, so the
+ * only sensible move left to the model is to go and find out what it refers to.
+ *
+ * Randomness alone does not guarantee that: six draws from a letters-and-digits
+ * alphabet can legitimately spell `budget` or `answer`, which lands straight
+ * back in the failure the design is avoiding. Forcing at least one digit makes
+ * a word structurally impossible, at a trivial cost in entropy.
+ *
+ * The alphabet also omits every character people transcribe wrongly from a
+ * screen: no 0/O, no 1/I/L. 23 letters and 8 digits over six characters is ~887
+ * million combinations - far past any plausible number of parked workstreams,
+ * and still short enough to retype from a screenshot.
  */
-const ALPHABET = 'abcdefghjkmnpqrstuvwxyz23456789';
+const LETTERS = 'abcdefghjkmnpqrstuvwxyz';
+const DIGITS = '23456789';
+const KEY_LENGTH = 6;
 
 function mintKey(): string {
-  let key = '';
-  for (let i = 0; i < 6; i++) key += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
-  return key;
+  const pick = (set: string) => set[Math.floor(Math.random() * set.length)];
+  const chars = [pick(DIGITS)];
+  while (chars.length < KEY_LENGTH) chars.push(pick(LETTERS + DIGITS));
+
+  // The guaranteed digit must not always sit first, or every key looks alike and
+  // the position leaks that it was special-cased.
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return chars.join('');
 }
 
 /**
@@ -61,6 +84,19 @@ export function normalizeKey(raw: string): string {
     if (key.startsWith(label) && key.length > label.length) key = key.slice(label.length);
   }
   return key;
+}
+
+/**
+ * The line a user pastes into a fresh session.
+ *
+ * A bare key depends on the receiving model choosing to investigate an opaque
+ * token. That is usually enough - the token has no other sensible reading - but
+ * "usually" is the wrong standard for the one message whose whole job is to not
+ * be misread. Naming the action and the tool removes the guess entirely, and
+ * still works in a session that never read knowl's tool descriptions.
+ */
+export function resumeInstruction(key: string): string {
+  return `Continue the parked workstream with key ${key} — use the knowl memory MCP (knowl_resume).`;
 }
 
 export async function createResumePoint(projectDir: string, brief: ResumeBrief): Promise<ResumePoint> {

--- a/src/store/resume-points.ts
+++ b/src/store/resume-points.ts
@@ -224,6 +224,12 @@ export function formatResumeBrief(point: ResumePoint): string {
     );
   }
 
-  lines.push('', 'Pick the work up from here. Do not restate this brief back to the user; just continue.');
+  lines.push(
+    '',
+    'STOP HERE. This brief restores context; it is not authorisation to act. A resume key means the user',
+    'wants the work REMEMBERED, not resumed on their behalf. Give them a short orientation — where the',
+    'work stands, what the next action would be, and any blocker that needs their ruling — then wait.',
+    'Do not edit files, run builds, or start the next action until they say go.',
+  );
   return lines.join('\n');
 }

--- a/src/store/session-directory.ts
+++ b/src/store/session-directory.ts
@@ -1,0 +1,168 @@
+import { getClient } from './database.js';
+import { ensureTranscriptIndex, sessionFiles } from './transcript-index.js';
+
+// A browsable directory of a project's Claude Code sessions, host-session
+// grained - the unit a person actually thinks in ("the UI session", "the forge
+// session"), not the fine-grained memory sessions the lifecycle hooks create
+// per agent turn.
+//
+// Everything here is derived deterministically from data that already exists:
+// names and opening asks captured by the transcript indexer as it streams,
+// activity figures from the index, and - where lifecycle hooks ran - the
+// knowledge each session actually promoted. No AI provider, no cap on how far
+// back it reaches, and sessions that were never named still appear with their
+// opening ask, which is precisely where the native picker gives up.
+
+export interface SessionDirectoryEntry {
+  sessionId: string;
+  /** Best available name: user rename > agent name > generated title > null. */
+  name: string | null;
+  /** The first real user ask, one line - what the session set out to do. */
+  opening: string | null;
+  /**
+   * Derived at read time from lifecycle data, never stored:
+   * 'interrupted' - an unconsumed crash handoff names this session; there is a
+   *                 blocker waiting to be resumed. Strongest signal, wins.
+   * 'active'      - a live memory session with a recent heartbeat is bound to
+   *                 it, or the transcript was written moments ago.
+   * 'idle'        - everything else; lastActiveAt carries the rest.
+   * Fine-grained working/stalled tiers exist in live monitors, but this is a
+   * recall surface - their precondition (real-time observation) is absent.
+   */
+  status: 'active' | 'interrupted' | 'idle';
+  /** Title of the newest declared session card, when one was stored (tags: session-card + session:<id>). */
+  card: string | null;
+  lastActiveAt: string;
+  sizeBytes: number;
+  messagesIndexed: number;
+  /** Titles of knowledge atoms this session promoted into memory, when lifecycle hooks captured any. */
+  promoted: string[];
+}
+
+/** A heartbeat older than this no longer counts as "working right now". */
+const ACTIVE_HEARTBEAT_MS = 30 * 60 * 1000;
+/** A transcript written this recently is active even without lifecycle hooks. */
+const ACTIVE_MTIME_MS = 10 * 60 * 1000;
+
+export interface SessionDirectoryOptions {
+  projectDir?: string;
+  /** Keyword filter over name + opening. All tokens must match. */
+  query?: string;
+  limit?: number;
+  /** Override transcript roots. Injected by tests so they never mutate HOME. */
+  stores?: string[];
+}
+
+export async function listSessionDirectory(
+  options: SessionDirectoryOptions = {},
+): Promise<{ entries: SessionDirectoryEntry[]; total: number; indexComplete: boolean }> {
+  const { projectDir = process.cwd(), query, limit = 12, stores } = options;
+  const client = getClient();
+
+  // Names and openings are captured by the indexer, so the directory is only as
+  // current as the index. Same budget-bounded call the search path uses.
+  const index = await ensureTranscriptIndex(projectDir, stores);
+  const files = await sessionFiles(projectDir, stores);
+
+  const rows = (await client.execute({
+    sql: `SELECT f.session_id, f.display_name, f.opening,
+                 (SELECT COUNT(*) FROM transcript_messages m WHERE m.session_id = f.session_id AND m.project_dir = ?) AS messages
+          FROM transcript_files f WHERE f.project_dir = ?`,
+    args: [projectDir, projectDir],
+  })).rows;
+  const meta = new Map(rows.map(row => [String(row.session_id), row]));
+
+  // Promoted knowledge per host session, through the lifecycle chain:
+  // host session -> bound memory sessions -> promoted item ids -> item titles.
+  // Best-effort: a project without lifecycle hooks simply has none of this.
+  const promoted = new Map<string, string[]>();
+  try {
+    const promotedRows = (await client.execute(
+      `SELECT b.external_session_id AS sid, i.title AS title
+       FROM host_session_bindings b
+       JOIN memory_sessions s ON s.id = b.memory_session_id
+       JOIN json_each(COALESCE(s.promotion_items, '[]')) p
+       JOIN knowledge_items i ON i.id = p.value
+       WHERE s.promotion_status = 'promoted'`,
+    )).rows;
+    for (const row of promotedRows) {
+      const sid = String(row.sid);
+      const list = promoted.get(sid) ?? [];
+      if (!list.includes(String(row.title))) list.push(String(row.title));
+      promoted.set(sid, list);
+    }
+  } catch { /* older schema or no lifecycle data */ }
+
+  // Lifecycle signals, one query each, mapped by host session id.
+  const activeHeartbeat = new Map<string, number>();
+  try {
+    const hb = (await client.execute(
+      `SELECT b.external_session_id AS sid, MAX(s.last_heartbeat_at) AS beat
+       FROM host_session_bindings b
+       JOIN memory_sessions s ON s.id = b.memory_session_id
+       WHERE s.status = 'active'
+       GROUP BY b.external_session_id`,
+    )).rows;
+    for (const row of hb) activeHeartbeat.set(String(row.sid), Date.parse(String(row.beat)));
+  } catch { /* no lifecycle data */ }
+
+  // Crash handoffs and declared cards both tag themselves session:<id>, so one
+  // scan of active state items covers both. Parsed in JS: tags are JSON text,
+  // and per-session LIKE queries would cost a round trip per session.
+  const interrupted = new Set<string>();
+  const cards = new Map<string, string>();
+  try {
+    const tagged = (await client.execute(
+      `SELECT title, tags, content, updated_at FROM knowledge_items
+       WHERE status = 'active' AND (tags LIKE '%"pending_handoff"%' OR tags LIKE '%"session-card"%')
+       ORDER BY updated_at ASC`,
+    )).rows;
+    for (const row of tagged) {
+      let tags: string[] = [];
+      try { tags = JSON.parse(String(row.tags ?? '[]')); } catch { continue; }
+      // Handoffs written before the session: tag existed carry the id only in
+      // their content JSON; real archives have these, so fall back to it.
+      let sid = tags.find(tag => tag.startsWith('session:'))?.slice('session:'.length);
+      if (!sid) { try { sid = JSON.parse(String(row.content)).externalSessionId; } catch { /* not JSON */ } }
+      if (!sid) continue;
+      if (tags.includes('pending_handoff') && !tags.includes('consumed')) {
+        try { if (JSON.parse(String(row.content)).consumed === true) continue; } catch { /* treat as live */ }
+        interrupted.add(sid);
+      }
+      // Ascending updated_at, so the newest card naturally wins.
+      if (tags.includes('session-card')) cards.set(sid, String(row.title));
+    }
+  } catch { /* no state items */ }
+
+  const now = Date.now();
+  let entries: SessionDirectoryEntry[] = files.map(file => {
+    const row = meta.get(file.sessionId);
+    const beat = activeHeartbeat.get(file.sessionId);
+    const status = interrupted.has(file.sessionId) ? 'interrupted' as const
+      : (beat !== undefined && now - beat < ACTIVE_HEARTBEAT_MS) || now - file.mtimeMs < ACTIVE_MTIME_MS ? 'active' as const
+      : 'idle' as const;
+    return {
+      sessionId: file.sessionId,
+      name: row?.display_name ? String(row.display_name) : null,
+      opening: row?.opening ? String(row.opening) : null,
+      status,
+      card: cards.get(file.sessionId) ?? null,
+      lastActiveAt: new Date(file.mtimeMs).toISOString(),
+      sizeBytes: file.size,
+      messagesIndexed: row ? Number(row.messages) : 0,
+      promoted: (promoted.get(file.sessionId) ?? []).slice(0, 3),
+    };
+  });
+
+  if (query?.trim()) {
+    // Substring AND-match over the intent fields. This filters the INVENTORY
+    // (what a session is about); content questions belong to transcript search.
+    const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+    entries = entries.filter(entry => {
+      const haystack = `${entry.name ?? ''}\n${entry.opening ?? ''}\n${entry.card ?? ''}\n${entry.promoted.join('\n')}`.toLowerCase();
+      return tokens.every(token => haystack.includes(token));
+    });
+  }
+
+  return { entries: entries.slice(0, limit), total: entries.length, indexComplete: index.complete };
+}

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -306,7 +306,12 @@ export function formatPendingHandoffContext(handoff: PendingHandoff): string {
     if (handoff.taskState.artifactRefs?.length) lines.push(`- Artifacts: ${handoff.taskState.artifactRefs.join(', ')}`);
     if (handoff.taskState.verificationStatus) lines.push(`- Verification: ${handoff.taskState.verificationStatus}`);
   }
-  lines.push('', 'Do not restart from scratch. Resume the interrupted work using this handoff plus recent project memory.');
+  lines.push(
+    '',
+    'This is context, not authorisation. Do not restart from scratch — and do not silently carry on either.',
+    'Tell the user in a few lines where the work stands, what the next action would be, and any blocker that',
+    'needs their decision, then wait for them to say go before editing files or running anything.',
+  );
   return truncateText(lines.join('\n'), DEFAULT_CONTEXT_MAX_CHARS);
 }
 

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -12,12 +12,24 @@ export const PROVIDER_OUTAGE_URGENCY = 'high';
 export const INTERRUPTED_URGENCY = 'high';
 export const GENERIC_FAILURE_URGENCY = 'high';
 
-export type SessionFailureKind =
-  | 'rate_limit'
-  | 'auth'
-  | 'provider_outage'
-  | 'interrupted'
-  | 'failed';
+export const HANDOFF_URGENCY = 'planned';
+
+/**
+ * 'handoff' is the one kind that is not a failure: the user deliberately parked
+ * a workstream. Kept in the same union because it rides the same slot, claim,
+ * and delivery machinery - but the receiving session must be able to tell a
+ * planned baton from a 3am crash, because they deserve opposite openings.
+ */
+export const SESSION_HANDOFF_KINDS = [
+  'handoff',
+  'rate_limit',
+  'auth',
+  'provider_outage',
+  'interrupted',
+  'failed',
+] as const;
+
+export type SessionFailureKind = typeof SESSION_HANDOFF_KINDS[number];
 
 export type HandoffTaskState = {
   goal?: string;
@@ -30,7 +42,7 @@ export type HandoffTaskState = {
 
 export type PendingHandoff = {
   kind: SessionFailureKind;
-  urgency: typeof RATE_LIMIT_URGENCY | typeof AUTH_URGENCY | typeof PROVIDER_OUTAGE_URGENCY | typeof INTERRUPTED_URGENCY | typeof GENERIC_FAILURE_URGENCY;
+  urgency: typeof RATE_LIMIT_URGENCY | typeof AUTH_URGENCY | typeof PROVIDER_OUTAGE_URGENCY | typeof INTERRUPTED_URGENCY | typeof GENERIC_FAILURE_URGENCY | typeof HANDOFF_URGENCY;
   host: string;
   projectRoot: string;
   externalSessionId: string;
@@ -164,7 +176,10 @@ function parseHandoffContent(content: string): PendingHandoff | null {
   try {
     const parsed = JSON.parse(content) as PendingHandoff;
     if (!parsed || typeof parsed !== 'object') return null;
-    if (!['rate_limit', 'auth', 'provider_outage', 'interrupted', 'failed'].includes(parsed.kind)) return null;
+    // Derived from the kind list, never a second copy of it: a hand-maintained
+    // duplicate here silently made a newly added kind unreadable, so every
+    // baton of that kind was written and then never delivered.
+    if (!(SESSION_HANDOFF_KINDS as readonly string[]).includes(parsed.kind)) return null;
     if (!parsed.failedAt || !parsed.host || !parsed.projectRoot || !parsed.externalSessionId) return null;
     return parsed;
   } catch {
@@ -260,15 +275,20 @@ async function findActivePendingHandoff(host: string) {
 }
 
 export function formatPendingHandoffContext(handoff: PendingHandoff): string {
+  // A planned baton and a crash both arrive here, and they deserve opposite
+  // openings: one resumes work, the other recovers from a blocker.
+  const planned = handoff.kind === 'handoff';
   const lines = [
-    '# KNOWL - PENDING SESSION HANDOFF',
+    planned ? '# KNOWL - SESSION HANDOFF' : '# KNOWL - PENDING SESSION HANDOFF',
     '',
-    'Previous host session ended before a clean finish. Continue from this handoff first.',
+    planned
+      ? 'The previous session parked this work for you on purpose. Pick it up from here.'
+      : 'Previous host session ended before a clean finish. Continue from this handoff first.',
     '',
     `- Kind: ${handoff.kind}`,
     `- Urgency: ${handoff.urgency}`,
     `- Host: ${handoff.host}`,
-    `- Failed at: ${handoff.failedAt}`,
+    planned ? `- Parked at: ${handoff.failedAt}` : `- Failed at: ${handoff.failedAt}`,
     `- External session: ${handoff.externalSessionId}`,
   ];
   if (handoff.memorySessionId) lines.push(`- Memory session: ${handoff.memorySessionId}`);
@@ -374,6 +394,68 @@ export async function recordPendingSessionHandoff(
     conflictExclusive: true,
   });
   await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${host}/${kind})`, [
+    { itemId: created.id, action: 'insert', after: created },
+  ]);
+  return { itemId: created.id, handoff };
+}
+
+/**
+ * Park a workstream on purpose. Same slot and same one-shot delivery as a crash
+ * handoff, so nothing new has to be built for the receiving side - only the
+ * kind differs, and with it the tone the next session should open in.
+ *
+ * One baton per project: an existing pending handoff is replaced, which is the
+ * right behaviour for "I am leaving this session now" and the reason this is a
+ * pass rather than a durable note. Anything worth keeping goes in knowl_store.
+ */
+export async function recordDeliberateHandoff(
+  projectId: string,
+  input: {
+    host: string;
+    projectRoot: string;
+    externalSessionId: string;
+    sessionTitle?: string;
+    taskState: HandoffTaskState;
+  },
+): Promise<{ itemId: string; handoff: PendingHandoff }> {
+  const handoff: PendingHandoff = {
+    kind: 'handoff',
+    urgency: HANDOFF_URGENCY,
+    host: input.host,
+    projectRoot: input.projectRoot,
+    externalSessionId: input.externalSessionId,
+    sessionTitle: input.sessionTitle,
+    taskState: input.taskState,
+    failedAt: new Date().toISOString(),
+    consumed: false,
+  };
+
+  const conflictKey = pendingHandoffConflictKey(input.host);
+  const identity = { host: input.host, externalSessionId: input.externalSessionId };
+  const tags = ['pending_handoff', 'handoff', HANDOFF_URGENCY, input.host, `session:${input.externalSessionId}`];
+  const fields = {
+    title: PENDING_HANDOFF_TITLE,
+    content: JSON.stringify(handoff),
+    tags,
+    source: `host://${input.host}/session-handoff`,
+    freshness: 'fresh' as const,
+    confidence: 1,
+    conflictKey,
+    conflictScope: identity,
+    conflictExclusive: true,
+  };
+
+  const existing = await findActivePendingHandoff(input.host);
+  if (existing) {
+    const updated = await repo.updateKnowledgeItem(existing.id, fields);
+    await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${input.host}/handoff)`, [
+      { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
+    ]);
+    return { itemId: updated.id, handoff };
+  }
+
+  const created = await repo.createKnowledgeItem(projectId, { category: 'state', ...fields });
+  await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${input.host}/handoff)`, [
     { itemId: created.id, action: 'insert', after: created },
   ]);
   return { itemId: created.id, handoff };

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 import { homedir } from 'node:os';
-import { join, basename, delimiter } from 'node:path';
+import { join, basename, delimiter, resolve } from 'node:path';
 import { getClient } from './database.js';
 
 // Incremental index over raw Claude Code session transcripts.
@@ -37,6 +37,29 @@ export function tokenize(text: string): string[] {
 /** Claude Code encodes the project path by replacing every non-alphanumeric character with '-'. */
 export function encodeProjectDir(dir: string): string {
   return dir.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * One directory, one key.
+ *
+ * project_dir is an opaque string in every one of these queries, so each
+ * spelling of the same path becomes a separate archive. On Windows that is not
+ * hypothetical: `D:\Code\x`, `d:\Code\x` and `d:/Code/x` all reach the same
+ * folder and all arrived here, depending on whether the caller was the CLI
+ * (path.resolve), the MCP server (its configured root) or a script.
+ *
+ * Measured on a real database before this existed: 59,358 messages indexed
+ * three times over under three spellings, and every embedding attached to just
+ * one of them - so semantic search from the MCP server scored against a set
+ * that had no vectors at all and silently returned lexical results. The
+ * duplicates also tripled the storage.
+ *
+ * Resolve, then upper-case the drive letter, which is the one part path.resolve
+ * leaves as the caller typed it.
+ */
+export function normalizeProjectDir(dir: string): string {
+  const resolved = resolve(dir);
+  return /^[a-z]:/.test(resolved) ? resolved[0].toUpperCase() + resolved.slice(1) : resolved;
 }
 
 /**
@@ -381,7 +404,8 @@ export interface IndexResult {
  * Bring the index up to date. Cheap when nothing changed: a file whose size
  * matches the stored offset is skipped without being opened.
  */
-export async function ensureTranscriptIndex(projectDir: string, stores?: string[], budgetMs = DEFAULT_INDEX_BUDGET_MS): Promise<IndexResult> {
+export async function ensureTranscriptIndex(rawProjectDir: string, stores?: string[], budgetMs = DEFAULT_INDEX_BUDGET_MS): Promise<IndexResult> {
+  const projectDir = normalizeProjectDir(rawProjectDir);
   const started = Date.now();
   const deadline = started + budgetMs;
   const files = await sessionFiles(projectDir, stores);
@@ -415,7 +439,8 @@ export async function ensureTranscriptIndex(projectDir: string, stores?: string[
   };
 }
 
-export async function transcriptIndexStats(projectDir: string): Promise<{ messages: number; avgLen: number; sessions: number }> {
+export async function transcriptIndexStats(rawProjectDir: string): Promise<{ messages: number; avgLen: number; sessions: number }> {
+  const projectDir = normalizeProjectDir(rawProjectDir);
   const client = getClient();
   const row = (await client.execute({
     sql: 'SELECT COUNT(*) AS n, COALESCE(AVG(len), 1) AS avg_len, COUNT(DISTINCT session_id) AS sessions FROM transcript_messages WHERE project_dir = ?',

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -93,7 +93,8 @@ function isNoise(text: string): boolean {
   const t = text.trimStart();
   if (!t) return true;
   if (t.startsWith('<local-command-caveat>')) return true;
-  if (t.startsWith('<command-name>')) return true;
+  // Slash-command invocations arrive wrapped either way round.
+  if (t.startsWith('<command-name>') || t.startsWith('<command-message>')) return true;
   return /^Caveat: The messages below were generated/.test(t);
 }
 
@@ -167,7 +168,20 @@ async function flush(projectDir: string, pending: PendingMessage[], nextId: { va
   // live session, and a long write transaction starves it into SQLITE_BUSY.
   for (let i = 0; i < statements.length; i += BATCH_STATEMENTS) {
     try {
-      await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+      // Observed repeatedly beside a live serve process writing to the same
+      // database: transient BUSY on commit. Retried with backoff because one
+      // retry proved too thin under sustained neighbour writes; a final
+      // failure is treated like any other batch error below.
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+          break;
+        } catch (error) {
+          const busy = /SQLITE_BUSY|statements in progress/i.test(String((error as Error).message));
+          if (!busy || attempt >= 3) throw error;
+          await new Promise(resolve => setTimeout(resolve, 250 * (attempt + 1)));
+        }
+      }
     } catch (error) {
       // A primary-key collision means another process allocated the same ids -
       // the file lease serializes work per FILE, but ids come from one MAX(id)
@@ -223,7 +237,7 @@ type FileOutcome = { added: number; complete: boolean; reason?: 'budget' | 'leas
 async function indexFile(projectDir: string, file: SessionFile, nextId: { value: number }, deadline: number): Promise<FileOutcome> {
   const client = getClient();
   const row = (await client.execute({
-    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms FROM transcript_files WHERE path = ?',
+    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms, display_name, name_kind, opening FROM transcript_files WHERE path = ?',
     args: [file.path],
   })).rows[0];
 
@@ -237,12 +251,18 @@ async function indexFile(projectDir: string, file: SessionFile, nextId: { value:
   // invisible, which real editing does not do.
   const rewrittenInPlace = row !== undefined
     && startByte === file.size && Number(row.mtime_ms) !== 0 && Number(row.mtime_ms) !== file.mtimeMs;
+  // Carried across incremental passes: a rename entry seen weeks ago must not
+  // be forgotten because later passes only read the appended tail.
+  let name = row?.display_name ? String(row.display_name) : null;
+  let nameKind = row ? Number(row.name_kind) : 0;
+  let opening = row?.opening ? String(row.opening) : null;
 
   // A file that shrank was rewritten rather than appended to, so the offset is
   // meaningless and its rows have to go. Same-size rewrites are caught above.
   if (startByte > file.size || rewrittenInPlace) {
     await purgeBeyond(projectDir, file.sessionId, 0);
-    startByte = 0; lineNo = 0;
+    // The file was rewritten, so metadata read from the old content is void.
+    startByte = 0; lineNo = 0; name = null; nameKind = 0; opening = null;
   }
   if (startByte === file.size) return { added: 0, complete: true };
 
@@ -292,9 +312,18 @@ async function indexFile(projectDir: string, file: SessionFile, nextId: { value:
       if (!line.trim()) continue;
       let entry: any;
       try { entry = JSON.parse(line); } catch { continue; }
+      // The transcript names itself: a user rename (custom-title, mirrored by
+      // agent-name) outranks the generated ai-title, and within a rank the
+      // later entry wins. External tools fall back to filenames or first
+      // prompts; the better source was here all along.
+      if (entry.type === 'custom-title' && typeof entry.customTitle === 'string') { name = entry.customTitle; nameKind = 3; continue; }
+      if (entry.type === 'agent-name' && typeof entry.agentName === 'string' && nameKind <= 2) { name = entry.agentName; nameKind = 2; continue; }
+      if (entry.type === 'ai-title' && typeof entry.aiTitle === 'string' && nameKind <= 1) { name = entry.aiTitle; nameKind = 1; continue; }
       if (entry.type !== 'user' && entry.type !== 'assistant') continue;
       const { text, toolChars } = extractText(entry);
       if (!text || isNoise(text)) continue;
+      // The first real ask, as the session's one-line descriptor.
+      if (opening === null && entry.type === 'user') opening = text.replace(/\s+/g, ' ').slice(0, 240);
       const clipped = text.slice(0, MAX_TEXT_CHARS);
       pending.push({
         sessionId: file.sessionId, line: lineNo, role: entry.type,
@@ -323,11 +352,12 @@ async function indexFile(projectDir: string, file: SessionFile, nextId: { value:
   const doneStamp = new Date().toISOString();
   ownClaims.add(doneStamp);
   await client.execute({
-    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
+    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at, display_name, name_kind, opening)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(path) DO UPDATE SET bytes_indexed = excluded.bytes_indexed,
-            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at`,
-    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp],
+            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at,
+            display_name = excluded.display_name, name_kind = excluded.name_kind, opening = excluded.opening`,
+    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp, name, nameKind, opening],
   });
   return complete ? { added, complete } : { added, complete, reason: 'budget' };
 }

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -4,6 +4,9 @@ import { createInterface } from 'node:readline';
 import { homedir } from 'node:os';
 import { join, basename, delimiter } from 'node:path';
 import { getClient } from './database.js';
+import { normalizeProjectDir } from './project-dir.js';
+
+export { normalizeProjectDir } from './project-dir.js';
 
 // Incremental index over raw Claude Code session transcripts.
 //
@@ -39,33 +42,6 @@ export function encodeProjectDir(dir: string): string {
   return dir.replace(/[^a-zA-Z0-9]/g, '-');
 }
 
-/**
- * One directory, one key.
- *
- * project_dir is an opaque string in every one of these queries, so each
- * spelling of the same path becomes a separate archive. On Windows that is not
- * hypothetical: `D:\Code\x`, `d:\Code\x` and `d:/Code/x` all reach the same
- * folder and all arrived here, depending on whether the caller was the CLI
- * (path.resolve), the MCP server (its configured root) or a script.
- *
- * Measured on a real database before this existed: 59,358 messages indexed
- * three times over under three spellings, and every embedding attached to just
- * one of them - so semantic search from the MCP server scored against a set
- * that had no vectors at all and silently returned lexical results. The
- * duplicates also tripled the storage.
- *
- * Purely lexical, and deliberately NOT path.resolve. This value is also what
- * encodeProjectDir turns into a transcript directory name, so it has to stay the
- * path Claude Code encoded - and resolve() rewrites a Windows-shaped path on a
- * POSIX host into cwd + the literal string, because backslashes are not
- * separators there. That pointed the whole index at a directory that does not
- * exist. Only the two things that actually vary are canonicalized: the case of
- * the drive letter, and which slash was typed.
- */
-export function normalizeProjectDir(dir: string): string {
-  if (!/^[a-zA-Z]:/.test(dir)) return dir;
-  return dir[0].toUpperCase() + dir.slice(1).replace(/\//g, '\\').replace(/[\\]+$/, '');
-}
 
 /**
  * Every config root that may hold transcripts. CLAUDE_CONFIG_DIR wins when set;

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
 import { homedir } from 'node:os';
-import { join, basename, delimiter, resolve } from 'node:path';
+import { join, basename, delimiter } from 'node:path';
 import { getClient } from './database.js';
 
 // Incremental index over raw Claude Code session transcripts.
@@ -54,12 +54,17 @@ export function encodeProjectDir(dir: string): string {
  * that had no vectors at all and silently returned lexical results. The
  * duplicates also tripled the storage.
  *
- * Resolve, then upper-case the drive letter, which is the one part path.resolve
- * leaves as the caller typed it.
+ * Purely lexical, and deliberately NOT path.resolve. This value is also what
+ * encodeProjectDir turns into a transcript directory name, so it has to stay the
+ * path Claude Code encoded - and resolve() rewrites a Windows-shaped path on a
+ * POSIX host into cwd + the literal string, because backslashes are not
+ * separators there. That pointed the whole index at a directory that does not
+ * exist. Only the two things that actually vary are canonicalized: the case of
+ * the drive letter, and which slash was typed.
  */
 export function normalizeProjectDir(dir: string): string {
-  const resolved = resolve(dir);
-  return /^[a-z]:/.test(resolved) ? resolved[0].toUpperCase() + resolved.slice(1) : resolved;
+  if (!/^[a-zA-Z]:/.test(dir)) return dir;
+  return dir[0].toUpperCase() + dir.slice(1).replace(/\//g, '\\').replace(/[\\]+$/, '');
 }
 
 /**

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -1,0 +1,379 @@
+import { createReadStream } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { homedir } from 'node:os';
+import { join, basename, delimiter } from 'node:path';
+import { getClient } from './database.js';
+
+// Incremental index over raw Claude Code session transcripts.
+//
+// The naive approach - stream every file on every query - costs seconds per
+// lookup and gets worse as history grows, which is exactly the wrong shape for
+// something an agent should reach for whenever it is unsure. Transcripts are
+// append-only, so a byte offset is a valid resume point: each pass reads only
+// what was written since the last one, and steady-state indexing is nearly free.
+//
+// Everything here is derived data. The .jsonl files are the source of truth, so
+// these tables can be dropped and rebuilt without losing anything.
+
+const ROLE_WEIGHT: Record<string, number> = { user: 2, assistant: 1 };
+const TOOL_WEIGHT = 0.3;
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'that', 'this', 'with', 'from', 'was', 'were', 'are', 'you', 'your',
+  'not', 'but', 'have', 'has', 'had', 'its', 'it', 'is', 'be', 'to', 'of', 'in', 'on', 'a',
+  'i', 'we', 'they', 'as', 'at', 'by', 'or', 'an', 'if', 'so', 'do', 'does', 'did', 'can',
+]);
+
+export function tokenize(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.toLowerCase().split(/[^a-z0-9_]+/)) {
+    if (raw.length < 2 || raw.length > 40 || STOPWORDS.has(raw)) continue;
+    out.push(raw);
+  }
+  return out;
+}
+
+/** Claude Code encodes the project path by replacing every non-alphanumeric character with '-'. */
+export function encodeProjectDir(dir: string): string {
+  return dir.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Every config root that may hold transcripts. CLAUDE_CONFIG_DIR wins when set;
+ * the default install location is always included. A machine with additional
+ * stores - a second account, a synced archive - names them in
+ * KNOWL_TRANSCRIPT_ROOTS (path-delimiter separated), because which extra roots
+ * exist is a property of one machine, not of this package.
+ */
+export function transcriptStores(): string[] {
+  const roots = new Set<string>();
+  if (process.env.CLAUDE_CONFIG_DIR) roots.add(process.env.CLAUDE_CONFIG_DIR);
+  roots.add(join(homedir(), '.claude'));
+  for (const extra of (process.env.KNOWL_TRANSCRIPT_ROOTS ?? '').split(delimiter)) {
+    if (extra.trim()) roots.add(extra.trim());
+  }
+  return [...roots].map(root => join(root, 'projects'));
+}
+
+export interface SessionFile { sessionId: string; path: string; mtimeMs: number; size: number }
+
+export async function sessionFiles(projectDir: string, stores?: string[]): Promise<SessionFile[]> {
+  const encoded = encodeProjectDir(projectDir);
+  // Two stores can hold the same session id; keep the most recently written copy.
+  const newest = new Map<string, SessionFile>();
+  for (const store of stores ?? transcriptStores()) {
+    let names: string[];
+    try { names = await readdir(join(store, encoded)); } catch { continue; }
+    for (const name of names) {
+      if (!name.endsWith('.jsonl')) continue;
+      const path = join(store, encoded, name);
+      let info;
+      try { info = await stat(path); } catch { continue; }
+      const sessionId = basename(name, '.jsonl');
+      const prev = newest.get(sessionId);
+      // Truncated to whole milliseconds: stat reports a float, the watermark
+      // column stores an integer, and comparing the two must not invent a
+      // rewrite out of the fractional part.
+      const mtimeMs = Math.trunc(info.mtimeMs);
+      if (!prev || prev.mtimeMs < mtimeMs) {
+        newest.set(sessionId, { sessionId, path, mtimeMs, size: info.size });
+      }
+    }
+  }
+  return [...newest.values()].sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/**
+ * Entries that are structurally present but carry no recallable content: the
+ * local-command caveat wrapper, bare slash commands, and the startup handshake.
+ * Indexing them pollutes document frequency and wastes result slots.
+ */
+function isNoise(text: string): boolean {
+  const t = text.trimStart();
+  if (!t) return true;
+  if (t.startsWith('<local-command-caveat>')) return true;
+  if (t.startsWith('<command-name>')) return true;
+  return /^Caveat: The messages below were generated/.test(t);
+}
+
+function extractText(entry: any): { text: string; toolChars: number } {
+  const content = entry?.message?.content;
+  if (typeof content === 'string') return { text: content, toolChars: 0 };
+  if (!Array.isArray(content)) return { text: '', toolChars: 0 };
+  const parts: string[] = [];
+  let toolChars = 0;
+  for (const block of content) {
+    if (block?.type === 'text' && typeof block.text === 'string') { parts.push(block.text); continue; }
+    // Tool traffic is most of the bytes and little of the signal, but a command,
+    // path or error string is sometimes the only place an answer survives. It is
+    // indexed and then weighted down, rather than discarded.
+    if (block?.type === 'tool_use') {
+      const s = JSON.stringify(block.input ?? {});
+      toolChars += s.length; parts.push(s);
+    } else if (block?.type === 'tool_result') {
+      const s = typeof block.content === 'string' ? block.content : JSON.stringify(block.content ?? '');
+      toolChars += s.length; parts.push(s);
+    }
+  }
+  return { text: parts.join('\n'), toolChars };
+}
+
+/** Bounded so one pasted 5MB file cannot dominate the index or a snippet. */
+const MAX_TEXT_CHARS = 20_000;
+
+/**
+ * How long one call may spend indexing. Indexing runs inside a tool call, so
+ * this is really a promise about latency: a first search on a large archive
+ * returns whatever is indexed so far and says the index is still warming,
+ * rather than blocking the caller for minutes.
+ */
+const DEFAULT_INDEX_BUDGET_MS = 8_000;
+
+/** Statements per write transaction. Small on purpose - see flush(). */
+const BATCH_STATEMENTS = 500;
+
+interface PendingMessage {
+  sessionId: string; line: number; role: string; ts: string | null;
+  weight: number; len: number; text: string;
+}
+
+/**
+ * Message ids are assigned here rather than read back from the database. The
+ * obvious shape - INSERT ... RETURNING per message - costs a round trip each,
+ * which on a real archive is tens of thousands of round trips and minutes of
+ * wall clock. Allocating ids from a counter lets a whole batch go out at once.
+ */
+async function flush(projectDir: string, pending: PendingMessage[], nextId: { value: number }): Promise<void> {
+  if (pending.length === 0) return;
+  const client = getClient();
+  const statements: Array<{ sql: string; args: any[] }> = [];
+  for (const message of pending) {
+    const messageId = nextId.value++;
+    statements.push({
+      sql: `INSERT INTO transcript_messages (id, project_dir, session_id, line, role, ts, weight, len, text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [messageId, projectDir, message.sessionId, message.line, message.role, message.ts, message.weight, message.len, message.text],
+    });
+    // FTS5 tokenizes and ranks; nothing here has to build a term index by hand.
+    statements.push({
+      sql: 'INSERT INTO transcript_fts (rowid, text) VALUES (?, ?)',
+      args: [messageId, message.text],
+    });
+  }
+  // libsql runs a batch as one transaction, so the per-statement fsync that
+  // dominates unbatched SQLite writes happens once instead of per row. The
+  // chunk stays small deliberately: this database is also being served to a
+  // live session, and a long write transaction starves it into SQLITE_BUSY.
+  for (let i = 0; i < statements.length; i += BATCH_STATEMENTS) {
+    try {
+      await client.batch(statements.slice(i, i + BATCH_STATEMENTS), 'write');
+    } catch (error) {
+      // A primary-key collision means another process allocated the same ids -
+      // the file lease serializes work per FILE, but ids come from one MAX(id)
+      // read per pass, so two passes on different files can still clash. The
+      // colliding transaction rolled back, so nothing partial landed from this
+      // chunk; surrender the file and let the next pass resume from a fresh
+      // MAX. Committed earlier chunks sit beyond the watermark and are purged
+      // by whoever claims the file next.
+      if (/SQLITE_CONSTRAINT|UNIQUE/i.test(String((error as Error).message))) throw new IdCollisionError();
+      throw error;
+    }
+  }
+}
+
+class IdCollisionError extends Error {
+  constructor() { super('transcript id collision: concurrent indexer detected'); }
+}
+
+async function nextMessageId(): Promise<number> {
+  const row = (await getClient().execute('SELECT COALESCE(MAX(id), 0) AS max_id FROM transcript_messages')).rows[0];
+  return Number(row.max_id) + 1;
+}
+
+/**
+ * How long one process's claim on a file is honoured. Knowl runs one serve
+ * process per connected session, so two sessions on the same project index
+ * concurrently unless something serializes them - both would read the same
+ * MAX(id) and the same watermark, then collide on primary keys or write the
+ * same messages twice. Longer than an index pass's budget, short enough that a
+ * crashed claimant only stalls a file briefly.
+ */
+const LEASE_MS = 20_000;
+
+/** Claims written by THIS process, so it can resume its own budget-paused files without waiting out the lease. */
+const ownClaims = new Set<string>();
+
+/** Remove indexed rows for a session beyond a line watermark, embeddings included - a purged id can be reallocated, and a stale cached vector would silently attach to the wrong message. */
+async function purgeBeyond(projectDir: string, sessionId: string, afterLine: number): Promise<void> {
+  const client = getClient();
+  const where = 'session_id = ? AND project_dir = ? AND line > ?';
+  const args = [sessionId, projectDir, afterLine];
+  await client.execute({
+    sql: `INSERT INTO transcript_fts(transcript_fts, rowid, text)
+          SELECT 'delete', id, text FROM transcript_messages WHERE ${where}`,
+    args,
+  });
+  await client.execute({ sql: `DELETE FROM transcript_embeddings WHERE message_id IN (SELECT id FROM transcript_messages WHERE ${where})`, args });
+  await client.execute({ sql: `DELETE FROM transcript_messages WHERE ${where}`, args });
+}
+
+type FileOutcome = { added: number; complete: boolean; reason?: 'budget' | 'leased' };
+
+async function indexFile(projectDir: string, file: SessionFile, nextId: { value: number }, deadline: number): Promise<FileOutcome> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT bytes_indexed, lines_indexed, indexed_at, mtime_ms FROM transcript_files WHERE path = ?',
+    args: [file.path],
+  })).rows[0];
+
+  let startByte = row ? Number(row.bytes_indexed) : 0;
+  let lineNo = row ? Number(row.lines_indexed) : 0;
+  const prevStamp = row ? String(row.indexed_at) : null;
+  // A file rewritten to the SAME size slips past the shrink check below, but
+  // not past its own mtime. Only meaningful on a completed row: partial rows
+  // store mtime 0 until their pass finishes. Bounded by filesystem timestamp
+  // granularity - a rewrite within the same tick as the indexed write is
+  // invisible, which real editing does not do.
+  const rewrittenInPlace = row !== undefined
+    && startByte === file.size && Number(row.mtime_ms) !== 0 && Number(row.mtime_ms) !== file.mtimeMs;
+
+  // A file that shrank was rewritten rather than appended to, so the offset is
+  // meaningless and its rows have to go. Same-size rewrites are caught above.
+  if (startByte > file.size || rewrittenInPlace) {
+    await purgeBeyond(projectDir, file.sessionId, 0);
+    startByte = 0; lineNo = 0;
+  }
+  if (startByte === file.size) return { added: 0, complete: true };
+
+  // Another process's fresh claim: leave the file to it. Our own claim from a
+  // budget-paused pass is exempt, or a paused pass could never resume itself.
+  if (prevStamp && !ownClaims.has(prevStamp)) {
+    const stampedAt = Date.parse(prevStamp);
+    if (Number.isFinite(stampedAt) && Date.now() - stampedAt < LEASE_MS) {
+      return { added: 0, complete: false, reason: 'leased' };
+    }
+  }
+
+  // Take the claim with a compare-and-set on the stamp we read, so two
+  // processes arriving together cannot both win. The loser skips the file.
+  const claim = new Date().toISOString();
+  const claimed = row
+    ? await client.execute({ sql: 'UPDATE transcript_files SET indexed_at = ? WHERE path = ? AND indexed_at = ?', args: [claim, file.path, prevStamp] })
+    : await client.execute({
+        sql: 'INSERT OR IGNORE INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at) VALUES (?, ?, ?, 0, 0, 0, ?)',
+        args: [file.path, projectDir, file.sessionId, claim],
+      });
+  if (Number(claimed.rowsAffected) === 0) return { added: 0, complete: false, reason: 'leased' };
+  ownClaims.add(claim);
+
+  // A previous claimant may have died mid-file: batches it committed past the
+  // watermark would be indexed AGAIN from the watermark, as duplicates with
+  // fresh ids. Purge beyond the watermark before resuming so the resume is
+  // idempotent. A no-op on a clean handoff.
+  await purgeBeyond(projectDir, file.sessionId, lineNo);
+
+  const pending: PendingMessage[] = [];
+  let added = 0;
+  // Bytes consumed since startByte, so a run that stops early can record where
+  // it got to. Transcripts are newline-delimited UTF-8, so line length plus one
+  // is exact; the offset is snapped to the real file size on completion anyway.
+  let consumed = 0;
+  let complete = true;
+  try {
+    const rl = createInterface({ input: createReadStream(file.path, { start: startByte }), crlfDelay: Infinity });
+    for await (const line of rl) {
+      lineNo++;
+      consumed += Buffer.byteLength(line, 'utf8') + 1;
+      // Checked per line rather than per file: one 170MB transcript can blow any
+      // budget on its own, and a caller left waiting minutes for a tool call will
+      // give up long before the index is warm.
+      if (Date.now() > deadline) { complete = false; rl.close(); break; }
+      if (!line.trim()) continue;
+      let entry: any;
+      try { entry = JSON.parse(line); } catch { continue; }
+      if (entry.type !== 'user' && entry.type !== 'assistant') continue;
+      const { text, toolChars } = extractText(entry);
+      if (!text || isNoise(text)) continue;
+      const clipped = text.slice(0, MAX_TEXT_CHARS);
+      pending.push({
+        sessionId: file.sessionId, line: lineNo, role: entry.type,
+        ts: typeof entry.timestamp === 'string' ? entry.timestamp : null,
+        weight: (ROLE_WEIGHT[entry.type] ?? 1) * (toolChars > clipped.length / 2 ? TOOL_WEIGHT : 1),
+        len: clipped.length, text: clipped,
+      });
+      added++;
+      if (pending.length >= 500) { await flush(projectDir, pending, nextId); pending.length = 0; }
+    }
+    await flush(projectDir, pending, nextId);
+  } catch (error) {
+    if (error instanceof IdCollisionError) {
+      // Deliberately no watermark write: it still points at the last state this
+      // process knows was fully committed, which is what the next claimant
+      // needs to purge-and-resume correctly.
+      return { added: 0, complete: false, reason: 'leased' };
+    }
+    throw error;
+  }
+
+  // On a complete pass the real file size is authoritative; on a partial one the
+  // running byte count is the resume point, so the next call picks up mid-file
+  // instead of starting the whole transcript again.
+  const bytesIndexed = complete ? file.size : startByte + consumed;
+  const doneStamp = new Date().toISOString();
+  ownClaims.add(doneStamp);
+  await client.execute({
+    sql: `INSERT INTO transcript_files (path, project_dir, session_id, bytes_indexed, lines_indexed, mtime_ms, indexed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(path) DO UPDATE SET bytes_indexed = excluded.bytes_indexed,
+            lines_indexed = excluded.lines_indexed, mtime_ms = excluded.mtime_ms, indexed_at = excluded.indexed_at`,
+    args: [file.path, projectDir, file.sessionId, bytesIndexed, lineNo, complete ? file.mtimeMs : 0, doneStamp],
+  });
+  return complete ? { added, complete } : { added, complete, reason: 'budget' };
+}
+
+export interface IndexResult {
+  filesScanned: number;
+  filesUpdated: number;
+  messagesAdded: number;
+  ms: number;
+  /** False when the budget ran out with work left. The next call resumes. */
+  complete: boolean;
+}
+
+/**
+ * Bring the index up to date. Cheap when nothing changed: a file whose size
+ * matches the stored offset is skipped without being opened.
+ */
+export async function ensureTranscriptIndex(projectDir: string, stores?: string[], budgetMs = DEFAULT_INDEX_BUDGET_MS): Promise<IndexResult> {
+  const started = Date.now();
+  const deadline = started + budgetMs;
+  const files = await sessionFiles(projectDir, stores);
+  const nextId = { value: await nextMessageId() };
+  let filesUpdated = 0;
+  let messagesAdded = 0;
+  let complete = true;
+  // Newest first, so a cold index makes the most recent history searchable
+  // first - that is what a question is most likely to be about.
+  for (const file of files) {
+    if (Date.now() > deadline) { complete = false; break; }
+    const result = await indexFile(projectDir, file, nextId, deadline);
+    if (result.added > 0) { filesUpdated++; messagesAdded += result.added; }
+    if (!result.complete) {
+      complete = false;
+      // Budget exhaustion ends the pass; a lease held by another process only
+      // ends THAT file - the rest of the archive is still ours to index.
+      if (result.reason === 'budget') break;
+    }
+  }
+  return { filesScanned: files.length, filesUpdated, messagesAdded, ms: Date.now() - started, complete };
+}
+
+export async function transcriptIndexStats(projectDir: string): Promise<{ messages: number; avgLen: number; sessions: number }> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: 'SELECT COUNT(*) AS n, COALESCE(AVG(len), 1) AS avg_len, COUNT(DISTINCT session_id) AS sessions FROM transcript_messages WHERE project_dir = ?',
+    args: [projectDir],
+  })).rows[0];
+  return { messages: Number(row.n), avgLen: Number(row.avg_len) || 1, sessions: Number(row.sessions) };
+}

--- a/src/store/transcript-index.ts
+++ b/src/store/transcript-index.ts
@@ -369,6 +369,12 @@ export interface IndexResult {
   ms: number;
   /** False when the budget ran out with work left. The next call resumes. */
   complete: boolean;
+  /**
+   * Session files not brought fully up to date this pass; 0 when complete. Coverage has to
+   * travel as a NUMBER, not as an adjective in a footer: a caller deciding whether "no
+   * matches" means absence needs to know how much of the archive was actually searched.
+   */
+  filesPending: number;
 }
 
 /**
@@ -385,6 +391,7 @@ export async function ensureTranscriptIndex(projectDir: string, stores?: string[
   let complete = true;
   // Newest first, so a cold index makes the most recent history searchable
   // first - that is what a question is most likely to be about.
+  let filesSettled = 0;
   for (const file of files) {
     if (Date.now() > deadline) { complete = false; break; }
     const result = await indexFile(projectDir, file, nextId, deadline);
@@ -394,9 +401,18 @@ export async function ensureTranscriptIndex(projectDir: string, stores?: string[
       // Budget exhaustion ends the pass; a lease held by another process only
       // ends THAT file - the rest of the archive is still ours to index.
       if (result.reason === 'budget') break;
+      continue;
     }
+    filesSettled++;
   }
-  return { filesScanned: files.length, filesUpdated, messagesAdded, ms: Date.now() - started, complete };
+  return {
+    filesScanned: files.length,
+    filesUpdated,
+    messagesAdded,
+    ms: Date.now() - started,
+    complete,
+    filesPending: files.length - filesSettled,
+  };
 }
 
 export async function transcriptIndexStats(projectDir: string): Promise<{ messages: number; avgLen: number; sessions: number }> {

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -1,0 +1,257 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { getClient } from './database.js';
+import { ensureTranscriptIndex, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+
+export { encodeProjectDir, transcriptStores } from './transcript-index.js';
+
+// Ranked search over raw Claude Code session transcripts.
+//
+// Knowl stores distilled atoms. Those are lossy by construction: whatever the
+// writer did not think worth keeping is gone, and there is no fallback. The
+// transcripts are the lossless floor underneath - every word actually
+// exchanged, still on disk. This makes that floor reachable, so a miss in
+// memory becomes a slower lookup rather than amnesia.
+//
+// Consumer is an agent, not a human: no TUI, no pager. What matters is
+// precision ranking, tight snippets, and a locator to cite when promoting a
+// finding back into memory.
+
+export interface TranscriptHit {
+  sessionId: string;
+  line: number;
+  role: string;
+  timestamp?: string;
+  score: number;
+  snippet: string;
+  /** Cite this in the atom when promoting, so the claim keeps its provenance. */
+  locator: string;
+}
+
+/** Supplied by the caller so this module never depends on how embeddings are configured. */
+export interface SemanticReranker {
+  model: string;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface TranscriptSearchOptions {
+  projectDir?: string;
+  limit?: number;
+  since?: string;
+  snippetChars?: number;
+  /**
+   * Restrict to one session, by id or a unique prefix. This is what makes a
+   * handoff brief actionable: a new session is told which session it continues
+   * from, and needs a way to ask that transcript specifically before widening
+   * to the whole archive.
+   */
+  sessionId?: string;
+  /** Override the config roots to scan. Injected by tests so they never mutate HOME. */
+  stores?: string[];
+  /** When present, the top BM25 candidates are re-ranked and the two orders fused. */
+  semantic?: SemanticReranker;
+}
+
+// Reciprocal Rank Fusion. 60 is the value from the original paper and is
+// deliberately large: it flattens the head so neither ranker can dictate the
+// result on its own, which is the point of fusing them.
+const RRF_K = 60;
+
+// How many BM25 candidates get embedded for the semantic pass. Embedding is the
+// expensive half, so recall is bounded by what BM25 surfaces first - a real
+// limitation, and the reason the lexical side is tuned to be good alone.
+const RERANK_DEPTH = 50;
+
+/**
+ * Cap for a full-entry read. Matches the index's own per-message clip, so the
+ * tool returns everything that was searchable and nothing more.
+ */
+export const MAX_TRANSCRIPT_ENTRY_CHARS = 20_000;
+
+interface Scored { messageId: number; score: number }
+
+/**
+ * Rank with FTS5's own BM25, then apply the field weighting it has no way to
+ * express. bm25() returns a negative number where more negative is better, so
+ * it is inverted before the weight is applied.
+ *
+ * A wider candidate window than `depth` is read on purpose: re-weighting can
+ * promote a row FTS5 ranked lower, and a window equal to the final limit would
+ * have already discarded it.
+ */
+async function lexicalRank(projectDir: string, terms: string[], depth: number, sessionId?: string): Promise<Scored[]> {
+  const client = getClient();
+  // Prefix matching, the same convention knowledge search uses. Tokens are
+  // already reduced to [a-z0-9_], so none of FTS5's operators can appear here.
+  const match = terms.map(term => `${term}*`).join(' OR ');
+  const rows = (await client.execute({
+    sql: `SELECT transcript_fts.rowid AS id, bm25(transcript_fts) AS rank, m.weight AS weight
+          FROM transcript_fts
+          JOIN transcript_messages m ON m.id = transcript_fts.rowid
+          WHERE transcript_fts MATCH ? AND m.project_dir = ?
+            ${sessionId ? 'AND m.session_id LIKE ?' : ''}
+          ORDER BY rank ASC
+          LIMIT ?`,
+    args: sessionId
+      ? [match, projectDir, `${sessionId}%`, Math.max(depth * 4, 100)]
+      : [match, projectDir, Math.max(depth * 4, 100)],
+  })).rows;
+
+  return rows
+    .map(row => ({ messageId: Number(row.id), score: -Number(row.rank) * Number(row.weight) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, depth);
+}
+
+function cosine(left: number[], right: number[]): number {
+  let dot = 0, l = 0, r = 0;
+  for (let i = 0; i < left.length; i++) { dot += left[i] * right[i]; l += left[i] * left[i]; r += right[i] * right[i]; }
+  return l === 0 || r === 0 ? 0 : dot / (Math.sqrt(l) * Math.sqrt(r));
+}
+
+/** Vectors for the candidates, embedding only those not already cached. */
+async function candidateVectors(
+  candidates: Array<{ messageId: number; text: string }>,
+  semantic: SemanticReranker,
+): Promise<Map<number, number[]>> {
+  const client = getClient();
+  const vectors = new Map<number, number[]>();
+  if (candidates.length === 0) return vectors;
+
+  const rows = (await client.execute({
+    sql: `SELECT message_id, vector FROM transcript_embeddings WHERE model = ? AND message_id IN (${candidates.map(() => '?').join(',')})`,
+    args: [semantic.model, ...candidates.map(c => c.messageId)],
+  })).rows;
+  for (const row of rows) {
+    try { vectors.set(Number(row.message_id), JSON.parse(String(row.vector))); } catch { /* re-embed below */ }
+  }
+
+  const missing = candidates.filter(c => !vectors.has(c.messageId));
+  if (missing.length > 0) {
+    const embedded = await semantic.embed(missing.map(c => c.text.slice(0, 2_000)));
+    for (let i = 0; i < missing.length; i++) {
+      const vector = embedded[i];
+      if (!vector) continue;
+      vectors.set(missing[i].messageId, vector);
+      await client.execute({
+        sql: 'INSERT OR REPLACE INTO transcript_embeddings (message_id, model, vector) VALUES (?, ?, ?)',
+        args: [missing[i].messageId, semantic.model, JSON.stringify(vector)],
+      });
+    }
+  }
+  return vectors;
+}
+
+function snippetAround(text: string, terms: Set<string>, chars: number): string {
+  const lower = text.toLowerCase();
+  let best = 0, bestCount = -1;
+  const step = Math.max(1, Math.floor(chars / 4));
+  for (let start = 0; start < Math.max(1, lower.length - chars); start += step) {
+    const window = lower.slice(start, start + chars);
+    let count = 0;
+    for (const term of terms) if (window.includes(term)) count++;
+    if (count > bestCount) { bestCount = count; best = start; }
+  }
+  const slice = text.slice(best, best + chars).replace(/\n{3,}/g, '\n\n').trim();
+  return (best > 0 ? '…' : '') + slice + (best + chars < text.length ? '…' : '');
+}
+
+export async function searchTranscripts(
+  query: string,
+  options: TranscriptSearchOptions = {},
+): Promise<{ hits: TranscriptHit[]; indexed: number; sessions: number; indexMs: number; indexComplete: boolean }> {
+  const { projectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId } = options;
+  const terms = [...new Set(tokenize(query))];
+
+  const index = await ensureTranscriptIndex(projectDir, stores);
+  const stats = await transcriptIndexStats(projectDir);
+  const base = { indexed: stats.messages, sessions: stats.sessions, indexMs: index.ms, indexComplete: index.complete };
+  if (terms.length === 0) return { hits: [], ...base };
+
+  const lexical = await lexicalRank(projectDir, terms, semantic ? RERANK_DEPTH : limit * 3, sessionId);
+  if (lexical.length === 0) return { hits: [], ...base };
+
+  const client = getClient();
+  const rows = (await client.execute({
+    sql: `SELECT id, session_id, line, role, ts, text FROM transcript_messages
+          WHERE id IN (${lexical.map(() => '?').join(',')})${since ? ' AND (ts IS NULL OR ts >= ?)' : ''}`,
+    args: since ? [...lexical.map(l => l.messageId), since] : lexical.map(l => l.messageId),
+  })).rows;
+  const byId = new Map(rows.map(row => [Number(row.id), row]));
+
+  let ordered = lexical.filter(entry => byId.has(entry.messageId));
+
+  if (semantic && ordered.length > 1) {
+    const candidates = ordered.map(entry => ({ messageId: entry.messageId, text: String(byId.get(entry.messageId)!.text) }));
+    try {
+      const byMessage = await candidateVectors(candidates, semantic);
+      const [queryVector] = await semantic.embed([query]);
+      if (queryVector && byMessage.size > 0) {
+        const semanticOrder = [...byMessage.entries()]
+          .map(([messageId, vector]) => ({ messageId, score: cosine(queryVector, vector) }))
+          .sort((a, b) => b.score - a.score);
+        // Reciprocal Rank Fusion: combine POSITIONS, not scores. BM25 magnitudes
+        // and cosine similarities are not on a comparable scale, and normalising
+        // them invents a relationship that isn't there.
+        const fused = new Map<number, number>();
+        ordered.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
+        semanticOrder.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
+        ordered = [...fused.entries()]
+          .map(([messageId, score]) => ({ messageId, score }))
+          .sort((a, b) => b.score - a.score);
+      }
+    } catch {
+      // Embeddings are optional and can fail (model not downloaded, provider off).
+      // Lexical order is a complete answer on its own, so degrade rather than error.
+    }
+  }
+
+  const termSet = new Set(terms);
+  const hits = ordered.slice(0, limit).map(entry => {
+    const row = byId.get(entry.messageId)!;
+    return {
+      sessionId: String(row.session_id),
+      line: Number(row.line),
+      role: String(row.role),
+      timestamp: row.ts ? String(row.ts) : undefined,
+      score: Number(entry.score.toFixed(4)),
+      snippet: snippetAround(String(row.text), termSet, snippetChars),
+      locator: `transcript://${row.session_id}#L${row.line}`,
+    };
+  });
+
+  return { hits, ...base };
+}
+
+/** Read one entry in full, straight from the file, for when a snippet cannot settle the question. */
+export async function readTranscriptEntry(
+  sessionId: string,
+  line: number,
+  projectDir = process.cwd(),
+  stores?: string[],
+): Promise<{ text: string; role: string; timestamp?: string } | null> {
+  const files = await sessionFiles(projectDir, stores);
+  const file = files.find(f => f.sessionId === sessionId || f.sessionId.startsWith(sessionId));
+  if (!file) return null;
+  const rl = createInterface({ input: createReadStream(file.path), crlfDelay: Infinity });
+  let lineNo = 0;
+  for await (const raw of rl) {
+    lineNo++;
+    if (lineNo !== line) continue;
+    rl.close();
+    try {
+      const entry = JSON.parse(raw);
+      const content = entry?.message?.content;
+      const text = typeof content === 'string'
+        ? content
+        : Array.isArray(content)
+          ? content.map((b: any) => b?.type === 'text' ? b.text
+              : b?.type === 'tool_use' ? JSON.stringify(b.input ?? {})
+              : b?.type === 'tool_result' ? (typeof b.content === 'string' ? b.content : JSON.stringify(b.content ?? ''))
+              : '').join('\n')
+          : '';
+      return { text, role: entry.type, timestamp: entry.timestamp };
+    } catch { return null; }
+  }
+  return null;
+}

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -1,7 +1,7 @@
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { getClient } from './database.js';
-import { ensureTranscriptIndex, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+import { ensureTranscriptIndex, normalizeProjectDir, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
 import { embedTranscripts, semanticCandidates, transcriptVectorStats, type TranscriptEmbedder } from './transcript-vectors.js';
 
 export { encodeProjectDir, transcriptStores } from './transcript-index.js';
@@ -155,7 +155,8 @@ export async function searchTranscripts(
    */
   inconclusive: boolean;
 }> {
-  const { projectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId, indexBudgetMs, embedBudgetMs = DEFAULT_EMBED_BUDGET_MS } = options;
+  const { projectDir: rawProjectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId, indexBudgetMs, embedBudgetMs = DEFAULT_EMBED_BUDGET_MS } = options;
+  const projectDir = normalizeProjectDir(rawProjectDir);
   const terms = [...new Set(tokenize(query))];
 
   const index = await ensureTranscriptIndex(projectDir, stores, indexBudgetMs);

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -199,7 +199,7 @@ export async function searchTranscripts(
   let semanticOrder: Scored[] = [];
   if (semantic && vectors.embedded > 0) {
     try {
-      const [queryVector] = await semantic.embed([query]);
+      const queryVector = semantic.embedQuery ? await semantic.embedQuery(query) : (await semantic.embed([query]))[0];
       if (queryVector) {
         semanticOrder = await semanticCandidates(projectDir, queryVector, semantic.model, FUSION_DEPTH, sessionId);
       }

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -1,7 +1,8 @@
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { getClient } from './database.js';
-import { ensureTranscriptIndex, normalizeProjectDir, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+import { ensureTranscriptIndex, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+import { normalizeProjectDir } from './project-dir.js';
 import { embedTranscripts, semanticCandidates, transcriptVectorStats, type TranscriptEmbedder } from './transcript-vectors.js';
 
 export { encodeProjectDir, transcriptStores } from './transcript-index.js';

--- a/src/store/transcript-search.ts
+++ b/src/store/transcript-search.ts
@@ -2,6 +2,7 @@ import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { getClient } from './database.js';
 import { ensureTranscriptIndex, sessionFiles, tokenize, transcriptIndexStats } from './transcript-index.js';
+import { embedTranscripts, semanticCandidates, transcriptVectorStats, type TranscriptEmbedder } from './transcript-vectors.js';
 
 export { encodeProjectDir, transcriptStores } from './transcript-index.js';
 
@@ -28,11 +29,7 @@ export interface TranscriptHit {
   locator: string;
 }
 
-/** Supplied by the caller so this module never depends on how embeddings are configured. */
-export interface SemanticReranker {
-  model: string;
-  embed(texts: string[]): Promise<number[][]>;
-}
+export type { TranscriptEmbedder } from './transcript-vectors.js';
 
 export interface TranscriptSearchOptions {
   projectDir?: string;
@@ -46,10 +43,17 @@ export interface TranscriptSearchOptions {
    * to the whole archive.
    */
   sessionId?: string;
+  /**
+   * Cap on the indexing pass this search triggers. Lower it when the caller is on a tighter
+   * deadline than the answer is worth — the result reports the coverage it actually got.
+   */
+  indexBudgetMs?: number;
   /** Override the config roots to scan. Injected by tests so they never mutate HOME. */
   stores?: string[];
-  /** When present, the top BM25 candidates are re-ranked and the two orders fused. */
-  semantic?: SemanticReranker;
+  /** When present, the archive is also ranked by vector similarity and the two orders fused. */
+  semantic?: TranscriptEmbedder;
+  /** Cap on the embedding top-up this search triggers. 0 disables it, leaving coverage to grow only via the CLI. */
+  embedBudgetMs?: number;
 }
 
 // Reciprocal Rank Fusion. 60 is the value from the original paper and is
@@ -57,10 +61,22 @@ export interface TranscriptSearchOptions {
 // result on its own, which is the point of fusing them.
 const RRF_K = 60;
 
-// How many BM25 candidates get embedded for the semantic pass. Embedding is the
-// expensive half, so recall is bounded by what BM25 surfaces first - a real
-// limitation, and the reason the lexical side is tuned to be good alone.
-const RERANK_DEPTH = 50;
+/**
+ * Candidates taken from EACH ranker before fusion. The two lists are built
+ * independently over the whole archive, so a message only the semantic side
+ * knows about can win outright. That is the point: this used to re-rank BM25's
+ * top 50, which meant semantic search could reorder the keyword results but
+ * never reach past them - and the query it exists to serve is the one whose
+ * remembered words are not the words that were used.
+ */
+const FUSION_DEPTH = 50;
+
+/**
+ * Time one search may spend embedding messages that have none yet. Small on
+ * purpose: this is a top-up so an archive warms as it is used, not the way to
+ * embed a large one. `knowl reindex --transcripts` does that in one pass.
+ */
+const DEFAULT_EMBED_BUDGET_MS = 1_500;
 
 /**
  * Cap for a full-entry read. Matches the index's own per-message clip, so the
@@ -103,45 +119,6 @@ async function lexicalRank(projectDir: string, terms: string[], depth: number, s
     .slice(0, depth);
 }
 
-function cosine(left: number[], right: number[]): number {
-  let dot = 0, l = 0, r = 0;
-  for (let i = 0; i < left.length; i++) { dot += left[i] * right[i]; l += left[i] * left[i]; r += right[i] * right[i]; }
-  return l === 0 || r === 0 ? 0 : dot / (Math.sqrt(l) * Math.sqrt(r));
-}
-
-/** Vectors for the candidates, embedding only those not already cached. */
-async function candidateVectors(
-  candidates: Array<{ messageId: number; text: string }>,
-  semantic: SemanticReranker,
-): Promise<Map<number, number[]>> {
-  const client = getClient();
-  const vectors = new Map<number, number[]>();
-  if (candidates.length === 0) return vectors;
-
-  const rows = (await client.execute({
-    sql: `SELECT message_id, vector FROM transcript_embeddings WHERE model = ? AND message_id IN (${candidates.map(() => '?').join(',')})`,
-    args: [semantic.model, ...candidates.map(c => c.messageId)],
-  })).rows;
-  for (const row of rows) {
-    try { vectors.set(Number(row.message_id), JSON.parse(String(row.vector))); } catch { /* re-embed below */ }
-  }
-
-  const missing = candidates.filter(c => !vectors.has(c.messageId));
-  if (missing.length > 0) {
-    const embedded = await semantic.embed(missing.map(c => c.text.slice(0, 2_000)));
-    for (let i = 0; i < missing.length; i++) {
-      const vector = embedded[i];
-      if (!vector) continue;
-      vectors.set(missing[i].messageId, vector);
-      await client.execute({
-        sql: 'INSERT OR REPLACE INTO transcript_embeddings (message_id, model, vector) VALUES (?, ?, ?)',
-        args: [missing[i].messageId, semantic.model, JSON.stringify(vector)],
-      });
-    }
-  }
-  return vectors;
-}
-
 function snippetAround(text: string, terms: Set<string>, chars: number): string {
   const lower = text.toLowerCase();
   let best = 0, bestCount = -1;
@@ -159,51 +136,104 @@ function snippetAround(text: string, terms: Set<string>, chars: number): string 
 export async function searchTranscripts(
   query: string,
   options: TranscriptSearchOptions = {},
-): Promise<{ hits: TranscriptHit[]; indexed: number; sessions: number; indexMs: number; indexComplete: boolean }> {
-  const { projectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId } = options;
+): Promise<{
+  hits: TranscriptHit[];
+  indexed: number;
+  sessions: number;
+  indexMs: number;
+  indexComplete: boolean;
+  /** Session files not yet searchable this pass; 0 when the index is complete. */
+  filesPending: number;
+  filesScanned: number;
+  /** Messages carrying a vector for the active model; 0 when the search was lexical only. */
+  vectorsEmbedded: number;
+  /**
+   * True when this result cannot distinguish "not in the archive" from "not indexed yet":
+   * nothing was found AND part of the archive was never searched. Callers must surface it as
+   * an inconclusive search rather than as an answer — an empty list reads as absence, and
+   * that inference is exactly what a partial index cannot support.
+   */
+  inconclusive: boolean;
+}> {
+  const { projectDir = process.cwd(), limit = 10, since, snippetChars = 600, stores, semantic, sessionId, indexBudgetMs, embedBudgetMs = DEFAULT_EMBED_BUDGET_MS } = options;
   const terms = [...new Set(tokenize(query))];
 
-  const index = await ensureTranscriptIndex(projectDir, stores);
+  const index = await ensureTranscriptIndex(projectDir, stores, indexBudgetMs);
   const stats = await transcriptIndexStats(projectDir);
-  const base = { indexed: stats.messages, sessions: stats.sessions, indexMs: index.ms, indexComplete: index.complete };
-  if (terms.length === 0) return { hits: [], ...base };
 
-  const lexical = await lexicalRank(projectDir, terms, semantic ? RERANK_DEPTH : limit * 3, sessionId);
-  if (lexical.length === 0) return { hits: [], ...base };
-
-  const client = getClient();
-  const rows = (await client.execute({
-    sql: `SELECT id, session_id, line, role, ts, text FROM transcript_messages
-          WHERE id IN (${lexical.map(() => '?').join(',')})${since ? ' AND (ts IS NULL OR ts >= ?)' : ''}`,
-    args: since ? [...lexical.map(l => l.messageId), since] : lexical.map(l => l.messageId),
-  })).rows;
-  const byId = new Map(rows.map(row => [Number(row.id), row]));
-
-  let ordered = lexical.filter(entry => byId.has(entry.messageId));
-
-  if (semantic && ordered.length > 1) {
-    const candidates = ordered.map(entry => ({ messageId: entry.messageId, text: String(byId.get(entry.messageId)!.text) }));
+  // Warm a slice of the archive, then report how much of it the semantic side
+  // could actually see. Partial coverage is normal and fine - the lexical side
+  // covers everything - but it must travel as a number, because "semantic
+  // search found nothing" means something different at 2% than at 100%.
+  let vectors = { embedded: 0, total: stats.messages };
+  if (semantic) {
     try {
-      const byMessage = await candidateVectors(candidates, semantic);
+      if (embedBudgetMs > 0) await embedTranscripts(projectDir, semantic, { budgetMs: embedBudgetMs });
+      vectors = await transcriptVectorStats(projectDir, semantic.model);
+    } catch { /* embeddings are optional; lexical search is unaffected */ }
+  }
+
+  const base = {
+    indexed: stats.messages,
+    sessions: stats.sessions,
+    indexMs: index.ms,
+    indexComplete: index.complete,
+    filesPending: index.filesPending,
+    filesScanned: index.filesScanned,
+    vectorsEmbedded: vectors.embedded,
+  };
+  // Nothing found against a partially-searched archive is not a finding. With hits in hand a
+  // caller has something real and `filesPending` tells them more may exist; with none, the
+  // only honest answer is that the search did not conclude.
+  const finish = (hits: TranscriptHit[]) => ({ hits, ...base, inconclusive: hits.length === 0 && !base.indexComplete });
+
+  // An unusable query is the caller's problem, not the index's: never blame coverage for it.
+  if (terms.length === 0) return { hits: [], ...base, inconclusive: false };
+
+  const lexical = await lexicalRank(projectDir, terms, semantic ? FUSION_DEPTH : limit * 3, sessionId);
+
+  // Built over the whole archive rather than over `lexical`, so it can bring
+  // back messages the keyword pass never saw.
+  let semanticOrder: Scored[] = [];
+  if (semantic && vectors.embedded > 0) {
+    try {
       const [queryVector] = await semantic.embed([query]);
-      if (queryVector && byMessage.size > 0) {
-        const semanticOrder = [...byMessage.entries()]
-          .map(([messageId, vector]) => ({ messageId, score: cosine(queryVector, vector) }))
-          .sort((a, b) => b.score - a.score);
-        // Reciprocal Rank Fusion: combine POSITIONS, not scores. BM25 magnitudes
-        // and cosine similarities are not on a comparable scale, and normalising
-        // them invents a relationship that isn't there.
-        const fused = new Map<number, number>();
-        ordered.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
-        semanticOrder.forEach((entry, rank) => fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1)));
-        ordered = [...fused.entries()]
-          .map(([messageId, score]) => ({ messageId, score }))
-          .sort((a, b) => b.score - a.score);
+      if (queryVector) {
+        semanticOrder = await semanticCandidates(projectDir, queryVector, semantic.model, FUSION_DEPTH, sessionId);
       }
     } catch {
       // Embeddings are optional and can fail (model not downloaded, provider off).
       // Lexical order is a complete answer on its own, so degrade rather than error.
     }
+  }
+
+  if (lexical.length === 0 && semanticOrder.length === 0) return finish([]);
+
+  const client = getClient();
+  const ids = [...new Set([...lexical.map(entry => entry.messageId), ...semanticOrder.map(entry => entry.messageId)])];
+  const rows = (await client.execute({
+    sql: `SELECT id, session_id, line, role, ts, text FROM transcript_messages
+          WHERE id IN (${ids.map(() => '?').join(',')})${since ? ' AND (ts IS NULL OR ts >= ?)' : ''}`,
+    args: since ? [...ids, since] : ids,
+  })).rows;
+  const byId = new Map(rows.map(row => [Number(row.id), row]));
+
+  let ordered = lexical.filter(entry => byId.has(entry.messageId));
+
+  if (semanticOrder.length > 0) {
+    // Reciprocal Rank Fusion: combine POSITIONS, not scores. BM25 magnitudes
+    // and quantized dot products are not on a comparable scale, and normalising
+    // them invents a relationship that isn't there.
+    const fused = new Map<number, number>();
+    const add = (entry: Scored, rank: number) => {
+      if (!byId.has(entry.messageId)) return;
+      fused.set(entry.messageId, (fused.get(entry.messageId) ?? 0) + 1 / (RRF_K + rank + 1));
+    };
+    ordered.forEach(add);
+    semanticOrder.forEach(add);
+    ordered = [...fused.entries()]
+      .map(([messageId, score]) => ({ messageId, score }))
+      .sort((a, b) => b.score - a.score);
   }
 
   const termSet = new Set(terms);
@@ -220,7 +250,7 @@ export async function searchTranscripts(
     };
   });
 
-  return { hits, ...base };
+  return finish(hits);
 }
 
 /** Read one entry in full, straight from the file, for when a snippet cannot settle the question. */

--- a/src/store/transcript-vectors.ts
+++ b/src/store/transcript-vectors.ts
@@ -17,6 +17,8 @@ import { normalizeProjectDir } from './project-dir.js';
 export interface TranscriptEmbedder {
   model: string;
   embed(texts: string[]): Promise<number[][]>;
+  /** Queries carry the model's instruction prefix; documents do not. Optional for symmetric models. */
+  embedQuery?(text: string): Promise<number[]>;
 }
 
 /**
@@ -160,7 +162,11 @@ export async function embedTranscripts(
       }
     }
     embedded += statements.length;
-    remaining -= statements.length;
+    // Never below zero: the archive GROWS during a long backfill, because live
+    // sessions keep writing to it, so a counter captured once at the start will
+    // undershoot and go negative. Clamping keeps the display honest; the exact
+    // figure is re-counted from the database at the end.
+    remaining = Math.max(0, remaining - statements.length);
     onProgress?.(embedded, remaining);
     // Checked after a batch, never before one. A pass that returns having done
     // nothing is indistinguishable from a broken one, and on a slow machine a

--- a/src/store/transcript-vectors.ts
+++ b/src/store/transcript-vectors.ts
@@ -1,5 +1,5 @@
 import { getClient } from './database.js';
-import { normalizeProjectDir } from './transcript-index.js';
+import { normalizeProjectDir } from './project-dir.js';
 
 // Semantic retrieval over the WHOLE transcript archive, not just what keyword
 // search already found.

--- a/src/store/transcript-vectors.ts
+++ b/src/store/transcript-vectors.ts
@@ -78,7 +78,10 @@ function asInt8(value: unknown): Int8Array | null {
 /** Clip per message. Matches what the model can read anyway: 512 word-pieces is roughly this. */
 const EMBED_TEXT_CHARS = 2_000;
 
-/** Texts per embed() call. Batches pad to the longest member, so a large batch spends its time on padding. */
+/**
+ * Rows claimed per pass, and the size of one write transaction. NOT the embed
+ * batch size — see below for why those are deliberately different.
+ */
 const EMBED_BATCH = 16;
 
 /** Vectors held in memory at once while scanning. */
@@ -126,6 +129,10 @@ export async function embedTranscripts(
     })).rows;
     if (rows.length === 0) break;
 
+    // Read and written in batches; the embedder handles them one forward pass
+    // at a time, because batching variable-length text costs more than it saves
+    // (see createLocalEmbeddingProvider). Database round trips still batch,
+    // because those genuinely do amortize.
     const vectors = await embedder.embed(rows.map(row => String(row.text).slice(0, EMBED_TEXT_CHARS)));
     const statements = [];
     for (let i = 0; i < rows.length; i++) {

--- a/src/store/transcript-vectors.ts
+++ b/src/store/transcript-vectors.ts
@@ -1,0 +1,240 @@
+import { getClient } from './database.js';
+
+// Semantic retrieval over the WHOLE transcript archive, not just what keyword
+// search already found.
+//
+// Re-ranking a lexical shortlist can only reorder what BM25 surfaced, so the
+// case it cannot serve is the one that matters most: the words you remember are
+// not the words that were used. That message is never in the shortlist, so no
+// amount of re-ranking reaches it. Fixing that means every message must carry a
+// vector, and every query must be able to score all of them.
+//
+// The cost of that is storage and scan time, which is why the vectors are
+// quantized rather than stored as float32 - see quantize().
+
+/** Supplied by the caller, so this module never depends on how embeddings are configured. */
+export interface TranscriptEmbedder {
+  model: string;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+/**
+ * Components of an L2-normalised vector are small - energy is spread over every
+ * dimension, so RMS is 1/sqrt(dims) - and int8 spends its resolution on the
+ * range it is told to expect. Clipping at ~6 sigma keeps almost everything and
+ * quantizes the rest finely.
+ *
+ * Checked against the real thing: for 384-dim bge-small this gives 0.306, while
+ * the corpus measured a largest component of 0.327 and a 99.9th percentile of
+ * 0.262. So a handful of components clip, which measurement says is the good
+ * trade - on our own eval corpus int8 at this scale scored MRR 0.668 against
+ * float32's 0.662, i.e. no loss at 4x smaller.
+ */
+function scaleFor(dims: number): number {
+  return 6 / Math.sqrt(dims);
+}
+
+/**
+ * float32 -> int8, one byte per dimension.
+ *
+ * Measured on 350 project atoms with 17 recall queries, against the float32
+ * reference (MRR 0.662):
+ *   int8    MRR 0.668  - 27 MB for our 69k messages, 36 ms to scan all of them
+ *   binary  MRR 0.310  - 3.3 MB and 5 ms, but the ranking falls apart
+ * The published binary-quantization results are far kinder than that, but they
+ * are measured on 1024-dim models; at 384 dims one sign bit per dimension is
+ * not enough information. Binary is only usable with a float32 rescoring pass,
+ * which means storing the float32 vectors too - 4x the disk to make up for the
+ * loss of quality it caused. int8 needs no rescoring stage at all.
+ */
+export function quantize(vector: number[]): Uint8Array {
+  const scale = scaleFor(vector.length);
+  const out = new Int8Array(vector.length);
+  for (let i = 0; i < vector.length; i++) {
+    const scaled = Math.round((vector[i] / scale) * 127);
+    out[i] = scaled > 127 ? 127 : scaled < -127 ? -127 : scaled;
+  }
+  return new Uint8Array(out.buffer);
+}
+
+/**
+ * Dot product of two quantized vectors. Both sides carry the same constant
+ * scale factor, and every candidate is scored against the same query, so the
+ * factor is never divided out: it is a ranking, not a similarity anyone reads.
+ */
+function score(query: Int8Array, doc: Int8Array): number {
+  let dot = 0;
+  const n = query.length < doc.length ? query.length : doc.length;
+  for (let i = 0; i < n; i++) dot += query[i] * doc[i];
+  return dot;
+}
+
+function asInt8(value: unknown): Int8Array | null {
+  if (value instanceof Uint8Array) return new Int8Array(value.buffer, value.byteOffset, value.byteLength);
+  if (value instanceof ArrayBuffer) return new Int8Array(value);
+  return null;
+}
+
+/** Clip per message. Matches what the model can read anyway: 512 word-pieces is roughly this. */
+const EMBED_TEXT_CHARS = 2_000;
+
+/** Texts per embed() call. Batches pad to the longest member, so a large batch spends its time on padding. */
+const EMBED_BATCH = 16;
+
+/** Vectors held in memory at once while scanning. */
+const SCAN_PAGE = 5_000;
+
+/**
+ * Embed messages that have no vector for this model yet.
+ *
+ * Newest first: a cold archive becomes useful for recent history immediately,
+ * which is what questions are usually about. Resumable by construction - the
+ * work left is "rows with no row in transcript_embeddings", so an interrupted
+ * pass leaves no state to repair.
+ */
+export async function embedTranscripts(
+  projectDir: string,
+  embedder: TranscriptEmbedder,
+  options: { budgetMs?: number; onProgress?: (done: number, remaining: number) => void } = {},
+): Promise<{ embedded: number; remaining: number; ms: number; complete: boolean }> {
+  const { budgetMs = 60_000, onProgress } = options;
+  const client = getClient();
+  const started = Date.now();
+  const deadline = started + budgetMs;
+  let embedded = 0;
+  // Counted once and then tracked, not re-counted per batch. The count is a
+  // LEFT JOIN over every message in the project; running it after each batch of
+  // 16 meant thousands of full scans across a backfill, interleaved with the
+  // writes they were reporting on - which is how the first long run died on
+  // "cannot commit transaction - SQL statements in progress".
+  let remaining = await countPending(projectDir, embedder.model);
+
+  // Vectors from a model no longer in use are unreachable - every read filters
+  // on the active model - and there is now one per message rather than one per
+  // re-ranked candidate, so leaving them behind means carrying a full dead copy
+  // of the archive for every model ever configured.
+  await client.execute({ sql: 'DELETE FROM transcript_embeddings WHERE model <> ?', args: [embedder.model] });
+
+  for (;;) {
+    const rows = (await client.execute({
+      sql: `SELECT m.id, m.text FROM transcript_messages m
+            LEFT JOIN transcript_embeddings e ON e.message_id = m.id AND e.model = ?
+            WHERE m.project_dir = ? AND e.message_id IS NULL
+            ORDER BY m.id DESC
+            LIMIT ?`,
+      args: [embedder.model, projectDir, EMBED_BATCH],
+    })).rows;
+    if (rows.length === 0) break;
+
+    const vectors = await embedder.embed(rows.map(row => String(row.text).slice(0, EMBED_TEXT_CHARS)));
+    const statements = [];
+    for (let i = 0; i < rows.length; i++) {
+      const vector = vectors[i];
+      if (!vector || vector.length === 0) continue;
+      statements.push({
+        sql: 'INSERT OR REPLACE INTO transcript_embeddings (message_id, model, vector) VALUES (?, ?, ?)',
+        args: [Number(rows[i].id), embedder.model, quantize(vector)],
+      });
+    }
+    // Retried on BUSY for the same reason indexing is: a backfill runs for
+    // tens of minutes beside live sessions writing to the same database, and
+    // losing the whole pass to one transient lock is the difference between a
+    // job that finishes and one that has to be babysat.
+    for (let attempt = 0; statements.length > 0; attempt++) {
+      try {
+        await client.batch(statements, 'write');
+        break;
+      } catch (error) {
+        const busy = /SQLITE_BUSY|statements in progress/i.test(String((error as Error).message));
+        if (!busy || attempt >= 5) throw error;
+        await new Promise(resolve => setTimeout(resolve, 250 * (attempt + 1)));
+      }
+    }
+    embedded += statements.length;
+    remaining -= statements.length;
+    onProgress?.(embedded, remaining);
+    // Checked after a batch, never before one. A pass that returns having done
+    // nothing is indistinguishable from a broken one, and on a slow machine a
+    // small budget would starve forever - so the floor is one batch, and the
+    // budget bounds how many more.
+    if (Date.now() > deadline) break;
+  }
+
+  const left = await countPending(projectDir, embedder.model);
+  return { embedded, remaining: left, ms: Date.now() - started, complete: left === 0 };
+}
+
+async function countPending(projectDir: string, model: string): Promise<number> {
+  const row = (await getClient().execute({
+    sql: `SELECT COUNT(*) AS n FROM transcript_messages m
+          LEFT JOIN transcript_embeddings e ON e.message_id = m.id AND e.model = ?
+          WHERE m.project_dir = ? AND e.message_id IS NULL`,
+    args: [model, projectDir],
+  })).rows[0];
+  return Number(row.n);
+}
+
+export async function transcriptVectorStats(projectDir: string, model: string): Promise<{ embedded: number; total: number }> {
+  const client = getClient();
+  const row = (await client.execute({
+    sql: `SELECT COUNT(*) AS total,
+                 COUNT(e.message_id) AS embedded
+          FROM transcript_messages m
+          LEFT JOIN transcript_embeddings e ON e.message_id = m.id AND e.model = ?
+          WHERE m.project_dir = ?`,
+    args: [model, projectDir],
+  })).rows[0];
+  return { embedded: Number(row.embedded), total: Number(row.total) };
+}
+
+/**
+ * Rank every embedded message in the project against the query vector.
+ *
+ * A brute-force scan, deliberately. An approximate index (HNSW, IVF) buys speed
+ * this does not need: 27 MB of int8 scores in tens of milliseconds, which is
+ * noise next to the model call that produced the query vector. It also costs
+ * nothing to keep correct - no rebuilds, no recall knobs, no native extension
+ * that has to load inside whatever SQLite build the host happens to have.
+ */
+export async function semanticCandidates(
+  projectDir: string,
+  queryVector: number[],
+  model: string,
+  depth: number,
+  sessionId?: string,
+): Promise<Array<{ messageId: number; score: number }>> {
+  const client = getClient();
+  const query = new Int8Array(quantize(queryVector).buffer);
+  const scored: Array<{ messageId: number; score: number }> = [];
+
+  // Paged by id rather than read in one go. The vectors themselves are tens of
+  // megabytes, but the row objects wrapping them are the larger cost, and
+  // materialising all of them at once is a spike inside a process that also has
+  // to serve a live session. Keyset paging, not OFFSET, so each page is a seek.
+  let after = 0;
+  for (;;) {
+    const rows = (await client.execute({
+      sql: `SELECT e.message_id AS id, e.vector AS vector
+            FROM transcript_embeddings e
+            JOIN transcript_messages m ON m.id = e.message_id
+            WHERE e.model = ? AND m.project_dir = ? AND e.message_id > ?${sessionId ? ' AND m.session_id LIKE ?' : ''}
+            ORDER BY e.message_id
+            LIMIT ${SCAN_PAGE}`,
+      args: sessionId ? [model, projectDir, after, `${sessionId}%`] : [model, projectDir, after],
+    })).rows;
+    if (rows.length === 0) break;
+
+    for (const row of rows) {
+      after = Number(row.id);
+      const vector = asInt8(row.vector);
+      // Rows written by an older build stored JSON text under the same column.
+      // They are a cache, so an unreadable one is skipped, not repaired.
+      if (!vector || vector.length !== query.length) continue;
+      scored.push({ messageId: after, score: score(query, vector) });
+    }
+    if (rows.length < SCAN_PAGE) break;
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, depth);
+}

--- a/src/store/transcript-vectors.ts
+++ b/src/store/transcript-vectors.ts
@@ -1,4 +1,5 @@
 import { getClient } from './database.js';
+import { normalizeProjectDir } from './transcript-index.js';
 
 // Semantic retrieval over the WHOLE transcript archive, not just what keyword
 // search already found.
@@ -96,10 +97,11 @@ const SCAN_PAGE = 5_000;
  * pass leaves no state to repair.
  */
 export async function embedTranscripts(
-  projectDir: string,
+  rawProjectDir: string,
   embedder: TranscriptEmbedder,
   options: { budgetMs?: number; onProgress?: (done: number, remaining: number) => void } = {},
 ): Promise<{ embedded: number; remaining: number; ms: number; complete: boolean }> {
+  const projectDir = normalizeProjectDir(rawProjectDir);
   const { budgetMs = 60_000, onProgress } = options;
   const client = getClient();
   const started = Date.now();
@@ -172,6 +174,7 @@ export async function embedTranscripts(
 }
 
 async function countPending(projectDir: string, model: string): Promise<number> {
+  // Callers inside this module already normalized; kept as a plain parameter.
   const row = (await getClient().execute({
     sql: `SELECT COUNT(*) AS n FROM transcript_messages m
           LEFT JOIN transcript_embeddings e ON e.message_id = m.id AND e.model = ?
@@ -181,7 +184,8 @@ async function countPending(projectDir: string, model: string): Promise<number> 
   return Number(row.n);
 }
 
-export async function transcriptVectorStats(projectDir: string, model: string): Promise<{ embedded: number; total: number }> {
+export async function transcriptVectorStats(rawProjectDir: string, model: string): Promise<{ embedded: number; total: number }> {
+  const projectDir = normalizeProjectDir(rawProjectDir);
   const client = getClient();
   const row = (await client.execute({
     sql: `SELECT COUNT(*) AS total,
@@ -204,12 +208,13 @@ export async function transcriptVectorStats(projectDir: string, model: string): 
  * that has to load inside whatever SQLite build the host happens to have.
  */
 export async function semanticCandidates(
-  projectDir: string,
+  rawProjectDir: string,
   queryVector: number[],
   model: string,
   depth: number,
   sessionId?: string,
 ): Promise<Array<{ messageId: number; score: number }>> {
+  const projectDir = normalizeProjectDir(rawProjectDir);
   const client = getClient();
   const query = new Int8Array(quantize(queryVector).buffer);
   const scored: Array<{ messageId: number; score: number }> = [];

--- a/src/store/vector-index.ts
+++ b/src/store/vector-index.ts
@@ -6,7 +6,21 @@ export type KnowledgeEmbedder = {
   provider: string;
   model: string;
   embed(texts: string[]): Promise<number[][]>;
+  /**
+   * Embed a QUERY rather than a document. Retrieval models are trained with an
+   * asymmetric instruction prefix, so the two are not interchangeable. Optional
+   * because a symmetric model does not need it and test stubs should not have to
+   * implement it -- callers fall back to embed().
+   */
+  embedQuery?(text: string): Promise<number[]>;
 };
+
+/** Embed one query, using the model's own instruction prefix when it has one. */
+export async function embedSearchQuery(embedder: KnowledgeEmbedder, query: string): Promise<number[]> {
+  if (embedder.embedQuery) return embedder.embedQuery(query);
+  const [vector] = await embedder.embed([query]);
+  return vector;
+}
 
 export type VectorReindexResult = {
   indexed: number;

--- a/tests/ai/embeddings.test.ts
+++ b/tests/ai/embeddings.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
 import { DEFAULT_CONFIG } from '../../src/core/config.js';
-import { createLocalEmbeddingProvider } from '../../src/ai/embeddings.js';
+import { createLocalEmbeddingProvider, getVectorSearchConfig, resetLocalEmbeddingPipeline } from '../../src/ai/embeddings.js';
+
+const withModel = (model?: string, pooling?: 'mean' | 'cls') => ({
+  ...DEFAULT_CONFIG,
+  search: { vector: { ...DEFAULT_CONFIG.search!.vector!, model, pooling } },
+});
 
 describe('local embeddings', () => {
   it('reports the first local model load and caches subsequent providers', async () => {
@@ -23,5 +28,34 @@ describe('local embeddings', () => {
 
     expect(loadPipeline).toHaveBeenCalledTimes(1);
     expect(onFirstLoad).toHaveBeenCalledTimes(1);
+  });
+
+  // Pooling is part of the model, not a preference. Granite run with mean
+  // pooling scored MRR 0.337 on our eval corpus against 0.750 with CLS - the
+  // same weights performing worse than the model it replaces, from one wrong
+  // string, with nothing anywhere reporting a problem.
+  it('defaults pooling to what the model family was trained for', () => {
+    expect(getVectorSearchConfig(withModel('onnx-community/granite-embedding-small-english-r2-ONNX')).pooling).toBe('cls');
+    expect(getVectorSearchConfig(withModel('intfloat/e5-small-v2')).pooling).toBe('cls');
+    expect(getVectorSearchConfig(withModel('Xenova/bge-small-en-v1.5')).pooling).toBe('mean');
+    expect(getVectorSearchConfig(withModel('Xenova/all-MiniLM-L6-v2')).pooling).toBe('mean');
+  });
+
+  it('lets config override the family default, since the mapping cannot know every model', () => {
+    expect(getVectorSearchConfig(withModel('Xenova/bge-small-en-v1.5', 'cls')).pooling).toBe('cls');
+    expect(getVectorSearchConfig(withModel('some/granite-shaped-name', 'mean')).pooling).toBe('mean');
+  });
+
+  it('passes the resolved pooling to the pipeline rather than a hardcoded one', async () => {
+    resetLocalEmbeddingPipeline();
+    const embedCall = vi.fn(async () => ({ data: [1, 0], dims: [1, 2] }));
+    const provider = await createLocalEmbeddingProvider(
+      withModel('onnx-community/granite-embedding-small-english-r2-ONNX'),
+      path.resolve('.knowl-embeddings-test'),
+      { loadPipeline: async () => embedCall as any },
+    );
+    await provider.embed(['anything']);
+
+    expect(embedCall).toHaveBeenCalledWith(['anything'], expect.objectContaining({ pooling: 'cls' }));
   });
 });

--- a/tests/ai/embeddings.test.ts
+++ b/tests/ai/embeddings.test.ts
@@ -37,8 +37,29 @@ describe('local embeddings', () => {
   it('defaults pooling to what the model family was trained for', () => {
     expect(getVectorSearchConfig(withModel('onnx-community/granite-embedding-small-english-r2-ONNX')).pooling).toBe('cls');
     expect(getVectorSearchConfig(withModel('intfloat/e5-small-v2')).pooling).toBe('cls');
-    expect(getVectorSearchConfig(withModel('Xenova/bge-small-en-v1.5')).pooling).toBe('mean');
+    expect(getVectorSearchConfig(withModel('Snowflake/snowflake-arctic-embed-m-v2.0')).pooling).toBe('cls');
+    // BGE documents CLS, and on our own corpus the two measured a tie (0.428 vs
+    // 0.426), so the model card wins where measurement cannot separate them.
+    expect(getVectorSearchConfig(withModel('Xenova/bge-small-en-v1.5')).pooling).toBe('cls');
     expect(getVectorSearchConfig(withModel('Xenova/all-MiniLM-L6-v2')).pooling).toBe('mean');
+  });
+
+  it('gives a query the instruction prefix its model family expects, and a document none', async () => {
+    // Retrieval models are asymmetric. Sending a bare query to one trained with
+    // `query: ` costs accuracy silently — the same failure shape as wrong pooling.
+    resetLocalEmbeddingPipeline();
+    const calls: string[][] = [];
+    const provider = await createLocalEmbeddingProvider(
+      withModel('Snowflake/snowflake-arctic-embed-m-v2.0'),
+      path.resolve('.knowl-embeddings-test'),
+      { loadPipeline: async () => (async (texts: string[]) => { calls.push(texts); return { data: [1, 0], dims: [1, 2] }; }) as any },
+    );
+
+    await provider.embed(['a stored document']);
+    await provider.embedQuery!('a search');
+
+    expect(calls[0]).toEqual(['a stored document']);
+    expect(calls[1]).toEqual(['query: a search']);
   });
 
   it('lets config override the family default, since the mapping cannot know every model', () => {

--- a/tests/cli/temporal-cli.test.ts
+++ b/tests/cli/temporal-cli.test.ts
@@ -19,7 +19,12 @@ describe('temporal CLI', () => {
     const client = createClient({ url: `file:${path.join(ROOT, '.knowl', 'knowl.db')}` });
     const row = (await client.execute('SELECT id, created_at FROM knowledge_items WHERE title = ?', ['Temporal storage'])).rows[0];
     itemId = String(row.id); createdAt = String(row.created_at); client.close();
-  }, 15_000);
+    // No local timeout. 15s was a RAISE over vitest's 5s default when it was written; once the
+    // shared config moved to 30s (now 60s) the same number silently became a LOWERING, capping
+    // the one hook here that spawns two `node dist/index.js` processes. It was the last suite
+    // still failing a full run. Inheriting the global keeps it aligned with every other
+    // CLI-spawning suite instead of drifting again the next time that value moves.
+  });
   afterAll(async () => { await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {}); });
 
   it('prints an item timeline and supports an as-of query', () => {
@@ -27,5 +32,5 @@ describe('temporal CLI', () => {
     const asOf = JSON.parse(execSync(`node "${CLI}" query storage --as-of ${createdAt}`, { cwd: ROOT, encoding: 'utf8' }));
     expect(timeline).toEqual([expect.objectContaining({ knowledgeItemId: itemId, content: 'SQLite is active.' })]);
     expect(asOf).toEqual([expect.objectContaining({ id: itemId, content: 'SQLite is active.' })]);
-  }, 15_000);
+  });
 });

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -17,6 +17,7 @@ const EXPECTED_TOOLS = [
   'knowl_query',
   'knowl_recent', 'knowl_state', 'knowl_context',
   'knowl_session_list', 'knowl_transcript_search', 'knowl_transcript_read',
+  'knowl_handoff',
   'knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish',
   'knowl_store', 'knowl_ingest_atoms', 'knowl_decide', 'knowl_update',
   'knowl_timeline', 'knowl_evidence_list', 'knowl_conflicts', 'knowl_feedback',
@@ -26,26 +27,27 @@ const EXPECTED_TOOLS = [
 
 const EXPECTED_CLAUDE_CARD = [
   'KNOWL WORKFLOW - for project work.',
-  'Start: use a relevant active lifecycle hit; else call knowl_query with 2-6 keywords before repository files or commands. A knowl_task_start hit counts in manual mode. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are unavailable, stop and tell the user.',
+  'Start: use a relevant active lifecycle hit; else call knowl_query with 2-6 keywords before files or commands. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are unavailable, stop and tell the user.',
   'Mode: Claude hooks own lifecycle. Never call knowl_task_start, knowl_task_checkpoint, knowl_task_finish, or knowl_session_finish while active.',
-  'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
+  'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones/blockers, knowl_task_finish once after verification.',
   'Route:',
   '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
   '- verbatim: knowl_session_list to browse/find past sessions; knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to one session; knowl_transcript_read one entry in full; promote what you use.',
+  '- handoff: knowl_handoff when parking a workstream; the next session in this project receives it once, then it is archived.',
   '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
   '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
   '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
-  '- special: knowl_ingest only for explicit raw-source ingestion, never silent chat; knowl_synthesize only for an explicit scope; knowl_session_finish only for an explicitly owned manual session; knowl_gc_preview before maintenance; knowl_gc_apply only after preview and explicit approval.',
+  '- special: knowl_ingest only on explicit request, never silent chat; knowl_synthesize only for a stated scope; knowl_session_finish only for an owned manual session; knowl_gc_preview then knowl_gc_apply, only after approval.',
   'During work, store or update verified durable findings; never store raw transcripts, secrets, or routine command noise.',
 ].join('\n');
 
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
 
 describe('canonical Knowl agent guidance', () => {
-  it('defines eight groups and the exact 27-tool inventory', () => {
-    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(8);
+  it('defines nine groups and the exact 28-tool inventory', () => {
+    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(9);
     expect(KNOWL_MCP_TOOL_NAMES).toEqual(EXPECTED_TOOLS);
-    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(27);
+    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(28);
     expect(KNOWL_MCP_TOOL_NAMES).not.toContain('knowl_ask');
   });
 
@@ -62,8 +64,8 @@ describe('canonical Knowl agent guidance', () => {
 
   it('keeps both compact renderings bounded and front-loads the required action', () => {
     expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toBe(EXPECTED_CLAUDE_CARD);
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_917);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_968);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_890);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_941);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -84,7 +86,7 @@ describe('canonical Knowl agent guidance', () => {
     const documentedTools = [...readme.matchAll(/^\| \`(knowl_[a-z_]+)\` \|/gm)]
       .map(match => match[1]);
     expect(documentedTools).toEqual([...KNOWL_MCP_TOOL_NAMES]);
-    expect(new Set(documentedTools).size).toBe(27);
+    expect(new Set(documentedTools).size).toBe(28);
     expect(readme).toContain('KNOWL.md');
     expect(readme).toContain('GEMINI.md');
     expect(readme).toContain('agent-reminder claude --json');

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -16,7 +16,7 @@ import {
 const EXPECTED_TOOLS = [
   'knowl_query',
   'knowl_recent', 'knowl_state', 'knowl_context',
-  'knowl_transcript_search', 'knowl_transcript_read',
+  'knowl_session_list', 'knowl_transcript_search', 'knowl_transcript_read',
   'knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish',
   'knowl_store', 'knowl_ingest_atoms', 'knowl_decide', 'knowl_update',
   'knowl_timeline', 'knowl_evidence_list', 'knowl_conflicts', 'knowl_feedback',
@@ -31,7 +31,7 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
   'Route:',
   '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
-  '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
+  '- verbatim: knowl_session_list to browse/find past sessions; knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to one session; knowl_transcript_read one entry in full; promote what you use.',
   '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
   '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
   '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
@@ -42,10 +42,10 @@ const EXPECTED_CLAUDE_CARD = [
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
 
 describe('canonical Knowl agent guidance', () => {
-  it('defines eight groups and the exact 26-tool inventory', () => {
+  it('defines eight groups and the exact 27-tool inventory', () => {
     expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(8);
     expect(KNOWL_MCP_TOOL_NAMES).toEqual(EXPECTED_TOOLS);
-    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(26);
+    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(27);
     expect(KNOWL_MCP_TOOL_NAMES).not.toContain('knowl_ask');
   });
 
@@ -62,8 +62,8 @@ describe('canonical Knowl agent guidance', () => {
 
   it('keeps both compact renderings bounded and front-loads the required action', () => {
     expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toBe(EXPECTED_CLAUDE_CARD);
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_871);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_922);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_917);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_968);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -84,7 +84,7 @@ describe('canonical Knowl agent guidance', () => {
     const documentedTools = [...readme.matchAll(/^\| \`(knowl_[a-z_]+)\` \|/gm)]
       .map(match => match[1]);
     expect(documentedTools).toEqual([...KNOWL_MCP_TOOL_NAMES]);
-    expect(new Set(documentedTools).size).toBe(26);
+    expect(new Set(documentedTools).size).toBe(27);
     expect(readme).toContain('KNOWL.md');
     expect(readme).toContain('GEMINI.md');
     expect(readme).toContain('agent-reminder claude --json');

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -16,6 +16,7 @@ import {
 const EXPECTED_TOOLS = [
   'knowl_query',
   'knowl_recent', 'knowl_state', 'knowl_context',
+  'knowl_transcript_search', 'knowl_transcript_read',
   'knowl_task_start', 'knowl_task_checkpoint', 'knowl_task_finish',
   'knowl_store', 'knowl_ingest_atoms', 'knowl_decide', 'knowl_update',
   'knowl_timeline', 'knowl_evidence_list', 'knowl_conflicts', 'knowl_feedback',
@@ -30,6 +31,7 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: one bounded command uses knowl task run; resumable work uses knowl_task_start once, knowl_task_checkpoint at meaningful milestones/blockers with its taskId, and knowl_task_finish once after verification.',
   'Route:',
   '- retrieval: knowl_query; knowl_recent only without bootstrap or for refresh; knowl_state for broad state; knowl_context for a token-budgeted pack.',
+  '- verbatim: knowl_transcript_search only after a miss or an ambiguous hit, sessionId to scope to a named parent; knowl_transcript_read one entry in full; promote what you use.',
   '- durable memory: knowl_store one atom; knowl_ingest_atoms a batch; knowl_decide a confirmed choice; knowl_update a stale or contradicted item.',
   '- audit: knowl_timeline, knowl_evidence_list, knowl_conflicts; knowl_feedback after actual use or correction.',
   '- skills: knowl_skill_list, knowl_skill_read, knowl_skill_run only for a trusted matching entrypoint; knowl_skill_create only when explicitly requested.',
@@ -40,10 +42,10 @@ const EXPECTED_CLAUDE_CARD = [
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
 
 describe('canonical Knowl agent guidance', () => {
-  it('defines seven groups and the exact 24-tool inventory', () => {
-    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(7);
+  it('defines eight groups and the exact 26-tool inventory', () => {
+    expect(KNOWL_MCP_TOOL_GROUPS).toHaveLength(8);
     expect(KNOWL_MCP_TOOL_NAMES).toEqual(EXPECTED_TOOLS);
-    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(24);
+    expect(new Set(KNOWL_MCP_TOOL_NAMES).size).toBe(26);
     expect(KNOWL_MCP_TOOL_NAMES).not.toContain('knowl_ask');
   });
 
@@ -60,8 +62,8 @@ describe('canonical Knowl agent guidance', () => {
 
   it('keeps both compact renderings bounded and front-loads the required action', () => {
     expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toBe(EXPECTED_CLAUDE_CARD);
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_695);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_746);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_871);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_922);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -82,7 +84,7 @@ describe('canonical Knowl agent guidance', () => {
     const documentedTools = [...readme.matchAll(/^\| \`(knowl_[a-z_]+)\` \|/gm)]
       .map(match => match[1]);
     expect(documentedTools).toEqual([...KNOWL_MCP_TOOL_NAMES]);
-    expect(new Set(documentedTools).size).toBe(24);
+    expect(new Set(documentedTools).size).toBe(26);
     expect(readme).toContain('KNOWL.md');
     expect(readme).toContain('GEMINI.md');
     expect(readme).toContain('agent-reminder claude --json');

--- a/tests/helpers/scratch.ts
+++ b/tests/helpers/scratch.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs/promises';
+
+/**
+ * Reset scratch fixture directories, and FAIL LOUDLY if the reset did not take.
+ *
+ * FOR FIXTURES WITHOUT A LIVE DATABASE — manifest homes, config dirs, plain files. A directory
+ * holding an open libSQL database must NOT use this: on Windows the `-wal`/`-shm` sidecars stay
+ * locked until after the test that opened them finishes, so inside `beforeEach` the removal
+ * cannot succeed no matter how long it waits, and best-effort really is the honest contract
+ * there. Verified, not assumed: forcing it produced EBUSY on `knowl.db-wal` on every single
+ * test in the suite.
+ *
+ * Where it DOES apply, the conventional `.catch(() => {})` is worth replacing. `fs.rm` recursive
+ * deletes what it can and throws on the one entry it cannot, so a swallowed failure in
+ * `beforeEach` silently hands the test a half-erased fixture. `tests/workspace/resolve.test.ts >
+ * names this repo and lists the others as peers` failed deterministically — in isolation, not
+ * only under load — with `ENOENT ... .knowl-resolve-home/workspaces/ws/workspace.json`, and
+ * passed 6/6 the moment that directory was cleared by hand. The error named a missing manifest;
+ * the cause was a fixture that never got cleared. A cleanup failure should report itself as one.
+ *
+ * Retries before giving up, since a transient handle usually clears within a few hundred
+ * milliseconds.
+ */
+export async function resetScratchDirs(...dirs: string[]): Promise<void> {
+  const ATTEMPTS = 5;
+  const BACKOFF_MS = 120;
+
+  for (const dir of dirs) {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+      try {
+        await fs.rm(dir, { recursive: true, force: true });
+        lastError = undefined;
+        break;
+      } catch (error) {
+        lastError = error;
+        await new Promise(resolve => setTimeout(resolve, BACKOFF_MS));
+      }
+    }
+
+    // `force: true` already makes a missing directory a success, so anything still present
+    // here is a directory that refused to go — the case the old swallow hid.
+    const stillThere = await fs
+      .stat(dir)
+      .then(() => true)
+      .catch(() => false);
+
+    if (stillThere) {
+      throw new Error(
+        `Scratch fixture could not be reset: ${dir}\n` +
+        `It survived ${ATTEMPTS} removal attempts, so this test would have run against ` +
+        `leftover state.\n` +
+        `MOST LIKELY CAUSE: this very process still holds a libSQL handle. \`closeDb()\` ` +
+        `closes only the ambient connection — peer repositories opened through the ` +
+        `connection pool need \`releaseAll()\` as well, and an EBUSY on knowl.db/-wal/-shm ` +
+        `is what a missing one looks like. Otherwise: a stray \`knowl serve\` outside the ` +
+        `suite, or a leftover directory to delete by hand.` +
+        (lastError ? `\nLast error: ${String(lastError)}` : ''),
+      );
+    }
+  }
+}

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(26);
+    expect(new Set(names).size).toBe(27);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(27);
+    expect(new Set(names).size).toBe(28);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(24);
+    expect(new Set(names).size).toBe(26);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -197,7 +197,7 @@ describe('MCP Server Layer', () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
     expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(28);
+    expect(new Set(names).size).toBe(30);
   });
 
   it('advertises lifecycle and mutation gates in tool descriptions', async () => {

--- a/tests/store/conflicts.test.ts
+++ b/tests/store/conflicts.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { closeDb, initDb } from '../../src/store/database.js';
-import { createKnowledgeItem, supersedeKnowledgeItem } from '../../src/store/repository.js';
-import { checkKnowledgeConflict, normalizeConflictKey } from '../../src/store/conflicts.js';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { createKnowledgeItem, getKnowledgeItem, supersedeKnowledgeItem, updateKnowledgeItem } from '../../src/store/repository.js';
+import { checkKnowledgeConflict, normalizeConflictKey, repairUnnormalizedConflictKeys } from '../../src/store/conflicts.js';
 
 const ROOT = path.resolve('./.knowl-conflicts-test');
 
@@ -40,5 +40,69 @@ describe('knowledge conflict keys', () => {
       category: 'decision', title: 'Session store engine duplicate', content: 'Memcached.',
       conflictKey: 'session.store.engine', conflictExclusive: true,
     } as any)).rejects.toMatchObject({ code: 'KNOWLEDGE_CONFLICT' });
+  });
+
+  it('normalizes a key written through UPDATE, not only through create', async () => {
+    // The regression. `createKnowledgeItem` normalized; `updateKnowledgeItem` spread its
+    // `updates` object into the row verbatim. Every lookup runs on the normalized form, so a
+    // key stored raw matched nothing ever again: the row went invisible to the exclusivity
+    // check meant to keep it unique AND to the reader meant to retire it — which is how six
+    // spent session handoffs stayed active and kept re-injecting.
+    const item = await createKnowledgeItem('local', {
+      category: 'state', title: 'Handoff under test', content: 'first',
+      conflictKey: 'pending-session-handoff:claude', conflictExclusive: true,
+    } as any);
+    expect(item.conflictKey).toBe('pending.session.handoff.claude');
+
+    await updateKnowledgeItem(item.id, {
+      content: 'second', conflictKey: 'pending-session-handoff:claude', conflictExclusive: true,
+    } as any);
+
+    expect((await getKnowledgeItem(item.id))!.conflictKey).toBe('pending.session.handoff.claude');
+    await expect(checkKnowledgeConflict({ conflictKey: 'pending-session-handoff:claude', conflictExclusive: true }))
+      .resolves.toEqual([expect.objectContaining({ id: item.id })]);
+  });
+
+  it('leaves identity alone when an update does not mention it', async () => {
+    const item = await createKnowledgeItem('local', {
+      category: 'fact', title: 'Untouched identity', content: 'first',
+      conflictKey: 'some.identity', conflictScope: { env: 'prod' }, conflictExclusive: true,
+    } as any);
+    await updateKnowledgeItem(item.id, { content: 'second' } as any);
+    const reread = await getKnowledgeItem(item.id);
+    expect(reread!.conflictKey).toBe('some.identity');
+    expect(reread!.conflictScope).toEqual({ env: 'prod' });
+  });
+
+  it('repairs keys already stored raw, and settles the duplicates that exposes', async () => {
+    // Rows written raw by the old code were invisible to the exclusivity check, so the same
+    // identity could be claimed twice. Normalizing makes that collision visible for the first
+    // time, so the repair has to settle it or leave the store asserting two active answers.
+    const older = await createKnowledgeItem('local', {
+      category: 'state', title: 'Raw handoff older', content: 'older',
+      conflictKey: 'legacy.raw.identity', conflictExclusive: true,
+    } as any);
+    const newer = await createKnowledgeItem('local', {
+      category: 'state', title: 'Raw handoff newer', content: 'newer',
+      conflictKey: 'unrelated.identity', conflictExclusive: true,
+    } as any);
+
+    // Reproduce the corruption the old update path produced: both rows raw, same identity.
+    for (const [id, when] of [[older.id, '2026-07-23T10:14:44.000Z'], [newer.id, '2026-07-26T10:26:56.000Z']] as const) {
+      await getClient().execute({
+        sql: 'UPDATE knowledge_items SET conflict_key = ?, updated_at = ? WHERE id = ?',
+        args: ['legacy-raw:identity', when, id],
+      });
+    }
+
+    const result = await repairUnnormalizedConflictKeys();
+    expect(result.repaired).toBe(2);
+    expect(result.archived).toBe(1);
+
+    expect((await getKnowledgeItem(older.id))!.conflictKey).toBe('legacy.raw.identity');
+    expect((await getKnowledgeItem(newer.id))!.conflictKey).toBe('legacy.raw.identity');
+    // Newest wins; the older duplicate is retired rather than left contradicting it.
+    expect((await getKnowledgeItem(newer.id))!.status).toBe('active');
+    expect((await getKnowledgeItem(older.id))!.status).toBe('archived');
   });
 });

--- a/tests/store/connection-pool.test.ts
+++ b/tests/store/connection-pool.test.ts
@@ -3,7 +3,10 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 const mockState = vi.hoisted(() => ({
+  /** Fails one bootstrap the way SQLite reports contention, so the retry path is exercised. */
   failNextBootstrap: false,
+  /** Fails every bootstrap with this error, for failures no retry should paper over. */
+  failBootstrapWith: null as Error | null,
   createdClients: [] as any[],
 }));
 
@@ -28,6 +31,7 @@ vi.mock('../../src/store/bootstrap.js', async (importOriginal) => {
   return {
     ...actual,
     bootstrapSchema: async (client: any) => {
+      if (mockState.failBootstrapWith) throw mockState.failBootstrapWith;
       if (mockState.failNextBootstrap) {
         mockState.failNextBootstrap = false;
         throw new Error('SQLITE_BUSY: simulated bootstrap failure');
@@ -134,15 +138,37 @@ describe('connection pool', () => {
   it('closes the client instead of leaking it when bootstrap fails', async () => {
     await releaseAll();
     mockState.createdClients.length = 0;
-    mockState.failNextBootstrap = true;
+    mockState.failBootstrapWith = new Error('simulated permanent bootstrap failure');
     const target = path.join(ROOT, 'bootstrap-fail.db');
 
-    await expect(acquireClient(target)).rejects.toThrow('simulated bootstrap failure');
+    await expect(acquireClient(target)).rejects.toThrow('simulated permanent bootstrap failure');
 
     // A leaked, un-closed client keeps whatever lock its partial bootstrap took,
     // wedging every later acquire on this path for the rest of the process.
     expect(mockState.createdClients).toHaveLength(1);
     expect(mockState.createdClients[0].close).toHaveBeenCalledTimes(1);
     expect(poolSize()).toBe(0);
+    // This one fails EVERY bootstrap, so leaving it armed would break whatever runs next.
+    mockState.failBootstrapWith = null;
+  });
+
+  it('retries a locked open instead of failing the command, and leaks nothing on the way', async () => {
+    // Opening runs bootstrap, which writes. Against a database a live session is
+    // also writing to, that lock is lost routinely -- and it used to end the whole
+    // command. The first attempt here fails the way SQLite reports contention; the
+    // second succeeds, which is what a transient lock deserves.
+    await releaseAll();
+    mockState.createdClients.length = 0;
+    mockState.failNextBootstrap = true;
+    const target = path.join(ROOT, 'bootstrap-busy.db');
+
+    const client = await acquireClient(target);
+    expect(client).toBeDefined();
+    expect(poolSize()).toBe(1);
+
+    // Two clients were built, and the one whose bootstrap failed was closed rather
+    // than abandoned holding a lock.
+    expect(mockState.createdClients).toHaveLength(2);
+    expect(mockState.createdClients[0].close).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/store/deliberate-handoff.test.ts
+++ b/tests/store/deliberate-handoff.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import {
+  consumePendingSessionHandoff,
+  formatPendingHandoffContext,
+  recordDeliberateHandoff,
+  recordPendingSessionHandoff,
+} from '../../src/store/session-handoff.js';
+
+const TEST_ROOT = path.resolve('./.knowl-deliberate-handoff-test');
+const HOST = 'claude';
+
+describe('deliberate session handoff', () => {
+  let projectId: string;
+
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    projectId = (await repo.createProject(TEST_ROOT, 'Deliberate handoff test')).id;
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const park = (goal: string, sessionId: string, extra: Record<string, unknown> = {}) =>
+    recordDeliberateHandoff(projectId, {
+      host: HOST,
+      projectRoot: TEST_ROOT,
+      externalSessionId: sessionId,
+      taskState: { goal, nextAction: 'continue where the last session stopped', ...extra },
+    });
+
+  it('parks a baton and delivers it exactly once to the next session', async () => {
+    await park('finish the trial screen meta band', 'session-a', {
+      completed: ['band contrast fixed'],
+      blocker: 'fork stage still unskinned',
+      verificationStatus: 'typecheck clean, not run in the browser',
+    });
+
+    const first = await consumePendingSessionHandoff(projectId, HOST);
+    expect(first).not.toBeNull();
+    expect(first!.handoff.kind).toBe('handoff');
+    expect(first!.handoff.taskState?.goal).toContain('meta band');
+    expect(first!.handoff.taskState?.blocker).toContain('fork stage');
+
+    // One-shot: the baton is spent, so a second session must not receive it.
+    expect(await consumePendingSessionHandoff(projectId, HOST)).toBeNull();
+  });
+
+  it('reads as a planned handoff, not as a crash', async () => {
+    await park('ship the embedding upgrade', 'session-b');
+    const consumed = await consumePendingSessionHandoff(projectId, HOST);
+    const context = formatPendingHandoffContext(consumed!.handoff);
+
+    // A parked baton and a 3am crash deserve opposite openings.
+    expect(context).toContain('parked this work for you on purpose');
+    expect(context).toContain('Parked at:');
+    expect(context).not.toContain('ended before a clean finish');
+    expect(context).not.toContain('Failed at:');
+  });
+
+  it('keeps the crash path reading as a failure', async () => {
+    const recorded = await recordPendingSessionHandoff(projectId, {
+      host: HOST,
+      projectRoot: TEST_ROOT,
+      externalSessionId: 'session-crash',
+      status: 'failed',
+      payload: { error: { code: 'rate_limit' } },
+    } as any);
+    expect(recorded).not.toBeNull();
+
+    const context = formatPendingHandoffContext(recorded!.handoff);
+    expect(context).toContain('ended before a clean finish');
+    expect(context).not.toContain('parked this work for you on purpose');
+    await consumePendingSessionHandoff(projectId, HOST);
+  });
+
+  it('holds one baton per project — parking again replaces the previous one', async () => {
+    await park('first workstream', 'session-c');
+    await park('second workstream', 'session-d');
+
+    const consumed = await consumePendingSessionHandoff(projectId, HOST);
+    expect(consumed!.handoff.taskState?.goal).toBe('second workstream');
+    expect(consumed!.handoff.externalSessionId).toBe('session-d');
+    // Only one slot existed, so nothing else is waiting behind it.
+    expect(await consumePendingSessionHandoff(projectId, HOST)).toBeNull();
+  });
+
+  it('a deliberate baton supersedes a stale crash handoff rather than queueing behind it', async () => {
+    await recordPendingSessionHandoff(projectId, {
+      host: HOST,
+      projectRoot: TEST_ROOT,
+      externalSessionId: 'session-old-crash',
+      status: 'failed',
+      payload: { error: { code: 'rate_limit' } },
+    } as any);
+
+    await park('deliberate work that matters now', 'session-e');
+
+    const consumed = await consumePendingSessionHandoff(projectId, HOST);
+    expect(consumed!.handoff.kind).toBe('handoff');
+    expect(consumed!.handoff.taskState?.goal).toBe('deliberate work that matters now');
+  });
+
+  it('carries artifact references through the round trip', async () => {
+    await park('land PR 7', 'session-f', {
+      artifactRefs: ['https://github.com/dat999zx/knowl/pull/7', 'src/store/transcript-index.ts'],
+    });
+    const consumed = await consumePendingSessionHandoff(projectId, HOST);
+    expect(consumed!.handoff.taskState?.artifactRefs).toContain('src/store/transcript-index.ts');
+    expect(formatPendingHandoffContext(consumed!.handoff)).toContain('pull/7');
+  });
+});

--- a/tests/store/gc-access.test.ts
+++ b/tests/store/gc-access.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import * as repo from '../../src/store/repository.js';
-import { recordKnowledgeAccess } from '../../src/store/access-feedback.js';
+import { recordKnowledgeAccess, recordKnowledgeFeedback } from '../../src/store/access-feedback.js';
 import { previewKnowledgeGc } from '../../src/store/gc.js';
 
 const ROOT = path.resolve('./.knowl-gc-access-test');
@@ -45,5 +45,81 @@ describe('access-weighted GC decay', () => {
     const forcedArchived = forced.candidates.filter(candidate => candidate.action === 'archive').map(candidate => candidate.itemId);
     expect(forcedArchived).toContain(cold.id);
     expect(forcedArchived).toContain(hot.id);
+  });
+
+  it('lets explicit feedback outrank retrieval volume in both directions', async () => {
+    // Retrieval alone is weak evidence of worth: an item that keeps surfacing in results it
+    // does not belong in gets retrieved BECAUSE it is noise, and counting that as heat let the
+    // worst rows earn the strongest protection from collection.
+    const rejected = await repo.createKnowledgeItem(projectId, { category: 'state', title: 'Noisy state', content: 'Retrieved often, useful never.' });
+    const used = await repo.createKnowledgeItem(projectId, { category: 'state', title: 'Quietly useful state', content: 'Retrieved once, actually used.' });
+    await backdate(rejected.id);
+    await backdate(used.id);
+
+    for (let index = 0; index < 5; index++) {
+      await recordKnowledgeAccess({ itemId: rejected.id, surface: 'agent_query', rank: 1, retrievedAt: NOW });
+    }
+    await recordKnowledgeFeedback({ itemId: rejected.id, used: true, useful: false, retrievedAt: NOW });
+
+    // One old retrieval — cold by count and by recency — but marked genuinely useful.
+    await recordKnowledgeAccess({ itemId: used.id, surface: 'agent_query', rank: 1, retrievedAt: OLD });
+    await recordKnowledgeFeedback({ itemId: used.id, used: true, useful: true, retrievedAt: OLD });
+
+    const archived = (await previewKnowledgeGc(projectId, { now: NOW }))
+      .candidates.filter(candidate => candidate.action === 'archive').map(candidate => candidate.itemId);
+    expect(archived).toContain(rejected.id);
+    expect(archived).not.toContain(used.id);
+  });
+});
+
+describe('spent one-shot records', () => {
+  let projectId = '';
+  const HANDOFF_ROOT = path.resolve('./.knowl-gc-oneshot-test');
+  const daysAgo = (days: number) => new Date(Date.now() - days * 86_400_000).toISOString();
+
+  async function handoff(title: string, body: Record<string, unknown>, updatedAt: string) {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'state', title, content: JSON.stringify(body),
+      tags: ['pending_handoff', 'claude'], conflictKey: 'pending-session-handoff:claude', conflictExclusive: false,
+    } as any);
+    await getClient().execute({ sql: 'UPDATE knowledge_items SET updated_at = ? WHERE id = ?', args: [updatedAt, item.id] });
+    return item;
+  }
+
+  beforeAll(async () => {
+    await fs.rm(HANDOFF_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(HANDOFF_ROOT, '.knowl'), { recursive: true });
+    await initDb(HANDOFF_ROOT);
+    projectId = (await repo.createProject(HANDOFF_ROOT, 'gc-oneshot')).id;
+  });
+  afterAll(async () => { await closeDb(); await fs.rm(HANDOFF_ROOT, { recursive: true, force: true }).catch(() => {}); });
+
+  it('collects spent handoffs well inside the 60-day clock, and spares a live one', async () => {
+    // These are one-shot: delivered to the NEXT session that starts. The old rule waited 60
+    // days for a `state` item and then let `isHot` protect it anyway — and these get retrieved
+    // precisely because they pollute unrelated result sets, so noise immunised itself.
+    const superseded = await handoff('Older pending', { kind: 'rate_limit', failedAt: daysAgo(10), consumed: false }, daysAgo(10));
+    const newest = await handoff('Newest pending', { kind: 'rate_limit', failedAt: daysAgo(1), consumed: false }, daysAgo(1));
+    const consumed = await handoff('Already consumed', { kind: 'auth', failedAt: daysAgo(2), consumed: true }, daysAgo(2));
+
+    // Make the spent ones look maximally "hot" — under the old rule this guaranteed survival.
+    for (let index = 0; index < 6; index++) {
+      await recordKnowledgeAccess({ itemId: superseded.id, surface: 'agent_query', rank: 1, retrievedAt: NOW });
+      await recordKnowledgeAccess({ itemId: consumed.id, surface: 'agent_query', rank: 1, retrievedAt: NOW });
+    }
+
+    const archived = (await previewKnowledgeGc(projectId, { now: NOW }))
+      .candidates.filter(candidate => candidate.action === 'archive').map(candidate => candidate.itemId);
+    expect(archived).toContain(superseded.id);
+    expect(archived).toContain(consumed.id);
+    // The one still legitimately pending is not collected.
+    expect(archived).not.toContain(newest.id);
+  });
+
+  it('collects a lone handoff nothing ever claimed', async () => {
+    const stale = await handoff('Never claimed', { kind: 'provider_outage', failedAt: daysAgo(9), consumed: false }, daysAgo(9));
+    const archived = (await previewKnowledgeGc(projectId, { now: NOW }))
+      .candidates.filter(candidate => candidate.action === 'archive').map(candidate => candidate.itemId);
+    expect(archived).toContain(stale.id);
   });
 });

--- a/tests/store/resume-points.test.ts
+++ b/tests/store/resume-points.test.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import {
+  createResumePoint,
+  formatResumeBrief,
+  listResumePoints,
+  normalizeKey,
+  readResumePoint,
+} from '../../src/store/resume-points.js';
+
+const TEST_ROOT = path.resolve('./.knowl-resume-points-test');
+const PROJECT = 'D:\\Code\\FakeProject';
+
+describe('resume points', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    await repo.createProject(TEST_ROOT, 'Resume points test');
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('mints a key a person can retype: short, lowercase, no lookalike characters', async () => {
+    const point = await createResumePoint(PROJECT, { goal: 'ship the thing', nextAction: 'run the tests' });
+    expect(point.key).toMatch(/^[a-z2-9]{6}$/);
+    // 0/O and 1/l/I are the characters people transcribe wrongly from a screen.
+    expect(point.key).not.toMatch(/[01loi]/);
+  });
+
+  it('accepts the key however the user pastes it', () => {
+    expect(normalizeKey('  K7X2QM ')).toBe('k7x2qm');
+    expect(normalizeKey('knowl:k7x2qm')).toBe('k7x2qm');
+    expect(normalizeKey('knowl/resume/k7x2qm')).toBe('k7x2qm');
+    expect(normalizeKey('k7x2-qm.')).toBe('k7x2qm');
+  });
+
+  it('resumes more than once, because work gets picked up and parked again', async () => {
+    const point = await createResumePoint(PROJECT, { goal: 'long haul', nextAction: 'continue' });
+
+    const first = await readResumePoint(point.key);
+    expect(first?.brief.goal).toBe('long haul');
+    expect(first?.resumeCount).toBe(0);
+
+    // A one-shot key would make Wednesday's pickup an error. It must not.
+    const second = await readResumePoint(point.key.toUpperCase());
+    expect(second?.brief.goal).toBe('long haul');
+    expect(second?.resumeCount).toBe(1);
+  });
+
+  it('holds several parked workstreams at once, unlike the single session baton', async () => {
+    const a = await createResumePoint(PROJECT, { goal: 'workstream A', nextAction: 'a' });
+    const b = await createResumePoint(PROJECT, { goal: 'workstream B', nextAction: 'b' });
+    expect(a.key).not.toBe(b.key);
+
+    const parked = await listResumePoints(PROJECT);
+    const goals = parked.map(p => p.brief.goal);
+    expect(goals).toContain('workstream A');
+    expect(goals).toContain('workstream B');
+  });
+
+  it('finds a key regardless of which directory it is pasted into', async () => {
+    const point = await createResumePoint(PROJECT, { goal: 'cross-directory', nextAction: 'go' });
+    // Someone pasting a key in the wrong folder means to reach the work, not to
+    // be told it does not exist.
+    const found = await readResumePoint(point.key);
+    expect(found?.brief.goal).toBe('cross-directory');
+  });
+
+  it('returns nothing for an unknown key rather than the nearest match', async () => {
+    expect(await readResumePoint('zzzzzz')).toBeNull();
+    expect(await readResumePoint('')).toBeNull();
+  });
+
+  it('points the resuming session at the transcript instead of trusting the brief', async () => {
+    const point = await createResumePoint(PROJECT, {
+      goal: 'finish the migration',
+      nextAction: 'run the backfill',
+      completed: ['schema written'],
+      blocker: 'waiting on review',
+      verificationStatus: 'typecheck clean, not run end to end',
+      sessionId: 'abc-123',
+    });
+
+    const brief = formatResumeBrief((await readResumePoint(point.key))!);
+    expect(brief).toContain('finish the migration');
+    expect(brief).toContain('run the backfill');
+    expect(brief).toContain('schema written');
+    expect(brief).toContain('waiting on review');
+    expect(brief).toContain('not run end to end');
+    // The pointer is the point: a brief cannot carry everything, so it must say
+    // where the rest lives.
+    expect(brief).toContain('abc-123');
+    expect(brief).toContain('knowl_transcript_search');
+  });
+});

--- a/tests/store/resume-points.test.ts
+++ b/tests/store/resume-points.test.ts
@@ -9,6 +9,7 @@ import {
   listResumePoints,
   normalizeKey,
   readResumePoint,
+  resumeInstruction,
 } from '../../src/store/resume-points.js';
 
 const TEST_ROOT = path.resolve('./.knowl-resume-points-test');
@@ -34,11 +35,46 @@ describe('resume points', () => {
     expect(point.key).not.toMatch(/[01loi]/);
   });
 
+  it('never mints a key that could read as a word, so it cannot be mistaken for an instruction', async () => {
+    // A key the user picked would be something like "fix-login-bug", and a fresh
+    // session would just start fixing a login bug. An opaque token has no
+    // competing reading — but randomness alone can still spell "budget", so a
+    // digit is guaranteed. Checked across many keys, not one lucky one.
+    const keys = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      const point = await createResumePoint(PROJECT, { goal: `bulk ${i}`, nextAction: 'x' });
+      expect(point.key).toMatch(/[2-9]/);
+      keys.add(point.key);
+    }
+    // And the digit is not pinned to one position, which would make every key
+    // look alike and leak the special-casing.
+    const digitPositions = new Set([...keys].map(k => k.search(/[2-9]/)));
+    expect(digitPositions.size).toBeGreaterThan(1);
+    // Minted, not sequential: 200 draws should not collide.
+    expect(keys.size).toBe(200);
+  });
+
   it('accepts the key however the user pastes it', () => {
     expect(normalizeKey('  K7X2QM ')).toBe('k7x2qm');
     expect(normalizeKey('knowl:k7x2qm')).toBe('k7x2qm');
     expect(normalizeKey('knowl/resume/k7x2qm')).toBe('k7x2qm');
     expect(normalizeKey('k7x2-qm.')).toBe('k7x2qm');
+  });
+
+  it('hands back a paste-ready instruction, not only a token', async () => {
+    // A bare key relies on the receiving model investigating an opaque string.
+    // That is usually enough, and "usually" is the wrong bar for the one message
+    // whose entire job is to not be misread.
+    const point = await createResumePoint(PROJECT, { goal: 'the work', nextAction: 'go' });
+    const line = resumeInstruction(point.key);
+
+    expect(line).toContain(point.key);
+    expect(line).toMatch(/knowl_resume/);
+    expect(line).toMatch(/^Continue/);
+    // And pasting the whole sentence must still resolve to the key.
+    const pastedWords = line.split(/\s+/);
+    const token = pastedWords.find(word => normalizeKey(word) === point.key);
+    expect(token).toBeDefined();
   });
 
   it('resumes more than once, because work gets picked up and parked again', async () => {

--- a/tests/store/session-directory.test.ts
+++ b/tests/store/session-directory.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { encodeProjectDir, ensureTranscriptIndex } from '../../src/store/transcript-index.js';
+import { listSessionDirectory } from '../../src/store/session-directory.js';
+
+const TEST_ROOT = path.resolve('./.knowl-session-directory-test');
+// Injected store, never HOME: mutating HOME/USERPROFILE leaks into other suites.
+const FAKE_STORE = path.join(TEST_ROOT, 'store', 'projects');
+const STORES = [FAKE_STORE];
+const PROJECT_DIR = 'D:\\Code\\DirectoryProject';
+
+const line = (obj: object) => JSON.stringify(obj) + '\n';
+const user = (text: string, ts: string) => line({ type: 'user', timestamp: ts, message: { content: text } });
+const assistant = (text: string, ts: string) => line({ type: 'assistant', timestamp: ts, message: { content: [{ type: 'text', text }] } });
+
+let sessionDir: string;
+let projectId: string;
+
+describe('session directory', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    projectId = (await repo.createProject(TEST_ROOT, 'Session directory test')).id;
+
+    sessionDir = path.join(FAKE_STORE, encodeProjectDir(PROJECT_DIR));
+    await fs.mkdir(sessionDir, { recursive: true });
+
+    // A renamed session: custom-title must beat the generated ai-title.
+    await fs.writeFile(path.join(sessionDir, 'ui-session.jsonl'),
+      line({ type: 'ai-title', sessionId: 'ui-session', aiTitle: 'Generated title about buttons' }) +
+      user('<local-command-caveat>Caveat: local commands</local-command-caveat>', '2026-01-01T00:00:00Z') +
+      user('polish the trial screen meta band and fix the fork stage', '2026-01-01T00:01:00Z') +
+      assistant('Starting on the meta band.', '2026-01-01T00:02:00Z') +
+      line({ type: 'custom-title', sessionId: 'ui-session', customTitle: 'ui-trial-screen' }));
+
+    // Never named: must still appear, described by its opening ask.
+    await fs.writeFile(path.join(sessionDir, 'unnamed.jsonl'),
+      user('investigate the postgres migration ordering bug', '2026-01-02T00:00:00Z') +
+      assistant('Reading the migrations.', '2026-01-02T00:01:00Z'));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('lists sessions newest first with names from the transcript itself', async () => {
+    const { entries, indexComplete } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    expect(indexComplete).toBe(true);
+    expect(entries.length).toBe(2);
+    const ui = entries.find(entry => entry.sessionId === 'ui-session')!;
+    // The user's rename wins over the generated title.
+    expect(ui.name).toBe('ui-trial-screen');
+    expect(ui.opening).toContain('polish the trial screen');
+    // The caveat wrapper is not an opening.
+    expect(ui.opening).not.toContain('local-command-caveat');
+  });
+
+  it('includes unnamed sessions, described by their opening ask', async () => {
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    const unnamed = entries.find(entry => entry.sessionId === 'unnamed')!;
+    expect(unnamed.name).toBeNull();
+    expect(unnamed.opening).toContain('postgres migration ordering');
+  });
+
+  it('answers "which session was about X" with a keyword filter', async () => {
+    const ui = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'trial screen' });
+    expect(ui.entries.map(entry => entry.sessionId)).toEqual(['ui-session']);
+    const pg = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'postgres migration' });
+    expect(pg.entries.map(entry => entry.sessionId)).toEqual(['unnamed']);
+    const none = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'kubernetes' });
+    expect(none.entries).toEqual([]);
+  });
+
+  it('a later rename appended to the transcript updates the name incrementally', async () => {
+    await fs.appendFile(path.join(sessionDir, 'ui-session.jsonl'),
+      line({ type: 'custom-title', sessionId: 'ui-session', customTitle: 'ui-trial-screen-v2' }));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    expect(entries.find(entry => entry.sessionId === 'ui-session')!.name).toBe('ui-trial-screen-v2');
+  });
+
+  it('derives status from lifecycle signals and surfaces declared cards, without storing anything', async () => {
+    const client = getClient();
+    const { storeKnowledgeItemDeduped } = await import('../../src/store/knowledge-writer.js');
+    const now = new Date().toISOString();
+
+    // An unconsumed crash handoff names ui-session -> interrupted, outranking activity.
+    await storeKnowledgeItemDeduped(projectId, {
+      category: 'state', title: 'Rate limit interrupted the ui worksession',
+      content: JSON.stringify({ kind: 'rate_limit', externalSessionId: 'ui-session', consumed: false }),
+      tags: ['pending_handoff', 'rate_limit', 'claude', 'session:ui-session'],
+    } as any, 'test');
+
+    // A live memory session with a fresh heartbeat bound to unnamed -> active.
+    await client.execute({
+      sql: `INSERT INTO memory_sessions (id, title, status, started_at, last_heartbeat_at, expires_at)
+            VALUES ('ms-live', 'Agent turn', 'active', ?, ?, '2099-01-01T00:00:00.000Z')`,
+      args: [now, now],
+    });
+    await client.execute({
+      sql: `INSERT INTO host_session_bindings (host, project_root, external_session_id, external_turn_id, memory_session_id, active, updated_at)
+            VALUES ('claude', ?, 'unnamed', '__session__', 'ms-live', 1, ?)`,
+      args: [PROJECT_DIR.toLowerCase(), now],
+    });
+
+    // A declared card, findable by the keyword filter.
+    await storeKnowledgeItemDeduped(projectId, {
+      category: 'state', title: 'ui-trial-screen: meta band polish, parked at contrast pass',
+      content: 'Session card.', tags: ['session-card', 'session:ui-session'],
+    } as any, 'test');
+
+    // A pre-tag-era handoff: session id only in content JSON. Real archives
+    // have these, so the fallback is load-bearing, not defensive.
+    await storeKnowledgeItemDeduped(projectId, {
+      category: 'state', title: 'Provider outage stranded an unnamed legacy run',
+      content: JSON.stringify({ kind: 'provider_outage', externalSessionId: 'unnamed-legacy', consumed: false }),
+      tags: ['pending_handoff', 'provider_outage', 'claude'],
+    } as any, 'test');
+
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    const ui = entries.find(entry => entry.sessionId === 'ui-session')!;
+    const unnamed = entries.find(entry => entry.sessionId === 'unnamed')!;
+    expect(ui.status).toBe('interrupted');
+    expect(ui.card).toContain('meta band polish');
+    expect(unnamed.status).toBe('active');
+
+    // Cards are part of intent, so the filter can find a session through one.
+    const byCard = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES, query: 'contrast parked' });
+    expect(byCard.entries.map(entry => entry.sessionId)).toEqual(['ui-session']);
+  });
+
+  it('surfaces knowledge a session promoted, joined through the lifecycle chain', async () => {
+    const client = getClient();
+    // Minimal lifecycle chain: memory session -> binding -> promoted item.
+    const { storeKnowledgeItemDeduped } = await import('../../src/store/knowledge-writer.js');
+    const stored = await storeKnowledgeItemDeduped(projectId, {
+      category: 'decision', title: 'Water shader uses two scrolling layers', content: 'Decided during the ui session.',
+    } as any, 'test');
+    const itemId = stored.item.id;
+    const now = new Date().toISOString();
+    await client.execute({
+      sql: `INSERT INTO memory_sessions (id, title, status, started_at, last_heartbeat_at, expires_at, promotion_status, promotion_items)
+            VALUES ('ms-1', 'Agent turn', 'finished', ?, ?, ?, 'promoted', ?)`,
+      args: [now, now, '2099-01-01T00:00:00Z', JSON.stringify([itemId])],
+    });
+    await client.execute({
+      sql: `INSERT INTO host_session_bindings (host, project_root, external_session_id, external_turn_id, memory_session_id, active, updated_at)
+            VALUES ('claude', ?, 'ui-session', '__session__', 'ms-1', 1, ?)`,
+      args: [PROJECT_DIR.toLowerCase(), now],
+    });
+
+    const { entries } = await listSessionDirectory({ projectDir: PROJECT_DIR, stores: STORES });
+    const ui = entries.find(entry => entry.sessionId === 'ui-session')!;
+    expect(ui.promoted.length).toBeGreaterThan(0);
+    expect(ui.promoted[0]).toContain('Water shader');
+  });
+});

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -490,6 +490,37 @@ describe('Storage Layer', () => {
     expect((await repo.getKnowledgeItem(unrelated.id))!.freshness).toBe('fresh');
   });
 
+  it('should not treat a bare topical tag as a directory during drift checks', async () => {
+    const project = await repo.getProjectByRootPath(TEST_ROOT);
+    const projectId = project!.id;
+
+    const topical = await repo.createKnowledgeItem(projectId, {
+      category: 'decision',
+      title: 'Face of the channel',
+      content: 'A strategy note with no file provenance at all.',
+      sourceCommit: 'base000',
+      tags: ['content', 'brand'],
+    });
+    const pathTagged = await repo.createKnowledgeItem(projectId, {
+      category: 'architecture',
+      title: 'Hook sweep tool',
+      content: 'A note whose tag is written as a real path.',
+      sourceCommit: 'base000',
+      tags: ['content/research/hook-sweep.mjs'],
+    });
+
+    const result = await checkKnowledgeDrift(projectId, {
+      sinceCommit: 'base000',
+      currentCommit: 'head222',
+      changedFiles: ['content/research/hook-sweep.mjs'],
+      apply: true,
+    });
+
+    expect(result.candidates.map(candidate => candidate.itemId)).toEqual([pathTagged.id]);
+    expect((await repo.getKnowledgeItem(topical.id))!.freshness).toBe('fresh');
+    expect((await repo.getKnowledgeItem(pathTagged.id))!.freshness).toBe('needs_review');
+  });
+
   it('should retrieve items hierarchically', async () => {
     const project = await repo.getProjectByRootPath(TEST_ROOT);
     const projectId = project!.id;

--- a/tests/store/transcript-search.test.ts
+++ b/tests/store/transcript-search.test.ts
@@ -379,6 +379,38 @@ describe('transcript search', () => {
     expect(third.embedded).toBe(0);
   });
 
+  // The bug this guards shipped and was invisible: project_dir is an opaque
+  // string key, so on Windows `D:\x`, `d:\x` and `d:/x` became three separate
+  // archives. A real database held the same 59,358 messages three times over
+  // with every embedding attached to one spelling, so searches issued with a
+  // different one scored against a set that had no vectors and quietly returned
+  // lexical results. Every test passed throughout, because tests use one string.
+  it('treats every spelling of a path as the same archive', async () => {
+    const { transcriptVectorStats, embedTranscripts } = await import('../../src/store/transcript-vectors.js');
+    const embedder = { model: 'spelling-model', embed: async (texts: string[]) => texts.map(() => [1, 0]) };
+
+    // Index and embed under the canonical spelling.
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    await embedTranscripts(PROJECT_DIR, embedder, { budgetMs: 30_000 });
+    const canonical = await transcriptVectorStats(PROJECT_DIR, embedder.model);
+    expect(canonical.total).toBeGreaterThan(0);
+
+    // Now ask as a different caller would spell it. Same folder, so the same
+    // archive: not an empty one, and not a second copy waiting to be indexed.
+    for (const spelling of ['d:\\Code\\FakeProject', 'd:/Code/FakeProject', 'D:/Code/FakeProject']) {
+      const stats = await transcriptVectorStats(spelling, embedder.model);
+      expect(stats).toEqual(canonical);
+
+      const fresh = await ensureTranscriptIndex(spelling, STORES);
+      expect(fresh.messagesAdded).toBe(0);
+    }
+
+    const { hits } = await searchTranscripts('boxed card variant rejected', {
+      projectDir: 'd:/Code/FakeProject', stores: STORES, embedBudgetMs: 0,
+    });
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
   it('quantized vectors rank the same way the float vectors did', async () => {
     const { quantize } = await import('../../src/store/transcript-vectors.js');
     // Unit-norm vectors at 8 dims, the shape the scale constant assumes.

--- a/tests/store/transcript-search.test.ts
+++ b/tests/store/transcript-search.test.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { encodeProjectDir, ensureTranscriptIndex, transcriptIndexStats } from '../../src/store/transcript-index.js';
+import { readTranscriptEntry, searchTranscripts } from '../../src/store/transcript-search.js';
+
+const TEST_ROOT = path.resolve('./.knowl-transcript-search-test');
+// A fake transcript store, injected rather than pointed at via HOME: mutating
+// HOME/USERPROFILE leaks into every other suite sharing the worker, and
+// os.homedir() reads USERPROFILE on Windows.
+const FAKE_STORE = path.join(TEST_ROOT, 'store', 'projects');
+const STORES = [FAKE_STORE];
+const PROJECT_DIR = 'D:\\Code\\FakeProject';
+
+function userLine(text: string, ts: string) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { content: text } }) + '\n';
+}
+function assistantLine(text: string, ts: string) {
+  return JSON.stringify({ type: 'assistant', timestamp: ts, message: { content: [{ type: 'text', text }] } }) + '\n';
+}
+function toolLine(result: string, ts: string) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { content: [{ type: 'tool_result', content: result }] } }) + '\n';
+}
+
+let sessionDir: string;
+
+describe('transcript search', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    await repo.createProject(TEST_ROOT, 'Transcript search test');
+
+    sessionDir = path.join(FAKE_STORE, encodeProjectDir(PROJECT_DIR));
+    await fs.mkdir(sessionDir, { recursive: true });
+
+    await fs.writeFile(path.join(sessionDir, 'session-one.jsonl'),
+      // Noise that must never be indexed.
+      userLine('<local-command-caveat>Caveat: ignore me</local-command-caveat>', '2026-01-01T00:00:00Z') +
+      userLine('<command-name>/rename</command-name>', '2026-01-01T00:01:00Z') +
+      // The target: a decision stated by the user.
+      userLine('the boxed card variant read as an advertisement so we rejected it', '2026-01-02T00:00:00Z') +
+      assistantLine('Understood, dropping the boxed variant.', '2026-01-02T00:01:00Z') +
+      // Distractor sharing one term only.
+      assistantLine('The card padding is sixteen pixels.', '2026-01-02T00:02:00Z'));
+
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'),
+      toolLine('boxed card variant advertisement rejected rejected rejected', '2026-01-03T00:00:00Z') +
+      assistantLine('Unrelated discussion about migrations.', '2026-01-03T00:01:00Z'));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    // Windows keeps a handle on the WAL briefly after close, so removal here can
+    // race and throw EBUSY. beforeAll clears the directory anyway, which is the
+    // guarantee the suite actually needs.
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('encodes a project directory the way Claude Code does', () => {
+    expect(encodeProjectDir('D:\\Code\\FakeProject')).toBe('D--Code-FakeProject');
+  });
+
+  it('ranks the user message that states the decision first', async () => {
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].role).toBe('user');
+    expect(hits[0].snippet).toContain('advertisement');
+    expect(hits[0].locator).toMatch(/^transcript:\/\/session-one#L\d+$/);
+  });
+
+  it('never returns the caveat wrapper or a bare slash command', async () => {
+    const { hits } = await searchTranscripts('rename caveat ignore', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    for (const hit of hits) {
+      expect(hit.snippet).not.toContain('local-command-caveat');
+      expect(hit.snippet).not.toContain('<command-name>');
+    }
+  });
+
+  it('indexes tool output but weights it below real prose', async () => {
+    const { hits } = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    // The tool result repeats the term more often, so an unweighted BM25 would
+    // put it first. The user message must still win.
+    expect(hits[0].sessionId).toBe('session-one');
+    expect(hits.some(hit => hit.sessionId === 'session-two')).toBe(true);
+  });
+
+  it('rewards covering every query term over repeating one', async () => {
+    const { hits } = await searchTranscripts('boxed variant advertisement', { projectDir: PROJECT_DIR, limit: 5, stores: STORES });
+    expect(hits[0].snippet).toContain('boxed');
+    expect(hits[0].snippet).toContain('advertisement');
+  });
+
+  it('returns nothing for a query of only stopwords', async () => {
+    const { hits } = await searchTranscripts('the and for', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits).toEqual([]);
+  });
+
+  it('reads a single entry in full from its locator', async () => {
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    const entry = await readTranscriptEntry(hits[0].sessionId, hits[0].line, PROJECT_DIR, STORES);
+    expect(entry?.role).toBe('user');
+    expect(entry?.text).toContain('rejected it');
+  });
+
+  it('re-indexing an unchanged archive adds nothing and opens no files', async () => {
+    const before = await transcriptIndexStats(PROJECT_DIR);
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(result.messagesAdded).toBe(0);
+    expect(result.filesUpdated).toBe(0);
+    expect((await transcriptIndexStats(PROJECT_DIR)).messages).toBe(before.messages);
+  });
+
+  it('picks up appended messages without reindexing what came before', async () => {
+    const before = await transcriptIndexStats(PROJECT_DIR);
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      userLine('the gradient headline was rejected because it looked like a crypto advert', '2026-01-04T00:00:00Z'));
+
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    // Exactly one new message, not the whole file again.
+    expect(result.messagesAdded).toBe(1);
+    expect((await transcriptIndexStats(PROJECT_DIR)).messages).toBe(before.messages + 1);
+
+    const { hits } = await searchTranscripts('gradient headline crypto', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits[0].snippet).toContain('gradient headline');
+  });
+
+  it('rebuilds a session that was rewritten rather than appended to', async () => {
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'),
+      assistantLine('short', '2026-01-05T00:00:00Z'));
+    const result = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(result.messagesAdded).toBeGreaterThan(0);
+    // The old tool-result line is gone, so its distinctive terms no longer match.
+    const { hits } = await searchTranscripts('migrations unrelated', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits.every(hit => hit.sessionId !== 'session-two')).toBe(true);
+  });
+
+  it('detects a same-size in-place rewrite by mtime and rebuilds the session', async () => {
+    // Same byte length, different content - invisible to the size check.
+    const before = assistantLine('the animal is a badger', '2026-01-05T01:00:00Z');
+    const after  = assistantLine('the animal is a ferret', '2026-01-05T01:00:00Z');
+    expect(Buffer.byteLength(after)).toBe(Buffer.byteLength(before));
+
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'), before);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect((await searchTranscripts('badger', { projectDir: PROJECT_DIR, stores: STORES })).hits.length).toBeGreaterThan(0);
+
+    // Rewrite the whole file with the one word changed; size is identical.
+    const content = await fs.readFile(path.join(sessionDir, 'session-one.jsonl'), 'utf8');
+    await fs.writeFile(path.join(sessionDir, 'session-one.jsonl'), content.replace('badger', 'ferret'));
+    // Detection is mtime-based, and a rewrite inside the same clock tick is
+    // indistinguishable - real rewrites happen later than that. Model it.
+    const later = new Date(Date.now() + 5_000);
+    await fs.utimes(path.join(sessionDir, 'session-one.jsonl'), later, later);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    expect((await searchTranscripts('badger', { projectDir: PROJECT_DIR, stores: STORES })).hits).toEqual([]);
+    expect((await searchTranscripts('ferret', { projectDir: PROJECT_DIR, stores: STORES })).hits.length).toBeGreaterThan(0);
+  });
+
+  it('stops at the time budget and resumes where it left off', async () => {
+    // Wipe the index so there is real work to interrupt.
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+    await client.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('delete-all')");
+    await client.execute('DELETE FROM transcript_messages');
+    await client.execute('DELETE FROM transcript_files');
+
+    // A zero budget expires on the first line, so the pass must report itself
+    // incomplete rather than quietly returning a half-built index as finished.
+    const first = await ensureTranscriptIndex(PROJECT_DIR, STORES, 0);
+    expect(first.complete).toBe(false);
+
+    // A generous budget finishes the job, and the total is the whole archive -
+    // proving the interrupted pass resumed instead of restarting or duplicating.
+    const second = await ensureTranscriptIndex(PROJECT_DIR, STORES, 60_000);
+    expect(second.complete).toBe(true);
+
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(hits[0].snippet).toContain('advertisement');
+
+    // No message indexed twice: one locator per line.
+    const all = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 50, stores: STORES });
+    const locators = all.hits.map(hit => hit.locator);
+    expect(new Set(locators).size).toBe(locators.length);
+  });
+
+  it('scopes to one session by id or prefix, which is what makes a handoff brief actionable', async () => {
+    // Own fixture: an earlier test rewrites session-two, so this cannot rely on
+    // the original contents still spanning both sessions.
+    await fs.appendFile(path.join(sessionDir, 'session-two.jsonl'),
+      userLine('a second take on the advertisement question', '2026-01-06T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    const all = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES });
+    expect(new Set(all.hits.map(hit => hit.sessionId)).size).toBeGreaterThan(1);
+
+    const scoped = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES, sessionId: 'session-one' });
+    expect(scoped.hits.length).toBeGreaterThan(0);
+    expect(scoped.hits.every(hit => hit.sessionId === 'session-one')).toBe(true);
+
+    // A prefix resolves the same way, so a brief can quote a short id.
+    const byPrefix = await searchTranscripts('advertisement', { projectDir: PROJECT_DIR, limit: 20, stores: STORES, sessionId: 'session-o' });
+    expect(byPrefix.hits.map(hit => hit.locator)).toEqual(scoped.hits.map(hit => hit.locator));
+  });
+
+  it('defers to another process\'s fresh lease, then reclaims it once stale', async () => {
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      userLine('the lease canary sentence about phosphorescent umbrellas', '2026-01-07T00:00:00Z'));
+
+    // Simulate a live claim by a DIFFERENT process: a fresh stamp this process
+    // never wrote. The file must be skipped without ending the whole pass.
+    await client.execute({
+      sql: "UPDATE transcript_files SET indexed_at = ? WHERE path LIKE '%session-one%'",
+      args: [new Date().toISOString()],
+    });
+    const deferred = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(deferred.complete).toBe(false);
+    const before = await searchTranscripts('phosphorescent umbrellas', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(before.hits).toEqual([]);
+
+    // Expire the claim: a crashed indexer must not stall the file forever.
+    await client.execute({
+      sql: "UPDATE transcript_files SET indexed_at = ? WHERE path LIKE '%session-one%'",
+      args: [new Date(Date.now() - 60_000).toISOString()],
+    });
+    const reclaimed = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(reclaimed.messagesAdded).toBeGreaterThan(0);
+    const after = await searchTranscripts('phosphorescent umbrellas', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(after.hits[0]?.snippet).toContain('phosphorescent');
+  });
+
+  it('drops cached embeddings when their messages are purged, so a reused id cannot inherit a stale vector', async () => {
+    const { getClient } = await import('../../src/store/database.js');
+    const client = getClient();
+
+    // Populate the embedding cache via a semantic search over current content.
+    const semantic = { model: 'purge-model', embed: async (texts: string[]) => texts.map(() => [1, 0]) };
+    // Two matching messages: the semantic pass only engages with >1 candidate.
+    await fs.appendFile(path.join(sessionDir, 'session-two.jsonl'),
+      userLine('embedding purge target phrase', '2026-01-08T00:00:00Z') +
+      assistantLine('a second embedding purge target for the ranker', '2026-01-08T00:01:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    await searchTranscripts('embedding purge target', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    const cached = Number((await client.execute("SELECT COUNT(*) n FROM transcript_embeddings WHERE model = 'purge-model'")).rows[0].n);
+    expect(cached).toBeGreaterThan(0);
+
+    // Rewrite the session so its rows are purged. No embedding row may survive
+    // pointing at a message that no longer exists.
+    await fs.writeFile(path.join(sessionDir, 'session-two.jsonl'), assistantLine('tiny', '2026-01-09T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    const orphans = Number((await client.execute(
+      'SELECT COUNT(*) n FROM transcript_embeddings e LEFT JOIN transcript_messages m ON m.id = e.message_id WHERE m.id IS NULL',
+    )).rows[0].n);
+    expect(orphans).toBe(0);
+  });
+
+  it('fuses a semantic ranking with the lexical one when a reranker is supplied', async () => {
+    // A stub embedder: vectors are keyed off a marker word, so the semantic pass
+    // has a defined preference without downloading a model.
+    const semantic = {
+      model: 'stub-model',
+      embed: async (texts: string[]) => texts.map(text => [text.includes('gradient') ? 1 : 0, text.includes('boxed') ? 1 : 0]),
+    };
+    const { hits } = await searchTranscripts('gradient headline crypto', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].snippet).toContain('gradient');
+  });
+
+  it('degrades to lexical ranking when the reranker throws', async () => {
+    const broken = { model: 'broken', embed: async () => { throw new Error('model unavailable'); } };
+    const { hits } = await searchTranscripts('boxed card variant rejected', { projectDir: PROJECT_DIR, stores: STORES, semantic: broken });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].role).toBe('user');
+  });
+});

--- a/tests/store/transcript-search.test.ts
+++ b/tests/store/transcript-search.test.ts
@@ -277,4 +277,126 @@ describe('transcript search', () => {
     expect(hits.length).toBeGreaterThan(0);
     expect(hits[0].role).toBe('user');
   });
+
+  it('reports coverage as a count, not just as a flag', async () => {
+    // The starved pass needs real work to leave undone. A file whose size matches the stored
+    // offset is skipped without being opened and without consulting the deadline, so a zero
+    // budget against an already-warm archive legitimately COMPLETES — correct behaviour, and
+    // the reason this has to add unindexed material rather than just starve the clock.
+    await fs.writeFile(path.join(sessionDir, 'session-coverage.jsonl'),
+      assistantLine('fresh unindexed material for the coverage assertion', '2026-01-09T00:00:00Z'));
+
+    const starved = await ensureTranscriptIndex(PROJECT_DIR, STORES, 0);
+    expect(starved.complete).toBe(false);
+    // The number is the point: "incomplete" alone cannot tell a caller how much was missed.
+    expect(starved.filesPending).toBeGreaterThan(0);
+    expect(starved.filesPending).toBeLessThanOrEqual(starved.filesScanned);
+
+    const full = await ensureTranscriptIndex(PROJECT_DIR, STORES);
+    expect(full.complete).toBe(true);
+    expect(full.filesPending).toBe(0);
+  });
+
+  it('calls a fruitless search against a partial archive inconclusive, not empty', async () => {
+    // The distinction the old code could not draw. Zero hits against an archive that was only
+    // partly searched does not mean absent, and returning an empty list said it did.
+    // Same reason as above: the starved pass must have genuinely unindexed material to leave.
+    await fs.writeFile(path.join(sessionDir, 'session-inconclusive.jsonl'),
+      assistantLine('further unindexed material so the starved pass stays incomplete', '2026-01-10T00:00:00Z'));
+
+    const partial = await searchTranscripts('nonexistentnonsenseterm', {
+      projectDir: PROJECT_DIR, stores: STORES, indexBudgetMs: 0,
+    });
+    expect(partial.hits).toHaveLength(0);
+    expect(partial.indexComplete).toBe(false);
+    expect(partial.inconclusive).toBe(true);
+
+    // Hits are a real answer even on partial coverage: the caller has something concrete,
+    // and filesPending tells them more may exist.
+    const found = await searchTranscripts('boxed card variant rejected', {
+      projectDir: PROJECT_DIR, stores: STORES, indexBudgetMs: 0,
+    });
+    expect(found.hits.length).toBeGreaterThan(0);
+    expect(found.inconclusive).toBe(false);
+
+    // And on a complete index, absence IS trustworthy — it must not refuse here.
+    const complete = await searchTranscripts('nonexistentnonsenseterm', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(complete.hits).toHaveLength(0);
+    expect(complete.indexComplete).toBe(true);
+    expect(complete.inconclusive).toBe(false);
+  });
+
+  // The reason index-time embeddings exist. Re-ranking a lexical shortlist can
+  // only reorder what BM25 found, so a message that shares NO word with the
+  // query was unreachable however good the embedder was. This is that message.
+  it('finds a message with no lexical overlap with the query at all', async () => {
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'),
+      assistantLine('the mallard prefers still water', '2026-01-11T00:00:00Z'));
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    // A stub embedder that only agrees on one thing: this query and that
+    // message mean the same. Nothing lexical connects them.
+    const semantic = {
+      model: 'duck-model',
+      embed: async (texts: string[]) => texts.map(text =>
+        /mallard|waterfowl/.test(text) ? [1, 0] : [0, 1]),
+    };
+
+    const lexicalOnly = await searchTranscripts('waterfowl', { projectDir: PROJECT_DIR, stores: STORES });
+    expect(lexicalOnly.hits).toHaveLength(0);
+
+    const fused = await searchTranscripts('waterfowl', { projectDir: PROJECT_DIR, stores: STORES, semantic });
+    expect(fused.hits.map(hit => hit.snippet).join(' ')).toContain('mallard');
+    expect(fused.vectorsEmbedded).toBeGreaterThan(0);
+  });
+
+  it('embeds within a budget and resumes, rather than blocking on a large archive', async () => {
+    const { embedTranscripts, transcriptVectorStats } = await import('../../src/store/transcript-vectors.js');
+    const embedder = { model: 'budget-model', embed: async (texts: string[]) => texts.map(() => [1, 0]) };
+
+    // More messages than one batch can hold, or a zero budget would finish the
+    // archive outright and prove nothing about stopping partway.
+    let bulk = '';
+    for (let i = 0; i < 40; i++) bulk += assistantLine(`bulk message number ${i}`, '2026-01-12T00:00:00Z');
+    await fs.appendFile(path.join(sessionDir, 'session-one.jsonl'), bulk);
+    await ensureTranscriptIndex(PROJECT_DIR, STORES);
+
+    // A zero budget still embeds one batch: the deadline is checked per batch,
+    // so the guarantee is bounded work, not zero work.
+    const first = await embedTranscripts(PROJECT_DIR, embedder, { budgetMs: 0 });
+    expect(first.embedded).toBeGreaterThan(0);
+    expect(first.complete).toBe(false);
+    expect(first.remaining).toBeGreaterThan(0);
+
+    const second = await embedTranscripts(PROJECT_DIR, embedder, { budgetMs: 30_000 });
+    expect(second.complete).toBe(true);
+    const stats = await transcriptVectorStats(PROJECT_DIR, embedder.model);
+    expect(stats.embedded).toBe(stats.total);
+
+    // Re-running finds nothing to do: coverage is the resume state, so an
+    // interrupted pass leaves no bookkeeping to repair.
+    const third = await embedTranscripts(PROJECT_DIR, embedder, { budgetMs: 30_000 });
+    expect(third.embedded).toBe(0);
+  });
+
+  it('quantized vectors rank the same way the float vectors did', async () => {
+    const { quantize } = await import('../../src/store/transcript-vectors.js');
+    // Unit-norm vectors at 8 dims, the shape the scale constant assumes.
+    const norm = (v: number[]) => { const n = Math.hypot(...v); return v.map(x => x / n); };
+    const query = norm([0.9, 0.4, 0.1, 0, 0, 0, 0, 0]);
+    const near = norm([0.85, 0.45, 0.15, 0, 0, 0, 0, 0]);
+    const far = norm([0, 0, 0, 0.3, 0.9, 0.2, 0, 0]);
+
+    const dot = (a: number[], b: number[]) => a.reduce((s, v, i) => s + v * b[i], 0);
+    const qi = new Int8Array(quantize(query).buffer);
+    const ints = (v: number[]) => {
+      const d = new Int8Array(quantize(v).buffer);
+      let sum = 0;
+      for (let i = 0; i < qi.length; i++) sum += qi[i] * d[i];
+      return sum;
+    };
+
+    expect(dot(query, near)).toBeGreaterThan(dot(query, far));
+    expect(ints(near)).toBeGreaterThan(ints(far));
+  });
 });

--- a/tests/workspace/resolve.test.ts
+++ b/tests/workspace/resolve.test.ts
@@ -9,6 +9,8 @@ import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js
 import { resolveStorage } from '../../src/store/storage-roles.js';
 import { closeDb } from '../../src/store/database.js';
 import { configuredNamespaces } from '../../src/store/namespaces.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { resetScratchDirs } from '../helpers/scratch.js';
 
 const HOME = path.resolve('./.knowl-resolve-home');
 const A = path.resolve('./.knowl-resolve-a');
@@ -23,7 +25,25 @@ describe('resolveWorkspace', () => {
   beforeEach(async () => {
     process.env.KNOWL_HOME = HOME;
     await closeDb();
-    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    // Pairs with closeDb(): that closes the ambient connection, while peer repositories
+    // opened through the connection pool need releaseAll(). rank-knowledge.test.ts already
+    // pairs them; this suite did not, which is why its fixtures used to survive teardown.
+    await releaseAll();
+
+    // Split deliberately, because the two kinds of fixture have different guarantees.
+    //
+    // A and B hold live libSQL databases, and on Windows the -wal/-shm sidecars stay locked
+    // until after the test that opened them finishes — inside beforeEach that removal simply
+    // cannot succeed, and no retry window fixes it. Best-effort is the honest contract there,
+    // and it is harmless: makeRepo() below rewrites everything this suite reads from them.
+    for (const dir of [A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+
+    // HOME is different: it holds workspace manifests, plain JSON, with no database handle on
+    // it. It CAN always be reset, every assertion here depends on it being empty, and stale
+    // state in it is what actually broke this suite — a run failed with
+    // `ENOENT .knowl-resolve-home/workspaces/ws/workspace.json` and passed 6/6 the moment the
+    // directory was cleared by hand. So this one is enforced rather than swallowed.
+    await resetScratchDirs(HOME);
     await makeRepo(A);
     await makeRepo(B);
     await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
@@ -31,6 +51,9 @@ describe('resolveWorkspace', () => {
   afterEach(async () => {
     delete process.env.KNOWL_HOME;
     await closeDb();
+    await releaseAll();
+    // Still swallowed here, deliberately: a fixture a straggling handle keeps alive must not
+    // fail a test that already passed. beforeEach is where the guarantee is enforced.
     for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,15 @@ export default defineConfig({
     // Several suites are true integration tests that spawn `node dist/index.js`
     // per assertion. Process start-up costs 1-3s on Windows, so vitest's 5s
     // default makes them flake even when the code is correct.
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
+    //
+    // Raised from 30s once it was measured rather than estimated: the dominant cost is not
+    // process spawn but per-test fixture rebuilds that open and close libSQL several times
+    // (tests/store/rank-knowledge.test.ts runs at 27.4s / 29.1s / 28.4s per test IN ISOLATION).
+    // Against a 30s cap those pass alone and fail under parallel load — a red suite that says
+    // nothing about the code. The headroom is the fix for the false signal; the fixture cost
+    // itself is worth attacking separately.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     // Suites delete their own fixtures, but on Windows libSQL holds the -shm sidecar until
     // the owning process lets go, so those removals routinely fail and are swallowed. This
     // sweeps up once, after every worker is done with its files.
@@ -35,13 +42,13 @@ export default defineConfig({
       // there, and `upgrade --all` and `doctor --fix` act on every repo in it -- so a suite
       // that spawns the CLI without this is one bug away from sweeping real projects.
       // Suites needing their own workspace still override this; they just no longer have to.
-      KNOWL_HOME: './.knowl-test-home',
-      // Machine-local Knowl state -- workspace manifests and the known-repository registry --
-      // lives under ~/.knowl by default. Suites that spawn the real CLI would otherwise write
-      // their scratch fixtures into the developer's own home directory, where nothing cleans
-      // them up and a later `knowl upgrade --all` would try to visit them. Absolute because a
-      // spawned CLI runs with its fixture as the working directory, and `knowlHome()` resolves
-      // a relative override against that. `.knowl-` prefixed, so global teardown sweeps it.
+      //
+      // ABSOLUTE, and declared exactly once. This key was previously written twice in this
+      // object -- './.knowl-test-home' then the resolved path -- so the safety above held only
+      // because a later duplicate key silently wins. A relative value is genuinely wrong here:
+      // a spawned CLI runs with its fixture as the working directory and `knowlHome()` resolves
+      // a relative override against THAT, which would put scratch state inside the fixture.
+      // `.knowl-` prefixed, so global teardown sweeps it.
       KNOWL_HOME: path.resolve('./.knowl-test-home'),
     },
   },


### PR DESCRIPTION
Stacked on #7, #8 and #10 — review the last two commits.

## The bound this removes

Semantic search re-ranked BM25's top 50. That means it could reorder keyword results but never reach past them, so the query the feature exists to serve was structurally unreachable: **the one where the words you remember are not the words that were used.** That message is never in the shortlist, and no embedding model can fix a candidate set it never sees.

Every indexed message now carries a vector. The lexical and semantic orders are built independently over the whole archive and fused with RRF, so a message sharing *no word* with the query can win outright. There is a test for exactly that, and it fails against the old design.

## Why int8 and not the published answer

Storing float32 for a 69k-message archive is 106 MB to read and multiply per query, so the representation has to shrink. The [sentence-transformers guidance](https://sbert.net/examples/sentence_transformer/applications/embedding-quantization/README.html) says binary quantization retains ~96% of retrieval quality with a rescoring pass, so I measured it here — 350 project atoms, 17 recall queries, float32 reference MRR 0.662:

| | MRR | size (69k msgs) | full scan |
|---|---|---|---|
| float32 | 0.662 | 106 MB | 91 ms |
| **int8** | **0.668** | **27 MB** | **36 ms** |
| binary | 0.310 | 3.3 MB | 5 ms |
| binary + float32 rescore | 0.664 | 110 MB | — |

Binary collapsed. The published figures come from 1024-dim models; at 384 dims one sign bit per dimension is not enough information to hold the ranking. Recovering it needs a float32 rescoring pass, which means storing the float32 vectors *as well* — 4x the disk to undo damage the compression caused. int8 measured no loss at a quarter the size with no rescoring stage at all.

The scale is `6 / sqrt(dims)` rather than a constant: L2-normalised components have RMS `1/sqrt(dims)`, so this clips at ~6 sigma and adapts to any model's dimensionality. For 384-dim bge-small it gives 0.306, against a measured largest component of 0.327 and p99.9 of 0.262.

Brute force rather than ANN, on purpose: 36 ms needs no index, and an index costs rebuilds, recall knobs, and a native extension `@libsql/client` cannot load anyway.

## Operationally

- `knowl reindex --transcripts [--budget <minutes>]` backfills. Resumable by construction — "messages with no vector" *is* the resume state, so an interrupted pass leaves no bookkeeping to repair.
- Searches top up ~1.5s worth, newest first, so an archive warms as it is used and the current session's messages are covered first.
- The MCP footer reports coverage as `embedded/indexed`. "BM25 + semantic" over 2% of an archive is a different claim from the same words over all of it, and only one of them justifies trusting a near-miss result.
- Vectors for a superseded model are dropped on the next pass. There is now one vector per *message* rather than per re-ranked candidate, so a stale model's copy is a full dead duplicate of the archive.

## Three concurrency bugs, each found by running a real backfill

None of these were theoretical — a 41k-message job beside a live session hit all three.

1. **Bootstrap had no retry on a contended open.** Opening a database runs migrations and DDL — real writes — against a database other sessions are also writing to. The whole command died on a transient lock.
2. **No `busy_timeout` anywhere.** SQLite's default busy handler gives up instantly. Survivable while indexing ran in 8-second slices inside the process holding the lock; not survivable for anything longer. Set at the connection, so statements nobody thought to wrap are covered too.
3. **A connection pinned to a stale read snapshot can never commit again.** `SQLITE_BUSY_SNAPSHOT` is permanent for that connection, so backing off waits for a condition only a reconnect clears. Measured directly: a fresh process wrote the same database in **71 ms** while the long-lived job had been failing on it for **fourteen minutes**. The backfill now reconnects and resumes.

Point 3 is also why the per-batch progress count had to go: it was a `LEFT JOIN` over every message in the project, running after each batch of 16, interleaved with the writes it was reporting on.


---

## Update: the model underneath this changed, and one number above is superseded

**Model.** `bge-small-en-v1.5` → `granite-embedding-small-english-r2`, measured the same way, all rows from one session on one corpus snapshot:

| model | pooling | @1 | @3 | MRR |
|---|---|---|---|---|
| **granite-embedding-small-english-r2** | **CLS** | **59%** | **94%** | **0.750** |
| bge-small-en-v1.5 | mean | 53% | 65% | 0.621 |
| granite-embedding-97m-multilingual-r2 | CLS | 47% | 76% | 0.643 |
| granite-embedding-97m-multilingual-r2 | mean | 18% | 29% | 0.337 |

The multilingual model of triple the size is not better on an English corpus. The last row is the same weights as the row above it with the wrong pooling — which is why pooling now follows the model family instead of being hardcoded, and why that has tests.

**Correction.** An earlier commit message here cites **61 ms/doc** for embedding, taken from the atom corpus (~2,000 chars/doc). Real transcript messages have a median of **169 characters**, and the measured production rate is **42 ms/doc** for bge-small and **60 ms/doc** for granite. The 61 figure was never wrong for what it measured; it was the wrong corpus to quote for this workload. Full 58k-message backfill: ~48 min then, ~54 min now.

**Vector storage is unaffected** — Granite is also 384 dimensions, so every int8 quantization measurement above still holds.
