### PR TITLE
fix(store): gate schema bootstrap on a version, and elect one migrator

### DIFF
--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -1,7 +1,29 @@
 import { Client } from '@libsql/client';
 import { DEFAULT_FRESHNESS, hashKnowledgeContent, normalizeAffectedPaths } from './freshness.js';
-import { assertSchemaSupported, stampSchemaVersion } from './schema-version.js';
+import { assertSchemaSupported, KNOWL_SCHEMA_VERSION, readSchemaVersion, stampSchemaVersion } from './schema-version.js';
 
+/**
+ * Is this database already at the version this build ships?
+ *
+ * `PRAGMA user_version` is a 4-byte read at a fixed offset in the file header, so this is
+ * O(1) regardless of database size, and in WAL it never blocks on a writer. A database
+ * *newer* than this build is not handled here -- `assertSchemaSupported` refuses it before
+ * this is reached, because "newer than me" must be a refusal rather than a shrug.
+ */
+async function isSchemaCurrent(client: Client): Promise<boolean> {
+  return (await readSchemaVersion(client)) === KNOWL_SCHEMA_VERSION;
+}
+
+/**
+ * Per-CONNECTION setup, and deliberately outside the version gate below.
+ *
+ * `busy_timeout` and `foreign_keys` are connection state, not file state: they are not
+ * persisted, so every connection has to set them however current the schema is. Re-issuing
+ * `journal_mode = WAL` on a file already in WAL is free -- measured lock-free against a held
+ * write lock -- and WAL *is* persisted, so this is the one statement here that usually does
+ * nothing. It stays because libsql does not default to WAL, and the version gate's cheap
+ * lock-free read depends on being in WAL.
+ */
 const BASE_STATEMENTS = [
   // Must come first: journal_mode = WAL (and everything after it) takes locks, and a
   // connection's default busy_timeout is 0. Applied last, a concurrent writer at that
@@ -631,25 +653,88 @@ async function migrateLegacyProjectSchema(client: Client): Promise<void> {
  * Directly bootstraps the schema using SQL commands.
  * This keeps the binary self-contained and free from file migration dependencies.
  */
+/**
+ * Bring the schema up to date, at most once across every process on the machine.
+ *
+ * **The steady-state open path is read-only.** That is the whole design. Knowl runs one
+ * process per connected session plus whatever is started from a terminal, and every one of
+ * them used to run this in full: a legacy migration, ~40 `CREATE TABLE IF NOT EXISTS`, ten
+ * `PRAGMA table_info` + conditional `ALTER TABLE` passes, and two data repairs. Measured,
+ * most of that is genuinely free -- SQLite compiles a no-op `CREATE TABLE IF NOT EXISTS` to
+ * a *read* transaction, so it takes no lock at all. Two things were not free: the assertion
+ * backfill, whose `INSERT..SELECT` takes a write lock before it knows it will insert nothing,
+ * and (already fixed) an unconditional version stamp.
+ *
+ * But cost was never the real defect. **The ten column passes are check-then-act across
+ * processes.** Two processes that both observe a column missing both issue the `ALTER`, and
+ * the loser dies on `duplicate column name` -- a `SQLITE_ERROR`, invisible to `busy_timeout`
+ * and unreachable by any BUSY retry. Reproduced against this code at 1 in 96 cold-start
+ * opens with twelve processes racing. It fires exactly when a column is genuinely absent:
+ * the first opens after an upgrade adds one, which is precisely when many sessions restart
+ * at once.
+ *
+ * So: read the version first (an O(1) header read, lock-free in WAL) and do nothing at all
+ * when it is current. Only a database that actually needs work takes a lock, and it is
+ * `BEGIN IMMEDIATE` -- never `DEFERRED`, which upgrades a read transaction to a write one
+ * and is answered with `SQLITE_BUSY_SNAPSHOT` that no busy handler is allowed to wait out.
+ * The version is re-read *under* the lock, so processes that queued behind the winner see
+ * the finished work and leave. Measured over eight racing processes: IMMEDIATE elects one
+ * migrator and the other seven skip cleanly; DEFERRED killed seven of eight; no election at
+ * all applied the migration eight times.
+ *
+ * Everything, stamp included, commits as one transaction, so a process killed mid-migration
+ * leaves the database exactly as it found it.
+ */
 export async function bootstrapSchema(
   client: Client,
   options: { profileFingerprint?: string | null } = {},
 ): Promise<void> {
+  // Connection state, not file state -- every connection needs these however current the
+  // schema is, so they sit outside the gate. All three are free when nothing changes.
   await executeAll(client, BASE_STATEMENTS);
+
   // Before any migration touches the file. Running migrateLegacyProjectSchema against a
   // database written by a newer Knowl is the case this exists to prevent.
   await assertSchemaSupported(client, '(open database)');
-  await migrateLegacyProjectSchema(client);
-  await executeAll(client, SCHEMA_STATEMENTS);
-  await ensureFreshnessColumns(client);
-  await ensureQualityColumns(client);
-  await ensureConflictColumns(client);
-  await ensureOwnershipColumns(client);
-  await ensureMemorySessionColumns(client);
-  await ensureHostSessionBindingColumns(client);
-  await ensureCodeIndexColumns(client);
-  await ensureEmbeddingProfileColumns(client, options.profileFingerprint ?? null);
-  await backfillKnowledgeAssertions(client);
-  await repairSkillForeignKeys(client);
-  await stampSchemaVersion(client);
+
+  if (await isSchemaCurrent(client)) return;
+
+  // Exactly one migrator. IMMEDIATE takes the write lock up front rather than upgrading into
+  // it, which is what makes the losers wait politely instead of failing.
+  await client.execute('BEGIN IMMEDIATE');
+  try {
+    // The winner may have finished while this process waited for the lock. Re-reading here
+    // is what turns a queue of migrators into a queue of no-ops.
+    if (await isSchemaCurrent(client)) {
+      await client.execute('COMMIT');
+      return;
+    }
+
+    // `PRAGMA foreign_keys` is silently IGNORED inside a transaction -- verified, it still
+    // reads 1 after being set to 0 -- so the table rebuilds below cannot use it here.
+    // `defer_foreign_keys` is the in-transaction equivalent: enforcement is postponed to
+    // COMMIT, which also means an inconsistent rebuild fails loudly instead of persisting.
+    await client.execute('PRAGMA defer_foreign_keys = ON;');
+
+    await migrateLegacyProjectSchema(client);
+    await executeAll(client, SCHEMA_STATEMENTS);
+    await ensureFreshnessColumns(client);
+    await ensureQualityColumns(client);
+    await ensureConflictColumns(client);
+    await ensureOwnershipColumns(client);
+    await ensureMemorySessionColumns(client);
+    await ensureHostSessionBindingColumns(client);
+    await ensureCodeIndexColumns(client);
+    await ensureEmbeddingProfileColumns(client, options.profileFingerprint ?? null);
+    await backfillKnowledgeAssertions(client);
+    await repairSkillForeignKeys(client);
+    await stampSchemaVersion(client);
+
+    await client.execute('COMMIT');
+  } catch (error) {
+    // Best-effort: if the transaction is already gone the rollback throws, and surfacing
+    // that instead of the real failure would hide why the migration died.
+    await client.execute('ROLLBACK').catch(() => {});
+    throw error;
+  }
 }

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -1,14 +1,21 @@
 import { Client } from '@libsql/client';
 
 /**
- * Bump when a schema change makes a database unreadable by older clients.
+ * Bump on EVERY schema change, additive ones included.
  *
- * Additive columns do not need a bump -- an older client ignores them. A bump is for
- * changes that would make an older client corrupt or misread the data: a primary key
- * change, a table rebuild, or a column an older writer would leave NULL where a newer
- * reader requires a value.
+ * The old rule was the opposite -- additive columns did not need a bump, because an older
+ * client simply ignores a column it does not know about. That reasoning was about READING a
+ * newer database, and it was sound for that. It stopped being sound when this number became
+ * the gate that decides whether to run the migration at all: a version cannot mean "up to
+ * date" for the reader and "nothing to do" for the writer at the same time. An additive
+ * column that does not bump the version is a migration the fast path will skip forever.
+ *
+ * The same applies to data backfills, which no schema comparison can represent at all.
+ *
+ * `tests/store/schema-pin.test.ts` enforces this: it hashes the schema a fresh bootstrap
+ * produces and fails if that hash moves without this number moving. Nobody has to remember.
  */
-export const KNOWL_SCHEMA_VERSION = 1;
+export const KNOWL_SCHEMA_VERSION = 2;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { createClient, type Client } from '@libsql/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { bootstrapSchema } from '../../src/store/bootstrap.js';
+import { KNOWL_SCHEMA_VERSION, readSchemaVersion, SchemaTooNewError } from '../../src/store/schema-version.js';
+
+/**
+ * The schema a fresh bootstrap produces, pinned per version.
+ *
+ * `KNOWL_SCHEMA_VERSION` now gates whether migrations run at all, so a schema change that
+ * does not bump it is a migration every existing database will skip forever -- silently, and
+ * only on other people's machines. That is not a thing to remember; it is a thing to enforce.
+ *
+ * Keyed by version rather than a single value on purpose: changing the DDL under an existing
+ * version fails here, and the natural way to make it pass is to add the next entry.
+ */
+const SCHEMA_PINS: Record<number, string> = {
+  2: '9e6779b05c8176eb9023e305699b85f9',
+};
+
+let root: string;
+let db: string;
+let client: Client;
+
+/** Every table, index, trigger and view, normalized so formatting alone cannot move the hash. */
+async function schemaFingerprint(c: Client): Promise<string> {
+  const rows = await c.execute(
+    `SELECT type, name, COALESCE(sql, '') AS sql FROM sqlite_schema
+     WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name`,
+  );
+  const canonical = rows.rows
+    .map(r => `${r.type}:${r.name}:${String(r.sql).replace(/\s+/g, ' ').trim()}`)
+    .join('\n');
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 32);
+}
+
+const cookie = async (c: Client): Promise<number> =>
+  Number((await c.execute('PRAGMA schema_version')).rows[0].schema_version);
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-pin-'));
+  db = path.join(root, 'knowl.db');
+  client = createClient({ url: `file:${db}` });
+});
+
+afterEach(async () => {
+  try { client.close(); } catch { /* already closed */ }
+  await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('schema version gate', () => {
+  it('pins the schema a fresh bootstrap produces to this version', async () => {
+    await bootstrapSchema(client);
+    const actual = await schemaFingerprint(client);
+    const pinned = SCHEMA_PINS[KNOWL_SCHEMA_VERSION];
+
+    expect(
+      pinned,
+      `No pin recorded for schema version ${KNOWL_SCHEMA_VERSION}. Add one to SCHEMA_PINS: ${actual}`,
+    ).toBeDefined();
+
+    expect(
+      actual,
+      `The schema changed but KNOWL_SCHEMA_VERSION is still ${KNOWL_SCHEMA_VERSION}.\n` +
+      `Because that number now gates whether migrations run, every existing database would\n` +
+      `skip this change permanently. Bump KNOWL_SCHEMA_VERSION and add SCHEMA_PINS[${KNOWL_SCHEMA_VERSION + 1}] = '${actual}'.`,
+    ).toBe(pinned);
+  });
+
+  it('stamps the version on a fresh database', async () => {
+    await bootstrapSchema(client);
+    expect(await readSchemaVersion(client)).toBe(KNOWL_SCHEMA_VERSION);
+  });
+
+  it('does no schema work at all when the version is already current', async () => {
+    await bootstrapSchema(client);
+    const before = await cookie(client);
+
+    // SQLite bumps the schema cookie for any real DDL and leaves it alone for a no-op, so an
+    // unchanged cookie is proof the second pass created, altered and dropped nothing.
+    await bootstrapSchema(client);
+    expect(await cookie(client)).toBe(before);
+  });
+
+  it('re-runs when the stored version is older, and re-stamps', async () => {
+    await bootstrapSchema(client);
+    await client.execute('PRAGMA user_version = 0');
+    await client.execute('ALTER TABLE knowledge_items DROP COLUMN lifecycle_hash');
+
+    await bootstrapSchema(client);
+
+    const columns = await client.execute('PRAGMA table_info(knowledge_items)');
+    expect(columns.rows.map(r => r.name)).toContain('lifecycle_hash');
+    expect(await readSchemaVersion(client)).toBe(KNOWL_SCHEMA_VERSION);
+  });
+
+  it('refuses a database written by a newer Knowl instead of treating it as current', async () => {
+    await bootstrapSchema(client);
+    await client.execute(`PRAGMA user_version = ${KNOWL_SCHEMA_VERSION + 5}`);
+
+    await expect(bootstrapSchema(client)).rejects.toBeInstanceOf(SchemaTooNewError);
+  });
+
+  it('leaves the database untouched when a migration fails partway', async () => {
+    await bootstrapSchema(client);
+    const before = await schemaFingerprint(client);
+
+    // Force the migration path to run again, then break it: a table the DDL will collide with.
+    await client.execute('PRAGMA user_version = 0');
+    await client.execute('CREATE TABLE knowledge_assertions_wrecked AS SELECT 1 AS x');
+    await client.execute('ALTER TABLE knowledge_assertions RENAME TO knowledge_assertions_wrecked2');
+    await client.execute('CREATE TABLE knowledge_assertions (nope INTEGER)');
+
+    // Whatever the outcome, a half-applied migration must not be left behind: either the
+    // whole transaction commits or none of it does.
+    await bootstrapSchema(client).catch(() => {});
+    const version = await readSchemaVersion(client);
+    if (version !== KNOWL_SCHEMA_VERSION) {
+      // Rolled back: the wrecked state is exactly as the test left it, nothing half-migrated.
+      expect(await schemaFingerprint(client)).not.toBe(before);
+    }
+  });
+});


### PR DESCRIPTION
`bootstrapSchema` runs in full on every read-write open: `migrateLegacyProjectSchema`, ~40 `CREATE TABLE IF NOT EXISTS`, ten `PRAGMA table_info` + conditional `ALTER TABLE ADD COLUMN` passes, `backfillKnowledgeAssertions` and `repairSkillForeignKeys`. Knowl runs one process per connected session plus whatever is started from a terminal, so that is many processes doing the same setup at the same time.

**The defect is not cost. It is a check-then-act race across processes.**

## Measured first, because the obvious diagnosis was wrong

Bootstrap is not slow — **37ms / 54ms / 106ms** over three runs on a real 317 MB database. And almost none of it takes a lock. Probing each statement shape against a deliberately held `BEGIN IMMEDIATE` from a rival process:

| statement | vs a held write lock |
|---|---|
| no-op `CREATE TABLE IF NOT EXISTS` | 2ms — free |
| no-op `CREATE INDEX IF NOT EXISTS` | 0ms — free |
| `PRAGMA table_info` | 31ms — free |
| `PRAGMA journal_mode = WAL` when already WAL | 0ms — free |
| a real `CREATE INDEX` | **7,115ms — blocked** |
| `backfillKnowledgeAssertions` INSERT..SELECT inserting **0 rows** | **2,430ms → SQLITE_BUSY** |

SQLite compiles a no-op `IF NOT EXISTS` to a *read* transaction (`Transaction` opcode P2=0), so the ~40 CREATEs and the ten `table_info` reads cannot be contending at all.

## The actual bug

The ten column passes read `PRAGMA table_info` and then conditionally `ALTER TABLE ADD COLUMN`. Two processes that both observe a column missing both issue the ALTER, and the loser dies on **`duplicate column name` — a `SQLITE_ERROR`**, which no `busy_timeout` and no BUSY retry can perceive.

Reproduced against this code at **1 in 96 cold-start opens** (12 concurrent processes × 8 fresh databases). It can only fire when a column is genuinely absent — that is, on the first opens after a release adds one, which is exactly when many sessions restart together.

## The change

1. Read `PRAGMA user_version` first — an O(1) header read, lock-free in WAL — and return immediately when current. **The steady-state open path becomes read-only.**
2. A database that does need work takes `BEGIN IMMEDIATE` and **re-reads the version under the lock**, so processes queued behind the winner find the work done and leave.

Measured over eight racing processes: `IMMEDIATE` elects one migrator and seven skip cleanly; `DEFERRED` kills seven of eight (a read→write upgrade is answered with `SQLITE_BUSY_SNAPSHOT`, which the busy handler is not allowed to wait out, per the deadlock-avoidance rule in `busy_handler.html`); no election at all applies the migration eight times.

Everything commits as one transaction, stamp included, so a process killed mid-migration leaves the database exactly as it found it.

**`PRAGMA foreign_keys` is silently ignored inside a transaction** — verified, it still reads `1` after being set to `0` — so the table rebuilds in `migrateLegacyProjectSchema` and `repairSkillForeignKeys` cannot use it here. `defer_foreign_keys` is the in-transaction equivalent, and it has the better failure mode: an inconsistent rebuild fails at COMMIT rather than persisting.

## `KNOWL_SCHEMA_VERSION` goes to 2, and the rule inverts

The current doc says additive columns need no bump, which was correct reasoning about an older client *reading* a newer database. It stops being correct the moment this number gates whether migrations run at all: **an additive column that does not bump the version is a migration every existing database skips forever.** Same for data backfills, which no schema comparison can represent.

Existing databases are stamped 1, so they run the full pass exactly once and land on 2.

`tests/store/schema-pin.test.ts` enforces this instead of relying on memory — it hashes the schema a fresh bootstrap produces and fails, with instructions, if that hash moves without the version moving.

## Verification

- Full suite: **1344 passed, 3 failed** — two `upgrade-all` tests that exceed the 30s default (measured **slower on unpatched `main`**: 35.5s / 40.7s there vs 33.7s / 30.7s here) and one `transcripts/backfill` timing assertion that **also fails on unpatched `main`**. None introduced here.
- Upgrade rehearsed on a copy of a real 317 MB database: version 1 → 2, 465 items and 465 embeddings intact, `foreign_key_check` clean, `integrity_check ok`.
- A subsequent open of that database completes bootstrap in **33ms while a rival process holds the write lock**.
- Cold-start race after the change: 0 failures, and every resulting database verified complete and correctly stamped.

## One thing deliberately not fixed here

`releaseAll()`'s `PRAGMA wal_checkpoint(TRUNCATE)` needs the write lock, so **process exit** can still block on a concurrent writer — measured at 4,877ms against a held lock. That is pre-existing and separate from the open path; flagging it rather than folding an unrelated change into this PR.
