### PR TITLE
ci: cache the embedding model so a HuggingFace 429 stops failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,16 @@ jobs:
       # then caches. `restore-keys` matters more than the exact key here: on a miss it still
       # restores the newest previous cache, so a profile change re-downloads only what
       # actually changed instead of everything.
-      - name: Cache embedding models
-        uses: actions/cache@v4
+      #
+      # Split into restore and save rather than one `actions/cache` step, because that step
+      # only saves when the job succeeds. This suite has a known timing-sensitive test, so a
+      # save-on-green cache stays cold exactly through the runs that need it most: one flake
+      # discards the download, the next run fetches again, and the rate limit this exists to
+      # avoid is hit by the retry. The weights are valid whatever the tests concluded about
+      # the code.
+      - name: Restore embedding model cache
+        id: model-cache
+        uses: actions/cache/restore@v4
         with:
           path: .knowl/models
           key: knowl-models-${{ runner.os }}-${{ hashFiles('src/core/vector-profile.ts', 'src/core/config.ts') }}
@@ -62,3 +70,15 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # `always()`, so a red suite still leaves the weights behind -- that is the whole point
+      # of the split above. Guarded twice: `cache-hit` skips the upload when the exact key was
+      # already restored, and `hashFiles` returns an empty string when nothing is on disk,
+      # which is what stops a job that died before the tests ran from failing again here on a
+      # missing path.
+      - name: Save embedding model cache
+        if: always() && steps.model-cache.outputs.cache-hit != 'true' && hashFiles('.knowl/models/**') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: .knowl/models
+          key: ${{ steps.model-cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,32 @@ jobs:
           node-version: 22
           cache: npm
 
+      # Three suites load a real embedding model, so without this every run re-downloads it
+      # from huggingface.co and a rate limit there fails the build for reasons unrelated to the
+      # change under test. Observed 2026-08-05: `Error (429) ... Xenova/all-MiniLM-L6-v2/
+      # config.json` took down `workspace-query`, `cross-repo-semantic` and `cross-repo-eval`
+      # on a PR that touched none of them.
+      #
+      # `.knowl/models` and not `~/.knowl/models`: `resolveModelCache` does default to
+      # `knowlHome()/models`, but no test ever sees the real home. vitest.config.ts pins
+      # KNOWL_HOME to `./.knowl-test-home` suite-wide and those three override it again to
+      # their own fixture, all of which are deleted before the job ends. The repo's own
+      # `.knowl/models` is the one path a model-loading suite both writes and outlives -- it
+      # is what `workspace-query.test.ts` and `write-embedding.test.ts` already point at, and
+      # the two cross-repo suites now do too.
+      #
+      # Keyed on the files that name the models, so adding or switching one fetches once and
+      # then caches. `restore-keys` matters more than the exact key here: on a miss it still
+      # restores the newest previous cache, so a profile change re-downloads only what
+      # actually changed instead of everything.
+      - name: Cache embedding models
+        uses: actions/cache@v4
+        with:
+          path: .knowl/models
+          key: knowl-models-${{ runner.os }}-${{ hashFiles('src/core/vector-profile.ts', 'src/core/config.ts') }}
+          restore-keys: |
+            knowl-models-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci
 

--- a/tests/workspace/cross-repo-eval.test.ts
+++ b/tests/workspace/cross-repo-eval.test.ts
@@ -29,6 +29,18 @@ const ROOTS: Record<string, string> = {
   server: path.resolve('./.knowl-xeval-server'),
 };
 
+// The repo's own cache, as `workspace-query.test.ts` and `write-embedding.test.ts` already do.
+// Left unset, `resolveModelCache` lands on `knowlHome()/models` -- and `knowlHome()` here is
+// the throwaway HOME above, which `afterAll` deletes. So every run fetched the weights again
+// from huggingface.co, which is a rate limiter this suite has no business depending on: a 429
+// there fails the build for reasons that have nothing to do with the change under test.
+// A stable path inside the repo is one CI can cache and a developer already has warm.
+const MODEL_CACHE = path.resolve('./.knowl/models');
+const CONFIG = {
+  ...DEFAULT_CONFIG,
+  search: { ...DEFAULT_CONFIG.search, vector: { ...DEFAULT_CONFIG.search?.vector, cacheDir: MODEL_CACHE } },
+};
+
 /**
  * Fixture ids are the suite's assertion vocabulary, but item ids are generated and
  * referenced by assertions and evidence with cascading foreign keys -- rewriting a primary
@@ -40,7 +52,7 @@ const realIds = new Map<string, string>();
 async function seedRepo(name: string) {
   const root = ROOTS[name];
   await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
-  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await saveConfig(root, CONFIG);
   await initDb(root);
   await getClient().execute('DELETE FROM knowledge_commits');
   await getClient().execute('DELETE FROM knowledge_items');
@@ -109,7 +121,7 @@ describe('cross-repo retrieval', () => {
         // Federation selects from every repo including this one, so no local pre-query.
         let vector: { enabled: boolean; profileFingerprint: string; embedding?: number[] } | undefined;
         if (semantic) {
-          const embedder = await createLocalEmbeddingProvider(DEFAULT_CONFIG, root);
+          const embedder = await createLocalEmbeddingProvider(CONFIG, root);
           const [embedding] = await embedder.embed([testCase.query]);
           // The fingerprint, not provider/model: those stopped being the eligibility filter
           // when dtype and pooling joined the identity, so the old pair left no fingerprint
@@ -169,7 +181,7 @@ describe('cross-repo retrieval', () => {
     // this is the only place the shipped default gets measured end to end.
     for (const name of Object.keys(ROOTS)) {
       await initDb(ROOTS[name]);
-      const embedder = await createLocalEmbeddingProvider(DEFAULT_CONFIG, ROOTS[name]);
+      const embedder = await createLocalEmbeddingProvider(CONFIG, ROOTS[name]);
       await reindexKnowledgeEmbeddings('local', embedder);
       await closeDb();
     }

--- a/tests/workspace/cross-repo-semantic.test.ts
+++ b/tests/workspace/cross-repo-semantic.test.ts
@@ -19,6 +19,18 @@ const HOME = path.resolve('./.knowl-semantic-home');
 const WEB = path.resolve('./.knowl-semantic-web');
 const SERVER = path.resolve('./.knowl-semantic-server');
 
+// The repo's own cache, as `workspace-query.test.ts` and `write-embedding.test.ts` already do.
+// Left unset, `resolveModelCache` lands on `knowlHome()/models` -- and `knowlHome()` here is
+// the throwaway HOME above, which `afterAll` deletes. So every run fetched the weights again
+// from huggingface.co, which is a rate limiter this suite has no business depending on: a 429
+// there fails the build for reasons that have nothing to do with the change under test.
+// A stable path inside the repo is one CI can cache and a developer already has warm.
+const MODEL_CACHE = path.resolve('./.knowl/models');
+const CONFIG = {
+  ...DEFAULT_CONFIG,
+  search: { ...DEFAULT_CONFIG.search, vector: { ...DEFAULT_CONFIG.search?.vector, cacheDir: MODEL_CACHE } },
+};
+
 /**
  * The case recorded in docs/evals/cross-repo-baseline.json as a known weakness.
  *
@@ -32,7 +44,7 @@ const SERVER_ANSWER = 'Access tokens issued by the server expire after fifteen m
 
 async function seed(root: string, name: string, title: string, content: string, visibility: string) {
   await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
-  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await saveConfig(root, CONFIG);
   await initDb(root);
   await getClient().execute('DELETE FROM knowledge_commits');
   await getClient().execute('DELETE FROM knowledge_items');
@@ -44,14 +56,14 @@ async function seed(root: string, name: string, title: string, content: string, 
   });
   // The suite disables write-time embedding, so build the index explicitly -- this test
   // exists precisely to exercise the path the rest of the suite cannot.
-  const embedder = await createLocalEmbeddingProvider(DEFAULT_CONFIG, root);
+  const embedder = await createLocalEmbeddingProvider(CONFIG, root);
   await reindexKnowledgeEmbeddings('local', embedder);
   await closeDb();
 }
 
 /** The vector config a caller hands federation: identity plus the query embedding. */
 async function vectorConfig(query: string) {
-  const embedder = await createLocalEmbeddingProvider(DEFAULT_CONFIG, WEB);
+  const embedder = await createLocalEmbeddingProvider(CONFIG, WEB);
   const [embedding] = await embedder.embed([query]);
   // The fingerprint, not provider/model: those stopped being the eligibility filter when
   // dtype and pooling joined the identity. Passing the old pair left the query with no


### PR DESCRIPTION
Supersedes #20, which found this and got the diagnosis exactly right. Same problem, cache pointed somewhere the suite can actually reach.

## The problem

Three suites load a real embedding model and nothing caches it, so every CI run re-downloads it from huggingface.co. That puts an unrelated third party's rate limiter in the pass/fail path. On 2026-08-05 a 429 on `Xenova/all-MiniLM-L6-v2/config.json` took down `workspace-query`, `cross-repo-semantic` and `cross-repo-eval` together — on #19, which touches none of them.

Those three are the whole set. Everything else either mocks `loadPipeline`, stubs the embedder, pre-places fake weight files, or skips when the model is absent.

## Why caching alone doesn't fix it

The obvious path to cache is `~/.knowl/models`, where `resolveModelCache` puts weights by default. No test ever sees the real home:

- `vitest.config.ts` pins `KNOWL_HOME` to `./.knowl-test-home` for every worker — deliberately, so a spawned CLI cannot scribble in a developer's home directory.
- `resolveModelCache` (src/ai/embeddings.ts) tries `knowlHome()/models` before `<projectRoot>/.knowl/models`, so under test the first candidate is always inside the repo.
- `cross-repo-semantic` and `cross-repo-eval` override `KNOWL_HOME` again to their own fixture, which `afterAll` deletes. `.knowl-*/` is gitignored and swept by `tests/global-teardown.ts` besides.

Every directory the resolver would pick is gone before the job ends, so an `actions/cache` step on `~/.knowl/models` saves nothing and restores nothing.

## What this does

Gives the three suites one cache to share, and caches that.

`workspace-query.test.ts` and `write-embedding.test.ts` already point at the repo's own `.knowl/models`, with a recorded reason: the model loads once instead of once per fixture root. The two cross-repo suites now do the same — a `MODEL_CACHE` constant and a `CONFIG` that sets `search.vector.cacheDir`, used for `saveConfig` and every `createLocalEmbeddingProvider` call.

`.github/workflows/ci.yml` then caches `.knowl/models`. The key design is #20's and unchanged: keyed on `vector-profile.ts` and `config.ts`, the two files that name the models, so switching or adding one fetches once and then caches. `restore-keys` carries more weight than the exact key — on a miss it still restores the newest previous cache, so a profile change re-downloads only what actually changed.

## What it doesn't do

The first run after this merges is a cache miss by definition and can still hit a 429; it's the runs after that this fixes. It doesn't help if HF is down while the cache is cold.

## Verification

- Cold run in a clean worktree with no `.knowl`: the three suites pass 14/14 and leave 23 MB at `.knowl/models/Xenova/all-MiniLM-L6-v2` — so the cache step has something to save, and the restore has somewhere to land.
- Warm: full suite green, 226 files / 1906 tests. `npm run build` and `git diff --check` clean.

One deliberate side effect: with `.knowl/models` warm, `write-embedding.test.ts`'s `it.skipIf(!MODEL_CACHED)` case stops being skipped in CI. It passes.
