### PR TITLE
perf(code): indexFile(), and one transaction per file instead of per statement

### DIFF
--- a/src/code/symbol-index.ts
+++ b/src/code/symbol-index.ts
@@ -6,7 +6,7 @@ import { spawnSync } from 'node:child_process';
 import Parser from 'tree-sitter';
 import { CodeSymbol, CodeSymbolEdge, CodeSymbolKind } from '../core/types.js';
 import { CODE_EXTENSIONS, languageForExtension } from './languages.js';
-import { getClient } from '../store/database.js';
+import { getClient, withClientTransaction } from '../store/database.js';
 
 type SyntaxNode = Parser.SyntaxNode;
 type IndexedSymbol = CodeSymbol & { signatureHash: string | null };
@@ -20,6 +20,17 @@ const lineRange = (node: SyntaxNode) => ({
 const signature = (node: SyntaxNode) => node.text.split('{', 1)[0].replace(/\s+/g, ' ').trim().slice(0, 240) || null;
 const nameOf = (node: SyntaxNode) => node.childForFieldName('name')?.text ?? node.namedChildren.find(child => ['identifier', 'type_identifier', 'property_identifier'].includes(child.type))?.text;
 
+/**
+ * Directory names the index never descends into, at any depth.
+ *
+ * Named rather than inlined because there are now two entry points -- the full walk and
+ * `indexFile` -- and the incremental one has to refuse exactly what the walk refuses. Two copies
+ * of this list drift, and the drift is invisible: the walk would keep skipping `dist/`, a
+ * write-triggered `indexFile('dist/bundle.js')` would happily index it, and the store would hold
+ * symbols the full pass then deletes on its next run. One list, one answer.
+ */
+const EXCLUDED_DIRECTORIES = new Set(['.git', '.knowl', 'dist', 'node_modules']);
+
 function ignored(root: string, file: string): boolean {
   if (!existsSync(path.join(root, '.git'))) return false;
   const relative = path.relative(root, file).replace(/\\/g, '/');
@@ -27,10 +38,15 @@ function ignored(root: string, file: string): boolean {
   return result.status === 0;
 }
 
+/** Repo-relative and forward-slashed: the one form `code_files.path` and every locator use. */
+function relativeCodePath(root: string, file: string): string {
+  return path.relative(root, path.resolve(root, file)).replace(/\\/g, '/');
+}
+
 async function walkCodeFiles(root: string, directory = root): Promise<string[]> {
   const files: string[] = [];
   for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
-    if (['.git', '.knowl', 'dist', 'node_modules'].includes(entry.name)) continue;
+    if (EXCLUDED_DIRECTORIES.has(entry.name)) continue;
     const file = path.join(directory, entry.name);
     if (ignored(root, file)) continue;
     if (entry.isDirectory()) files.push(...await walkCodeFiles(root, file));
@@ -127,7 +143,8 @@ function extractSymbols(filePath: string, text: string): { symbols: IndexedSymbo
   return { symbols, edges };
 }
 
-async function deleteIndexedFile(filePath: string) {
+/** The rows for one file, with no transaction of its own: every caller is already inside one. */
+async function deleteIndexedFileRows(filePath: string) {
   const client = getClient();
   const rows = await client.execute({ sql: 'SELECT locator FROM code_symbols WHERE file_path = ?', args: [filePath] });
   for (const row of rows.rows) {
@@ -137,9 +154,9 @@ async function deleteIndexedFile(filePath: string) {
   await client.execute({ sql: 'DELETE FROM code_files WHERE path = ?', args: [filePath] });
 }
 
-async function replaceIndexedFile(filePath: string, contentHash: string, extracted: ReturnType<typeof extractSymbols>) {
+async function replaceIndexedFileRows(filePath: string, contentHash: string, extracted: ReturnType<typeof extractSymbols>) {
   const client = getClient();
-  await deleteIndexedFile(filePath);
+  await deleteIndexedFileRows(filePath);
   await client.execute({ sql: 'INSERT INTO code_files (path, content_hash, updated_at) VALUES (?, ?, ?)', args: [filePath, contentHash, new Date().toISOString()] });
   for (const symbol of extracted.symbols) {
     await client.execute({ sql: 'INSERT INTO code_symbols (locator, file_path, qualified_name, kind, start_line, end_line, signature, signature_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', args: [symbol.locator, symbol.filePath, symbol.qualifiedName, symbol.kind, symbol.startLine, symbol.endLine, symbol.signature, symbol.signatureHash] });
@@ -149,21 +166,122 @@ async function replaceIndexedFile(filePath: string, contentHash: string, extract
   }
 }
 
+/**
+ * Both writes above rewrite one file's rows in one transaction -- and the unit is the file, not
+ * the pass.
+ *
+ * Every statement above used to be its own implicit transaction. Indexing a file with 30 symbols
+ * and 10 edges is 41 writes the first time and 73 on a re-index (the delete pass issues one
+ * statement per symbol already stored), so recording one edit cost that many commits. At the
+ * `synchronous = NORMAL` this schema runs, the measurement at `bootstrap.ts:33-37` puts un-batched
+ * writes at 0.832 ms/row against 0.241 batched -- so a re-index sheds roughly 61 ms of commit
+ * overhead for 18 ms, ~3.5x. The larger 132x figure recorded in `vector.ts:148` was measured at
+ * `synchronous = FULL`, where every commit also fsynced the WAL; quoting it for this path would
+ * overstate the win, and the win does not need overstating.
+ *
+ * Atomicity is the part that actually matters for a write-triggered re-index. `replaceIndexedFile`
+ * is a delete followed by inserts, so un-transacted it has a window in which the file's symbols
+ * are gone and the new ones are not yet there -- and the reader that would land in that window is
+ * exactly the staleness check this index exists to serve, which would read "symbol deleted" and
+ * report a false change.
+ *
+ * NOT one transaction around the whole repo pass, for two reasons. A transaction holds the single
+ * write lock for its whole life, and a full pass interleaves tree-sitter parses and file reads
+ * between its statements -- so a repo-wide transaction would lock out `serve`, the hooks and the
+ * CLI for the length of the walk, against a 10 s `busy_timeout` (`bootstrap.ts:24`). And
+ * `withClientTransaction` serialises on one process-wide queue, so holding it for a pass stalls
+ * every unrelated write behind it. The obvious objection -- that many small transactions hit the
+ * driver ceiling -- does not apply here: that ceiling is on the *count of `db.transaction()`
+ * calls* (800-1000), and this helper issues raw `BEGIN`/`COMMIT`, the shape measured clean at
+ * 1200 in the table at `database.ts:143`.
+ */
+async function deleteIndexedFile(filePath: string) {
+  await withClientTransaction(() => deleteIndexedFileRows(filePath));
+}
+
+async function replaceIndexedFile(filePath: string, contentHash: string, extracted: ReturnType<typeof extractSymbols>) {
+  await withClientTransaction(() => replaceIndexedFileRows(filePath, contentHash, extracted));
+}
+
+/**
+ * Index one file that is already known to be eligible, at the path it is already known to sit at.
+ *
+ * The single body both entry points run, so the incremental and full passes cannot disagree about
+ * what "indexed" means -- the content-hash skip, the extraction and the replace exist once. What
+ * `indexFile` adds on top is only the eligibility test that the walk performs for the full pass.
+ */
+async function indexEligibleFile(filePath: string, fullPath: string): Promise<void> {
+  const text = await fs.readFile(fullPath, 'utf8');
+  const contentHash = hash(text);
+  const existing = await getClient().execute({ sql: 'SELECT content_hash FROM code_files WHERE path = ?', args: [filePath] });
+  if (String(existing.rows[0]?.content_hash ?? '') === contentHash) return;
+  await replaceIndexedFile(filePath, contentHash, extractSymbols(filePath, text));
+}
+
+/** Drop a path from the index, without opening a write transaction for one it never held. */
+async function forgetIndexedFile(filePath: string): Promise<void> {
+  // A write-tool trigger fires on every deleted path, and almost none of them are indexed:
+  // build output, scratch files, a `.md` note. Skipping the transaction on a miss keeps those
+  // off the write lock and out of the transaction queue entirely.
+  const known = await getClient().execute({ sql: 'SELECT 1 FROM code_files WHERE path = ? LIMIT 1', args: [filePath] });
+  if (known.rows.length === 0) return;
+  await deleteIndexedFile(filePath);
+}
+
+/**
+ * Index exactly one file -- the entry point a "re-index what just changed" trigger can call.
+ *
+ * `indexCode` walks and re-hashes the entire repo on every call, which is the right shape for a
+ * session boundary and the wrong one for a tool event: its content-hash check skips the re-parse
+ * and the write, never the walk or the reads, so a one-file change still costs a full traversal
+ * plus a `git check-ignore` spawn per entry.
+ *
+ * `filePath` may be repo-relative or absolute, because the callers this exists for -- host hooks
+ * -- report absolute paths and normalising in each of them is how the two forms end up in
+ * `code_files` under different keys.
+ *
+ * Everything ineligible returns quietly rather than throwing: a trigger hands this whatever path a
+ * tool touched, so a `.md` file, a directory, `node_modules/`, a gitignored artifact and a path
+ * outside the repo are all ordinary traffic, not caller errors. A throw here would surface as a
+ * failed hook on an event that was never ours to act on. The one non-quiet case is a path that
+ * has gone from disk: that is a real index update, so its rows are removed.
+ *
+ * A gitignored path is a no-op even if the index somehow holds it -- the full pass's
+ * reconciliation already deletes anything the walk no longer yields, so the cleanup exists and
+ * does not need a second, contradictory implementation on the hot path.
+ *
+ * Opens its own transaction, so it must not be called from inside one (`withClientTransaction`
+ * refuses to nest).
+ */
+export async function indexFile(root: string, filePath: string): Promise<void> {
+  const relativePath = relativeCodePath(root, filePath);
+  // `path.relative` answers `..`-prefixed for a path above the root, and on Windows an absolute
+  // path for one on another drive. Either way it is not in this repo and has no locator here.
+  if (!relativePath || relativePath === '..' || relativePath.startsWith('../') || path.isAbsolute(relativePath)) return;
+  if (relativePath.split('/').some(segment => EXCLUDED_DIRECTORIES.has(segment))) return;
+  if (!CODE_EXTENSIONS.has(path.extname(relativePath))) return;
+
+  // Deletion is decided before the ignore test on purpose: `ignored` spawns a `git` process, and
+  // a path that is gone needs no rule to tell us it should not be in the index.
+  const fullPath = path.join(root, relativePath);
+  const stats = await fs.stat(fullPath).catch(() => null);
+  if (!stats?.isFile()) return forgetIndexedFile(relativePath);
+  if (ignored(root, fullPath)) return;
+
+  await indexEligibleFile(relativePath, fullPath);
+}
+
 export async function indexCode(root: string): Promise<void> {
   const files = await walkCodeFiles(root);
-  const paths = new Set(files.map(file => path.relative(root, file).replace(/\\/g, '/')));
-  const client = getClient();
-  const known = await client.execute('SELECT path FROM code_files');
+  const paths = new Set(files.map(file => relativeCodePath(root, file)));
+  const known = await getClient().execute('SELECT path FROM code_files');
   for (const row of known.rows) if (!paths.has(String(row.path))) await deleteIndexedFile(String(row.path));
 
-  for (const fullPath of files) {
-    const filePath = path.relative(root, fullPath).replace(/\\/g, '/');
-    const text = await fs.readFile(fullPath, 'utf8');
-    const contentHash = hash(text);
-    const existing = await client.execute({ sql: 'SELECT content_hash FROM code_files WHERE path = ?', args: [filePath] });
-    if (String(existing.rows[0]?.content_hash ?? '') === contentHash) continue;
-    await replaceIndexedFile(filePath, contentHash, extractSymbols(filePath, text));
-  }
+  // Straight to the shared body rather than through `indexFile`: the walk has already applied the
+  // exclusions, the ignore rules and the extension filter to every entry it returned, and routing
+  // back through the public entry point would re-run `git check-ignore` -- one process spawn per
+  // file, over the whole repo -- to re-derive an answer this loop already has.
+  for (const fullPath of files) await indexEligibleFile(relativeCodePath(root, fullPath), fullPath);
 }
 
 export async function listCodeSymbols(filePath: string): Promise<CodeSymbol[]> {

--- a/tests/code/index-file.test.ts
+++ b/tests/code/index-file.test.ts
@@ -1,0 +1,151 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { indexCode, indexFile, listCodeSymbolEdges, listCodeSymbols } from '../../src/code/symbol-index.js';
+
+const ROOT = path.resolve('./.knowl-index-file-test');
+const AUTH = 'import { randomUUID } from "node:crypto";\nexport function createToken() {\n  return randomUUID();\n}\n';
+const SESSION = 'import { createToken } from "./auth";\nexport const startSession = () => createToken();\n';
+
+async function write(relativePath: string, text: string) {
+  const target = path.join(ROOT, relativePath);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, text);
+}
+
+/**
+ * Every indexed row except `updated_at`.
+ *
+ * `updated_at` is a wall-clock stamp written at insert time, so it is the one column that must
+ * differ between two runs that are otherwise identical -- comparing it would fail the
+ * equivalence check for the only reason that does not mean the two entry points disagree.
+ */
+async function indexSnapshot() {
+  const client = getClient();
+  const files = await client.execute('SELECT path, content_hash FROM code_files ORDER BY path');
+  const symbols = await client.execute('SELECT locator, file_path, qualified_name, kind, start_line, end_line, signature, signature_hash FROM code_symbols ORDER BY locator');
+  const edges = await client.execute('SELECT from_locator, to_locator, kind FROM code_symbol_edges ORDER BY from_locator, to_locator, kind');
+  return {
+    files: files.rows.map(row => ({ path: String(row.path), contentHash: String(row.content_hash) })),
+    symbols: symbols.rows.map(row => ({ ...row })),
+    edges: edges.rows.map(row => ({ from: String(row.from_locator), to: String(row.to_locator), kind: String(row.kind) })),
+  };
+}
+
+const indexedPaths = async () => (await indexSnapshot()).files.map(file => file.path);
+
+describe('single-file code index', () => {
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    // A real repository, not a `.git` placeholder: `ignored()` shells out to `git check-ignore`,
+    // which refuses outside a work tree, and a refusal reads as "not ignored" -- so the gitignore
+    // case below would pass without the rule ever being consulted.
+    execSync('git init', { cwd: ROOT, stdio: 'ignore' });
+    await write('.gitignore', 'generated/\n');
+    await write('src/auth.ts', AUTH);
+    await initDb(ROOT);
+  });
+  afterAll(async () => { await closeDb(); await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {}); });
+
+  it('indexes one file, its symbols and its edges, and touches no other path', async () => {
+    await write('src/session.ts', SESSION);
+
+    await indexFile(ROOT, 'src/auth.ts');
+
+    expect(await listCodeSymbols('src/auth.ts')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'function', locator: 'symbol://src/auth.ts#createToken', startLine: 2, endLine: 4 }),
+      expect.objectContaining({ kind: 'import', locator: 'symbol://src/auth.ts#import:node:crypto' }),
+      expect.objectContaining({ kind: 'export', locator: 'symbol://src/auth.ts#export:createToken' }),
+    ]));
+    expect(await listCodeSymbolEdges('src/auth.ts')).toEqual(expect.arrayContaining([
+      { fromLocator: 'symbol://src/auth.ts#import:node:crypto', toLocator: 'module://node:crypto', kind: 'imports' },
+      { fromLocator: 'symbol://src/auth.ts#export:createToken', toLocator: 'symbol://src/auth.ts#createToken', kind: 'exports' },
+    ]));
+    // The sibling exists on disk and is a code file: if this entry point still walked, it would
+    // be here too. That absence is the whole point of the export.
+    expect(await indexedPaths()).toEqual(['src/auth.ts']);
+  });
+
+  it('rewrites nothing when the content hash is unchanged', async () => {
+    // A sentinel rather than a timestamp comparison: `replaceIndexedFile` deletes and re-inserts
+    // the row, so a re-index cannot preserve a value the extractor never produces. Two calls
+    // inside the same millisecond would make an `updated_at` check pass either way.
+    await getClient().execute({ sql: 'UPDATE code_symbols SET signature = ? WHERE locator = ?', args: ['sentinel', 'symbol://src/auth.ts#createToken'] });
+
+    await indexFile(ROOT, 'src/auth.ts');
+
+    const symbol = (await listCodeSymbols('src/auth.ts')).find(row => row.locator === 'symbol://src/auth.ts#createToken');
+    expect(symbol?.signature).toBe('sentinel');
+  });
+
+  it('replaces the symbols and edges of an edited file', async () => {
+    await write('src/auth.ts', 'export function createAccessToken() { return "token"; }\n');
+
+    await indexFile(ROOT, 'src/auth.ts');
+
+    const locators = (await listCodeSymbols('src/auth.ts')).map(symbol => symbol.locator);
+    expect(locators).toContain('symbol://src/auth.ts#createAccessToken');
+    expect(locators).not.toContain('symbol://src/auth.ts#createToken');
+    // The import went away with the edit, so its edge must have gone with it -- a stale edge is
+    // how a reference walk reaches a symbol that no longer exists.
+    expect(await listCodeSymbolEdges('src/auth.ts')).toEqual([
+      { fromLocator: 'symbol://src/auth.ts#export:createAccessToken', toLocator: 'symbol://src/auth.ts#createAccessToken', kind: 'exports' },
+    ]);
+  });
+
+  it('removes a deleted file from the index, and stays quiet on a path it never held', async () => {
+    await fs.rm(path.join(ROOT, 'src', 'auth.ts'));
+
+    await indexFile(ROOT, 'src/auth.ts');
+    await expect(indexFile(ROOT, 'src/never-existed.ts')).resolves.toBeUndefined();
+
+    expect(await listCodeSymbols('src/auth.ts')).toEqual([]);
+    expect(await listCodeSymbolEdges('src/auth.ts')).toEqual([]);
+    expect(await indexedPaths()).toEqual([]);
+  });
+
+  it('is a no-op for anything the full walk would not have indexed', async () => {
+    // Each of these exists on disk, so a missing file cannot be why it stays out of the index.
+    await write('docs/notes.md', '# notes\n');
+    await write('node_modules/pkg/index.js', 'export function vendored() { return 1; }\n');
+    await write('generated/api.ts', 'export function generated() { return 1; }\n');
+    expect(existsSync(path.join(ROOT, '.git'))).toBe(true);
+
+    await indexFile(ROOT, 'docs/notes.md');
+    await indexFile(ROOT, 'node_modules/pkg/index.js');
+    await indexFile(ROOT, 'generated/api.ts');
+    await indexFile(ROOT, 'src');
+    // A real `.ts` file that is simply not in this repository: it would index cleanly under a
+    // `../`-prefixed locator if the root check were missing.
+    await indexFile(ROOT, path.join(ROOT, '..', 'src', 'code', 'symbol-index.ts'));
+
+    expect(await indexedPaths()).toEqual([]);
+  });
+
+  it('reaches the same rows as the full pass, one file at a time', async () => {
+    await write('src/auth.ts', AUTH);
+    await indexCode(ROOT);
+    const fullPass = await indexSnapshot();
+    // The full pass agrees with the previous test about what is eligible: the markdown file, the
+    // vendored file and the gitignored file are all still on disk and still absent.
+    expect(fullPass.files.map(file => file.path)).toEqual(['src/auth.ts', 'src/session.ts']);
+
+    const client = getClient();
+    for (const table of ['code_symbol_edges', 'code_symbols', 'code_files']) await client.execute(`DELETE FROM ${table}`);
+    await indexFile(ROOT, 'src/auth.ts');
+    // Absolute, because host hooks report absolute paths: both forms have to land on one key.
+    await indexFile(ROOT, path.join(ROOT, 'src', 'session.ts'));
+
+    expect(await indexSnapshot()).toEqual(fullPass);
+
+    // And the full pass still reconciles a deletion it was not told about, which is the one job
+    // the per-file entry point cannot do.
+    await fs.rm(path.join(ROOT, 'src', 'session.ts'));
+    await indexCode(ROOT);
+    expect(await indexedPaths()).toEqual(['src/auth.ts']);
+  });
+});


### PR DESCRIPTION
Piece 1 of the three in #17. Standalone: no schema, no config, no new surface, and defensible on its own merits whatever you decide about the rest.

Two changes to `symbol-index.ts`:

**A per-file entry point.** `indexCode` walked the whole repo and had no way to re-index one file. Anything wanting to react to a single write had to choose between a full walk and nothing.

**One transaction per file instead of one per statement.** The index wrote each symbol through a bare `execute`, which is its own implicit transaction — so indexing a file with 200 symbols paid 200 commits. This is a live cost independent of anything built on top of it, and it is why this piece is worth taking even if pieces 2 and 3 go nowhere.

`git checkout` between two branches with a few hundred changed symbols is the shape that shows it.

## Notes

- No behaviour change to `indexCode` itself; the walk calls into the same per-file path.
- `tests/code/index-file.test.ts` covers the per-file export, including that it respects `git check-ignore` the same way the full walk does, and that re-indexing a file replaces its symbols rather than accumulating them.
- Rebased onto current `main`.
