### PR TITLE
fix(serve): complete the MCP handshake before opening the database

### DIFF
--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -3,6 +3,7 @@ import fsPromises from 'node:fs/promises';
 import { ProjectConfig } from '../core/types.js';
 import { KnowledgeEmbedder } from '../store/vector-index.js';
 import { fingerprintProfile, resolveVectorProfile, type VectorPooling } from '../core/vector-profile.js';
+import { noteModelLoad } from '../core/startup-trace.js';
 
 type TransformersPipeline = (texts: string[], options: { pooling: VectorPooling; normalize: boolean }) => Promise<{
   data: Float32Array | number[];
@@ -124,6 +125,10 @@ export async function createLocalEmbeddingProvider(
       .then(() => true)
       .catch(() => false);
     options.onFirstLoad?.({ model: vector.model, cacheDir, cached });
+    // How long building the pipeline actually costs, recorded rather than assumed. The model
+    // was blamed for stalls it cannot cause -- serve never loads one during startup -- and the
+    // only way that claim gets settled is a number per process, per model, cold and warm.
+    const loadStartedAt = Date.now();
     if (options.loadPipeline) {
       localPipeline = await options.loadPipeline(vector.model, vector.dtype, cacheDir);
     } else {
@@ -133,6 +138,7 @@ export async function createLocalEmbeddingProvider(
         dtype: vector.dtype as any,
       }) as TransformersPipeline;
     }
+    noteModelLoad(vector.model, cached, Date.now() - loadStartedAt);
     localPipelineKey = pipelineKey;
   }
 

