### PR TITLE
ci: cache the embedding models so a HuggingFace hiccup stops failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,27 @@ jobs:
           node-version: 22
           cache: npm
 
+      # The suite loads a real embedding model, so without this every run re-downloads it from
+      # huggingface.co and a rate limit there fails the build for reasons unrelated to the change
+      # under test. Observed on 2026-08-05: `Error (429) ... Xenova/all-MiniLM-L6-v2/config.json`
+      # took down `workspace-query`, `cross-repo-semantic` and `cross-repo-eval` on a PR that
+      # touched none of them.
+      #
+      # `~/.knowl/models` is where `resolveModelCache` puts weights by default -- shared per
+      # machine rather than per repo, because nothing about them varies by repository.
+      #
+      # Keyed on the files that name the models, so adding or switching one fetches once and then
+      # caches. `restore-keys` matters more than the exact key here: on a miss it still restores
+      # the newest previous cache, so a profile change re-downloads only what actually changed
+      # instead of everything.
+      - name: Cache embedding models
+        uses: actions/cache@v4
+        with:
+          path: ~/.knowl/models
+          key: knowl-models-${{ runner.os }}-${{ hashFiles('src/core/vector-profile.ts', 'src/core/config.ts') }}
+          restore-keys: |
+            knowl-models-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Splitting this out of #19 since it isn't about that change.

CI loads a real embedding model and nothing caches it, so every run re-downloads it from huggingface.co. That puts an unrelated third party's rate limiter in the pass/fail path.

It bit #19, which changes exactly one file in `src/code/`:

```
Error (429) occurred while trying to load file:
"https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/config.json"
```

`workspace-query`, `cross-repo-semantic` and `cross-repo-eval` went red together — the three suites that need the model, none of which that PR touches. All three pass locally against a warm cache.

## What this does

Caches `~/.knowl/models`, which is where `resolveModelCache` puts weights by default. Keyed on the two files that name the models (`vector-profile.ts`, `config.ts`), so switching or adding a model fetches once and then caches.

`restore-keys` is carrying more weight than the exact key: on a miss it still restores the newest previous cache, so a profile change re-downloads only what actually changed instead of the whole set.

## What it doesn't do

The first run after this merges is a cache miss by definition and can still hit a 429 — it's the runs after that this fixes. And it doesn't help if HF is down when the cache is cold.

If you'd rather pin this harder, the next step would be failing fast with a clear message when the model can't be fetched, so a network problem reads as a network problem instead of six assertion failures in suites that look unrelated. Happy to add that if you want it, but it's a bigger change to the embedding path and I didn't want to bundle it with a workflow tweak.