--- a/src/cli/startup-report.ts
+++ b/src/cli/startup-report.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import { startupLogPath } from '../core/startup-trace.js';
+
+/**
+ * Read the startup trace back as an answer, not as a log.
+ *
+ * The question this exists to settle is "why did the server drop, and did the change fix it" —
+ * so it reports the two things that decide that: how long boots take now, and which phase owns
+ * the time. A boot that started and never ended is the signature of a host kill, and it is
+ * counted separately, because a kill leaves no summary line of its own to count.
+ */
+
+interface Record_ { event: string; [k: string]: any }
+
+const percentile = (sorted: number[], p: number): number =>
+  sorted.length ? sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))] : 0;
+
+export function formatStartupReport(sinceHours: number): string {
+  const file = startupLogPath();
+  if (!fs.existsSync(file)) {
+    return `No startup trace yet at ${file}\nIt is written by \`knowl serve\`; start a session and re-run.`;
+  }
+
+  const cutoff = Date.now() - sinceHours * 3600_000;
+  const records: Record_[] = [];
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const r = JSON.parse(line);
+      if (r.at && Date.parse(r.at) >= cutoff) records.push(r);
+    } catch { /* a torn final line from a killed process is expected */ }
+  }
+  if (!records.length) return `No serve startups recorded in the last ${sinceHours}h (${file})`;
+
+  const starts = records.filter(r => r.event === 'boot-start');
+  const ends = records.filter(r => r.event === 'boot-end');
+  const stalls = records.filter(r => r.event === 'stall');
+  const models = records.filter(r => r.event === 'model-load');
+  const crashes = records.filter(r => r.event === 'crash' || r.event === 'signal' || r.event === 'exit-before-ready');
+
+  const endedIds = new Set(ends.map(r => r.bootId));
+  const neverReady = starts.filter(r => !endedIds.has(r.bootId));
+
+  const out: string[] = [];
+  out.push(`KNOWL SERVE STARTUP — last ${sinceHours}h`);
+  out.push(`  source: ${file}`);
+  out.push('');
+  out.push(`  boots started            ${starts.length}`);
+  out.push(`  boots that became ready  ${ends.length}`);
+  out.push(`  never became ready       ${neverReady.length}${neverReady.length ? '   <-- killed or crashed before initialization finished' : ''}`);
+  out.push(`  watchdog stalls (>5s)    ${stalls.length}`);
+
+  const totals = ends.map(r => r.totalMs as number).sort((a, b) => a - b);
+  if (totals.length) {
+    out.push('');
+    out.push(`  time to ready   p50 ${percentile(totals, 50)}ms   p95 ${percentile(totals, 95)}ms   max ${totals[totals.length - 1]}ms`);
+  }
+
+  // Which phase owns the time. This is the whole point: "startup was slow" was already known.
+  const perPhase = new Map<string, number[]>();
+  for (const end of ends) {
+    for (const phase of end.phases ?? []) {
+      if (!perPhase.has(phase.name)) perPhase.set(phase.name, []);
+      perPhase.get(phase.name)!.push(phase.ms);
+    }
+  }
+  if (perPhase.size) {
+    out.push('');
+    out.push('  PHASE            p50      p95      max     n');
+    for (const [name, list] of perPhase) {
+      const s = [...list].sort((a, b) => a - b);
+      out.push(
+        `  ${name.padEnd(16)}${String(percentile(s, 50) + 'ms').padEnd(9)}` +
+        `${String(percentile(s, 95) + 'ms').padEnd(9)}${String(s[s.length - 1] + 'ms').padEnd(8)}${s.length}`
+      );
+    }
+  }
+
+  if (models.length) {
+    const cold = models.filter(m => !m.cached);
+    const warm = models.filter(m => m.cached);
+    out.push('');
+    out.push('  EMBEDDING MODEL LOADS');
+    for (const [label, list] of [['cold (weights absent)', cold], ['warm (weights on disk)', warm]] as const) {
+      if (!list.length) continue;
+      const ms = list.map(m => m.ms as number).sort((a, b) => a - b);
+      out.push(`    ${label.padEnd(24)} n=${String(list.length).padEnd(4)} p50 ${percentile(ms, 50)}ms  max ${ms[ms.length - 1]}ms  (${list[0].model})`);
+    }
+    // `bootId` is what distinguishes a serve boot from an ordinary CLI run. Every CLI
+    // invocation loads a model with no startup trace running, so `afterReady` is false for
+    // reasons that have nothing to do with a handshake -- counting those reported a startup
+    // problem that did not exist.
+    const onDeadline = models.filter(m => m.bootId && m.afterReady === false);
+    out.push(`    loads on a serve startup path: ${onDeadline.length}` +
+      (onDeadline.length ? '   <-- these DO sit on the connect deadline' : '   (none — a model load never delays a handshake)'));
+  }
+
+  if (stalls.length) {
+    out.push('');
+    out.push('  STALLS (phase running when the watchdog fired)');
+    const byPhase = new Map<string, number>();
+    for (const s of stalls) byPhase.set(s.phase ?? 'unknown', (byPhase.get(s.phase ?? 'unknown') ?? 0) + 1);
+    for (const [phase, n] of [...byPhase.entries()].sort((a, b) => b[1] - a[1])) {
+      out.push(`    ${String(phase).padEnd(18)} ${n}`);
+    }
+    const worst = stalls.slice().sort((a, b) => (b.elapsedMs ?? 0) - (a.elapsedMs ?? 0))[0];
+    out.push(`    worst: ${worst.elapsedMs}ms in "${worst.phase}" (pid ${worst.pid}, ${worst.at})`);
+  }
+
+  if (crashes.length) {
+    out.push('');
+    out.push('  ABNORMAL EXITS');
+    for (const c of crashes.slice(-8)) {
+      out.push(`    ${c.at}  ${c.event}${c.kind ? '/' + c.kind : ''}${c.signal ? '/' + c.signal : ''}  phase=${c.phase ?? 'n/a'}  ${String(c.message ?? '').slice(0, 90)}`);
+    }
+  }
+
+  // Concurrent boots are the contention hypothesis stated as a number: if stalls cluster where
+  // boots overlap, the cause is the neighbours, not the repo.
+  const buckets = new Map<string, number>();
+  for (const s of starts) buckets.set(String(s.at).slice(0, 16), (buckets.get(String(s.at).slice(0, 16)) ?? 0) + 1);
+  const bursts = [...buckets.entries()].filter(([, n]) => n >= 3).sort((a, b) => b[1] - a[1]);
+  if (bursts.length) {
+    out.push('');
+    out.push('  CONCURRENT BOOT BURSTS (>=3 servers starting in the same minute)');
+    for (const [minute, n] of bursts.slice(0, 8)) out.push(`    ${minute}   ${n} servers`);
+  }
+
+  return out.join('\n');
+}

--- a/src/core/startup-trace.ts
+++ b/src/core/startup-trace.ts
@@ -1,0 +1,235 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { knowlHome } from '../workspace/paths.js';
+
+/**
+ * Why a `knowl serve` startup took as long as it did.
+ *
+ * The host gives an MCP server a fixed window to complete its handshake -- 30s in Claude
+ * Code, configurable via `MCP_TIMEOUT` -- and kills the process when it expires. A server
+ * killed that way leaves almost nothing behind: the last thing on stderr is whatever it
+ * happened to print before it stalled, which says where it got to but never why. Diagnosing
+ * one from the outside is guesswork, and guesswork picks the most visible suspect rather
+ * than the responsible one.
+ *
+ * So the boot reports on itself. Three properties, each answering a way an after-the-fact
+ * investigation cannot:
+ *
+ * 1. **It reports from inside a hang, not after it.** A process killed at the deadline never
+ *    reaches its own summary line, so a summary-only design is silent in exactly the case
+ *    worth diagnosing. A watchdog fires at 5s/15s/25s -- inside the host's window -- and
+ *    names the phase that is *currently* running.
+ * 2. **It writes to both stderr and a file.** stderr lands in the host's own MCP log beside
+ *    the host's timeout line, so cause and effect sit in one place. The file survives the
+ *    kill, and it is machine-wide rather than per-project, which is the only way to see
+ *    several servers stalling in the same second -- the signature of contention between
+ *    processes rather than of any one project being slow.
+ * 3. **It is silent when healthy.** A fast boot prints nothing to stderr and appends one line
+ *    to the durable log, so the healthy distribution stays measurable without making normal
+ *    operation noisy. Diagnostics that shout during normal operation get ignored during
+ *    abnormal operation.
+ *
+ * Never throws and never blocks: a diagnostic that can fail a startup is worse than no
+ * diagnostic. Set KNOWL_DISABLE_STARTUP_TRACE=1 to turn it off.
+ */
+
+type Phase = { name: string; startedAt: number; endedAt?: number };
+
+const WATCHDOG_MARKS_MS = [5_000, 15_000, 25_000];
+
+let bootId = '';
+let bootStartedAt = 0;
+let phases: Phase[] = [];
+let current: Phase | null = null;
+let modelLoad: { model: string; cached: boolean; ms: number } | null = null;
+let timers: NodeJS.Timeout[] = [];
+let finished = false;
+let active = false;
+
+const now = () => Date.now();
+const enabled = () => process.env.KNOWL_DISABLE_STARTUP_TRACE !== '1';
+
+export function diagnosticsDir(): string {
+  return path.join(knowlHome(), 'diagnostics');
+}
+
+export function startupLogPath(): string {
+  return path.join(diagnosticsDir(), 'serve-startup.jsonl');
+}
+
+/**
+ * Append one record. Synchronous on purpose: this is called from watchdogs and exit handlers,
+ * where an async write may never flush before the process dies -- which is precisely the
+ * record worth keeping.
+ */
+function append(record: Record<string, unknown>): void {
+  try {
+    fs.mkdirSync(diagnosticsDir(), { recursive: true });
+    fs.appendFileSync(startupLogPath(), JSON.stringify(record) + '\n');
+  } catch {
+    // A diagnostic must never be the reason a server fails to start.
+  }
+}
+
+function emitStderr(line: string): void {
+  try {
+    process.stderr.write(line + '\n');
+  } catch {
+    /* stdio may already be torn down */
+  }
+}
+
+function elapsed(): number {
+  return now() - bootStartedAt;
+}
+
+function snapshot() {
+  return {
+    bootId,
+    pid: process.pid,
+    elapsedMs: elapsed(),
+    phase: current ? current.name : null,
+    phaseMs: current ? now() - current.startedAt : null,
+    done: phases.filter(p => p.endedAt).map(p => `${p.name}=${p.endedAt! - p.startedAt}ms`),
+  };
+}
+
+export function beginStartupTrace(context: { projectRoot?: string | null; version?: string } = {}): void {
+  if (!enabled() || active) return;
+  active = true;
+  finished = false;
+  bootStartedAt = now();
+  // No crypto import for an identifier that only has to be unique among concurrent boots.
+  bootId = `${process.pid.toString(36)}-${bootStartedAt.toString(36)}`;
+  phases = [];
+  modelLoad = null;
+
+  append({
+    event: 'boot-start',
+    at: new Date(bootStartedAt).toISOString(),
+    bootId,
+    pid: process.pid,
+    projectRoot: context.projectRoot ?? process.cwd(),
+    version: context.version ?? null,
+    node: process.version,
+    host: os.hostname(),
+    // Load average is the cheapest cross-platform proxy for "this machine is busy right
+    // now", which is the leading explanation for a startup that is slow only sometimes.
+    // Windows always reports zeroes, so it is recorded rather than interpreted.
+    loadavg: os.loadavg(),
+    freemem: os.freemem(),
+  });
+
+  for (const mark of WATCHDOG_MARKS_MS) {
+    const timer = setTimeout(() => {
+      if (finished) return;
+      const state = snapshot();
+      emitStderr(
+        `[knowl serve] STALL bootId=${state.bootId} elapsed=${state.elapsedMs}ms ` +
+        `phase=${state.phase ?? 'unknown'} phaseMs=${state.phaseMs ?? 0} ` +
+        `done=[${state.done.join(' ')}]`
+      );
+      append({
+        event: 'stall',
+        at: new Date().toISOString(),
+        mark,
+        ...state,
+        // A machine with little free memory pages the database file in and out and makes
+        // opening it slow for reasons no per-phase timing would explain on its own. Sampled
+        // at the moment of the stall, not at boot, so it describes the conditions during it.
+        freemem: os.freemem(),
+        loadavg: os.loadavg(),
+      });
+    }, mark);
+    // A diagnostic timer must not be the reason the process stays alive.
+    timer.unref?.();
+    timers.push(timer);
+  }
+
+  // How the process actually died. "Killed by the host at the deadline" and "crashed during
+  // bootstrap" look identical from the outside, and they need opposite fixes.
+  process.once('uncaughtException', (error) => {
+    append({ event: 'crash', at: new Date().toISOString(), kind: 'uncaughtException', message: String(error?.message ?? error), ...snapshot() });
+    throw error;
+  });
+  process.once('unhandledRejection', (reason) => {
+    append({ event: 'crash', at: new Date().toISOString(), kind: 'unhandledRejection', message: String(reason), ...snapshot() });
+  });
+  for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
+    process.once(signal, () => {
+      append({ event: 'signal', at: new Date().toISOString(), signal, ...snapshot() });
+      process.exit(0);
+    });
+  }
+  process.once('exit', (code) => {
+    if (!finished) {
+      append({ event: 'exit-before-ready', at: new Date().toISOString(), code, ...snapshot() });
+    }
+  });
+}
+
+/** Time one named startup phase, and make it the phase a watchdog would report. */
+export async function tracePhase<T>(name: string, run: () => Promise<T>): Promise<T> {
+  if (!enabled() || !active) return run();
+  const phase: Phase = { name, startedAt: now() };
+  phases.push(phase);
+  current = phase;
+  try {
+    return await run();
+  } finally {
+    phase.endedAt = now();
+    if (current === phase) current = null;
+  }
+}
+
+/** Called once per process when the embedding pipeline is actually built. */
+export function noteModelLoad(model: string, cached: boolean, ms: number): void {
+  if (!enabled()) return;
+  modelLoad = { model, cached, ms };
+  append({
+    event: 'model-load',
+    at: new Date().toISOString(),
+    bootId: bootId || null,
+    pid: process.pid,
+    model,
+    cached,
+    ms,
+    // Whether a model load ever lands on the connect deadline is the question that decides
+    // whether the model can be responsible for a failed handshake at all.
+    afterReady: finished,
+    sinceBootMs: bootStartedAt ? elapsed() : null,
+  });
+}
+
+/** The handshake completed. Records the full phase breakdown and silences the watchdogs. */
+export function finishStartupTrace(outcome: { ok: boolean; initError?: string | null; vectorModel?: string | null }): void {
+  if (!enabled() || !active || finished) return;
+  finished = true;
+  for (const timer of timers) clearTimeout(timer);
+  timers = [];
+
+  const totalMs = elapsed();
+  const record = {
+    event: 'boot-end',
+    at: new Date().toISOString(),
+    bootId,
+    pid: process.pid,
+    totalMs,
+    ok: outcome.ok,
+    initError: outcome.initError ?? null,
+    vectorModel: outcome.vectorModel ?? null,
+    phases: phases.map(p => ({ name: p.name, ms: (p.endedAt ?? now()) - p.startedAt })),
+    modelLoad,
+  };
+  append(record);
+
+  // Only speak up on stderr when the boot was slow enough to be worth explaining. The host
+  // renders every stderr line as an error, so a healthy boot stays quiet.
+  if (totalMs >= 5_000) {
+    emitStderr(
+      `[knowl serve] SLOW-BOOT ${totalMs}ms bootId=${bootId} ` +
+      record.phases.map(p => `${p.name}=${p.ms}ms`).join(' ')
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2137,5 +2137,20 @@ program
     }
   });
 
+// --- 17. STARTUP DIAGNOSTICS ---
+program
+  .command('diagnose-startup')
+  .description('Report why `knowl serve` startups were slow: per-phase timings, SQLite contention, stalls and host kills')
+  .option('--since <hours>', 'How far back to look', '48')
+  .action(async (options) => {
+    const { formatStartupReport } = await import('./cli/startup-report.js');
+    const hours = Number(options.since);
+    if (!Number.isFinite(hours) || hours <= 0) {
+      console.error('--since must be a positive number of hours');
+      process.exit(1);
+    }
+    console.log(formatStartupReport(hours));
+  });
+
 // Parse commands
 program.parse(process.argv);

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -10,7 +10,11 @@ import { formatInitError } from './init-error.js';
 export function registerResources(
   server: Server,
   getProjectId: () => string | null,
-  getInitError: () => string | null
+  getInitError: () => string | null,
+  // Same reason as `registerTools`: the handshake now completes before the database is open,
+  // so a read arriving early would see neither a project id nor an init error and proceed
+  // against null. Listing resources is a static literal and needs no such wait.
+  whenReady: () => Promise<void> = async () => {}
 ): void {
   // 1. List resources
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
@@ -35,6 +39,7 @@ export function registerResources(
   // 2. Read resource
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const { uri } = request.params;
+    await whenReady();
     const initError = getInitError();
     const projectId = getProjectId();
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,8 +11,26 @@ import {
   KNOWL_MCP_TOOL_NAMES,
   mcpServerInstructions,
 } from '../core/knowl-guidance.js';
+import { beginStartupTrace, finishStartupTrace, tracePhase } from '../core/startup-trace.js';
 
 export { KNOWL_MCP_TOOL_NAMES };
+
+/**
+ * Values the server does not have yet when it is built.
+ *
+ * `startMcpServer` completes the handshake before the database is open, so its project id,
+ * root and config arrive later. Passing getters rather than values lets the same server
+ * object serve both callers: tests hand over settled values positionally, and the real
+ * startup hands over a window onto variables it is still filling in.
+ */
+export interface DeferredServerState {
+  getProjectId?: () => string | null;
+  getProjectRoot?: () => string | null;
+  getConfig?: () => ProjectConfig | null;
+  getInitError?: () => string | null;
+  /** Resolves once initialization has settled, successfully or not. */
+  whenReady?: () => Promise<void>;
+}
 
 /**
  * Creates and configures the MCP Server.
@@ -21,7 +39,8 @@ export function createMcpServer(
   projectId: string | null,
   projectRoot: string | null,
   config: ProjectConfig | null,
-  initError: string | null = null
+  initError: string | null = null,
+  deferred: DeferredServerState = {}
 ): Server {
   const server = new Server(
     {
@@ -38,18 +57,23 @@ export function createMcpServer(
   );
 
   // Register tools and resources
+  const getProjectId = deferred.getProjectId ?? (() => projectId);
+  const getInitError = deferred.getInitError ?? (() => initError);
+
   registerTools(
     server,
-    () => projectId,
-    () => projectRoot,
-    () => config,
-    () => initError
+    getProjectId,
+    deferred.getProjectRoot ?? (() => projectRoot),
+    deferred.getConfig ?? (() => config),
+    getInitError,
+    deferred.whenReady ?? (async () => {})
   );
 
   registerResources(
     server,
-    () => projectId,
-    () => initError
+    getProjectId,
+    getInitError,
+    deferred.whenReady ?? (async () => {})
   );
 
   return server;
@@ -57,44 +81,80 @@ export function createMcpServer(
 
 /**
  * Utility to start the stdio transport server.
+ *
+ * **The handshake completes before the database opens, deliberately.**
+ *
+ * The host allows 30s for an MCP server to connect and then kills it. Opening the database
+ * runs `bootstrapSchema` -- real writes -- against a file every other live session is also
+ * writing to, and the pool waits out a lock rather than failing on it: `busy_timeout` is 10s
+ * and `acquireClient` retries five times. That is a bound of roughly 50s of legitimate,
+ * working-as-designed waiting on a 30s deadline, so a busy machine could not help but lose
+ * the race. Twenty-two recorded kills across four repos are that arithmetic, not a fault.
+ *
+ * Nothing in the handshake needs the database: the tool list is a static literal and the
+ * declared capabilities are constants. So connect first and initialize behind it. Tool calls
+ * await `ready`, and they answer to the tool-call timeout -- hours, not seconds -- which is
+ * the right clock for work whose duration depends on what other processes are doing.
+ *
+ * The startup trace deliberately stays armed until initialization settles, so a database that
+ * is still stuck at 25s says so on stderr even though the handshake itself already succeeded.
  */
 export async function startMcpServer(): Promise<void> {
+  beginStartupTrace({ version: PACKAGE_VERSION });
+
   let projectRoot: string | null = null;
   let config: ProjectConfig | null = null;
   let project: any = null;
   let initError: string | null = null;
 
-  try {
-    projectRoot = await findProjectRoot(process.cwd());
-    config = await loadConfig(projectRoot);
-    
-    // Init DB. AI is optional and initialized lazily only for AI-backed tools.
-    await initDb(projectRoot);
+  // Never rejects: every failure is captured as `initError`, which the tools already render
+  // for the user. An unhandled rejection here would take down a server that is otherwise fine.
+  const ready = (async () => {
+    try {
+      projectRoot = await tracePhase('findProjectRoot', () => findProjectRoot(process.cwd()));
+      config = await tracePhase('loadConfig', () => loadConfig(projectRoot!));
 
-    // Get project details
-    project = await getProjectByRootPath(projectRoot);
-    if (!project) {
-      throw new Error('Knowl project is not initialized. Run "knowl init" first.');
+      // Init DB. AI is optional and initialized lazily only for AI-backed tools.
+      await tracePhase('initDb', () => initDb(projectRoot!));
+
+      // Get project details
+      project = await tracePhase('getProject', () => getProjectByRootPath(projectRoot!));
+      if (!project) {
+        throw new Error('Knowl project is not initialized. Run "knowl init" first.');
+      }
+    } catch (error: any) {
+      initError = error.message;
     }
-  } catch (error: any) {
-    initError = error.message;
-  }
+  })();
 
+  const server = createMcpServer(null, null, null, null, {
+    getProjectId: () => (project ? project.id : null),
+    getProjectRoot: () => projectRoot,
+    getConfig: () => config,
+    getInitError: () => initError,
+    whenReady: () => ready,
+  });
+
+  const transport = new StdioServerTransport();
+  await tracePhase('connect', () => server.connect(transport));
+
+  // Printed after the handshake rather than after initialization: this line is the host log's
+  // proof that the process is alive and talking, and it used to be withheld until the slowest
+  // part of startup had finished -- which is why a stalled boot left no evidence but a banner.
   process.stderr.write(
     [
       '[knowl serve]',
       `pid=${process.pid}`,
-      projectRoot ? `projectRoot=${projectRoot}` : 'projectRoot=unresolved',
+      'projectRoot=pending',
       'note=host-owned stdio process; one serve process per connected host session; hooks use agent-hook and do not spawn serve',
     ].join(' ') + '\n'
   );
 
-  const server = createMcpServer(
-    project ? project.id : null,
-    projectRoot,
-    config,
-    initError
-  );
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  void ready.then(() => {
+    finishStartupTrace({
+      ok: !initError,
+      initError,
+      vectorModel: (config as any)?.search?.vector?.model ?? null,
+    });
+  });
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -79,7 +79,11 @@ export function registerTools(
   getProjectId: () => string | null,
   getProjectRoot: () => string | null,
   getConfig: () => ProjectConfig | null,
-  getInitError: () => string | null
+  getInitError: () => string | null,
+  // Startup completes the handshake before the database is open (see `startMcpServer`), so a
+  // tool call can arrive while project id, root and config are all still null. Awaiting this
+  // is what makes that restructure invisible to every handler below.
+  whenReady: () => Promise<void> = async () => {}
 ): void {
   // 1. List tools
   server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -725,6 +729,7 @@ export function registerTools(
   // 2. Call tool
   const callTool = async (request: CallToolRequest): Promise<CallToolResult> => {
     const { name, arguments: args } = request.params;
+    await whenReady();
     const initError = getInitError();
     const projectId = getProjectId();
     const projectRoot = getProjectRoot();
@@ -1378,6 +1383,9 @@ export function registerTools(
    * notice" -- memory news must never be able to fail a tool call.
    */
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    // Before `getProjectRoot()`, not just before dispatch: startup fills that variable in
+    // behind the handshake, and reading it early would take a watermark against `null`.
+    await whenReady();
     const projectRoot = getProjectRoot();
     const watermark = await captureChangeWatermark(projectRoot);
     const result = await callTool(request);


### PR DESCRIPTION
`startMcpServer` opens the database, runs `bootstrapSchema` and looks the project up **before** it connects the transport. The host allows a fixed window for the handshake — 30s in Claude Code, configurable with `MCP_TIMEOUT` — and kills the process when it expires. So every one of those steps is charged against a deadline none of them knows about.

## Why this is worth fixing

None of that work is needed to answer `initialize`. The tool list is a static literal, the declared capabilities are constants, and the resource list is static too. The database is needed by tool *calls*, and those answer to the tool-call timeout instead — hours rather than seconds, which is the right clock for work whose duration depends on what other processes are doing to the same file.

And `bootstrapSchema` is not a cheap open. Every read-write open runs the base statements, `migrateLegacyProjectSchema`, the schema statements, ten `ensure*Columns` passes, `backfillKnowledgeAssertions` and `repairSkillForeignKeys`. That is real write work against a file other Knowl processes may be opening at the same moment — one per connected session, plus anything started from a terminal. It is usually fast and occasionally not, and when it is not, the whole server dies rather than that one open merely being slow.

The failure is silent in a particularly unhelpful way: the host kills the process, and the only thing in its log is the boot banner, because the line printed after the database opens never runs. There is nothing to distinguish "hung opening the database" from "crashed on startup".

## How I hit it

In my host's MCP logs there are 22 kills of exactly this shape — `connection timed out after 30000ms`, stderr ending at the boot banner — across four projects, sometimes several within the same second, which is the signature of processes contending rather than of any one project being slow.

**Being straight about the conditions:** I run a fork that adds `busy_timeout` and a retry loop to `acquireClient`, which makes a contended open wait rather than fail, and that is what turns this from "occasionally slow" into "reliably fatal" on a busy machine. This repo has neither, so the exposure here is smaller. But the structural problem — unbounded work sitting on a bounded deadline — is the same in this codebase, and a slow open for any reason (large migration, slow or network-backed disk, a machine under load) lands on the connect deadline today.

## The change

**Connect first, initialize behind it.** Tool calls and resource reads await readiness. A failure still surfaces exactly as before: the error is captured and rendered through `formatInitError`.

The wait is awaited in three places rather than one — inside `callTool`, in the `CallToolRequest` wrapper *before* it reads `projectRoot` for the change watermark, and in `ReadResource`, which would otherwise see neither a project id nor an init error and proceed against `null`. `createMcpServer` keeps its positional signature and gains an optional `DeferredServerState`, so every existing caller — the tests among them — is unchanged.

The banner now prints straight after the handshake rather than after initialization, so a stalled boot is distinguishable from a dead one in the host log.

**Plus a startup trace,** because this took far longer to diagnose than it should have. A watchdog fires at 5s/15s/25s — inside the host's window — and names the phase currently running, since a process killed at the deadline never reaches its own summary line. It writes to stderr (landing in the host's MCP log beside the host's own timeout line) and to a machine-wide JSONL that survives the kill and spans projects. It is silent on healthy boots. `knowl diagnose-startup [--since <hours>]` reads it back: boots started vs became ready, per-phase percentiles, model load times split cold/warm, stalls by owning phase, and concurrent-boot bursts. `KNOWL_DISABLE_STARTUP_TRACE=1` turns it off.

Model loads are timed because "the embedding model is what makes startup slow" is the intuitive explanation and it was worth being able to settle rather than argue about — `serve` never builds a pipeline during startup, and the trace now reports whether any load landed on a startup path at all.

## Measured

| | before | after |
|---|---|---|
| handshake, project A | blocked behind the database open | **666ms** |
| handshake, project B | blocked behind the database open | **766ms** |
| database open alone | 111ms – 2,066ms, **on the deadline** | unchanged, **off the deadline** |

The slow opens are unchanged. They are simply no longer able to kill the server.

## A deeper cause this does NOT fix

This moves the wait off the fatal path; it does not remove it. The wait exists because `bootstrapSchema` re-runs the full migration suite on every read-write open, taking write locks on a shared file.

`stampSchemaVersion` already has the right idea and says so in its own comment — *"Every rw open runs this. Writing unconditionally means several processes racing to bootstrap the same file each take a header-write lock even when nothing changed"* — but the fast path is applied to that one statement rather than to the suite. Gating the whole of `bootstrapSchema` behind a cheap check would turn ~15 write operations into one read on the hot path. `KNOWL_SCHEMA_VERSION` can't serve as that check on its own, since additive columns deliberately don't bump it, so it would need a schema fingerprint — the shape `ensureEmbeddingProfileColumns` already uses for the embedding profile. Happy to follow up with that separately if you'd want it.

## Testing

- Full suite on this branch: **1340 passed, 1 failed**. The failure is `tests/transcripts/backfill.test.ts` — a wall-clock budget assertion that fails only inside the full parallel run on a loaded machine. Verified as pre-existing flake, not caused by this change: **3/3 passes in isolation on this branch and 3/3 on clean `main`**, and it passed in one full run and failed in another.
- Verified end to end by driving a real stdio `initialize` against the built `dist/` in two projects.
