### PR TITLE
fix: the 2026-08-06 audit — nineteen findings across the CLI, MCP surface and store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,68 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+The 2026-08-06 audit: nineteen findings across the CLI, the MCP surface and the store.
+
+### Data loss
+
+- **`doctor` no longer rebuilds the store it was asked to inspect.** It is exempt from the
+  missing-database guard so it can run when something is wrong, but it still called `initDb`, and
+  opening a libSQL `file:` URL creates the file — so diagnosing a repository whose database had
+  moved wrote an empty one, reported it ready, and left the guard unable to fire again.
+  `knowl-sync` runs doctor everywhere, which made routine maintenance the trigger.
+- **`snapshot` is no longer blocked by that guard**, which had been refusing the one command its
+  own error names as the first recovery to try.
+- **`snapshot restore` refuses another repository's snapshot.** The origin is recorded in the
+  manifest; `--accept-origin-mismatch` covers a repository that moved.
+- **`import` verifies each item's `contentHash` against its own content.** Divergence is decided on
+  that field, so an item edited with its hash left alone imported as "identical" and its real
+  content was discarded — under every policy, including `fail`.
+- **`knowl init` refuses to fork memory from a subdirectory.**
+
+### Failures that reported success
+
+- `isError` is set on the uninitialized-project banner and on every cross-repo ownership refusal.
+- `import` exits non-zero when it refuses.
+- `knowl_skill_create` refuses rather than overwriting an existing package.
+- `knowl_handoff` reports replacing an unconsumed baton.
+- `knowl_task_finish` refuses a second finish or a post-finish checkpoint.
+- `supersede` validates the replacement it is given.
+- `knowl_timeline` and `knowl_conflicts` name their overflow instead of truncating blind.
+
+### Context and correctness
+
+- **`knowl_query` is bounded** — 45,147 characters measured for a 25-result query, on the one path
+  with no ceiling. Lowest-ranked results are dropped with the count reported.
+- **`knowl_query` takes an `id`,** returning one item whole. 262 of 639 atoms on a real store
+  exceed the content ceiling, including `reasoning`, which `knowl_decide` requires and no tool
+  could read back.
+- **Tool order is deliberate.** The list led with `knowl_ingest`, which needs an unconfigured AI
+  provider, while `knowl_query` sat seventh.
+- Unknown tools and missing resources return `-32602` rather than a successful `isError` result or
+  the server's own `-32603`; a call omitting `arguments` no longer throws.
+- `knowl_ingest_atoms` is capped at 50.
+
+### Reads that wrote
+
+- **`knowl eval` no longer writes to the store it measures**, and no longer reindexes the live
+  embedding table before measuring it.
+- **`upgrade --all --dry-run` no longer edits the machine registry.**
+
+### The rest
+
+- **Write transactions take their lock up front** (`BEGIN IMMEDIATE`), as `bootstrapSchema` already
+  did for the same reason.
+- **GC compression cannot grow an item** — `summarize` truncated on UTF-16 length while the gate
+  measured bytes, so CJK and accented text came back larger with the original destroyed.
+- **Numeric and timestamp options are validated**, not coerced: `--limit abc` reached a bound
+  parameter as `NaN`, and `--as-of banana` matched every row through SQLite string comparison.
+- **Resume keys are eight characters and a miss costs 250 ms**; existing six-character keys still
+  resolve.
+- **Write failures are diagnosable** — the SQLite verdict in `error.cause` is surfaced through the
+  same sanitizer.
+- **`--json` failures emit an envelope on stdout** while stderr keeps the human line.
 ## 3.2.2 — 2026-08-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ The 2026-08-06 audit: nineteen findings across the CLI, the MCP surface and the 
   opening a libSQL `file:` URL creates the file — so diagnosing a repository whose database had
   moved wrote an empty one, reported it ready, and left the guard unable to fire again.
   `knowl-sync` runs doctor everywhere, which made routine maintenance the trigger.
-- **`snapshot` is no longer blocked by that guard**, which had been refusing the one command its
-  own error names as the first recovery to try.
+- **`snapshot restore` is no longer blocked by that guard**, which had been refusing the one
+  command its own error names as the first recovery to try. The subcommand only: `snapshot
+  create` opens the database, and opening one creates it, so exempting the group would let the
+  backup command rebuild an empty store and snapshot that.
 - **`snapshot restore` refuses another repository's snapshot.** The origin is recorded in the
   manifest; `--accept-origin-mismatch` covers a repository that moved.
 - **`import` verifies each item's `contentHash` against its own content.** Divergence is decided on
@@ -36,7 +38,9 @@ The 2026-08-06 audit: nineteen findings across the CLI, the MCP surface and the 
 ### Context and correctness
 
 - **`knowl_query` is bounded** — 45,147 characters measured for a 25-result query, on the one path
-  with no ceiling. Lowest-ranked results are dropped with the count reported.
+  with no ceiling. The bound spends bodies before it spends results: the lowest-ranked results
+  are cut to an excerpt, keeping their id, title and score so the agent can read any of them
+  whole with `id`. Dropping is the last resort, for when every body is already an excerpt.
 - **`knowl_query` takes an `id`,** returning one item whole. 262 of 639 atoms on a real store
   exceed the content ceiling, including `reasoning`, which `knowl_decide` requires and no tool
   could read back.
@@ -65,6 +69,29 @@ The 2026-08-06 audit: nineteen findings across the CLI, the MCP surface and the 
 - **Write failures are diagnosable** — the SQLite verdict in `error.cause` is surfaced through the
   same sanitizer.
 - **`--json` failures emit an envelope on stdout** while stderr keeps the human line.
+- **`import` takes `--repair-content-hash`** for an export written by a writer whose hash formula
+  predates this build. It recomputes rather than waives, so divergence is still decided on a hash
+  that describes the body it arrived with.
+
+### Changed
+
+- **`knowl doctor` now distinguishes advisory from broken, and its exit code changed with it.**
+  The verdict was `every check is OK`, which collapsed a three-level status into two outcomes:
+  a freshly initialized repository — every check OK except "nothing stored yet" — reported NOT
+  READY, so `knowl init` printed "ready" and `knowl doctor` called the same install broken.
+  READY now means no check FAILED, warnings are counted on the verdict line, and only a FAIL
+  exits non-zero. **Anything gating CI on `knowl doctor` or `knowl upgrade --all` returning
+  non-zero for a warning will stop firing.** The findings themselves are unchanged and still
+  printed, per repository, in the sweep.
+- **Doctor's retrieval check runs a real query.** The old one called `queryKnowledgeForAgent`
+  with no query string, which the ranker treats as browsing — so it was `COUNT(active) > 0`
+  wearing a query's clothes, and an item present in the table but missing from the index counted
+  as proof retrieval worked. It now queries a stored item by its own title words and asserts it
+  comes back, counts FTS membership for every active item beside it, and records no
+  `knowledge_access` rows while doing so.
+- **A warning-only integrity audit reports WARN rather than OK.** It used to stamp `[OK]` and
+  print a Fix line underneath it.
+
 ## 3.2.2 — 2026-08-06
 
 ### Fixed

--- a/src/cli/database-presence.ts
+++ b/src/cli/database-presence.ts
@@ -102,8 +102,15 @@ export function assertKnowledgeDatabasePresent(root: string): void {
  * Commands that create or repair a store are exempt by name rather than by inspection:
  * `init` writes the database, and `upgrade` is the documented way to accept an empty one.
  * `doctor` has to be able to run precisely when something is wrong.
+ *
+ * `snapshot` is exempt because the error above names `knowl snapshot restore` as the first
+ * recovery to try, and the guard was refusing it -- the one command the message prescribes was
+ * the one it blocked. That left the operator with `upgrade` (which accepts the empty store the
+ * guard exists to prevent) or `doctor`, and doctor used to rebuild the database and certify it.
+ * Being exempt only skips this presence check; `snapshot restore` still verifies its source and
+ * refuses an attachment with no `knowledge_items` of its own.
  */
-const EXEMPT_COMMANDS = new Set(['init', 'upgrade', 'doctor', 'config', 'diagnose-startup']);
+const EXEMPT_COMMANDS = new Set(['init', 'upgrade', 'doctor', 'config', 'diagnose-startup', 'snapshot']);
 
 export function assertDatabasePresentForCommand(commandName: string, cwd = process.cwd()): void {
   if (EXEMPT_COMMANDS.has(commandName)) return;

--- a/src/cli/database-presence.ts
+++ b/src/cli/database-presence.ts
@@ -103,17 +103,37 @@ export function assertKnowledgeDatabasePresent(root: string): void {
  * `init` writes the database, and `upgrade` is the documented way to accept an empty one.
  * `doctor` has to be able to run precisely when something is wrong.
  *
- * `snapshot` is exempt because the error above names `knowl snapshot restore` as the first
- * recovery to try, and the guard was refusing it -- the one command the message prescribes was
- * the one it blocked. That left the operator with `upgrade` (which accepts the empty store the
- * guard exists to prevent) or `doctor`, and doctor used to rebuild the database and certify it.
- * Being exempt only skips this presence check; `snapshot restore` still verifies its source and
- * refuses an attachment with no `knowledge_items` of its own.
+ * `snapshot restore` is exempt because the error above names it as the first recovery to try,
+ * and the guard was refusing it -- the one command the message prescribes was the one it
+ * blocked. That left the operator with `upgrade` (which accepts the empty store the guard
+ * exists to prevent) or `doctor`, and doctor used to rebuild the database and certify it.
+ * Being exempt only skips this presence check; `snapshot restore` still verifies its source
+ * and refuses an attachment with no `knowledge_items` of its own.
+ *
+ * The subcommand, not the group. `snapshot create` opens the database, and opening a libSQL
+ * `file:` URL creates it -- so exempting `snapshot` wholesale let the backup command rebuild
+ * an empty store, snapshot THAT, report success, and disarm this guard for good, which is
+ * precisely the defect the exemption was written to make recoverable. It is worse than the
+ * `doctor` case it mirrors: `createSnapshot` prunes to `SNAPSHOT_KEEP`, so three such calls
+ * evict the real snapshots -- the material the recovery needs.
  */
-const EXEMPT_COMMANDS = new Set(['init', 'upgrade', 'doctor', 'config', 'diagnose-startup', 'snapshot']);
+const EXEMPT_COMMANDS = new Set([
+  'init',
+  'upgrade',
+  'doctor',
+  'config',
+  'diagnose-startup',
+  'snapshot restore',
+]);
 
-export function assertDatabasePresentForCommand(commandName: string, cwd = process.cwd()): void {
-  if (EXEMPT_COMMANDS.has(commandName)) return;
+/**
+ * `commandPath` is the command's full path, top-level first, space-joined: `status`,
+ * `snapshot restore`. An entry naming only a top-level command exempts that whole group; an
+ * entry naming a path exempts that one subcommand and leaves its siblings guarded.
+ */
+export function assertDatabasePresentForCommand(commandPath: string, cwd = process.cwd()): void {
+  if (EXEMPT_COMMANDS.has(commandPath)) return;
+  if (EXEMPT_COMMANDS.has(commandPath.split(' ')[0])) return;
   const root = findProjectRootSync(cwd);
   if (!root) return;
   assertKnowledgeDatabasePresent(root);

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -8,11 +8,12 @@ import { vectorCoverageCheck } from './vector-coverage.js';
 import { isKnowlProjectGuidanceCurrent } from '../core/agents-guidance.js';
 import { closeDb, getDb, initDb } from '../store/database.js';
 import { getProjectByRootPath } from '../store/repository.js';
-import { queryKnowledgeForAgent } from '../store/agent-query.js';
+import { runLexicalCoverage, runRetrievalProbe } from './retrieval-probe.js';
 import { KNOWL_MCP_TOOL_NAMES } from '../core/knowl-guidance.js';
 import { getVectorSearchConfig, isVectorSearchEnabled } from '../ai/embeddings.js';
 import { fingerprintProfile, resolveVectorProfile } from '../core/vector-profile.js';
 import { auditKnowledgeStore } from '../store/integrity.js';
+import { assertKnowledgeDatabasePresent } from './database-presence.js';
 import { createAgentRegistry } from './agents/registry.js';
 import type { DoctorRemedy } from './doctor-remedy.js';
 
@@ -81,6 +82,16 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
       remedy: ignoresKnowl ? undefined : { kind: 'gitignore' },
     });
 
+    // `doctor` is exempt from the preAction missing-database guard so it can run precisely when
+    // something is wrong. That exemption was only ever meant to skip the *throw*, never to
+    // license the write: `initDb` opens a libSQL `file:` URL, and opening one CREATES it. So
+    // diagnosing a repository whose database had gone missing rebuilt an empty one, reported
+    // `[OK] Local project store ready`, and from then on the guard could never fire again --
+    // the file exists. `knowl-sync` runs doctor in every repository on this machine, which made
+    // routine maintenance the trigger that turned a recoverable move into a certified-healthy
+    // empty store. Ask the same question the guard asks, and let the catch below report it.
+    assertKnowledgeDatabasePresent(root);
+
     await initDb(root);
     dbOpen = true;
     const integrity = await auditKnowledgeStore(config.security);
@@ -91,7 +102,12 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
     const integrityErrors = integrity.findings.filter(finding => finding.severity === 'error').length;
     const integrityWarnings = integrity.findings.length - integrityErrors;
     checks.push({
-      status: integrityErrors > 0 ? 'FAIL' : 'OK',
+      // A warning-only audit reports WARN rather than OK. It stamped [OK] and then printed a
+      // Fix line under it, which is a report contradicting itself, and one of the findings it
+      // hid this way is `missing-index-row` -- the exact condition the retrieval self-test
+      // below fails on. Safe to say out loud only now that WARN no longer decides the verdict:
+      // before, any integrity warning anywhere would have reported the whole repository broken.
+      status: integrityErrors > 0 ? 'FAIL' : integrityWarnings > 0 ? 'WARN' : 'OK',
       message: integrity.findings.length === 0
         ? 'Knowledge integrity audit passed'
         : `Knowledge integrity audit found ${integrityErrors} error(s) and ${integrityWarnings} warning(s)`,
@@ -129,23 +145,21 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
       checks.push({ status: 'WARN', message: 'Database schema missing memory sessions; run knowl upgrade' });
     }
 
+    // Resolved once. Both coverage checks below filter on the profile that search actually uses,
+    // and a store where they disagreed about which profile that is would report a gap in one and
+    // full coverage in the other. Null means vector search is off, which the lexical check reads
+    // as "there is no semantic fallback".
+    const vectorFingerprint = isVectorSearchEnabled(config)
+      ? fingerprintProfile(resolveVectorProfile(config))
+      : null;
+
     const project = await getProjectByRootPath(root);
     if (!project) {
       checks.push({ status: 'FAIL', message: 'Project not registered in Knowl database' });
     } else {
       checks.push({ status: 'OK', message: 'Local project store ready' });
-
-      const queryResults = await queryKnowledgeForAgent(project.id, {
-        status: 'active',
-        limit: 3,
-      });
-      checks.push({
-        status: queryResults.length > 0 ? 'OK' : 'WARN',
-        message: queryResults.length > 0
-          ? `Agent query returned ${queryResults.length} item(s)`
-          : 'Agent query returned no active items; store durable project knowledge',
-        fix: queryResults.length > 0 ? undefined : 'store at least one durable fact, decision, constraint, architecture note, state item, or skill',
-      });
+      checks.push(await runLexicalCoverage(vectorFingerprint));
+      checks.push(await runRetrievalProbe(project.id));
     }
 
     const hasQuery = KNOWL_MCP_TOOL_NAMES.includes('knowl_query');
@@ -243,7 +257,7 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
       // duckprep store carried a NULL fingerprint, were invisible to every query, and doctor
       // reported `all 470 active item(s) embedded`. A check written to turn a silent
       // permanent gap into a visible one could not see the gap it was written for.
-      const fingerprint = fingerprintProfile(resolveVectorProfile(config));
+      const fingerprint = vectorFingerprint!;
       const counts = await (getDb() as any).all(sql`
         SELECT
           (SELECT COUNT(*) FROM knowledge_items WHERE status = 'active') AS active,
@@ -273,7 +287,14 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
   }
 
   return {
-    ready: checks.every(check => check.status === 'OK'),
+    // WARN is advisory by definition, so it must not decide the verdict. The old gate was
+    // `every(check => check.status === 'OK')`, which collapsed a three-level status into two
+    // outcomes and made a freshly initialized repository -- every check OK except "no knowledge
+    // stored yet" -- report NOT READY. `knowl init` printed "ready" and `knowl doctor` then
+    // called the same install broken, which is how this was found. Advisory findings are not
+    // lost: `formatDoctorReport` counts them on the verdict line and the sweep in
+    // `upgrade-all.ts` prints each one under its repository.
+    ready: checks.every(check => check.status !== 'FAIL'),
     checks,
   };
 }
@@ -288,8 +309,14 @@ export function formatDoctorReport(result: DoctorResult): string {
     }
   }
 
+  // Counted on the verdict line because READY must not read as spotless now that warnings no
+  // longer gate it: this is what carries an advisory finding to someone who reads only the last
+  // line, which for a long report is most people.
+  const warnings = result.checks.filter(check => check.status === 'WARN').length;
+  const advisory = warnings > 0 ? ` (${warnings} advisory warning${warnings === 1 ? '' : 's'})` : '';
+
   lines.push('');
-  lines.push(`Result: ${result.ready ? 'READY' : 'NOT READY'}`);
+  lines.push(`Result: ${result.ready ? 'READY' : 'NOT READY'}${advisory}`);
 
   return lines.join('\n');
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -58,7 +58,7 @@ import { approveSkill, listTrust, revokeSkill } from '../skills/trust.js';
 import { auditKnowledgeStore } from '../store/integrity.js';
 import { createSnapshot, restoreSnapshot } from '../store/snapshots.js';
 import { isEvidenceStale, listEvidenceForItem, resolveSymbolEvidence } from '../store/evidence-repository.js';
-import { queryKnowledgeForAgent } from '../store/agent-query.js';
+import { rankKnowledge } from '../store/agent-query.js';
 import { evaluateRetrieval, RetrievalEvaluationCase } from '../store/retrieval-evaluation.js';
 import { getKnowledgeAccessReport } from '../store/access-feedback.js';
 import { finishMemorySession, purgeExpiredSessionEvents, recoverAbandonedSessions, startMemorySession } from '../store/session-repository.js';
@@ -311,6 +311,26 @@ program
           `${knowlDir} is this machine's Knowl home, not a project. Run "knowl init" inside a repository.`
         );
       }
+      // Existence is tested on `cwd` only, and `findProjectRoot` -- which walks ancestors --
+      // was never consulted on the create path. So `knowl init` in a subpackage of an
+      // initialized repository printed "Successfully initialized" and built a second store
+      // inside it. Every later command run under that subtree then resolved to the shadow:
+      // writes landed there, queries from the subtree returned nothing, and nothing anywhere
+      // reported the split. Re-running init at the *root* already detects and upgrades; this
+      // is that same question asked one directory further up.
+      const enclosing = await findProjectRoot(cwd).catch(() => null);
+      if (enclosing && path.resolve(enclosing) !== path.resolve(cwd)) {
+        throw new Error(
+          `${cwd} is inside the Knowl repository at ${enclosing}.\n` +
+          'Initializing here would create a second store, and every command run below this ' +
+          'directory would then read and write that one instead of the repository\'s -- ' +
+          'silently, because both are valid.\n' +
+          `  - to use the existing memory: run knowl commands from anywhere under ${enclosing}\n` +
+          `  - to upgrade that repository: cd ${enclosing} && knowl init\n` +
+          '  - if this really is a separate project, move it outside that repository first',
+        );
+      }
+
       const isExisting = await isProjectRoot(cwd);
 
       if (isExisting) {
@@ -474,20 +494,79 @@ program.command('timeline').argument('<itemId>').description('Show the recorded 
   try { const root = await findProjectRoot(process.cwd()); await initDb(root); console.log(JSON.stringify(await listAssertions(itemId), null, 2)); await closeDb(); } catch (error: any) { console.error(`Error reading timeline: ${error.message}`); process.exit(1); }
 });
 
+/**
+ * How a `--json` command reports failure: an envelope on stdout, still exit 1.
+ *
+ * These flags exist for agent host hooks, and a hook parses stdout. Every failure used to be
+ * a plain-text line on stderr with stdout left empty, so the machine contract held on success
+ * and vanished exactly when the caller most needed to know what happened -- `JSON.parse('')`
+ * in the hook, on top of whatever went wrong here. One case (`agent-event session-event`)
+ * already returned a structured `{"accepted":false,...}`, proving the envelope was the intent;
+ * this makes it the rule.
+ */
+function reportCommandFailure(json: boolean | undefined, label: string, error: { message?: unknown }): never {
+  const message = `${label}: ${String(error?.message ?? error)}`;
+  // stderr always carries the human line -- that is where a person and the existing tests look.
+  // Under --json, stdout ALSO gets a parseable envelope, because these commands are host hooks
+  // and a hook parses stdout; before, failure left it empty and the hook got `JSON.parse('')`.
+  // Both streams, not one or the other: the message is identical and safe to repeat (the secret
+  // scanner has already stripped any secret from it before it reaches here).
+  console.error(message);
+  if (json) console.log(JSON.stringify({ error: { message } }));
+  process.exit(1);
+}
+
+/**
+ * A numeric option is either a number or a refusal -- never `NaN`.
+ *
+ * `Number(options.limit)` on a typo produced `NaN`, which flowed straight into a bound
+ * parameter: `knowl query x --limit abc` printed the raw FTS statement and `params: ...,NaN`.
+ * The `gc` flags were worse than noisy -- every comparison against `NaN` is false, so a
+ * mistyped `--stale-days` made `knowl gc --apply` a silent no-op that reported success.
+ * `context --token-budget` already validated; this is that rule applied everywhere else.
+ */
+function numericOption(raw: unknown, flag: string, { min = 1 }: { min?: number } = {}): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < min) {
+    throw new Error(`${flag} must be a number >= ${min}; received "${String(raw)}".`);
+  }
+  return value;
+}
+
+/**
+ * An unparseable `--as-of` used to mean "now", which is the one answer it must never give.
+ *
+ * Assertion validity is compared as SQLite *strings*, so `'banana'` sorts above every ISO
+ * timestamp and matched every row -- the feature whose entire purpose is "what did we believe
+ * on date X" answered with today's state and said nothing. An empty string fell off the
+ * temporal path altogether and silently took the ranker branch instead, returning a different
+ * shape and a different count.
+ */
+function timestampOption(raw: unknown, flag: string): string | undefined {
+  if (raw === undefined) return undefined;
+  const text = String(raw).trim();
+  if (!text || Number.isNaN(Date.parse(text))) {
+    throw new Error(`${flag} must be an ISO-8601 timestamp; received "${String(raw)}".`);
+  }
+  return text;
+}
+
 program.command('query').argument('[query]').description('Search project memory by keywords').option('--as-of <timestamp>').option('--limit <count>').action(async (query, options) => {
   try {
     const root = await findProjectRoot(process.cwd());
     await initDb(root);
     const project = await repo.getProjectByRootPath(root);
     if (!project) throw new Error('Project not found in database.');
-    const limit = options.limit === undefined ? undefined : Number(options.limit);
+    const limit = numericOption(options.limit, '--limit');
+    const asOf = timestampOption(options.asOf, '--as-of');
 
     // One engine, whether or not this repo is linked and whether an agent or a human asked.
     // The ranking used to differ on both axes: this command read queryKnowledgeBase directly
     // while knowl_query used the shared ranker, and the workspace branch used the ranker while
     // the solo branch did not -- the same command disagreeing with itself.
     const { items, skipped } = await runCliQuery({
-      projectRoot: root, projectId: project.id, query, limit, asOf: options.asOf,
+      projectRoot: root, projectId: project.id, query, limit, asOf,
     });
 
     console.log(JSON.stringify(items, null, 2));
@@ -508,7 +587,23 @@ program.command('conflicts').description('List knowledge items that contradict e
 });
 
 program.command('supersede').argument('<itemId>').argument('<replacementId>').description('Retire one item and point it at its replacement').action(async (itemId, replacementId) => {
-  try { const root = await findProjectRoot(process.cwd()); await initDb(root); console.log(JSON.stringify(await repo.supersedeKnowledgeItem(itemId, replacementId), null, 2)); await closeDb(); } catch (error: any) { console.error(`Error superseding knowledge: ${error.message}`); process.exit(1); }
+  try {
+    const root = await findProjectRoot(process.cwd());
+    await initDb(root);
+    // Only the first id was ever checked -- `supersedeKnowledgeItem` verifies the item being
+    // retired and takes the replacement on trust. So `supersede <id> <id>` pointed an item at
+    // itself, and a typo'd replacement stored a dangling `superseded_by_id`. Both retire the
+    // item out of every query, and `knowl audit` reports neither: integrity only walks
+    // dependent tables keyed by `knowledge_item_id` and never looks at `superseded_by_id`.
+    if (itemId === replacementId) {
+      throw new Error('An item cannot supersede itself; name the replacement that takes its place.');
+    }
+    if (!(await repo.getKnowledgeItem(replacementId))) {
+      throw new Error(`No knowledge item "${replacementId}" to supersede with. Nothing was retired.`);
+    }
+    console.log(JSON.stringify(await repo.supersedeKnowledgeItem(itemId, replacementId), null, 2));
+    await closeDb();
+  } catch (error: any) { console.error(`Error superseding knowledge: ${error.message}`); process.exit(1); }
 });
 
 program.command('context').description('Print a token-budgeted context pack for an agent').option('--query <query>').option('--task <task>').requiredOption('--token-budget <budget>').action(async options => {
@@ -869,6 +964,17 @@ program.command('import').argument('<path>').description('Load portable JSONL me
       // never share". Printed to stderr so a script parsing stdout is unaffected.
       for (const line of importOwnershipNotice(result.ownership)) console.error(line);
       await closeDb();
+      // An import that refused to apply must not report success. `--on-divergence fail` is the
+      // safe policy, and it printed `applied: false, conflicts: 1` and exited 0 -- so
+      // `knowl import x --on-divergence fail && echo synced` said synced on a refused merge.
+      // Only a *thrown* error reached the catch below; a declined result returned normally.
+      if (result.applied === false && !options.dryRun) {
+        console.error(
+          `Import did not apply${result.conflicts ? ` (${result.conflicts} conflict(s))` : ''}. ` +
+          'Re-run with a different --on-divergence policy, or reconcile the source.',
+        );
+        process.exitCode = 1;
+      }
     } catch (error: any) {
       await closeDb().catch(() => {});
       console.error(`Error importing knowledge: ${error.message}`);
@@ -1389,7 +1495,11 @@ program
         const config = await loadConfig(root);
         if (!isVectorSearchEnabled(config)) throw new Error('Vector search is not enabled. Set search.vector.enabled true to run --vector.');
         embedder = await createLocalEmbeddingProvider(config, root);
-        await reindexKnowledgeEmbeddings(project.id, embedder);
+        // No reindex. An "evaluate" command was rewriting the live embedding table before
+        // measuring it, which both mutates the store the user asked it to observe and makes
+        // the numbers describe a state the store was not in. Measure what retrieval would
+        // actually return today; if coverage is the problem, that is the user's call to fix.
+        console.error('Note: evaluates the store as it stands. If embedding coverage is incomplete, run `knowl reindex --vectors` first.');
       }
 
       const evaluation = await evaluateRetrieval(cases, async (testCase) => {
@@ -1402,13 +1512,18 @@ program
             relevanceFloor: embedder.relevanceFloor,
           }
           : undefined;
-        const items = await queryKnowledgeForAgent(project.id, {
+        // rankKnowledge, not queryKnowledgeForAgent: the latter records a knowledge_access row
+        // per returned item, and access rows feed GC liveness and tier confirmation -- so every
+        // benchmark run was promoting whichever items it returned and shielding them from GC.
+        // A measurement that mutates its subject is the defect the doctor check already had.
+        const items = (await rankKnowledge(project.id, {
           query: testCase.query,
           status: 'active',
-          surface: 'cli_eval',
           limit: testCase.limit,
           vector: vectorOption,
-        });
+          // The explanation is dropped rather than ignored: `contextChars` below measures the
+          // serialized result, so carrying it would inflate the very number being reported.
+        })).map(({ explanation: _explanation, ...item }) => item);
         return {
           itemIds: items.map(item => item.id),
           staleItemIds: items.filter(item => item.freshness !== 'fresh').map(item => item.id),
@@ -1446,8 +1561,7 @@ program
       await closeDb();
       if (fixtureRoot) await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => {});
     } catch (error: any) {
-      console.error(`Error evaluating retrieval: ${error.message}`);
-      process.exit(1);
+      reportCommandFailure(options.json, 'Error evaluating retrieval', error);
     }
   });
 
@@ -1510,7 +1624,7 @@ program
       // already the corrected one. A registry line is dropped only when the filesystem
       // positively says it is not a repository, and a sweep must not shrink in silence:
       // these are the paths `upgrade --all` and `doctor --fix` will stop acting on.
-      const { forgotten } = await readKnownRepos();
+      const { forgotten } = await readKnownRepos({ persist: !options.dryRun });
       for (const stale of forgotten) {
         console.log(`Forgot ${stale} -- recorded as a Knowl repository, but no longer one.`);
       }
@@ -1565,11 +1679,11 @@ program
       if (!project) throw new Error('Project not found in database.');
 
       const gcOptions = {
-        staleStateDays: options.staleDays !== undefined ? Number(options.staleDays) : undefined,
-        compressArchivedDays: options.compressDays !== undefined ? Number(options.compressDays) : undefined,
-        minCompressBytes: options.minBytes !== undefined ? Number(options.minBytes) : undefined,
+        staleStateDays: numericOption(options.staleDays, '--stale-days', { min: 0 }),
+        compressArchivedDays: numericOption(options.compressDays, '--compress-days', { min: 0 }),
+        minCompressBytes: numericOption(options.minBytes, '--min-bytes', { min: 0 }),
         ignoreAccess: Boolean(options.ignoreAccess),
-        tombstoneDays: options.tombstoneDays !== undefined ? Number(options.tombstoneDays) : undefined,
+        tombstoneDays: numericOption(options.tombstoneDays, '--tombstone-days', { min: 0 }),
       };
       const result = options.apply
         ? await applyKnowledgeGc(project.id, gcOptions)
@@ -1622,16 +1736,16 @@ program
 // --- 12. SESSION COMMAND ---
 const sessionCommand = program.command('session').description('Capture bounded temporary session memory');
 sessionCommand.command('start').argument('<title>').option('-q, --query <query>').option('--agent <agent>').option('--json').action(async (title, options) => {
-  try { const root = await findProjectRoot(process.cwd()); await initDb(root); const result = await startMemorySession({ title, query: options.query, agent: options.agent }); console.log(options.json ? JSON.stringify(result) : `Session started: ${result.id}`); await closeDb(); } catch (error: any) { console.error(`Error starting session: ${error.message}`); process.exit(1); }
+  try { const root = await findProjectRoot(process.cwd()); await initDb(root); const result = await startMemorySession({ title, query: options.query, agent: options.agent }); console.log(options.json ? JSON.stringify(result) : `Session started: ${result.id}`); await closeDb(); } catch (error: any) { reportCommandFailure(options.json, 'Error starting session', error); }
 });
 sessionCommand.command('event').argument('<id>').argument('<type>').option('--exit-code <code>').option('--summary <summary>').option('--command <command>').option('--json').action(async (id, type, options) => {
-  try { const root = await findProjectRoot(process.cwd()); await initDb(root); const result = await captureMemorySessionEvent(id, type, { exitCode: options.exitCode === undefined ? undefined : Number(options.exitCode), summary: options.summary, command: options.command }); console.log(options.json ? JSON.stringify(result) : `Session event recorded: ${result.id}`); await closeDb(); } catch (error: any) { console.error(`Error recording session event: ${error.message}`); process.exit(1); }
+  try { const root = await findProjectRoot(process.cwd()); await initDb(root); const result = await captureMemorySessionEvent(id, type, { exitCode: options.exitCode === undefined ? undefined : Number(options.exitCode), summary: options.summary, command: options.command }); console.log(options.json ? JSON.stringify(result) : `Session event recorded: ${result.id}`); await closeDb(); } catch (error: any) { reportCommandFailure(options.json, 'Error recording session event', error); }
 });
 sessionCommand.command('finish').argument('<id>').requiredOption('--status <status>', 'finished or failed').option('--summary <summary>').option('--json').action(async (id, options) => {
-  try { if (options.status !== 'finished' && options.status !== 'failed') throw new Error('Status must be finished or failed.'); const root = await findProjectRoot(process.cwd()); await initDb(root); const result = await finishMemorySession(id, options.status, options.summary); const project = await repo.getProjectByRootPath(root); const promotion = project ? await finalizeMemorySession(project.id, id) : null; console.log(options.json ? JSON.stringify({ ...result, promotion }) : `Session ${result.status}: ${result.id}`); await closeDb(); } catch (error: any) { console.error(`Error finishing session: ${error.message}`); process.exit(1); }
+  try { if (options.status !== 'finished' && options.status !== 'failed') throw new Error('Status must be finished or failed.'); const root = await findProjectRoot(process.cwd()); await initDb(root); const result = await finishMemorySession(id, options.status, options.summary); const project = await repo.getProjectByRootPath(root); const promotion = project ? await finalizeMemorySession(project.id, id) : null; console.log(options.json ? JSON.stringify({ ...result, promotion }) : `Session ${result.status}: ${result.id}`); await closeDb(); } catch (error: any) { reportCommandFailure(options.json, 'Error finishing session', error); }
 });
 sessionCommand.command('recover').option('--json').action(async (options) => {
-  try { const root = await findProjectRoot(process.cwd()); await initDb(root); const recovered = await recoverAbandonedSessions(); const purgedEventCount = await purgeExpiredSessionEvents(); const result = { recoveredCount: recovered.length, purgedEventCount }; console.log(options.json ? JSON.stringify(result) : `Recovered: ${result.recoveredCount}; purged events: ${result.purgedEventCount}`); await closeDb(); } catch (error: any) { console.error(`Error recovering sessions: ${error.message}`); process.exit(1); }
+  try { const root = await findProjectRoot(process.cwd()); await initDb(root); const recovered = await recoverAbandonedSessions(); const purgedEventCount = await purgeExpiredSessionEvents(); const result = { recoveredCount: recovered.length, purgedEventCount }; console.log(options.json ? JSON.stringify(result) : `Recovered: ${result.recoveredCount}; purged events: ${result.purgedEventCount}`); await closeDb(); } catch (error: any) { reportCommandFailure(options.json, 'Error recovering sessions', error); }
 });
 
 // --- 13. AGENT LIFECYCLE COMMAND ---
@@ -1695,9 +1809,8 @@ program
         await closeDb().catch(() => {});
         return;
       }
-      console.error(`Error handling agent lifecycle event: ${error.message}`);
       await closeDb().catch(() => {});
-      process.exit(1);
+      reportCommandFailure(options.json, 'Error handling agent lifecycle event', error);
     }
   });
 
@@ -2207,11 +2320,20 @@ snapshotCommand
   .description('Restore a snapshot after creating a pre-restore snapshot')
   .argument('<path>', 'Snapshot database path')
   .requiredOption('--confirm', 'Confirm the destructive restore operation')
+  .option(
+    '--accept-origin-mismatch',
+    'Restore a snapshot whose recorded origin is a different path than this repository. ' +
+    'For a repo that moved or was renamed since the snapshot; restoring another project\'s ' +
+    'snapshot replaces this one\'s memory with it.',
+  )
   .action(async (snapshotPath, options) => {
     try {
       const root = await findProjectRoot(process.cwd());
       await initDb(root);
-      const result = await restoreSnapshot(root, snapshotPath, { confirm: options.confirm });
+      const result = await restoreSnapshot(root, snapshotPath, {
+        confirm: options.confirm,
+        acceptOriginMismatch: options.acceptOriginMismatch,
+      });
       await closeDb();
       console.log('Snapshot restored.');
       console.log(`Pre-restore snapshot: ${result.preRestore.path}`);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -101,10 +101,14 @@ const program = new Command();
  * than the check.
  */
 program.hook('preAction', (_thisCommand, actionCommand) => {
-  let top = actionCommand;
-  while (top.parent && top.parent.parent) top = top.parent;
+  // The full path, top-level first, because exemption has to be able to name a single
+  // subcommand: `snapshot restore` must run when the database is gone -- the guard's own
+  // message prescribes it -- while `snapshot create` must not, since it opens the database
+  // and opening one creates it. Collapsing to the top-level name exempted the whole group.
+  const names: string[] = [];
+  for (let node = actionCommand; node?.parent; node = node.parent) names.unshift(node.name());
   try {
-    assertDatabasePresentForCommand(top.name());
+    assertDatabasePresentForCommand(names.join(' '));
   } catch (error: any) {
     console.error(error.message);
     process.exit(1);
@@ -948,6 +952,13 @@ program.command('import').argument('<path>').description('Load portable JSONL me
     'use it for your own backup or a second machine you cannot link and re-export from. It ' +
     'claims authorship only -- the items stay private until you promote them.',
   )
+  .option(
+    '--repair-content-hash',
+    'Import a file whose items carry a contentHash that does not describe their own content, ' +
+    'by recomputing it from the content. Import refuses such a file by default, because ' +
+    'divergence is decided on that field and a stale hash silently discards the real body. ' +
+    'For an export written by an older writer, which cannot be re-exported to fix.',
+  )
   .action(async (inputPath, options) => {
     try {
       if (!DIVERGENCE_POLICIES.includes(options.onDivergence)) {
@@ -957,12 +968,21 @@ program.command('import').argument('<path>').description('Load portable JSONL me
       await initDb(root);
       const result = await importKnowledge(path.resolve(inputPath), {
         dryRun: options.dryRun, projectRoot: root, onDivergence: options.onDivergence, claimAsMine: options.mine,
+        repairContentHash: options.repairContentHash,
       });
       console.log(JSON.stringify(result, null, 2));
       // The counts alone never say whose knowledge this now is, and for `attributed` that is
       // the difference between "imported 40 items" and "imported 40 items that this repo can
       // never share". Printed to stderr so a script parsing stdout is unaffected.
       for (const line of importOwnershipNotice(result.ownership)) console.error(line);
+      // Named for the same reason as the ownership notice: the file was accepted on different
+      // terms than it asked for, and nothing in the counts says so.
+      if (result.hashRepaired) {
+        console.error(
+          `Recomputed contentHash for ${result.hashRepaired} item(s) whose stated hash did not ` +
+          'describe their content; divergence for those was decided on the content itself.',
+        );
+      }
       await closeDb();
       // An import that refused to apply must not report success. `--on-divergence fail` is the
       // safe policy, and it printed `applied: false, conflicts: 1` and exited 0 -- so

--- a/src/cli/repo-registry.ts
+++ b/src/cli/repo-registry.ts
@@ -106,7 +106,14 @@ export type KnownRepos = {
  * `assertKnowledgeDatabasePresent` reads this file to tell a moved database from a fresh
  * clone, and an empty registry silently disables that guard.
  */
-export async function readKnownRepos(): Promise<KnownRepos> {
+export async function readKnownRepos(options: { persist?: boolean } = {}): Promise<KnownRepos> {
+  // Self-healing is a *write*, and `upgrade --all --dry-run` called this before its own dry-run
+  // guard -- so a command that closes with "Dry run: nothing was changed" permanently dropped
+  // entries from the registry. That registry is what `upgrade --all` and `doctor --fix` act on,
+  // and a repo whose checkout is momentarily absent (mid-clone, mid-restore, renamed) classifies
+  // as forgotten, so an inspection could quietly narrow every future sweep. Callers that are
+  // only looking pass `persist: false` and still get the same classification back to report.
+  const { persist = true } = options;
   const registry = await readRegistry();
 
   const repos: string[] = [];
@@ -129,7 +136,7 @@ export async function readKnownRepos(): Promise<KnownRepos> {
     }
   }
 
-  if (forgotten.length > 0) {
+  if (forgotten.length > 0 && persist) {
     try {
       await writeRegistry([...new Set(keep)].sort());
     } catch {

--- a/src/cli/retrieval-probe.ts
+++ b/src/cli/retrieval-probe.ts
@@ -1,0 +1,225 @@
+import { sql } from 'drizzle-orm';
+import { getDb } from '../store/database.js';
+import { rankKnowledge } from '../store/agent-query.js';
+
+export type RetrievalProbeCheck = { status: 'OK' | 'WARN' | 'FAIL'; message: string; fix?: string };
+
+/**
+ * What the probe found. Kept separate from the message so the wording is testable without a
+ * database, the way `vectorCoverageCheck` is.
+ */
+export type RetrievalProbeOutcome =
+  | { kind: 'empty' }
+  | { kind: 'unprobeable'; inspected: number }
+  | { kind: 'found'; title: string; terms: string[]; rank: number; returned: number }
+  | { kind: 'missed'; title: string; terms: string[]; returned: number };
+
+/**
+ * Whether every stored item is in the lexical index, not just the one the probe queried.
+ *
+ * The probe proves the query path works on a single item. That is exactly one item: deleting the
+ * FTS rows of 624 of a real store's 625 items leaves the probe passing at "rank 1 of 1" -- and
+ * "of 1" is the tell, but nothing was reading it. So membership is counted rather than sampled,
+ * the same way `vectorCoverageCheck` counts embeddings instead of trusting one query.
+ *
+ * `dark` is the number that decides severity: an item missing from the FTS index is still
+ * reachable semantically if it has a usable embedding, so a lexical gap alone is degradation.
+ * An item in neither index is reachable by nothing -- it is stored, counted, backed up, and
+ * permanently invisible to every agent that asks for it -- which is a failure, not a warning.
+ */
+export function lexicalCoverageCheck(input: {
+  activeItems: number;
+  indexedItems: number;
+  darkItems: number;
+}): RetrievalProbeCheck {
+  if (input.darkItems > 0) {
+    return {
+      status: 'FAIL',
+      message: `${input.darkItems} of ${input.activeItems} active item(s) are in neither the FTS index nor the vector index, so no query can reach them`,
+      fix: 'run `knowl audit` to list them; `missing-index-row` findings are the same items',
+    };
+  }
+
+  // The probe below already says an empty store is empty, and "covers all 0 item(s)" would be a
+  // second line saying the same thing in worse English.
+  if (input.activeItems === 0) {
+    return { status: 'OK', message: 'Lexical index has nothing to cover yet' };
+  }
+
+  const missing = Math.max(0, input.activeItems - input.indexedItems);
+  if (missing === 0) {
+    return {
+      status: 'OK',
+      message: `Lexical index covers all ${input.activeItems} active item(s)`,
+    };
+  }
+
+  return {
+    status: 'WARN',
+    message: `${missing} of ${input.activeItems} active item(s) are missing from the FTS index, so keyword search cannot reach them; they remain reachable by vector search only`,
+    fix: 'run `knowl audit` to list them (`missing-index-row`)',
+  };
+}
+
+/** How many stored items to consider before giving up on finding a probeable title. */
+const PROBE_CANDIDATES = 25;
+
+/**
+ * How deep the item is allowed to be and still count as found. Deliberately looser than the
+ * default query limit: this check asks whether search can reach a known item at all, not how
+ * well it ranks it. A store where every title shares a word would otherwise fail a check about
+ * something else entirely.
+ */
+const PROBE_DEPTH = 10;
+
+/**
+ * Words that prove nothing about retrieval because they match everything. A probe whose only
+ * term is "the" passes on a store whose index is empty, since the LIKE fallback in
+ * `queryKnowledgeCandidates` will still return rows.
+ */
+const PROBE_STOPWORDS = new Set([
+  'about', 'after', 'also', 'because', 'been', 'before', 'being', 'both', 'does', 'done',
+  'each', 'even', 'every', 'from', 'have', 'into', 'just', 'made', 'make', 'more', 'most',
+  'must', 'only', 'over', 'same', 'should', 'some', 'such', 'than', 'that', 'their', 'them',
+  'then', 'there', 'these', 'they', 'this', 'those', 'under', 'until', 'were', 'what', 'when',
+  'where', 'which', 'while', 'will', 'with', 'would', 'your',
+]);
+
+/**
+ * The distinctive words of a title, longest first.
+ *
+ * Longest first because a rare long word discriminates and a short common one does not, and the
+ * probe only needs one term that genuinely points at this item. Non-ASCII titles reduce to
+ * nothing here and are reported as unprobeable rather than failed -- a check that cannot build a
+ * fair question must not answer it.
+ */
+export function probeTermsFromTitle(title: string): string[] {
+  return [...new Set(title.toLowerCase().split(/[^a-z0-9]+/))]
+    .filter(term => term.length >= 4 && !PROBE_STOPWORDS.has(term))
+    .sort((left, right) => right.length - left.length)
+    .slice(0, 4);
+}
+
+function truncate(title: string): string {
+  return title.length <= 60 ? title : `${title.slice(0, 57)}...`;
+}
+
+export function retrievalProbeCheck(outcome: RetrievalProbeOutcome): RetrievalProbeCheck {
+  switch (outcome.kind) {
+    case 'empty':
+      // An empty store is a new repository, not a broken one, and since WARN no longer decides
+      // the verdict this can stay a nudge instead of a false alarm.
+      return {
+        status: 'WARN',
+        message: 'No knowledge stored yet, so retrieval could not be probed',
+        fix: 'store at least one durable fact, decision, constraint, architecture note, state item, or skill',
+      };
+    case 'unprobeable':
+      return {
+        status: 'WARN',
+        message: `Retrieval self-test skipped: none of the ${outcome.inspected} most recent item(s) has a title distinctive enough to query with`,
+      };
+    case 'found':
+      return {
+        status: 'OK',
+        message: `Retrieval self-test passed: "${truncate(outcome.title)}" came back at rank ${outcome.rank} of ${outcome.returned} when queried by its own title words`,
+      };
+    case 'missed':
+      return {
+        status: 'FAIL',
+        message: `Retrieval self-test FAILED: querying "${outcome.terms.join(' ')}" returned ${outcome.returned} item(s), none of them "${truncate(outcome.title)}" -- the item those words are the title of. Stored knowledge is not reachable by search.`,
+        fix: 'run `knowl audit`: a `missing-index-row` finding means the FTS index lost rows the item table still has',
+      };
+  }
+}
+
+/**
+ * Whether an agent querying this store would actually get its knowledge back.
+ *
+ * The check this replaces called `queryKnowledgeForAgent` with no query string and no vector,
+ * which `selectCandidates` treats as browsing -- it skips lexical scoring ("Browsing has no
+ * lexical evidence, only an order") and skips vector search entirely. So it was `COUNT(active)
+ * > 0` wearing a query's clothes, and an item present in the table but absent from the index
+ * counted as proof that retrieval worked.
+ *
+ * What this covers and what it does not, stated plainly so nobody reads a green line as more
+ * than it is: it covers the FTS index and the ranker. Vector reachability is `vectorCoverageCheck`,
+ * not this. The MCP response-shaping layer is covered by neither -- this calls `rankKnowledge`,
+ * below where `compactKnowledgeItem` runs, so the class of defect where a field is dropped on the
+ * way out to the agent still has no doctor check.
+ *
+ * Probing the most recently written item is deliberate: the FTS rows are maintained by triggers,
+ * so a trigger that has stopped firing shows up here immediately instead of being masked by old
+ * rows that were indexed correctly back when it worked.
+ *
+ * Lexical only, on purpose. Embedding a probe query would download and load an ONNX model, and a
+ * diagnostic that takes thirty seconds is one people stop running; vector reachability is already
+ * measured separately by `vectorCoverageCheck`. Reads only -- `rankKnowledge` rather than
+ * `queryKnowledgeForAgent`, because the latter records a `knowledge_access` row per hit, and
+ * those rows are counted as tier confirmations and as GC liveness. Doctor runs in every
+ * repository on the machine under `knowl-sync`, so the old check was quietly inflating the usage
+ * signal of whichever three items happened to sort first.
+ */
+/**
+ * Count index membership for every active item.
+ *
+ * `profileFingerprint` is the vector profile search will actually filter on, or null when vector
+ * search is switched off. Null makes every lexically-missing item dark, which is correct: with no
+ * semantic fallback configured, an item outside the FTS index has nothing left to find it.
+ */
+export async function runLexicalCoverage(profileFingerprint: string | null): Promise<RetrievalProbeCheck> {
+  const rows = await (getDb() as any).all(sql`
+    SELECT
+      (SELECT COUNT(*) FROM knowledge_items WHERE status = 'active') AS active,
+      (SELECT COUNT(*) FROM knowledge_items i
+         WHERE i.status = 'active'
+           AND EXISTS (SELECT 1 FROM knowledge_items_fts f WHERE f.item_id = i.id)) AS indexed,
+      (SELECT COUNT(*) FROM knowledge_items i
+         WHERE i.status = 'active'
+           AND NOT EXISTS (SELECT 1 FROM knowledge_items_fts f WHERE f.item_id = i.id)
+           AND NOT EXISTS (
+             SELECT 1 FROM knowledge_embeddings e
+             WHERE e.knowledge_item_id = i.id
+               AND ${profileFingerprint === null ? sql`1 = 0` : sql`e.profile_fingerprint = ${profileFingerprint}`}
+           )) AS dark
+  `);
+
+  return lexicalCoverageCheck({
+    activeItems: Number(rows[0]?.active ?? 0),
+    indexedItems: Number(rows[0]?.indexed ?? 0),
+    darkItems: Number(rows[0]?.dark ?? 0),
+  });
+}
+
+export async function runRetrievalProbe(projectId: string): Promise<RetrievalProbeCheck> {
+  const rows = await (getDb() as any).all(sql`
+    SELECT id, title FROM knowledge_items
+    WHERE status = 'active'
+    ORDER BY updated_at DESC
+    LIMIT ${PROBE_CANDIDATES}
+  `);
+
+  if (rows.length === 0) return retrievalProbeCheck({ kind: 'empty' });
+
+  const target = rows
+    .map((row: any) => ({ id: String(row.id), title: String(row.title) }))
+    .map((row: { id: string; title: string }) => ({ ...row, terms: probeTermsFromTitle(row.title) }))
+    .find((row: { terms: string[] }) => row.terms.length > 0);
+
+  if (!target) return retrievalProbeCheck({ kind: 'unprobeable', inspected: rows.length });
+
+  const results = await rankKnowledge(projectId, {
+    query: target.terms.join(' '),
+    status: 'active',
+    limit: PROBE_DEPTH,
+  });
+
+  const position = results.findIndex(item => item.id === target.id);
+  return position >= 0
+    ? retrievalProbeCheck({
+      kind: 'found', title: target.title, terms: target.terms, rank: position + 1, returned: results.length,
+    })
+    : retrievalProbeCheck({
+      kind: 'missed', title: target.title, terms: target.terms, returned: results.length,
+    });
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -1,5 +1,5 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { ListResourcesRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, ListResourcesRequestSchema, McpError, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { KnowledgeCategory } from '../core/types.js';
 import { getRecentContext } from '../store/recent-context.js';
 import { formatRecentContextToMarkdown, formatHierarchyToMarkdown } from '../core/format.js';
@@ -118,8 +118,15 @@ export function registerResources(
         };
       }
 
-      throw new Error(`Resource not found: ${uri}`);
+      // The spec is explicit: a resource that does not exist MUST come back as -32602
+      // (Invalid params), and -32603 (Internal error) is reserved for the server having
+      // failed. Thrown as a plain Error this fell into the catch below, was re-wrapped, and
+      // the SDK mapped it to -32603 -- so knowl reported the caller's bad URI as its own
+      // fault, and a client could not tell "you asked for something that isn't here" from
+      // "this server is broken". McpError carries the code through the re-wrap untouched.
+      throw new McpError(ErrorCode.InvalidParams, `Resource not found: ${uri}`);
     } catch (error: any) {
+      if (error instanceof McpError) throw error;
       // The second place a raw driver message can reach a client. No resource URI carries a
       // caller-supplied field, so the missing-argument route into it does not exist here --
       // but "statement text and bound parameters never leave the process" is the rule, and a

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -218,6 +218,11 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
             properties: {
               atoms: {
                 type: 'array',
+                // Every other array on this surface is capped -- tags/repos/completed at 20 --
+                // and this one, the one that writes the store, was unbounded. 400 atoms in a
+                // single call produced a 92,000-character response and one transaction that
+                // could retire other atoms from the same batch.
+                maxItems: 50,
                 items: {
                   type: 'object',
                   properties: {
@@ -304,10 +309,15 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           name: 'knowl_query',
           description: 'Use this first for specific project questions, before each new subtask, and when switching areas during multi-step work. Use every word that names the subject and none that does not: one more on-subject term retrieves better, one off-subject term retrieves worse, so never pad a query to reach a length and never drop a real term to stay under one. Skip only for directly relevant active lifecycle context, a same-request query, or relevant memory returned by knowl_task_start. If results contain a relevant active item, answer from Knowl without inspecting repository files. Inspect files only on miss, conflict, stale or low-confidence results, or explicit verification requests -- and on a miss, re-run once with different words first, because a first-pass miss is usually vocabulary rather than absence. `content` is cut at '
             + MAX_ITEM_CONTENT_CHARS
-            + ' characters and marked `truncated` when it was; `affectedPaths` names the files the item depends on, so open those rather than searching for them. Results carry `score` (0-1) when semantic search is available: it is the relevance the ranker ordered by and it is comparable across queries, so a low top score means the best available match is weak rather than that it is the answer. When no calibrated number exists, `score` is the string `uncalibrated (<reason>)`: the ranker has an order but no opinion on strength, so do not read position as confidence -- judge the content itself.',
+            + ' characters and marked `truncated` when it was; `affectedPaths` names the files the item depends on, so open those rather than searching for them. To read a truncated item in full, call again with `id` set to the id of that result. Results carry `score` (0-1) when semantic search is available: it is the relevance the ranker ordered by and it is comparable across queries, so a low top score means the best available match is weak rather than that it is the answer. When no calibrated number exists, `score` is the string `uncalibrated (<reason>)`: the ranker has an order but no opinion on strength, so do not read position as confidence -- judge the content itself.',
           inputSchema: {
             type: 'object',
             properties: {
+              id: {
+                type: 'string',
+                minLength: 1,
+                description: 'Fetch exactly this item, whole: full untruncated content plus the fields a search result omits (reasoning, alternatives, provenance, status, source, timestamps). Use it to read the rest of a result that came back `truncated`. When set, every other argument except includeEvidence is ignored.',
+              },
               query: {
                 type: 'string',
                 maxLength: 500,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,5 +1,5 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { captureChangeWatermark, consumeChangeNotice } from './change-notice.js';
 import { KNOWLEDGE_CATEGORIES, ProjectConfig, KnowledgeCategory, KnowledgeItem, KnowledgeStatus } from '../core/types.js';
@@ -96,6 +96,40 @@ export function describeWriteReconciliation(result: {
  * its own declaration, and the two drifted: confidence documented as 0.0-1.0 and accepted
  * at 999, entrypoints documented as an object and accepted as an array.
  */
+/**
+ * The tools a caller reaches for most, first.
+ *
+ * Models bias toward tools listed earlier, and this list led with `knowl_ingest` purely because
+ * it was written first -- a tool that requires an AI provider, unconfigured on most installs, so
+ * the first thing the surface advertised was the one thing it usually cannot do. `knowl_query`,
+ * which the documented workflow says to call before anything else, sat seventh.
+ *
+ * Order is data rather than a sort key on the definitions, so it stays byte-stable across builds:
+ * a tool list whose order changes between runs breaks prompt-prefix caching for every client that
+ * holds the catalog in context. Anything unnamed keeps its existing relative position after the
+ * named ones, so adding a tool needs no change here.
+ */
+const SELECTION_ORDER = [
+  'knowl_query',
+  'knowl_store',
+  'knowl_update',
+  'knowl_recent',
+  'knowl_state',
+  'knowl_decide',
+  'knowl_context',
+];
+
+function orderForSelection(tools: ToolDefinition[]): ToolDefinition[] {
+  const rank = (tool: ToolDefinition) => {
+    const index = SELECTION_ORDER.indexOf(tool.name);
+    return index === -1 ? SELECTION_ORDER.length : index;
+  };
+  // Stable: equal ranks keep source order, so only the named few move.
+  return tools.map((tool, index) => ({ tool, index }))
+    .sort((a, b) => rank(a.tool) - rank(b.tool) || a.index - b.index)
+    .map(entry => entry.tool);
+}
+
 export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefinition[] {
   const tools: ToolDefinition[] = [
     ...CORE_TOOL_DEFINITIONS,
@@ -105,7 +139,7 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
     tools.push(...TRANSCRIPT_TOOL_DEFINITIONS);
   }
 
-  return tools;
+  return orderForSelection(tools);
 }
 
 /**
@@ -118,6 +152,33 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
 const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
   [...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS].map(tool => [tool.name, tool.inputSchema]),
 );
+
+/**
+ * Drop lowest-ranked results until the serialized array fits the response ceiling.
+ *
+ * `MAX_RESPONSE_CHARS` is declared as the ceiling for this half of the surface and was wired
+ * into `boundContextResponse` only -- so `knowl_context` was bounded and `knowl_query`, the
+ * most-called tool on the server, had none. Measured at 45,147 characters for a 25-result
+ * query over 2,000-character atoms, and 59,990 with `includeEvidence` and `explain`; raising
+ * `MAX_ITEM_CONTENT_CHARS` from 600 to 2,000 tripled that floor on the one path nothing
+ * watched.
+ *
+ * Results arrive ranked, so the tail is the cheapest thing to give up. At least one result is
+ * always kept: a single oversized atom should come back truncated-but-present rather than as
+ * an empty array that reads like a miss. The omitted count is returned rather than folded into
+ * the payload, because the first block must stay a bare JSON array for callers that parse it.
+ */
+function boundQueryPayload(payload: unknown[]): { text: string; omitted: number } {
+  const kept = [...payload];
+  let omitted = 0;
+  let text = compactMcpJson(kept);
+  while (text.length > MAX_RESPONSE_CHARS && kept.length > 1) {
+    kept.pop();
+    omitted += 1;
+    text = compactMcpJson(kept);
+  }
+  return { text, omitted };
+}
 
 /**
  * A context pack serialized under a hard character ceiling.
@@ -179,7 +240,13 @@ export function registerTools(
 
   // 2. Call tool
   const callTool = async (request: CallToolRequest): Promise<CallToolResult> => {
-    const { name, arguments: args } = request.params;
+    const { name } = request.params;
+    // `arguments` is optional in the protocol, and a conformant client omits it for a tool whose
+    // properties are all optional. `validateToolArguments` already reads undefined as `{}` -- but
+    // every handler destructures `args` directly, so the four zero-required tools (knowl_query,
+    // knowl_state, knowl_recent, knowl_resume) threw a raw `Cannot destructure property ... of
+    // undefined` onto the wire. Normalise once here rather than in fourteen handlers.
+    const args = request.params.arguments ?? {};
     await whenReady();
     const initError = getInitError();
     const projectId = getProjectId();
@@ -188,6 +255,11 @@ export function registerTools(
 
     if (initError) {
       return {
+        // `isError` is the only signal an agent has that a call did not do what it asked.
+        // Without it this banner -- "the server is up but this is not a Knowl project" --
+        // read as a successful write, so an agent stored nothing and carried on believing
+        // memory held it.
+        isError: true,
         content: [
           {
             type: 'text',
@@ -267,7 +339,7 @@ export function registerTools(
           throw new Error(`Invalid knowledge category: ${category}`);
         }
         try { await assertOwnedTargets([supersedes], projectRoot, config); }
-        catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
 
         const store = () => storeKnowledgeItemDeduped(
           projectId!,
@@ -322,7 +394,7 @@ export function registerTools(
         // Every atom's retire target, before the first atom is written. A batch that fails
         // partway leaves the earlier atoms behind, so this cannot be checked per atom.
         try { await assertOwnedTargets(atoms.map((atom: any) => atom.supersedes), projectRoot, config); }
-        catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
 
         const result = await storeKnowledgeAtomsDeduped(
           projectId!,
@@ -359,7 +431,7 @@ export function registerTools(
       else if (name === 'knowl_decide') {
         const { title, content, reasoning, alternatives, tags, supersedes } = args as any;
         try { await assertOwnedTargets([supersedes], projectRoot, config); }
-        catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
         const result = await recordDecisionDirect(projectId!, {
           title,
           content,
@@ -381,7 +453,58 @@ export function registerTools(
       }
       
       else if (name === 'knowl_query') {
-        const { query, category, status, tags, limit, includeEvidence, explain, asOf, repos } = args as any;
+        const { id, query, category, status, tags, limit, includeEvidence, explain, asOf, repos } = args as any;
+        // Fetch-by-id: the second half of progressive disclosure. Truncation with no way to read
+        // the rest is not disclosure, it is loss with a warning label -- 262 of 639 atoms on a
+        // real store exceed the content ceiling and no tool could return them whole. A parameter
+        // rather than a 31st tool, deliberately: the tool list already costs ~6,700 tokens per
+        // session. This is also the first surface that returns `reasoning` and `alternatives` --
+        // `knowl_decide` REQUIRES reasoning and until now nothing could hand it back.
+        if (id) {
+          const { getKnowledgeItem } = await import('../store/repository.js');
+          const item = await getKnowledgeItem(String(id));
+          if (!item) {
+            return {
+              isError: true,
+              content: [{
+                type: 'text',
+                text: `No knowledge item "${id}" in this repo's store. If it belongs to a linked repo, run this from that repo -- fetch is local so a foreign atom's paths are never read against the wrong checkout.`,
+              }],
+            };
+          }
+          const full = {
+            id: item.id,
+            category: item.category,
+            title: item.title,
+            content: item.content,
+            ...(item.reasoning ? { reasoning: item.reasoning } : {}),
+            ...(item.alternatives?.length ? { alternatives: item.alternatives } : {}),
+            status: item.status,
+            freshness: item.freshness,
+            confidence: item.confidence,
+            ...(item.provenance ? { provenance: item.provenance } : {}),
+            ...(item.tags?.length ? { tags: item.tags } : {}),
+            ...(item.source ? { source: item.source } : {}),
+            ...(item.sourceCommit ? { sourceCommit: item.sourceCommit } : {}),
+            ...(item.affectedPaths?.length ? { affectedPaths: item.affectedPaths } : {}),
+            ...(item.conflictKey ? { conflictKey: item.conflictKey } : {}),
+            ...(item.supersededById ? { supersededById: item.supersededById } : {}),
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
+          };
+          const evidenceWithStale = async (itemId: string) => Promise.all(
+            (await listEvidenceForItem(itemId)).map(async evidence => ({
+              ...evidence,
+              stale: projectRoot ? await isEvidenceStale(evidence, projectRoot) : false,
+            })),
+          );
+          const payload = includeEvidence
+            ? [{ ...full, evidence: boundedEvidence(await evidenceWithStale(item.id)) }]
+            : [full];
+          // An array of one, not a bare object: every existing caller parses the first block as
+          // an array, and a fetch that changed the shape would break each of them.
+          return { content: [{ type: 'text', text: compactMcpJson(payload) }] };
+        }
         if (asOf) {
           // queryKnowledgeBase hard-filters on category, unlike every other query path,
           // which passes category: undefined and uses it only as a ranking boost. Without
@@ -553,7 +676,14 @@ export function registerTools(
           : resolvedItems.map(compact);
         // The notice is a separate block so the first block stays a bare JSON array for
         // every existing caller.
-        const blocks: { type: 'text'; text: string }[] = [{ type: 'text', text: compactMcpJson(payload) }];
+        const { text: payloadText, omitted: omittedResults } = boundQueryPayload(payload);
+        const blocks: { type: 'text'; text: string }[] = [{ type: 'text', text: payloadText }];
+        if (omittedResults > 0) {
+          blocks.push({
+            type: 'text',
+            text: `RESPONSE BOUNDED: ${omittedResults} lower-ranked result(s) omitted to keep this response under ${MAX_RESPONSE_CHARS} characters. They were the weakest matches, not a scoping failure — narrow the query or lower \`limit\` if you need to see them.`,
+          });
+        }
         if (skippedRepos.length) {
           const described = skippedRepos.map(skip => `${skip.repo} (${skip.reason})`).join(', ');
           blocks.push({
@@ -598,15 +728,31 @@ export function registerTools(
       else if (name === 'knowl_timeline') {
         const { itemId } = args as any;
         const owner = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
-        try { await assertOwnedItem(itemId, owner); } catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        try { await assertOwnedItem(itemId, owner); } catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
         const { listAssertions } = await import('../store/assertions.js');
-        return { content: [{ type: 'text', text: compactMcpJson((await listAssertions(itemId)).slice(0, 5).map(compactAssertionResponse)) }] };
+        // The bare array stays the first block -- callers and a test parse it as one. But a
+        // short complete history looked identical to the opening five of a long one, so a
+        // second block names the overflow, the way gc_preview reports its candidateCount.
+        const assertions = await listAssertions(itemId);
+        const timelineBlocks: { type: 'text'; text: string }[] = [
+          { type: 'text', text: compactMcpJson(assertions.slice(0, 5).map(compactAssertionResponse)) },
+        ];
+        if (assertions.length > 5) {
+          timelineBlocks.push({ type: 'text', text: `TIMELINE TRUNCATED: showing the 5 most recent of ${assertions.length} assertions.` });
+        }
+        return { content: timelineBlocks };
       }
 
       else if (name === 'knowl_conflicts') {
         const { listActiveConflictKeys } = await import('../store/conflicts.js');
         const items = await listActiveConflictKeys();
-        return { content: [{ type: 'text', text: compactMcpJson(items.slice(0, 3).map(item => ({ id: item.id, title: item.title, conflictKey: item.conflictKey, conflictScope: item.conflictScope, freshness: item.freshness }))) }] };
+        const conflictBlocks: { type: 'text'; text: string }[] = [
+          { type: 'text', text: compactMcpJson(items.slice(0, 3).map(item => ({ id: item.id, title: item.title, conflictKey: item.conflictKey, conflictScope: item.conflictScope, freshness: item.freshness }))) },
+        ];
+        if (items.length > 3) {
+          conflictBlocks.push({ type: 'text', text: `CONFLICTS TRUNCATED: showing 3 of ${items.length} conflicting items.` });
+        }
+        return { content: conflictBlocks };
       }
 
       else if (name === 'knowl_context') {
@@ -628,7 +774,7 @@ export function registerTools(
       else if (name === 'knowl_evidence_list') {
         const { itemId } = args as any;
         const owner = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
-        try { await assertOwnedItem(itemId, owner); } catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        try { await assertOwnedItem(itemId, owner); } catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
         const evidence = await Promise.all((await listEvidenceForItem(itemId)).map(async item => ({
           ...item,
           stale: projectRoot ? await isEvidenceStale(item, projectRoot) : false,
@@ -639,7 +785,7 @@ export function registerTools(
       else if (name === 'knowl_feedback') {
         const { itemId, used, useful, causedCorrection } = args as any;
         const owner = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
-        try { await assertOwnedItem(itemId, owner); } catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        try { await assertOwnedItem(itemId, owner); } catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
         const feedback = await recordKnowledgeFeedback({ itemId, used, useful, causedCorrection });
         // Standing is the deliberate consequence of feedback, applied here rather than
         // inside telemetry recording, which still never alters retrieval by itself.
@@ -676,7 +822,7 @@ export function registerTools(
         // and `supersedeId` reached `supersedeKnowledgeItem` with no ownership check at all
         // while the item named by `id` was guarded on the line above.
         try { await assertOwnedItem(id, owner); if (supersedeId) await assertOwnedItem(supersedeId, owner); }
-        catch (error) { return { content: [{ type: 'text', text: (error as Error).message }] }; }
+        catch (error) { return { isError: true, content: [{ type: 'text', text: (error as Error).message }] }; }
         // Checked BEFORE the update is written. It used to be resolved after, so an unknown
         // supersedeId threw once the update had already committed and the whole call was
         // reported as failed -- the agent believed nothing happened while memory had moved.
@@ -820,7 +966,7 @@ export function registerTools(
 
       else if (name === 'knowl_handoff') {
         const { goal, completed, nextAction, blocker, artifactRefs, verificationStatus, sessionId } = args as any;
-        const { handoff } = await recordDeliberateHandoff(projectId!, {
+        const { handoff, replacedPrevious } = await recordDeliberateHandoff(projectId!, {
           // The MCP layer is host-neutral and has no way to learn which host is calling, so a
           // baton parked here is filed under the host whose hooks deliver it on session start.
           host: 'claude',
@@ -838,7 +984,10 @@ export function registerTools(
         return {
           content: [{
             type: 'text',
-            text: `Parked. The next session in this project will receive this once.\n\n${formatPendingHandoffContext(handoff)}`,
+            // One baton per project. Parking again overwrites, and the previous baton's goal, next
+            // action and blocker are gone -- the schema comment calls that "the destruction of
+            // the real one", so the response no longer stays silent about it.
+            text: `${replacedPrevious ? 'Replaced the previous unconsumed handoff for this project — its goal, next action and blocker are gone. ' : ''}Parked. The next session in this project will receive this once.\n\n${formatPendingHandoffContext(handoff)}`,
           }],
         };
       }
@@ -936,16 +1085,35 @@ export function registerTools(
         return { content: [{ type: 'text', text }] };
       }
 
-      throw new Error(`Unknown tool: ${name}`);
+      // A name the server does not serve is a malformed request, which the spec groups with
+      // unknown methods as a protocol error (-32602). Thrown as a plain Error it fell into the
+      // catch below and came back as `isError` on a SUCCESSFUL response. The ToolInputError
+      // branch beneath is the deliberate opposite case and stays: SEP-1303 asks for argument
+      // validation to surface as a tool execution error so the model can self-correct.
+      throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${name}`);
     } catch (error: any) {
+      if (error instanceof McpError) throw error;
       if (error instanceof ToolInputError) {
         // Refused, not executed. Named separately so the caller can tell "I sent this wrong"
         // from "the store failed", and so the message is the argument rather than a statement.
         return { isError: true, content: [{ type: 'text', text: `Invalid arguments for "${name}": ${error.message}` }] };
       }
-      const message = error instanceof KnowledgeValidationError
-        ? `${error.code}: ${error.message}`
-        : sanitizeToolErrorMessage(String(error?.message ?? error));
+      let message: string;
+      if (error instanceof KnowledgeValidationError) {
+        message = `${error.code}: ${error.message}`;
+      } else {
+        message = sanitizeToolErrorMessage(String(error?.message ?? error));
+        // Drizzle's message BEGINS with "Failed query:", so the sanitizer's keep-the-prefix
+        // rule kept nothing and a failed write carried zero diagnosis -- while the actual
+        // SQLite verdict sat unread in `error.cause`. Sanitized through the same gate, so
+        // statement text and bound parameters still never leave the process; what does is
+        // the one line saying WHY it failed.
+        const cause = (error as { cause?: { message?: unknown } })?.cause?.message;
+        if (cause) {
+          const causeText = sanitizeToolErrorMessage(String(cause));
+          if (causeText && !message.includes(causeText)) message += ` Cause: ${causeText}`;
+        }
+      }
       return {
         isError: true,
         content: [{ type: 'text', text: `Error executing tool "${name}": ${message}` }],

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -153,8 +153,11 @@ const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
   [...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS].map(tool => [tool.name, tool.inputSchema]),
 );
 
+/** What a shortened result keeps of its body: enough to judge relevance, not to answer from. */
+const QUERY_EXCERPT_CHARS = 240;
+
 /**
- * Drop lowest-ranked results until the serialized array fits the response ceiling.
+ * Shrink the lowest-ranked results until the serialized array fits the response ceiling.
  *
  * `MAX_RESPONSE_CHARS` is declared as the ceiling for this half of the surface and was wired
  * into `boundContextResponse` only -- so `knowl_context` was bounded and `knowl_query`, the
@@ -163,21 +166,45 @@ const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
  * `MAX_ITEM_CONTENT_CHARS` from 600 to 2,000 tripled that floor on the one path nothing
  * watched.
  *
- * Results arrive ranked, so the tail is the cheapest thing to give up. At least one result is
- * always kept: a single oversized atom should come back truncated-but-present rather than as
- * an empty array that reads like a miss. The omitted count is returned rather than folded into
- * the payload, because the first block must stay a bare JSON array for callers that parse it.
+ * Bodies go before results do. Dropping a result hides that the item exists at all, which is
+ * indistinguishable from a retrieval miss; shortening one costs the body and keeps the id,
+ * title and score -- and `knowl_query { id }` now reads any of them whole, so the information
+ * is deferred rather than lost. Measured against dropping: a `limit: 25` query over 2 KB atoms
+ * returned 5 of 25, where shortening returns all 25 with the weakest bodies excerpted.
+ *
+ * Results arrive ranked, so the tail gives up its body first. Dropping remains the last
+ * resort, for when every body is already an excerpt and the count itself is the cost. At least
+ * one result is always kept: a single oversized atom should come back truncated-but-present
+ * rather than as an empty array that reads like a miss. The counts are returned rather than
+ * folded into the payload, because the first block must stay a bare JSON array for callers
+ * that parse it.
  */
-function boundQueryPayload(payload: unknown[]): { text: string; omitted: number } {
-  const kept = [...payload];
+function boundQueryPayload(payload: unknown[]): { text: string; shortened: number; omitted: number } {
+  const kept = payload.map(entry => ({ value: entry as Record<string, unknown>, shortened: false }));
+  const serialize = () => compactMcpJson(kept.map(entry => entry.value));
+  let text = serialize();
+  if (text.length <= MAX_RESPONSE_CHARS) return { text, shortened: 0, omitted: 0 };
+
+  for (let index = kept.length - 1; index >= 0 && text.length > MAX_RESPONSE_CHARS; index--) {
+    const content = kept[index].value.content;
+    if (typeof content !== 'string' || content.length <= QUERY_EXCERPT_CHARS) continue;
+    // `truncated` is the same flag a content-ceiling cut sets, so the instruction the tool
+    // description already gives -- call again with `id` to read the rest -- covers this too.
+    kept[index] = {
+      value: { ...kept[index].value, content: truncateText(content, QUERY_EXCERPT_CHARS), truncated: true },
+      shortened: true,
+    };
+    text = serialize();
+  }
+
   let omitted = 0;
-  let text = compactMcpJson(kept);
   while (text.length > MAX_RESPONSE_CHARS && kept.length > 1) {
     kept.pop();
     omitted += 1;
-    text = compactMcpJson(kept);
+    text = serialize();
   }
-  return { text, omitted };
+
+  return { text, shortened: kept.filter(entry => entry.shortened).length, omitted };
 }
 
 /**
@@ -676,12 +703,18 @@ export function registerTools(
           : resolvedItems.map(compact);
         // The notice is a separate block so the first block stays a bare JSON array for
         // every existing caller.
-        const { text: payloadText, omitted: omittedResults } = boundQueryPayload(payload);
+        const { text: payloadText, shortened, omitted: omittedResults } = boundQueryPayload(payload);
         const blocks: { type: 'text'; text: string }[] = [{ type: 'text', text: payloadText }];
-        if (omittedResults > 0) {
+        if (shortened > 0 || omittedResults > 0) {
+          const what = [
+            shortened > 0 ? `the content of ${shortened} lower-ranked result(s) was cut to an excerpt` : '',
+            omittedResults > 0 ? `${omittedResults} lower-ranked result(s) were dropped entirely` : '',
+          ].filter(Boolean).join(', and ');
           blocks.push({
             type: 'text',
-            text: `RESPONSE BOUNDED: ${omittedResults} lower-ranked result(s) omitted to keep this response under ${MAX_RESPONSE_CHARS} characters. They were the weakest matches, not a scoping failure — narrow the query or lower \`limit\` if you need to see them.`,
+            text: `RESPONSE BOUNDED: ${what}, to keep this response under ${MAX_RESPONSE_CHARS} characters. `
+              + 'These were the weakest matches, not a scoping failure. Read any result whole with '
+              + '`knowl_query` and its `id`; narrow the query or lower `limit` to see more of them at once.',
           });
         }
         if (skippedRepos.length) {

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -169,6 +169,16 @@ function normalizeEntrypoints(entrypoints?: Record<string, SkillEntrypoint>): Re
 export async function createSkillPackage(projectRoot: string, input: CreateSkillPackageInput): Promise<SkillPackage> {
   validateSkillName(input.name);
   const skillDir = getSkillPackageDir(projectRoot, input.name);
+  // Create means create. `mkdir -p` + `writeFile` silently overwrote an existing package --
+  // a second create of the same name replaced its SKILL.md and entrypoints, reported
+  // "Successfully created", and did not bump the version, so a working skill could vanish
+  // with no trace. Refuse instead; editing an existing skill is its own operation.
+  if (await fs.access(path.join(skillDir, 'skill.json')).then(() => true, () => false)) {
+    throw new Error(
+      `A skill named "${input.name}" already exists. Creating would overwrite it. ` +
+      `Delete it first, or choose another name.`,
+    );
+  }
   const now = new Date().toISOString();
   const manifest: SkillManifest = {
     name: input.name,

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -210,7 +210,18 @@ export async function withClientTransaction<T>(run: (conn: DbConnection) => Prom
     return await transactionScope.run(true, async () => {
       const client = getClient();
       const db = getDb();
-      await client.execute('BEGIN');
+      // IMMEDIATE, never a bare (DEFERRED) BEGIN. Every caller of this helper writes, and a
+      // deferred transaction takes its write lock lazily -- on the first write, after reads have
+      // already run. SQLite answers that upgrade with SQLITE_BUSY_SNAPSHOT rather than waiting,
+      // because the reader's snapshot is already stale; no busy handler may wait it out, so
+      // `PRAGMA busy_timeout` does not apply and the retry in connection-pool.ts does not match
+      // it. The write simply failed. Measured across processes on one store: 20 concurrent
+      // writes lost 0 through one server, 10 through two, 14 through three.
+      //
+      // IMMEDIATE takes the write lock up front, which IS waitable, so contention becomes a
+      // wait bounded by busy_timeout instead of an error. `bootstrapSchema` already did this
+      // for the same reason (bootstrap.ts) -- the rule was stated there and not applied here.
+      await client.execute('BEGIN IMMEDIATE');
       try {
         const result = await run(db);
         await client.execute('COMMIT');

--- a/src/store/gc.ts
+++ b/src/store/gc.ts
@@ -255,6 +255,14 @@ function buildCandidates(
       daysSince(item.updatedAt, now) >= compressArchivedDays
     ) {
       const replacementContent = summarize(item);
+      // Compression that grows the item is not compression. `summarize` truncates on UTF-16
+      // *length* (>120 chars) while the gate above and the report below measure *bytes*, so any
+      // content averaging >=1.5 bytes/char -- CJK, emoji, accented Latin -- could clear the
+      // 180-byte gate, stay under the 120-char limit, and come back whole plus the 20-byte
+      // `Compressed summary: ` prefix. Measured 189 -> 209 bytes, applied, with the original
+      // content destroyed in exchange for the growth. Skipping leaves the item archived and
+      // intact, which is the correct outcome for something already small enough.
+      if (Buffer.byteLength(replacementContent, 'utf8') >= beforeBytes) continue;
       candidates.push({
         itemId: item.id,
         action: 'compress',

--- a/src/store/portability.ts
+++ b/src/store/portability.ts
@@ -117,6 +117,12 @@ export type ImportResult = {
    * dump would see only counts, and never learn that those rows are unpromotable here.
    */
   ownership: 'trusted' | 'claimed' | 'attributed';
+  /**
+   * Items whose stated `contentHash` did not describe their own body and were recomputed under
+   * `--repair-content-hash`. Reported because the file was accepted on different terms than it
+   * asked for: divergence was decided on the content rather than on what the file claimed.
+   */
+  hashRepaired?: number;
   /** Present only on a dry run: what the counts WOULD have been. */
   wouldApply?: { inserted: number; identical: number; updated: number; keptLocal: number };
 };
@@ -517,6 +523,14 @@ export async function importKnowledge(
      * knows. Claims authorship, not publication.
      */
     claimAsMine?: boolean;
+    /**
+     * Import a file whose items misdescribe themselves, by believing the content rather than
+     * the hash. The refusal below is right about the danger and wrong to be the only answer:
+     * a hash formula that predates this build, or an export written by an older writer, leaves
+     * a legitimate backup permanently un-importable with no way through. Recomputing is
+     * strictly safer than the behaviour this replaced, which trusted the stated hash outright.
+     */
+    repairContentHash?: boolean;
   } = {},
 ): Promise<ImportResult> {
   const records = await readImportRecords(inputPath);
@@ -539,25 +553,40 @@ export async function importKnowledge(
   // and its real content was discarded in silence. Every policy behaved the same way, which
   // means `--on-divergence fail`, the safe one, was exactly the one that could not protect
   // you. Recompute and refuse: a file that misdescribes itself is not a file to merge from.
-  const misdescribed = items.filter(item => {
-    if (typeof item?.contentHash !== 'string' || !item.contentHash) return false;
-    return item.contentHash !== hashKnowledgeContent({
+  const misdescribed: Array<{ item: any; actual: string }> = [];
+  for (const item of items) {
+    if (typeof item?.contentHash !== 'string' || !item.contentHash) continue;
+    const actual = hashKnowledgeContent({
       title: String(item.title ?? ''),
       content: String(item.content ?? ''),
       reasoning: item.reasoning ?? null,
       source: item.source ?? null,
       affectedPaths: item.affectedPaths ?? null,
     });
-  });
-  if (misdescribed.length > 0) {
-    const named = misdescribed.slice(0, 3).map(item => String(item.id)).join(', ');
+    if (item.contentHash !== actual) misdescribed.push({ item, actual });
+  }
+  if (misdescribed.length > 0 && !options.repairContentHash) {
+    const named = misdescribed.slice(0, 3).map(entry => String(entry.item.id)).join(', ');
     throw new Error(
       `${misdescribed.length} item(s) carry a contentHash that does not match their own content ` +
       `(${named}${misdescribed.length > 3 ? ', ...' : ''}). The file's manifest checksum passed, so ` +
       'the bytes are intact and the mismatch was written that way -- by a hand-edit, a partial ' +
       'rewrite, or an older writer. Divergence is decided on that field, so importing this would ' +
-      'silently discard the real content. Re-export from the source repository.',
+      'silently discard the real content. Re-export from the source repository, or re-run with ' +
+      '--repair-content-hash to decide divergence on the content itself.',
     );
+  }
+  // Believing the content over the hash, not the hash over the content. The refusal above is
+  // the default because a file that misdescribes itself usually means something upstream is
+  // wrong and should be fixed there. But an export from an older writer is not repairable at
+  // the source, and leaving it permanently un-importable is its own kind of loss -- so the
+  // override recomputes rather than waives. Every downstream comparison then runs against a
+  // hash that genuinely describes the body it arrived with, which is strictly safer than the
+  // behaviour this whole guard replaced.
+  let hashRepaired = 0;
+  if (misdescribed.length > 0 && options.repairContentHash) {
+    for (const { item, actual } of misdescribed) item.contentHash = actual;
+    hashRepaired = misdescribed.length;
   }
   const assertions = records.filter(record => record.type === 'assertion').map(record => record.assertion);
   const evidence = records.filter(record => record.type === 'evidence').map(record => record.evidence);
@@ -668,6 +697,7 @@ export async function importKnowledge(
       inserted: 0, identical: 0, updated: 0, keptLocal: 0, deleted: 0,
       conflicts, blockedByTombstone, applied: false, ownership,
       divergent: options.dryRun ? divergent : [],
+      ...(hashRepaired ? { hashRepaired } : {}),
       ...(options.dryRun ? { wouldApply: counts } : {}),
     };
   }
@@ -795,5 +825,8 @@ export async function importKnowledge(
   // and stays best-effort: a project without vectors enabled simply stays on BM25.
   await indexKnowledgeItemsBestEffort('local', written);
 
-  return { ...counts, deleted, conflicts: 0, blockedByTombstone, applied: true, divergent, ownership };
+  return {
+    ...counts, deleted, conflicts: 0, blockedByTombstone, applied: true, divergent, ownership,
+    ...(hashRepaired ? { hashRepaired } : {}),
+  };
 }

--- a/src/store/portability.ts
+++ b/src/store/portability.ts
@@ -11,7 +11,7 @@ import { validateKnowledgeWrite } from '../core/knowledge-validation.js';
 import { listEvidenceForItem } from './evidence-repository.js';
 import { indexKnowledgeItemsBestEffort } from './write-embedding.js';
 import { listTombstones } from './tombstones.js';
-import { hashKnowledgeLifecycle } from './freshness.js';
+import { hashKnowledgeContent, hashKnowledgeLifecycle } from './freshness.js';
 import {
   classifyIncomingItem,
   DEFAULT_DIVERGENCE_POLICY,
@@ -531,6 +531,34 @@ export async function importKnowledge(
     );
   }
   const items = records.filter(record => record.type === 'item').map(record => record.item);
+
+  // The manifest checksum proves the bytes are the bytes the writer wrote. It says nothing
+  // about whether each item's own `contentHash` describes its own body -- and divergence is
+  // decided by comparing that field against the local row, never by looking at the content.
+  // So an item whose body was edited while its hash was left alone imported as "identical",
+  // and its real content was discarded in silence. Every policy behaved the same way, which
+  // means `--on-divergence fail`, the safe one, was exactly the one that could not protect
+  // you. Recompute and refuse: a file that misdescribes itself is not a file to merge from.
+  const misdescribed = items.filter(item => {
+    if (typeof item?.contentHash !== 'string' || !item.contentHash) return false;
+    return item.contentHash !== hashKnowledgeContent({
+      title: String(item.title ?? ''),
+      content: String(item.content ?? ''),
+      reasoning: item.reasoning ?? null,
+      source: item.source ?? null,
+      affectedPaths: item.affectedPaths ?? null,
+    });
+  });
+  if (misdescribed.length > 0) {
+    const named = misdescribed.slice(0, 3).map(item => String(item.id)).join(', ');
+    throw new Error(
+      `${misdescribed.length} item(s) carry a contentHash that does not match their own content ` +
+      `(${named}${misdescribed.length > 3 ? ', ...' : ''}). The file's manifest checksum passed, so ` +
+      'the bytes are intact and the mismatch was written that way -- by a hand-edit, a partial ' +
+      'rewrite, or an older writer. Divergence is decided on that field, so importing this would ' +
+      'silently discard the real content. Re-export from the source repository.',
+    );
+  }
   const assertions = records.filter(record => record.type === 'assertion').map(record => record.assertion);
   const evidence = records.filter(record => record.type === 'evidence').map(record => record.evidence);
   const links = records.filter(record => record.type === 'knowledge_evidence').map(record => record.link);
@@ -662,7 +690,10 @@ export async function importKnowledge(
     after: { id: String(item.id), category: item.category, title: String(item.title ?? '') },
   });
   let deleted = 0;
-  await client.execute('BEGIN;');
+  // IMMEDIATE for the same reason as `withClientTransaction`: this block writes, and a deferred
+  // BEGIN would take its write lock on the first insert, which SQLite refuses with
+  // SQLITE_BUSY_SNAPSHOT rather than waiting whenever another process wrote in between.
+  await client.execute('BEGIN IMMEDIATE;');
   try {
     for (const entry of plan) {
       if (entry.action === 'insert') {

--- a/src/store/resume-keys.ts
+++ b/src/store/resume-keys.ts
@@ -28,12 +28,12 @@ const pick = (alphabet: string) => alphabet[randomInt(alphabet.length)];
 /**
  * A key the user keeps.
  *
- * Letter-digit alternating, six characters. The shape is not cosmetic: a key is pasted back
- * into a prompt, and a six-character key from a full alphabet can legitimately spell `budget`
- * or `delete`. A key that reads as an instruction is one a model may act on instead of look up.
+ * Letter-digit alternating, eight characters. The shape is not cosmetic: a key is pasted back
+ * into a prompt, and a key from a full alphabet can legitimately spell `budget` or `delete`.
+ * A key that reads as an instruction is one a model may act on instead of look up.
  * Alternating positions makes a pronounceable word structurally impossible.
  *
- * 18 letters x 6 digits per pair, three pairs: about 1.26 million keys. Collisions are handled
+ * 18 letters x 6 digits per pair, four pairs: about 136 million keys. Collisions are handled
  * by the caller retrying on a unique-constraint violation, not by making the key longer.
  */
 export function mintResumeKey(): string {

--- a/src/store/resume-keys.ts
+++ b/src/store/resume-keys.ts
@@ -12,7 +12,16 @@ const LETTERS = 'bcdfghjkmnpqrtvwxy';
 /** Digits with the same treatment: no `0`, `1`, `2` or `5`. */
 const DIGITS = '346789';
 
-const KEY_LENGTH = 6;
+/**
+ * Eight characters, up from six. Three pairs gave ~1.26 million keys, and the read path
+ * answers a wrong key in about a millisecond with no limit -- full enumeration of every
+ * parked workstream on the machine in ~20 minutes from any directory. Four pairs is ~136
+ * million, which together with the miss delay in `readResumePoint` moves enumeration from
+ * "a lunch break" to "not worth it" while staying transcribable. Keys already in people's
+ * hands stay six characters and keep resolving; only newly minted ones grow.
+ */
+const KEY_LENGTH = 8;
+const LEGACY_KEY_LENGTH = 6;
 
 const pick = (alphabet: string) => alphabet[randomInt(alphabet.length)];
 
@@ -33,7 +42,7 @@ export function mintResumeKey(): string {
   return key;
 }
 
-const KEY_SHAPE = new RegExp(`^([${LETTERS}][${DIGITS}]){${KEY_LENGTH / 2}}$`);
+const KEY_SHAPE = new RegExp(`^([${LETTERS}][${DIGITS}]){${LEGACY_KEY_LENGTH / 2},${KEY_LENGTH / 2}}$`);
 
 /**
  * The key inside whatever the user pasted, or null.

--- a/src/store/resume-points.ts
+++ b/src/store/resume-points.ts
@@ -21,9 +21,11 @@ export type ResumePoint = ResumeBrief & {
 /**
  * Retries on a key collision rather than lengthening every key.
  *
- * Collisions are expected, not exceptional: the keyspace is 1,259,712 and 2,000 independent
- * draws collide about 80% of the time. What matters is that a *stored* key is unique, which the
- * primary key enforces and this retry absorbs.
+ * Collisions are rare at the current keyspace of 136,048,896 -- they were expected at the
+ * 1,259,712 of six-character keys, where 2,000 independent draws collided about 80% of the
+ * time -- but the retry stays either way. What matters is that a *stored* key is unique, which
+ * the primary key enforces and this absorbs, and that guarantee must not depend on how long
+ * the key happens to be this year.
  */
 const MINT_ATTEMPTS = 5;
 

--- a/src/store/resume-points.ts
+++ b/src/store/resume-points.ts
@@ -82,7 +82,17 @@ export async function readResumePoint(rawKey: string): Promise<ResumePoint | nul
     args: [key],
   })).rows;
 
-  return rows[0] ? toPoint(rows[0] as Record<string, unknown>) : null;
+  // A wrong key costs a quarter second. Lookups answered in ~1 ms with no limit made the
+  // machine-wide keyspace enumerable in minutes from any directory -- 50 misses were measured
+  // in 47 ms -- and a hit hands over another repo's goal, blocker and artifact paths. A human
+  // mistyping feels nothing at 250 ms; an enumeration of the 8-character space now costs years
+  // instead of an afternoon. On a hit there is no delay at all.
+  if (!rows[0]) {
+    await new Promise(resolve => setTimeout(resolve, 250));
+    return null;
+  }
+
+  return toPoint(rows[0] as Record<string, unknown>);
 }
 
 /**

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -364,9 +364,8 @@ async function persistPendingHandoff(
   const existing = await findActivePendingHandoff(host);
   if (existing) {
     // One active handoff per host. Only repeated failures from the same host session merge.
-    const merged = options.merge && existing.handoff.externalSessionId === handoff.externalSessionId
-      ? mergeHandoff(existing.handoff, handoff)
-      : handoff;
+    const extendsExisting = options.merge && existing.handoff.externalSessionId === handoff.externalSessionId;
+    const merged = extendsExisting ? mergeHandoff(existing.handoff, handoff) : handoff;
     const updated = await repo.updateKnowledgeItem(existing.id, write(merged));
     await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${host}/${merged.kind})`, [
       { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
@@ -374,7 +373,13 @@ async function persistPendingHandoff(
     // A merge extends the same session's baton; anything else overwrote a different active
     // handoff whose contents are now gone. The caller reports which, so parking again does not
     // silently discard a baton the schema comment itself calls "the destruction of the real one".
-    return { itemId: updated.id, handoff: merged, replacedPrevious: merged !== existing.handoff };
+    //
+    // Read off the branch that decided it, not off object identity: `mergeHandoff` always
+    // allocates, so `merged !== existing.handoff` reported a replacement for every merge too --
+    // wrong the moment any caller passes `merge: true` and surfaces this. Today only
+    // `recordDeliberateHandoff` reads it, and it never merges, so the identity test happened to
+    // agree with the intent. Latent agreement is not the same as saying what you mean.
+    return { itemId: updated.id, handoff: merged, replacedPrevious: !extendsExisting };
   }
 
   const created = await repo.createKnowledgeItem(projectId, { category: 'state', ...write(handoff) });

--- a/src/store/session-handoff.ts
+++ b/src/store/session-handoff.ts
@@ -342,7 +342,7 @@ async function persistPendingHandoff(
   projectId: string,
   handoff: PendingHandoff,
   options: { merge: boolean },
-): Promise<{ itemId: string; handoff: PendingHandoff }> {
+): Promise<{ itemId: string; handoff: PendingHandoff; replacedPrevious: boolean }> {
   const host = handoff.host;
   // Normalized here because `findActivePendingHandoff` looks the slot up normalized. Passing
   // the raw spelling survived a create, which normalizes for us, but an update wrote it
@@ -371,14 +371,17 @@ async function persistPendingHandoff(
     await repo.createKnowledgeCommit(projectId, `Update pending session handoff (${host}/${merged.kind})`, [
       { itemId: updated.id, action: 'update', before: existing.handoff as any, after: updated },
     ]);
-    return { itemId: updated.id, handoff: merged };
+    // A merge extends the same session's baton; anything else overwrote a different active
+    // handoff whose contents are now gone. The caller reports which, so parking again does not
+    // silently discard a baton the schema comment itself calls "the destruction of the real one".
+    return { itemId: updated.id, handoff: merged, replacedPrevious: merged !== existing.handoff };
   }
 
   const created = await repo.createKnowledgeItem(projectId, { category: 'state', ...write(handoff) });
   await repo.createKnowledgeCommit(projectId, `Record pending session handoff (${host}/${handoff.kind})`, [
     { itemId: created.id, action: 'insert', after: created },
   ]);
-  return { itemId: created.id, handoff };
+  return { itemId: created.id, handoff, replacedPrevious: false };
 }
 
 export async function recordPendingSessionHandoff(
@@ -446,7 +449,7 @@ export async function recordDeliberateHandoff(
     sessionTitle?: string;
     taskState: HandoffTaskState;
   },
-): Promise<{ itemId: string; handoff: PendingHandoff }> {
+): Promise<{ itemId: string; handoff: PendingHandoff; replacedPrevious: boolean }> {
   const handoff: PendingHandoff = {
     kind: 'handoff',
     urgency: HANDOFF_URGENCY,

--- a/src/store/snapshots.ts
+++ b/src/store/snapshots.ts
@@ -14,6 +14,15 @@ export type SnapshotManifest = {
   createdAt: string;
   byteSize: number;
   sha256: string;
+  /**
+   * The repository this snapshot was taken from. The database itself carries no project
+   * identity (the projects table is gone), and every repo's snapshots sit at the identically
+   * shaped path `.knowl/snapshots/<timestamp>-<hex>.db` -- so nothing stopped repo B from
+   * restoring repo A's snapshot and adopting its entire memory, with the post-restore audit
+   * reporting clean. Absent on snapshots written before this field existed; restore treats
+   * that as unknown rather than wrong.
+   */
+  originRoot?: string;
 };
 
 export type Snapshot = {
@@ -57,6 +66,7 @@ export async function createSnapshot(
     createdAt,
     byteSize: stat.size,
     sha256: await sha256(snapshotPath),
+    originRoot: root,
   };
   const manifestPath = `${snapshotPath}.manifest.json`;
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
@@ -273,7 +283,7 @@ async function verifySnapshotBytes(file: string, manifest: SnapshotManifest): Pr
 export async function restoreSnapshot(
   projectRoot: string,
   snapshotPath: string,
-  options: { confirm?: boolean } = {},
+  options: { confirm?: boolean; acceptOriginMismatch?: boolean } = {},
 ): Promise<{ preRestore: Snapshot; findings: Awaited<ReturnType<typeof auditKnowledgeStore>>['findings'] }> {
   if (!options.confirm) throw new Error('Snapshot restore requires --confirm.');
   const root = path.resolve(projectRoot);
@@ -283,6 +293,25 @@ export async function restoreSnapshot(
   await fs.access(source).catch(() => { throw new Error('Snapshot file was not found.'); });
 
   const manifest = await readSnapshotManifest(source);
+
+  // Restoring another repository's snapshot replaces this repository's entire memory with the
+  // foreign one, and it used to succeed silently: the paths are identically shaped, so a
+  // tab-completion slip was all it took, and the post-restore audit reported the adopted store
+  // as clean. Compared case-insensitively because Windows paths are. A mismatch can also be
+  // legitimate -- the same repository moved or renamed since the snapshot -- which is what the
+  // override is for, and why the refusal names both paths instead of just saying no.
+  if (manifest.originRoot !== undefined && !options.acceptOriginMismatch) {
+    const sameRoot = path.resolve(manifest.originRoot).toLowerCase() === root.toLowerCase();
+    if (!sameRoot) {
+      throw new Error(
+        `This snapshot was taken from a different repository.\n` +
+        `  snapshot origin: ${manifest.originRoot}\n` +
+        `  restoring into:  ${root}\n` +
+        `Restoring it would replace this repository's memory with that one's. If this repo ` +
+        `simply moved since the snapshot was taken, re-run with --accept-origin-mismatch.`,
+      );
+    }
+  }
 
   // Copied out of the snapshot directory before anything else runs, and everything after this
   // point reads the copy. `.knowl/` rather than `.knowl/snapshots/`, so the pre-restore

--- a/src/store/work-loop.ts
+++ b/src/store/work-loop.ts
@@ -58,6 +58,12 @@ async function requireWorkLoopTask(taskId: string): Promise<KnowledgeItem> {
   return task;
 }
 
+/** Whether a `finish` step has already been recorded for this task. */
+async function taskAlreadyFinished(taskId: string): Promise<boolean> {
+  const items = await repo.listKnowledgeItems();
+  return items.some(item => item.tags?.includes(`task:${taskId}`) && item.tags?.includes('finish'));
+}
+
 function stringList(value: unknown, maxItems = 20, maxLength = 500): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const values = value
@@ -155,6 +161,17 @@ async function recordWorkLoopStep(
   taskStateInput: WorkLoopTaskState = {},
 ): Promise<WorkLoopStepResult> {
   const task = await requireWorkLoopTask(taskId);
+  // Finish once. The session layer already enforces a terminal state -- a second finish logs
+  // "Cannot append an event to a terminal memory session" -- but the work-loop layer ignored
+  // that and wrote a fresh `finish` item anyway, minting two different completions for one
+  // task against a description that says "exactly once". A checkpoint after finish is the same
+  // contradiction. Refuse both, naming the earlier finish.
+  if (await taskAlreadyFinished(taskId)) {
+    throw new Error(
+      `Work loop ${taskId} is already finished; it cannot be ${stepTag === 'finish' ? 'finished again' : 'checkpointed after finishing'}. ` +
+      'Start a new work loop for further steps.',
+    );
+  }
   const now = new Date().toISOString();
   const taskState = normalizeTaskState(taskStateInput);
   const item = await repo.createKnowledgeItem(projectId, {

--- a/src/store/work-loop.ts
+++ b/src/store/work-loop.ts
@@ -1,5 +1,6 @@
 import type { KnowledgeItem } from '../core/types.js';
 import { queryKnowledgeForAgent } from './agent-query.js';
+import { getClient } from './database.js';
 import * as repo from './repository.js';
 import { captureMemorySessionEvent } from './session-capture.js';
 import { finishMemorySession, startMemorySession } from './session-repository.js';
@@ -58,10 +59,23 @@ async function requireWorkLoopTask(taskId: string): Promise<KnowledgeItem> {
   return task;
 }
 
-/** Whether a `finish` step has already been recorded for this task. */
+/**
+ * Whether a `finish` step has already been recorded for this task.
+ *
+ * An existence check rather than a scan. This runs on every checkpoint and every finish, and
+ * `listKnowledgeItems` reads and maps every row in the store to answer it -- the same cost
+ * `listActiveSkillItems` exists to avoid on the mid-turn skill lookup. Tag matching follows
+ * the store's own idiom (`search.ts`, `vector.ts`): tags serialize as a JSON array, so the
+ * quoted needle cannot match a longer tag that merely starts with the same characters.
+ */
 async function taskAlreadyFinished(taskId: string): Promise<boolean> {
-  const items = await repo.listKnowledgeItems();
-  return items.some(item => item.tags?.includes(`task:${taskId}`) && item.tags?.includes('finish'));
+  const rows = (await getClient().execute({
+    sql: `SELECT 1 FROM knowledge_items
+      WHERE tags LIKE ? AND tags LIKE '%"finish"%'
+      LIMIT 1`,
+    args: [`%"task:${taskId}"%`],
+  })).rows;
+  return rows.length > 0;
 }
 
 function stringList(value: unknown, maxItems = 20, maxLength = 500): string[] | undefined {

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -333,9 +333,14 @@ describe('CLI Integration', () => {
       encoding: 'utf8',
       env: { ...process.env, KNOWL_NO_UPDATE_CHECK: '1' },
     });
-    expect(result.status).toBe(1);
+    // Exit 0: stale host instructions are a WARN, and a WARN is advisory. The repository is
+    // usable -- MCP still answers -- so the verdict stays READY and the finding is carried by
+    // the WARN line and its fix hint, which is what this test is actually about. Only FAIL
+    // exits non-zero now.
+    expect(result.status).toBe(0);
     expect(result.stdout).toContain('[WARN] claude native instructions missing or stale');
     expect(result.stdout).toContain('run `knowl init claude`');
+    expect(result.stdout).toContain('advisory warning');
     await fs.rm(root, { recursive: true, force: true });
   });
 
@@ -657,7 +662,10 @@ describe('CLI Integration', () => {
     expect(output).toContain('[OK] Config includes vector search defaults');
     expect(output).toContain('[OK] Database schema includes knowledge_embeddings');
     expect(output).toContain('[OK] .gitignore ignores .knowl/');
-    expect(output).toContain('[OK] Agent query returned');
+    // The check this replaced only counted rows. This one runs a real query and asserts the
+    // stored decision comes back from it, so the assertion covers the index and the ranker
+    // rather than the row count.
+    expect(output).toContain('[OK] Retrieval self-test passed: "Doctor Ready" came back at rank 1');
     expect(output).toContain('[OK] MCP tools expose knowl_query and hide knowl_ask');
     expect(output).toContain('[OK] MCP tools expose work-loop task tools');
     expect(output).toContain('[OK] codex lifecycle hooks configured');
@@ -685,9 +693,16 @@ describe('CLI Integration', () => {
     await fs.writeFile(path.join(staleDir, 'AGENTS.md'), '# Agent Instructions\n', 'utf-8');
     await fs.writeFile(path.join(staleDir, '.gitignore'), 'node_modules/\n', 'utf-8');
 
-    let output = '';
+    // No initializer: both the try and the catch assign it, so a placeholder here would be
+    // dead — and a `''` that can never survive is exactly the kind of default that hides a
+    // path where neither branch ran.
+    let output: string;
     try {
-      execSync(`node "${CLI_PATH}" doctor`, {
+      // Captured from the success path too. This used to read stdout only out of the thrown
+      // error, which silently assumed doctor exits non-zero here -- it did, because a WARN
+      // used to mean NOT READY. Both stale files are advisory, so it now exits 0 and the
+      // assertions below were reading an empty string.
+      output = execSync(`node "${CLI_PATH}" doctor`, {
         cwd: staleDir,
         encoding: 'utf-8',
         stdio: 'pipe',

--- a/tests/cli/doctor-report.test.ts
+++ b/tests/cli/doctor-report.test.ts
@@ -50,7 +50,10 @@ async function onlyItemId(): Promise<string> {
 }
 
 function coverageCheck(checks: Array<{ status: string; message: string; fix?: string }>) {
-  return checks.find(check => /active item\(s\)|invisible to semantic search/i.test(check.message))!;
+  // Anchored on the opening words, which only the vector coverage check uses. Matching
+  // "active item(s)" loosely used to be unambiguous; the lexical coverage check now reports a
+  // count in the same words and sits earlier in the list, so a loose match selected that one.
+  return checks.find(check => /^Vector search/i.test(check.message))!;
 }
 
 describe('doctor vector coverage', () => {
@@ -108,5 +111,152 @@ describe('doctor vector coverage', () => {
 
     expect(check.status).toBe('OK');
     expect(check.message).toMatch(/all 1 active item\(s\) embedded/);
+  });
+});
+
+describe('doctor retrieval self-test', () => {
+  afterEach(async () => {
+    await closeDb();
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  /** A repository with a registered project and nothing in it. */
+  async function bareRepo(): Promise<string> {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-probe-'));
+    await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+    await fs.writeFile(path.join(root, '.knowl', 'config.json'), JSON.stringify(DEFAULT_CONFIG), 'utf-8');
+    await initDb(root);
+    return (await repo.createProject(root, 'doctor-probe')).id;
+  }
+
+  /** Make this item unambiguously the newest, so the probe is known to target it. */
+  async function makeNewest(itemId: string): Promise<void> {
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET updated_at = ? WHERE id = ?',
+      args: ['2999-01-01T00:00:00.000Z', itemId],
+    });
+  }
+
+  function probeCheck(checks: Array<{ status: string; message: string; fix?: string }>) {
+    return checks.find(check => /retrieval self-test|no knowledge stored yet/i.test(check.message))!;
+  }
+
+  function coverageLine(checks: Array<{ status: string; message: string; fix?: string }>) {
+    return checks.find(check => /lexical index|FTS index/i.test(check.message))!;
+  }
+
+  it('catches the items the probe never looked at', async () => {
+    // The hole a single-item probe leaves, found by attacking a real store: deleting the FTS
+    // rows of 624 of its 625 items left the probe passing at "rank 1 of 1". Coverage is counted
+    // for every item precisely so one green query cannot stand in for the whole store.
+    const projectId = await bareRepo();
+    const stale = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'An older item that keyword search is about to lose',
+      content: 'Reachable until its index row goes.',
+    });
+    const newest = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Postgres connection pool exhausts during concurrent migrations',
+      content: 'Migrations open their own connections.',
+    });
+    await makeNewest(newest.id);
+    await getClient().execute({
+      sql: 'DELETE FROM knowledge_items_fts WHERE item_id = ?',
+      args: [stale.id],
+    });
+    await closeDb();
+
+    const result = await runDoctor(root);
+
+    // The probe is happy: it queried the item that still works.
+    expect(probeCheck(result.checks).status).toBe('OK');
+    // Coverage is not. This suite runs with embedding writes disabled, so the item it lost is
+    // in no index at all -- reachable by nothing, which is a failure rather than degradation.
+    expect(coverageLine(result.checks).status).toBe('FAIL');
+    expect(coverageLine(result.checks).message).toContain('1 of 2');
+    expect(result.ready).toBe(false);
+  });
+
+  it('reports READY on a repository with nothing stored yet', async () => {
+    // The bug this whole change came from: `knowl init` on a fresh repo printed "ready", then
+    // `knowl doctor` printed NOT READY on the same install, because the only non-OK line was
+    // an advisory "nothing stored yet" and the verdict gated on every check being OK.
+    await bareRepo();
+    await closeDb();
+
+    const result = await runDoctor(root);
+
+    expect(probeCheck(result.checks).status).toBe('WARN');
+    expect(result.ready).toBe(true);
+    expect(result.checks.some(check => check.status === 'FAIL')).toBe(false);
+  });
+
+  it('re-finds a stored item by its own title words', async () => {
+    const projectId = await bareRepo();
+    await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Postgres connection pool exhausts during concurrent migrations',
+      content: 'Migrations open their own connections.',
+    });
+    await closeDb();
+
+    const result = await runDoctor(root);
+
+    expect(probeCheck(result.checks).status).toBe('OK');
+    expect(probeCheck(result.checks).message).toMatch(/came back at rank \d+ of \d+/);
+    expect(result.ready).toBe(true);
+  });
+
+  it('FAILS, and gates the verdict, when the index has lost the item', async () => {
+    // The failure the old check could not see: the item row is present and countable, so
+    // `COUNT(active) > 0` reports a healthy store, while search cannot reach it. Only the
+    // probed item's FTS row is deleted -- bootstrap backfills the index when it is entirely
+    // empty, so a total wipe would heal itself on the next `initDb` and prove nothing. A
+    // partial gap is also the real-world shape: `integrity.ts` looks for exactly it.
+    const projectId = await bareRepo();
+    await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'An unrelated item keeping the index table populated',
+      content: 'Present so the backfill does not run.',
+    });
+    const target = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Postgres connection pool exhausts during concurrent migrations',
+      content: 'Migrations open their own connections.',
+    });
+    await makeNewest(target.id);
+    await getClient().execute({
+      sql: 'DELETE FROM knowledge_items_fts WHERE item_id = ?',
+      args: [target.id],
+    });
+    await closeDb();
+
+    const result = await runDoctor(root);
+
+    expect(probeCheck(result.checks).status).toBe('FAIL');
+    expect(probeCheck(result.checks).fix).toContain('knowl audit');
+    expect(result.ready).toBe(false);
+  });
+
+  it('records no knowledge_access rows: a diagnostic must not feed the ranking signal', async () => {
+    // The old check called `queryKnowledgeForAgent`, which writes a `knowledge_access` row per
+    // returned item tagged as a real agent query. Those rows are counted as tier confirmations
+    // (`tier.ts`) and as GC liveness (`getAccessSummary`), and `knowl-sync` runs doctor in every
+    // repository on the machine -- so merely diagnosing a store promoted whichever items
+    // happened to sort first.
+    const projectId = await bareRepo();
+    await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Postgres connection pool exhausts during concurrent migrations',
+      content: 'Migrations open their own connections.',
+    });
+    await closeDb();
+
+    await runDoctor(root);
+
+    await initDb(root);
+    const rows = await getClient().execute('SELECT COUNT(*) AS total FROM knowledge_access');
+    expect(Number((rows.rows[0] as any).total)).toBe(0);
   });
 });

--- a/tests/cli/missing-database-recovery.test.ts
+++ b/tests/cli/missing-database-recovery.test.ts
@@ -69,6 +69,28 @@ describe('a knowledge database that has gone missing', () => {
     await expect(fs.access(path.join(repo, '.knowl', 'knowl.db'))).rejects.toThrow();
   });
 
+  it('is not silently recreated by the backup command either', async () => {
+    // The exemption that lets `snapshot restore` run has to name the subcommand, not the group.
+    // `snapshot create` opens the database, and opening a libSQL `file:` URL creates it -- so a
+    // group-wide exemption let the BACKUP command rebuild an empty store, snapshot that empty
+    // store, report "KNOWL SNAPSHOT CREATED", and leave the guard unable to fire again. Worse
+    // than the `doctor` case it mirrors: create prunes to SNAPSHOT_KEEP, so three of these
+    // evict the real snapshots -- exactly the material the recovery needs.
+    const created = run(['snapshot', 'create'], repo, home);
+    const snapshot = (created.stdout.match(/^Snapshot:\s*(.+)$/m) ?? [])[1]?.trim();
+    expect(snapshot).toBeTruthy();
+
+    await removeDatabase();
+
+    const result = run(['snapshot', 'create'], repo, home);
+
+    expect(result.stdout + result.stderr).toMatch(/database is missing/i);
+    expect(result.status).toBe(1);
+    await expect(fs.access(path.join(repo, '.knowl', 'knowl.db'))).rejects.toThrow();
+    // The real snapshot is still there to restore from, not pruned to make room for an empty one.
+    await expect(fs.access(snapshot!)).resolves.toBeUndefined();
+  });
+
   it('can be restored by the command the error message prescribes', async () => {
     const created = run(['snapshot', 'create'], repo, home);
     const snapshot = (created.stdout.match(/^Snapshot:\s*(.+)$/m) ?? [])[1]?.trim();

--- a/tests/cli/missing-database-recovery.test.ts
+++ b/tests/cli/missing-database-recovery.test.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * A database that went missing must stay missing until a person decides otherwise.
+ *
+ * Two defects made routine maintenance destroy the evidence of a recoverable loss:
+ *
+ * 1. `doctor` is exempt from the preAction missing-database guard so it can run when something
+ *    is wrong. The exemption skipped the throw, but `runDoctor` still called `initDb`, and
+ *    opening a libSQL `file:` URL creates the file. So diagnosing a repository whose database
+ *    had moved rebuilt an empty one and reported the store ready -- and the guard could never
+ *    fire again afterwards, because now the file existed. `knowl-sync` runs `doctor` in every
+ *    repository on the machine.
+ *
+ * 2. The guard's own error names `knowl snapshot restore` as the first recovery to try, and
+ *    `snapshot` was not exempt -- so the guard refused the one command it told you to run.
+ *
+ * Fixtures live outside the checkout: `findProjectRoot` walks up, so a fixture under the repo
+ * resolves to the repo on any machine where `knowl init` has been run in it.
+ */
+
+const CLI = path.resolve(__dirname, '../../dist/index.js');
+
+function run(args: string[], cwd: string, home: string) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, KNOWL_HOME: home },
+  });
+}
+
+describe('a knowledge database that has gone missing', () => {
+  let root = '';
+  let repo = '';
+  let home = '';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-missing-db-'));
+    repo = path.join(root, 'repo');
+    home = path.join(root, 'home');
+    await fs.mkdir(repo, { recursive: true });
+    run(['init'], repo, home);
+    run(['decide', 'Irreplaceable', 'the one fact this repository holds'], repo, home);
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function removeDatabase() {
+    const dir = path.join(repo, '.knowl');
+    for (const suffix of ['', '-shm', '-wal']) {
+      await fs.rm(path.join(dir, `knowl.db${suffix}`), { force: true });
+    }
+  }
+
+  it('is not silently recreated by the command that diagnoses it', async () => {
+    await removeDatabase();
+
+    const result = run(['doctor'], repo, home);
+
+    expect(result.stdout + result.stderr).toMatch(/database is missing/i);
+    expect(result.stdout).toContain('NOT READY');
+    // The actual damage: a rebuilt file makes the loss permanent and undetectable.
+    await expect(fs.access(path.join(repo, '.knowl', 'knowl.db'))).rejects.toThrow();
+  });
+
+  it('can be restored by the command the error message prescribes', async () => {
+    const created = run(['snapshot', 'create'], repo, home);
+    const snapshot = (created.stdout.match(/^Snapshot:\s*(.+)$/m) ?? [])[1]?.trim();
+    expect(snapshot).toBeTruthy();
+
+    await removeDatabase();
+
+    const restored = run(['snapshot', 'restore', snapshot!, '--confirm'], repo, home);
+
+    expect(restored.status).toBe(0);
+    expect(restored.stdout).toContain('Snapshot restored.');
+    expect(run(['status'], repo, home).stdout).toMatch(/Active:\s+1/);
+  });
+});

--- a/tests/cli/retrieval-probe.test.ts
+++ b/tests/cli/retrieval-probe.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { lexicalCoverageCheck, probeTermsFromTitle, retrievalProbeCheck } from '../../src/cli/retrieval-probe.js';
+
+describe('probeTermsFromTitle', () => {
+  it('keeps the distinctive words and drops the ones that match everything', () => {
+    // A probe whose terms are "with"/"that"/"this" passes against an index that has lost the
+    // item, because the LIKE fallback in `queryKnowledgeCandidates` still returns rows. The
+    // filter is what makes a passing self-test mean something.
+    expect(probeTermsFromTitle('Migrations that run with this connection pool'))
+      .not.toContain('that');
+    expect(probeTermsFromTitle('Migrations that run with this connection pool'))
+      .toContain('connection');
+  });
+
+  it('orders by length, because a long rare word discriminates and a short one does not', () => {
+    const terms = probeTermsFromTitle('Postgres connection pool exhausts');
+
+    expect(terms[0]).toBe('connection');
+    expect(terms).toHaveLength(4);
+  });
+
+  it('caps the query and never repeats a word', () => {
+    const terms = probeTermsFromTitle('backup backup restore restore snapshot rollback archive');
+
+    expect(terms).toHaveLength(4);
+    expect(new Set(terms).size).toBe(4);
+  });
+
+  it('returns nothing for a title it cannot build a fair question from', () => {
+    // Non-ASCII and all-short titles reduce to nothing here. That is reported as skipped
+    // rather than failed: a check that cannot ask a fair question must not answer it.
+    expect(probeTermsFromTitle('日本語のタイトル')).toEqual([]);
+    expect(probeTermsFromTitle('a b c to be or not')).toEqual([]);
+  });
+});
+
+describe('lexicalCoverageCheck', () => {
+  it('fails when items are in neither index, because nothing can reach them', () => {
+    // The one state that is not degradation: the item is stored, counted and backed up, and no
+    // query of any kind can return it.
+    const check = lexicalCoverageCheck({ activeItems: 582, indexedItems: 1, darkItems: 581 });
+
+    expect(check.status).toBe('FAIL');
+    expect(check.message).toContain('581 of 582');
+  });
+
+  it('warns, not fails, when the lexical gap is still covered by vectors', () => {
+    // Keyword search is broken for these items but an agent can still retrieve them
+    // semantically, so this is degradation. The count is in the message because that is the
+    // part a reader acts on -- 581 missing and 1 missing are not the same morning.
+    const check = lexicalCoverageCheck({ activeItems: 582, indexedItems: 1, darkItems: 0 });
+
+    expect(check.status).toBe('WARN');
+    expect(check.message).toContain('581 of 582');
+  });
+
+  it('passes a fully indexed store and says nothing alarming about an empty one', () => {
+    expect(lexicalCoverageCheck({ activeItems: 12, indexedItems: 12, darkItems: 0 }).status).toBe('OK');
+    expect(lexicalCoverageCheck({ activeItems: 0, indexedItems: 0, darkItems: 0 }).status).toBe('OK');
+  });
+});
+
+describe('retrievalProbeCheck', () => {
+  it('treats an empty store as advisory, not broken', () => {
+    // A new repository is not a broken one. This is the line that used to make `knowl doctor`
+    // print NOT READY seconds after `knowl init` printed "ready".
+    const check = retrievalProbeCheck({ kind: 'empty' });
+
+    expect(check.status).toBe('WARN');
+    expect(check.fix).toMatch(/store at least one durable fact/);
+  });
+
+  it('fails when the item behind the query did not come back', () => {
+    const check = retrievalProbeCheck({
+      kind: 'missed', title: 'Postgres connection pool exhausts', terms: ['connection', 'exhausts'], returned: 10,
+    });
+
+    expect(check.status).toBe('FAIL');
+    expect(check.message).toContain('connection exhausts');
+    expect(check.fix).toContain('knowl audit');
+  });
+
+  it('truncates a long title instead of printing a paragraph into the report', () => {
+    const check = retrievalProbeCheck({
+      kind: 'found', title: 'x'.repeat(200), terms: ['xxxx'], rank: 1, returned: 3,
+    });
+
+    expect(check.status).toBe('OK');
+    expect(check.message).toContain('...');
+    expect(check.message.length).toBeLessThan(160);
+  });
+});

--- a/tests/cli/upgrade-all.test.ts
+++ b/tests/cli/upgrade-all.test.ts
@@ -79,13 +79,20 @@ describe('upgrade --all sweep', () => {
     await expect(fs.readdir(path.join(A, '.knowl', 'snapshots'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
-  it('reports a repository not ready when a finding has no automatic repair', async () => {
-    // A repo with no knowledge in it warns, and no automatic action can resolve that. A
-    // sweep that called it READY would be lying about the one thing it exists to report.
+  it('reports an empty repository ready, and still reports what is missing from it', async () => {
+    // Reversed deliberately. This used to assert NOT READY, on the reasoning that a sweep
+    // calling an empty repo READY would hide the one thing it exists to report. But the
+    // finding is reported either way -- it is in `warnings` and in `unfixable`, and the
+    // report prints both under the repository -- so the verdict was not carrying it. What
+    // the verdict did instead was tell someone who had just run `knowl init` that their
+    // install was broken, and put a permanent NOT READY beside every new repo in the sweep
+    // table until it happened to acquire knowledge. NOT READY has to mean broken, or the
+    // rows that are genuinely broken stop standing out.
     const results = await sweepRepos([A], {});
 
-    expect(results[0].ready).toBe(false);
-    expect(results[0].unfixable.join(' ')).toMatch(/no active items/i);
+    expect(results[0].ready).toBe(true);
+    expect(results[0].unfixable.join(' ')).toMatch(/no knowledge stored yet/i);
+    expect(results[0].warnings.join(' ')).toMatch(/no knowledge stored yet/i);
   });
 
   it('sweeps every discovered repository from the command line', { timeout: 120_000 }, async () => {
@@ -105,10 +112,13 @@ describe('upgrade --all sweep', () => {
     expect(swept.stdout).toContain('KNOWL SWEEP');
     expect(swept.stdout).toContain(A);
     expect(swept.stdout).toContain(B);
-    // Both repos are empty of knowledge, which doctor warns about and nothing can auto-fix,
-    // so the sweep must report them not ready and exit non-zero.
-    expect(swept.stdout).toMatch(/0 of 2 repositories ready/);
-    expect(swept.status).toBe(1);
+    // Both repos are empty of knowledge. That is a WARN -- reported per repository in the
+    // table below each row -- not a breakage, so the sweep counts them ready and exits 0.
+    // This used to assert "0 of 2", which meant a machine full of healthy new repositories
+    // reported zero ready and left nothing to distinguish the one that was actually broken.
+    expect(swept.stdout).toMatch(/2 of 2 repositories ready/);
+    expect(swept.stdout).toMatch(/no knowledge stored yet/i);
+    expect(swept.status).toBe(0);
   });
 
   it('lists what a sweep would visit without touching anything', { timeout: 120_000 }, async () => {

--- a/tests/mcp/error-signalling.test.ts
+++ b/tests/mcp/error-signalling.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * Whether a call failed has to be readable from the response.
+ *
+ * Three separate ways this surface said "fine" when it meant "no":
+ *
+ * - `arguments` is optional in the protocol, and a conformant client omits it for a tool whose
+ *   properties are all optional. The argument validator was taught to treat that as `{}`; the
+ *   handlers still destructured `args` directly, so the four zero-required tools threw a raw
+ *   `Cannot destructure property ... of undefined` onto the wire.
+ * - A tool name the server does not serve is a malformed request. Thrown as a plain Error it
+ *   landed in the generic catch and came back as `isError` inside a *successful* response.
+ * - A resource URI that does not exist is the caller's mistake (-32602), not the server's
+ *   (-32603) -- and re-wrapping it as a plain Error meant the SDK reported the latter.
+ *
+ * The opposite case is asserted too: SEP-1303 wants *argument* validation to arrive as a tool
+ * execution error so the model can read it and correct itself, so that one must stay `isError`.
+ */
+
+const TEST_ROOT = path.resolve('./.knowl-mcp-error-signalling');
+const CONFIG: ProjectConfig = { version: 1, security: { rejectSecrets: true, secretPatterns: [] } };
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+let projectId = '';
+
+/** Returns the whole JSON-RPC response, so `error` is inspectable and not just `result`. */
+async function rpc(method: string, params: Record<string, unknown>): Promise<any> {
+  const server = createMcpServer(projectId, TEST_ROOT, CONFIG);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(resolve => {
+    transport.onSend = message => { if (message.id === id) resolve(message); };
+  });
+  const initialized = waitFor('init');
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'error-test', version: '1.0' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const answered = waitFor('call');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method, params });
+  const response = await answered;
+  await server.close();
+  return response;
+}
+
+const INVALID_PARAMS = -32602;
+
+describe('a failed MCP call is distinguishable from a successful one', () => {
+  beforeAll(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    projectId = (await repo.createProject(TEST_ROOT, 'error-signalling')).id;
+    await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Settlement cutoff',
+      content: 'Settlement cutoff is 23:00 UTC.',
+    });
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  // Note the params object: no `arguments` key at all, which is what the protocol permits and
+  // what a conformant client actually sends for these four.
+  for (const tool of ['knowl_query', 'knowl_state', 'knowl_recent', 'knowl_resume']) {
+    it(`${tool} survives a call that omits arguments entirely`, async () => {
+      const response = await rpc('tools/call', { name: tool });
+      const text = String(response.result?.content?.[0]?.text ?? response.error?.message ?? '');
+      expect(text).not.toMatch(/Cannot destructure/i);
+    });
+  }
+
+  it('reports an unknown tool as a protocol error, not a successful isError result', async () => {
+    const response = await rpc('tools/call', { name: 'knowl_not_a_tool', arguments: {} });
+    expect(response.error?.code).toBe(INVALID_PARAMS);
+  });
+
+  it('reports a missing resource as invalid params rather than an internal failure', async () => {
+    const response = await rpc('resources/read', { uri: 'knowl://definitely-not-a-resource' });
+    expect(response.error?.code).toBe(INVALID_PARAMS);
+  });
+
+  it('still returns argument-validation failures as isError so the model can self-correct', async () => {
+    const response = await rpc('tools/call', { name: 'knowl_query', arguments: { limit: 9999 } });
+    expect(response.error).toBeUndefined();
+    expect(response.result?.isError).toBe(true);
+  });
+});

--- a/tests/mcp/query-fetch-by-id.test.ts
+++ b/tests/mcp/query-fetch-by-id.test.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import { MAX_ITEM_CONTENT_CHARS } from '../../src/core/token-budget.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The second half of progressive disclosure: read a truncated result in full.
+ *
+ * A search result is capped at MAX_ITEM_CONTENT_CHARS and marked `truncated`, and until now no
+ * tool could return the rest -- on a real store 262 of 639 atoms exceeded the ceiling. `id`
+ * fetches one item whole, plus the fields a search result drops (reasoning, provenance, source,
+ * timestamps). A parameter rather than a 31st tool, because the tool list is already the
+ * heaviest thing on the surface.
+ */
+
+const TEST_ROOT = path.resolve('.knowl-fetch-by-id');
+const CONFIG: ProjectConfig = { version: 1, security: { rejectSecrets: true, secretPatterns: [] } };
+
+class InMemoryTransport {
+  onclose?: () => void; onerror?: (e: Error) => void; onmessage?: (m: any) => void; onSend?: (m: any) => void;
+  async start(): Promise<void> {}
+  async send(m: any): Promise<void> { this.onSend?.(m); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+let projectId = '';
+
+async function call(name: string, args: Record<string, unknown>): Promise<any> {
+  const server = createMcpServer(projectId, TEST_ROOT, CONFIG);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(res => { transport.onSend = m => { if (m.id === id) res(m); }; });
+  const initialized = waitFor('init');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'init', method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const answered = waitFor('call');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name, arguments: args } });
+  const response = await answered;
+  await server.close();
+  return response.result;
+}
+
+const parse = (result: any) => JSON.parse(String(result?.content?.[0]?.text ?? ''));
+
+describe('knowl_query fetch-by-id', () => {
+  let bigId = '';
+
+  beforeAll(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    projectId = (await repo.createProject(TEST_ROOT, 'fetch')).id;
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'decision',
+      title: 'Ledger reconciliation policy',
+      content: `Reconciliation detail. ${'Sentence about the reconciliation pass. '.repeat(Math.ceil((MAX_ITEM_CONTENT_CHARS * 1.5) / 40))}`,
+      reasoning: 'REASONING-SENTINEL: chosen because settlement is idempotent.',
+      alternatives: ['polling the ledger', 'a nightly batch'],
+    });
+    bigId = item.id;
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('returns the whole item and the fields a search result omits', async () => {
+    const search = parse(await call('knowl_query', { query: 'ledger reconciliation policy' }));
+    expect(search[0].truncated).toBe(true);
+
+    const [full] = parse(await call('knowl_query', { id: bigId }));
+    expect(full.content.length).toBeGreaterThan(search[0].content.length);
+    expect(full.content).not.toMatch(/\[Content truncated\]/);
+    // reasoning is REQUIRED by knowl_decide and no tool could ever read it back until now.
+    expect(full.reasoning).toContain('REASONING-SENTINEL');
+    expect(full.alternatives).toContain('a nightly batch');
+    expect(full).toHaveProperty('createdAt');
+  });
+
+  it('refuses an unknown id with isError, not an empty array that reads as a miss', async () => {
+    const result = await call('knowl_query', { id: 'no-such-item' });
+    expect(result.isError).toBe(true);
+    expect(String(result.content[0].text)).toMatch(/No knowledge item/i);
+  });
+});

--- a/tests/mcp/query-response-bound.test.ts
+++ b/tests/mcp/query-response-bound.test.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The response ceiling costs bodies before it costs results.
+ *
+ * `knowl_query` had no ceiling at all -- 45,147 characters measured for a 25-result query over
+ * 2,000-character atoms -- and the first fix dropped lowest-ranked results until it fit. That
+ * bounded the response and cost recall: measured on a store of 25 such atoms, a `limit: 25`
+ * query came back with 5 results and 20 gone, which an agent cannot tell from a store that
+ * only holds 5.
+ *
+ * Shortening is the cheaper trade now that `knowl_query { id }` exists. A shortened result
+ * keeps its id, title and score, so the agent still learns the item exists and can read it
+ * whole on demand; a dropped one is indistinguishable from a miss. Dropping stays as the last
+ * resort for when every body is already an excerpt.
+ */
+
+const TEST_ROOT = path.resolve('.knowl-query-bound');
+const CONFIG: ProjectConfig = { version: 1, security: { rejectSecrets: true, secretPatterns: [] } };
+
+/** Mirrors `MAX_RESPONSE_CHARS` in `src/mcp/tools.ts`, which is module-private. */
+const MAX_RESPONSE_CHARS = 12_000;
+const SEEDED_ITEMS = 15;
+
+class InMemoryTransport {
+  onclose?: () => void; onerror?: (e: Error) => void; onmessage?: (m: any) => void; onSend?: (m: any) => void;
+  async start(): Promise<void> {}
+  async send(m: any): Promise<void> { this.onSend?.(m); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+let projectId = '';
+
+async function call(name: string, args: Record<string, unknown>): Promise<any> {
+  const server = createMcpServer(projectId, TEST_ROOT, CONFIG);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(res => { transport.onSend = m => { if (m.id === id) res(m); }; });
+  const initialized = waitFor('init');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'init', method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const answered = waitFor('call');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name, arguments: args } });
+  const response = await answered;
+  await server.close();
+  return response.result;
+}
+
+describe('knowl_query response bound', () => {
+  beforeAll(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+    await initDb(TEST_ROOT);
+    projectId = (await repo.createProject(TEST_ROOT, 'query-bound')).id;
+    for (let index = 0; index < SEEDED_ITEMS; index++) {
+      await repo.createKnowledgeItem(projectId, {
+        category: 'fact',
+        title: `Deployment rollback procedure variant ${index}`,
+        content: `Rollback detail ${index}. ${'The rollback pass re-reads the ledger and replays the deployment journal. '.repeat(30)}`,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('keeps every result and excerpts the weakest bodies instead of dropping them', async () => {
+    const result = await call('knowl_query', { query: 'deployment rollback procedure', limit: SEEDED_ITEMS });
+    const [block, notice] = result.content;
+    const items = JSON.parse(String(block.text));
+
+    // Unbounded this is ~33,000 characters, so the ceiling genuinely binds here.
+    expect(block.text.length).toBeLessThanOrEqual(MAX_RESPONSE_CHARS);
+    expect(items).toHaveLength(SEEDED_ITEMS);
+
+    // The tail gave up its body; every one of them still carries what an agent needs to decide
+    // whether to fetch it.
+    const last = items[items.length - 1];
+    expect(last.truncated).toBe(true);
+    expect(last.id).toBeTruthy();
+    expect(last.title).toContain('Deployment rollback procedure');
+
+    // The notice names the trade and the way out of it.
+    expect(String(notice.text)).toContain('RESPONSE BOUNDED');
+    expect(String(notice.text)).toContain('excerpt');
+    expect(String(notice.text)).toContain('`id`');
+  });
+
+  it('says nothing when the results already fit', async () => {
+    const result = await call('knowl_query', { query: 'deployment rollback procedure', limit: 2 });
+
+    expect(result.content).toHaveLength(1);
+    expect(JSON.parse(String(result.content[0].text))).toHaveLength(2);
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -221,7 +221,7 @@ describe('MCP Server Layer', () => {
     const parked = await runRpcRequest('tools/call', {
       name: 'knowl_park', arguments: { goal: 'Ship the parser' },
     });
-    const key = /([a-z]\d[a-z]\d[a-z]\d)/.exec(JSON.stringify(parked.result))![1];
+    const key = /knowl resume (([a-z]\d){3,4})/.exec(JSON.stringify(parked.result))![1];
 
     const resumed = await runRpcRequest('tools/call', {
       name: 'knowl_resume', arguments: { key },

--- a/tests/skills/registry.test.ts
+++ b/tests/skills/registry.test.ts
@@ -270,4 +270,24 @@ describe('Skill Registry', () => {
     expect(read.manifest.entrypoints.default?.autoRun).toBe(false);
     await expect(runSkillPackage(TEST_ROOT, 'no_optin')).rejects.toThrow(/auto-run/);
   });
+
+  it('refuses to overwrite an existing package instead of silently replacing it', async () => {
+    await createSkillPackage(TEST_ROOT, {
+      name: 'overwrite_target',
+      purpose: 'Original purpose',
+      entrypoints: { default: { type: 'shell', command: 'echo original', autoRun: true } },
+    });
+
+    // A second create of the same name used to clobber SKILL.md and the entrypoints, report
+    // "Successfully created", and not bump the version -- a working skill gone with no trace.
+    await expect(createSkillPackage(TEST_ROOT, {
+      name: 'overwrite_target',
+      purpose: 'Replacement purpose',
+    })).rejects.toThrow(/already exists/i);
+
+    // The original survives the refusal intact.
+    const read = await readSkillPackage(TEST_ROOT, 'overwrite_target');
+    expect(read.manifest.purpose).toBe('Original purpose');
+    expect(read.manifest.entrypoints.default).toBeDefined();
+  });
 });

--- a/tests/store/embedding-write-batch.test.ts
+++ b/tests/store/embedding-write-batch.test.ts
@@ -75,9 +75,9 @@ describe('embedding writes commit as a batch', () => {
     // The mechanism, not the clock: five rows, one BEGIN, one COMMIT. Every bare statement is
     // its own implicit commit, and this schema fsyncs the WAL on each one.
     expect(countOf(trace.seen, /INSERT INTO knowledge_embeddings/)).toBe(5);
-    expect(countOf(trace.seen, /^BEGIN$/)).toBe(1);
+    expect(countOf(trace.seen, /^BEGIN( IMMEDIATE)?$/)).toBe(1);
     expect(countOf(trace.seen, /^COMMIT$/)).toBe(1);
-    expect(trace.seen.indexOf('BEGIN')).toBeLessThan(trace.seen.findIndex(sql => /INSERT INTO knowledge_embeddings/.test(sql)));
+    expect(trace.seen.findIndex(sql => /^BEGIN( IMMEDIATE)?$/.test(sql))).toBeLessThan(trace.seen.findIndex(sql => /INSERT INTO knowledge_embeddings/.test(sql)));
 
     const stored = await getClient().execute('SELECT count(*) AS n FROM knowledge_embeddings');
     expect(Number((stored.rows[0] as any).n)).toBe(5);
@@ -94,7 +94,7 @@ describe('embedding writes commit as a batch', () => {
     // One statement is already atomic and already one fsync; a transaction around it would
     // only add round trips to the path every ordinary knowledge write takes.
     expect(countOf(trace.seen, /INSERT INTO knowledge_embeddings/)).toBe(1);
-    expect(countOf(trace.seen, /^BEGIN$/)).toBe(0);
+    expect(countOf(trace.seen, /^BEGIN( IMMEDIATE)?$/)).toBe(0);
   });
 
   it('writes nothing when any row in the batch has a bad dimension', async () => {
@@ -136,7 +136,7 @@ describe('embedding writes commit as a batch', () => {
     expect(result.indexed).toBe(ids.length);
     expect(countOf(trace.seen, /INSERT INTO knowledge_embeddings/)).toBe(ids.length);
     // One page of 500 covers all twelve, so exactly one transaction -- and crucially not twelve.
-    expect(countOf(trace.seen, /^BEGIN$/)).toBe(1);
+    expect(countOf(trace.seen, /^BEGIN( IMMEDIATE)?$/)).toBe(1);
     expect(countOf(trace.seen, /^COMMIT$/)).toBe(1);
   });
 

--- a/tests/store/portability.test.ts
+++ b/tests/store/portability.test.ts
@@ -22,6 +22,7 @@ import {
   updateKnowledgeItem,
 } from '../../src/store/repository.js';
 import * as portability from '../../src/store/portability.js';
+import { hashKnowledgeContent } from '../../src/store/freshness.js';
 import { createEvidence, linkKnowledgeEvidence, listEvidenceForItem } from '../../src/store/evidence-repository.js';
 
 const ROOT = path.resolve('.knowl-portability-test');
@@ -202,15 +203,23 @@ describe('portability', () => {
 
     const stream = (await fs.readFile(first, 'utf8')).split('\n').filter(Boolean);
     const records = stream.slice(0, -1).map(line => JSON.parse(line));
+    // Real hashes, not placeholders. A peer that edits an item recomputes its content hash --
+    // that is what makes divergence detectable at all -- and `importKnowledge` now refuses a
+    // file whose items misdescribe themselves, because divergence is decided on that field and
+    // a stale hash silently discarded the real content. Verified against the 689 hashed items
+    // in a live store: every one matches its own body, so a hand-written hash here was the
+    // fixture being unrealistic rather than the guard being strict.
+    const peerSharedHash = hashKnowledgeContent({ title: 'Round trip fact', content: 'Peer content.' });
+    const peerOnlyHash = hashKnowledgeContent({ title: 'Peer only', content: 'From the peer.' });
     for (const record of records) {
       if (record.type === 'item' && record.item.id === shared.id) {
         record.item.content = 'Peer content.';
-        record.item.contentHash = 'peer-hash';
+        record.item.contentHash = peerSharedHash;
         record.item.updatedAt = '2030-01-01T00:00:00.000Z';
         record.item.version = record.item.version + 1;
       }
     }
-    records.push({ type: 'item', item: { ...shared, id: 'peer-only-item', title: 'Peer only', content: 'From the peer.', contentHash: 'peer-only-hash', updatedAt: '2030-01-01T00:00:00.000Z' } });
+    records.push({ type: 'item', item: { ...shared, id: 'peer-only-item', title: 'Peer only', content: 'From the peer.', reasoning: null, source: null, affectedPaths: [], contentHash: peerOnlyHash, updatedAt: '2030-01-01T00:00:00.000Z' } });
     const joined = `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
     const sha = createHash('sha256').update(joined).digest('hex');
     const second = path.join(TARGET, 'rt-2.jsonl');
@@ -221,7 +230,7 @@ describe('portability', () => {
     expect(result.applied).toBe(true);
     expect(result.inserted).toBe(1);
     expect(result.updated).toBe(1);
-    expect((await getKnowledgeItem(shared.id))!.contentHash).toBe('peer-hash');
+    expect((await getKnowledgeItem(shared.id))!.contentHash).toBe(peerSharedHash);
     expect(await getKnowledgeItem('peer-only-item')).not.toBeNull();
 
     const repeat = await portability.importKnowledge(second, { projectRoot: TARGET, onDivergence: 'newer' });

--- a/tests/store/portability.test.ts
+++ b/tests/store/portability.test.ts
@@ -238,6 +238,56 @@ describe('portability', () => {
     expect(repeat.inserted).toBe(0);
   });
 
+  it('refuses a file whose items misdescribe themselves, and imports it on recomputed hashes when told to', async () => {
+    // The guard is right that a stale hash silently discards the real content -- divergence is
+    // decided on that field and never on the body. It was also the only answer, which leaves an
+    // export written by an older writer permanently un-importable with nowhere to fix it. The
+    // override recomputes rather than waives: every later comparison then runs against a hash
+    // that genuinely describes the body it arrived with.
+    const item = await createKnowledgeItem('local', {
+      category: 'fact', title: 'Misdescribed fact', content: 'The content the hash was taken from.',
+    });
+    const exportPath = path.join(TARGET, 'misdescribed-1.jsonl');
+    await portability.exportKnowledge('local', exportPath, TARGET);
+
+    const stream = (await fs.readFile(exportPath, 'utf8')).split('\n').filter(Boolean);
+    const records = stream.slice(0, -1).map(line => JSON.parse(line));
+    for (const record of records) {
+      // The body moves on; the hash is left describing the body it used to have.
+      if (record.type === 'item' && record.item.id === item.id) {
+        record.item.content = 'A body the stated hash knows nothing about.';
+        record.item.updatedAt = '2030-01-01T00:00:00.000Z';
+        record.item.version = record.item.version + 1;
+      }
+    }
+    const joined = `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
+    const misdescribedPath = path.join(TARGET, 'misdescribed-2.jsonl');
+    await fs.writeFile(
+      misdescribedPath,
+      `${joined}${JSON.stringify({ type: 'manifest', sha256: createHash('sha256').update(joined).digest('hex') })}\n`,
+      'utf8',
+    );
+
+    // The bytes are intact -- the manifest checksum passes -- so only the recompute catches it.
+    await expect(portability.importKnowledge(misdescribedPath, { projectRoot: TARGET, onDivergence: 'newer' }))
+      .rejects.toThrow(/--repair-content-hash/);
+    expect((await getKnowledgeItem(item.id))!.content).toBe('The content the hash was taken from.');
+
+    const repaired = await portability.importKnowledge(misdescribedPath, {
+      projectRoot: TARGET, onDivergence: 'newer', repairContentHash: true,
+    });
+
+    expect(repaired.applied).toBe(true);
+    expect(repaired.hashRepaired).toBe(1);
+    const stored = (await getKnowledgeItem(item.id))!;
+    expect(stored.content).toBe('A body the stated hash knows nothing about.');
+    // The stored hash describes the stored body, so a re-import of the same file is a no-op
+    // rather than a permanent divergence.
+    expect(stored.contentHash).toBe(hashKnowledgeContent({
+      title: 'Misdescribed fact', content: 'A body the stated hash knows nothing about.',
+    }));
+  });
+
   it('re-indexes an item adopted from the peer, not just fresh inserts', async () => {
     // An adopted divergent item has different content, so its stored embedding is now
     // wrong. Indexing only inserts would leave vector search matching the old text.

--- a/tests/store/resume-keys.test.ts
+++ b/tests/store/resume-keys.test.ts
@@ -5,7 +5,7 @@ describe('mintResumeKey', () => {
   it('mints a key a person can retype: short, lowercase, no lookalike characters', () => {
     for (let i = 0; i < 200; i++) {
       const key = mintResumeKey();
-      expect(key).toHaveLength(6);
+      expect(key).toHaveLength(8);
       expect(key).toBe(key.toLowerCase());
       expect(key).not.toMatch(/[l1i0o5s2z]/);
     }
@@ -15,13 +15,13 @@ describe('mintResumeKey', () => {
     for (let i = 0; i < 500; i++) {
       const key = mintResumeKey();
       // Digits in the even positions make a pronounceable English word structurally impossible.
-      expect(key).toMatch(/^[a-z]\d[a-z]\d[a-z]\d$/);
+      expect(key).toMatch(/^[a-z]\d[a-z]\d[a-z]\d[a-z]\d$/);
     }
   });
 
   it('draws from the whole keyspace rather than a degenerate corner of it', () => {
-    // Measured, not assumed: the keyspace is 18^3 * 6^3 = 1,259,712, so 2,000 independent
-    // draws collide about 80% of the time by the birthday bound -- typically once or twice.
+    // Measured, not assumed: the keyspace is 18^4 * 6^4 = 136,048,896, so 2,000 independent
+    // draws collide rarely by the birthday bound; the margin below still absorbs a couple.
     // Asserting 2,000 distinct would be a test that fails four runs in five.
     //
     // Uniqueness of *stored* keys is a different guarantee, and a real one: createResumePoint
@@ -31,15 +31,15 @@ describe('mintResumeKey', () => {
   });
 
   it('uses every position, so no character is effectively fixed', () => {
-    const seen = Array.from({ length: 6 }, () => new Set<string>());
+    const seen = Array.from({ length: 8 }, () => new Set<string>());
     for (let i = 0; i < 500; i++) {
       const key = mintResumeKey();
-      for (let position = 0; position < 6; position++) seen[position].add(key[position]);
+      for (let position = 0; position < 8; position++) seen[position].add(key[position]);
     }
     // 18 letters in the even positions, 6 digits in the odd ones. A generator that pinned a
     // position would still satisfy the shape regex above; this is what catches it.
-    for (const position of [0, 2, 4]) expect(seen[position].size).toBe(18);
-    for (const position of [1, 3, 5]) expect(seen[position].size).toBe(6);
+    for (const position of [0, 2, 4, 6]) expect(seen[position].size).toBe(18);
+    for (const position of [1, 3, 5, 7]) expect(seen[position].size).toBe(6);
   });
 });
 

--- a/tests/store/resume-points.test.ts
+++ b/tests/store/resume-points.test.ts
@@ -45,7 +45,7 @@ describe('resume points', () => {
         goal: 'Ship the parser', nextAction: 'Wire the CLI flag',
       });
 
-      expect(point.key).toMatch(/^[a-z]\d[a-z]\d[a-z]\d$/);
+      expect(point.key).toMatch(/^[a-z]\d[a-z]\d[a-z]\d[a-z]\d$/);
       expect(point.goal).toBe('Ship the parser');
 
       const read = await readResumePoint(point.key);

--- a/tests/store/snapshot-origin.test.ts
+++ b/tests/store/snapshot-origin.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { createProject, createKnowledgeItem, listKnowledgeItems } from '../../src/store/repository.js';
+import { createSnapshot, restoreSnapshot } from '../../src/store/snapshots.js';
+
+/**
+ * A snapshot knows where it came from, and restore checks.
+ *
+ * The database carries no project identity (the projects table is gone), and every repo's
+ * snapshots sit at the identically shaped path `.knowl/snapshots/<stamp>.db` -- so restoring
+ * repo A's snapshot into repo B succeeded silently, replaced B's entire memory with A's, and
+ * the post-restore audit called the result clean. The origin now rides in the manifest;
+ * a mismatch refuses with both paths named, and `acceptOriginMismatch` exists because the
+ * same repository legitimately moves.
+ */
+
+// Three roots rather than two, so no test has to delete and rebuild a store another test in
+// this file already opened. `closeDb`/`releaseAll` are process-global, and a mid-file teardown
+// raced whatever else shared the worker -- the failure only ever appeared in a full run.
+const ROOT_A = path.resolve('.knowl-origin-a');
+const ROOT_B = path.resolve('.knowl-origin-b');
+const ROOT_C = path.resolve('.knowl-origin-c');
+const ROOTS = [ROOT_A, ROOT_B, ROOT_C];
+
+describe('snapshot origin', () => {
+  beforeAll(async () => {
+    for (const root of ROOTS) {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+      await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+    }
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('records where it was taken, refuses a foreign restore, and allows an explicit override', async () => {
+    await initDb(ROOT_A);
+    const projectA = await createProject(ROOT_A, 'origin-a');
+    await createKnowledgeItem(projectA.id, {
+      category: 'fact', title: 'Alpha secret', content: 'belongs to repository A',
+    });
+    const snapshot = await createSnapshot(ROOT_A);
+    expect(snapshot.manifest.originRoot).toBe(path.resolve(ROOT_A));
+    await closeDb();
+    await releaseAll();
+
+    await initDb(ROOT_B);
+    const projectB = await createProject(ROOT_B, 'origin-b');
+    await createKnowledgeItem(projectB.id, {
+      category: 'fact', title: 'Beta secret', content: 'belongs to repository B',
+    });
+
+    // The accident: restoring A's snapshot while sitting in B.
+    await expect(restoreSnapshot(ROOT_B, snapshot.path, { confirm: true }))
+      .rejects.toThrow(/different repository/i);
+    // B's memory must be untouched by the refusal.
+    expect((await listKnowledgeItems()).map(item => item.title)).toContain('Beta secret');
+
+    // The legitimate case -- a moved repo -- goes through only when said out loud.
+    await restoreSnapshot(ROOT_B, snapshot.path, { confirm: true, acceptOriginMismatch: true });
+    const titles = (await listKnowledgeItems()).map(item => item.title);
+    expect(titles).toContain('Alpha secret');
+    expect(titles).not.toContain('Beta secret');
+  });
+
+  it('treats a legacy manifest with no origin as unknown, not wrong', async () => {
+    await initDb(ROOT_C);
+    const project = await createProject(ROOT_C, 'origin-legacy');
+    await createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Legacy fact', content: 'snapshotted before originRoot existed',
+    });
+    const snapshot = await createSnapshot(ROOT_C);
+
+    // Strip the field, as a pre-field snapshot's manifest genuinely lacks it.
+    const manifest = JSON.parse(await fs.readFile(snapshot.manifestPath, 'utf8'));
+    delete manifest.originRoot;
+    await fs.writeFile(snapshot.manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+
+    await restoreSnapshot(ROOT_C, snapshot.path, { confirm: true });
+    expect((await listKnowledgeItems()).map(item => item.title)).toContain('Legacy fact');
+  });
+});

--- a/tests/store/work-loop.test.ts
+++ b/tests/store/work-loop.test.ts
@@ -60,4 +60,17 @@ describe('work loop session capture', () => {
       verificationStatus: 'tests-passing',
     });
   });
+
+  it('finishes exactly once: a second finish and a post-finish checkpoint are refused', async () => {
+    const project = await repo.createProject(TEST_ROOT, 'Work loop finish-once');
+    const started = await startWorkLoop(project.id, 'Finish once', 'finish-once');
+    await finishWorkLoop(project.id, started.taskId, 'done');
+
+    // The description says "exactly once"; the layer used to mint a second completion item
+    // against a terminal memory session, so two different finishes existed for one task.
+    await expect(finishWorkLoop(project.id, started.taskId, 'done again'))
+      .rejects.toThrow(/already finished/i);
+    await expect(checkpointWorkLoop(project.id, started.taskId, 'zombie checkpoint'))
+      .rejects.toThrow(/already finished/i);
+  });
 });


### PR DESCRIPTION
A sweep of the CLI, the MCP surface and the store, run against 3.1.0 and re-applied here on 3.2.1. Every finding was re-checked against current `main` before being carried over — none of them had been fixed upstream in the meantime.

Each item below was reproduced before it was changed. Where a number appears, it was measured rather than estimated. One claim I could not reproduce is called out honestly at the bottom.

## Data loss

**`doctor` rebuilt the store it was asked to inspect.** It is exempt from the preAction missing-database guard so it can run when something is wrong — that was meant to skip the throw, not license a write, but `runDoctor` still called `initDb`, and opening a libSQL `file:` URL creates the file. So diagnosing a repository whose database had moved wrote an empty one, reported `[OK] Local project store ready`, and left the guard unable to fire again because the file now existed. `knowl-sync` runs doctor in every repository on a machine, which makes routine maintenance the trigger that turns a recoverable move into a certified-healthy empty store.

The same guard also refused `snapshot`, while its own error names `knowl snapshot restore <path> --confirm` as the first recovery to try. The one command the message prescribed was the one it blocked, leaving `upgrade` (which accepts the empty store the guard exists to prevent) or `doctor` (which rebuilt it).

**`snapshot restore` accepted another repository's snapshot.** The database carries no project identity and every repo's snapshots sit at the identically shaped `.knowl/snapshots/<stamp>.db`, so restoring A's into B replaced B's memory with A's and the post-restore audit reported `Integrity findings: 0`. The origin is now recorded in the manifest; `--accept-origin-mismatch` covers a repository that legitimately moved, and a manifest written before the field existed is treated as unknown rather than wrong.

**`import` trusted each item's self-reported `contentHash`.** Divergence is decided by comparing that field against the local row, never by reading the content — so an item whose body was edited with its hash left alone imported as `identical` and its real content was discarded. Every policy behaved that way, which means `--on-divergence fail`, the safe one, was precisely the one that could not protect you. Checked before trusting the new guard: all 689 hashed items in a live store match their own content, so a real export never trips it.

**`knowl init` tested only the current directory.** `findProjectRoot`, which walks ancestors, was never consulted on the create path, so running init in a subpackage of an initialized repository printed "Successfully initialized" and built a second store inside it. Every later command under that subtree resolved to the shadow — writes landed there, queries returned nothing, and nothing reported the split.

## Failures that reported success

- `isError` was absent on the uninitialized-project banner and on all four cross-repo ownership refusals, so a refused write read as a completed one.
- `import --on-divergence fail` printed `applied: false, conflicts: 1` and exited **0**, so `knowl import x --on-divergence fail && echo synced` said synced on a refused merge.
- `knowl_skill_create` overwrote an existing package — SKILL.md and entrypoints gone, `version` not bumped, "Successfully created" reported. It refuses now.
- `knowl_handoff` discarded the previous unconsumed baton silently. The schema comment already called that "the destruction of the real one"; the response now says so.
- `knowl_task_finish` minted a second completion for an already-finished loop, against a description that says "exactly once". A second finish and a post-finish checkpoint are both refused.
- `supersede` verified the item being retired but took the replacement on trust, so an item could point at itself or at an id that does not exist. Both retire it from every query and `knowl audit` reports neither, because integrity only walks tables keyed by `knowledge_item_id`.
- `knowl_timeline` and `knowl_conflicts` sliced to 5 and 3 with no marker, so a short complete answer and the opening third of a long one were identical. The array shape is unchanged — callers parse it — and a second block names the overflow.

## Context and correctness

**`knowl_query` had no response ceiling.** `MAX_RESPONSE_CHARS` is declared as the ceiling "for this half of the surface" and was wired into `boundContextResponse` alone, so `knowl_context` was bounded and the most-called tool on the server was not. Measured at **45,147 characters** for a 25-result query over 2,000-character atoms, and 59,990 with `includeEvidence` and `explain`. 3.1.0's 600→2,000 item change tripled that floor on the one path nothing watched. Lowest-ranked results are now dropped with the count reported; one result is always kept, so a single oversized atom comes back truncated-but-present rather than as an empty array that reads like a miss.

**`knowl_query` gained `id`,** returning one item whole. 262 of 639 atoms on a real store exceed the content ceiling, and nothing could return them — including `reasoning`, which `knowl_decide` *requires* and which no tool could ever read back. A parameter rather than a 31st tool: the list already costs ~6,700 tokens per session, which is the wrong direction to grow.

**Tool order is now deliberate.** The list led with `knowl_ingest`, which needs an AI provider most installs do not configure, while `knowl_query` — the first call the documented workflow makes — sat seventh, and models bias toward what is listed first. The order is an explicit list rather than a sort, so it stays byte-stable across builds and does not break prompt-prefix caching for clients holding the catalog.

**Spec conformance.** An unknown tool name is a malformed request; thrown as a plain `Error` it fell into the generic catch and came back as `isError` inside a *successful* response. A missing resource is the caller's mistake (`-32602`) and was re-wrapped into the SDK's `-32603`, so a bad URI was reported as the server's own failure. The neighbouring `ToolInputError → isError` branch is deliberately untouched: SEP-1303 asks for argument validation to arrive as a tool execution error so the model can self-correct, and a regression test now pins that direction too.

**`arguments` may be omitted,** which the protocol permits. `validateToolArguments` already read a missing object as `{}`, but every handler destructured `args` directly, so the four zero-required tools — `knowl_query`, `knowl_state`, `knowl_recent`, `knowl_resume` — threw a raw `Cannot destructure property ... of undefined` onto the wire. `knowl_query` is the first call a session makes, so this was reachable on turn one.

## Reads that wrote

**`knowl eval` recorded an access row per returned item** — rows that feed GC liveness and tier confirmation — so every benchmark run promoted whatever it returned and shielded it from collection, and `--vector` reindexed the live embedding table before measuring it. It now ranks read-only.

**`upgrade --all --dry-run` edited the machine registry** while closing with "Dry run: nothing was changed": `readKnownRepos` self-heals by rewriting the file and ran before the dry-run guard. That registry is what the sweep and `doctor --fix` act on, and a checkout that is momentarily absent classifies as forgotten — so an inspection could quietly narrow every future sweep.

## The rest

- **Write transactions take their lock up front.** Every caller of `withClientTransaction` writes, but it opened with a bare `BEGIN`, which is DEFERRED: the write lock is taken lazily, after reads, and SQLite answers that upgrade with `SQLITE_BUSY_SNAPSHOT` rather than waiting. No busy handler may wait that out, so `busy_timeout` did not apply and the retry in `connection-pool.ts` did not match it. `bootstrapSchema` already used `IMMEDIATE` for exactly this reason.
- **GC compression could make an item larger.** `summarize` truncates on UTF-16 length (>120 chars) while the gate and the report measure bytes (≥180), so content averaging ≥1.5 bytes/char — CJK, emoji, accented Latin — cleared the byte gate, stayed under the char limit, and came back whole plus the 20-byte prefix. Measured 189 → 209 bytes, applied, original destroyed.
- **Numeric and timestamp options are validated, not coerced.** `--limit abc` reached a bound parameter as `NaN` and printed the raw FTS statement. Every `gc` comparison against `NaN` is false, so a mistyped `--stale-days` made `gc --apply` a silent no-op reporting success. `--as-of banana` sorted above every ISO timestamp in SQLite's string comparison and matched everything — the one feature whose purpose is "what did we believe on date X" answered with today's state.
- **Resume keys are eight characters and a miss costs 250 ms.** Six characters gave ~1.26M keys and a ~1 ms miss (50 wrong-key probes measured in 47 ms), so the machine-wide space was walkable in about twenty minutes from any directory, and a hit returns another repo's goal, blocker and artifact paths. Existing six-character keys still resolve.
- **Write failures are diagnosable.** Drizzle's message *begins* with `Failed query:`, so the sanitizer's keep-the-prefix rule kept nothing while the SQLite verdict sat unread in `error.cause`. The cause is surfaced through the same sanitizer, so statement text and bound parameters still never leave the process.
- **`--json` failures emit an envelope on stdout** while stderr keeps the human line. These commands are agent host hooks and a hook parses stdout; failure used to leave it empty.
- **`knowl_ingest_atoms` is capped at 50.** Every other array on the surface is capped at 20; this one, the one that writes the store, was unbounded — 400 atoms produced a 92,000-character response.

## The one claim I could not reproduce

The transaction fix is the change I am least able to evidence. An audit measured 10 of 20 concurrent writes lost through two server processes and 14 of 20 through three, reproduced across four rounds, with 0 lost through one process. Afterwards I could not reproduce it on demand — two and three concurrent `knowl serve` processes, twenty writes each, with distinct titles and with colliding titles to force supersede contention on a shared row, before and after the change: zero failures every time. The original measurement was taken on a heavily loaded machine; mine were not.

`IMMEDIATE` is correct on its own merits for a helper every caller writes through, and it converts contention from an unwaitable error into a wait bounded by `busy_timeout`, so it lands regardless — but **without a before/after number behind it**, and I would rather say so than quote a figure I could not reproduce.

## Checks

Run locally on Windows against this branch:

- `npm test` — 236 files, 1963 passed, 4 skipped
- `npm run typecheck`, `npm run lint` (0 errors, 46 warnings — unchanged from `main`), `npm run build`
- `npm run docs:check`, `npm run check:lockfile`, `npm run audit:prod`
- `git diff --check` clean; tarball packed and installed into a scratch project, `--version` and `--help` both fine

New tests: `tests/cli/missing-database-recovery.test.ts`, `tests/mcp/error-signalling.test.ts`, `tests/mcp/query-fetch-by-id.test.ts`, `tests/store/snapshot-origin.test.ts`, plus cases added to the work-loop, skill-registry and portability suites.

## Notes for review

This is one large commit because the findings came from a single sweep, but they are independent — happy to split it into per-area commits, or to drop any individual change, if that is easier to review.

Two findings are deliberately **not** addressed here, because they are design decisions rather than defects:

1. **Hook cost.** `knowl agent-hook ... PostToolUse` measured at ~265 ms mean against a bare-Node floor of 137 ms, paid on every tool call in every session. Fixing it means the hook talking to the already-running server over a socket or pipe instead of paying process startup.
2. **Tool surface size.** 30 tools serialize to ~6,700 tokens per session, 66% of it JSON schemas. The ordering is fixed here; the size is not, because shrinking it means a search-and-execute façade over a small always-visible core, which changes the agent contract.

One thing I would flag as unresolved rather than fixed: `knowl_conflicts` is documented as listing items that contradict each other, but conflicts are prevented at write time, so two live items can never share a key — measured 0 groups with ≥2 members on a real store. The command cannot show a contradiction as built. That reads like a feature decision, so I left it alone.

---

## Review round (2026-08-06)

Reviewed against `main` at `39361ae`, verified in a clean worktree at the PR head: typecheck clean, build clean, full suite green. One reproduced regression, one undisclosed behaviour change, and one design trade fixed here; the rest of the sweep stands as written.

### The regression: the snapshot exemption was wider than the recovery it was for

`snapshot` went into `EXEMPT_COMMANDS` as a whole group, and the `preAction` hook collapses to the top-level command name — so `snapshot create` and `snapshot list` were exempt too. `snapshot create`'s action calls `initDb`, and opening a libSQL `file:` URL creates it. Reproduced end to end:

```
$ rm .knowl/knowl.db
$ knowl status          → correctly refuses: "Knowl's database is missing"
$ knowl snapshot create → "KNOWL SNAPSHOT CREATED"   ← rebuilds an empty 303 KB store
$ knowl status          → Active: 0                   ← guard disarmed for good
$ knowl doctor          → "Result: READY (1 advisory warning)", exit 0
```

That is the defect this PR opens by fixing for `doctor`, arriving through the door held open for the recovery — and worse in one respect: `createSnapshot` prunes to `SNAPSHOT_KEEP = 3`, so three such calls evict the real snapshots, which is the material the restore needs.

The hook now passes the command's full path (`snapshot restore`) and `EXEMPT_COMMANDS` names that one subcommand. An entry naming only a top-level command still exempts its whole group, so nothing else moved. Covered by a new case in `tests/cli/missing-database-recovery.test.ts` that asserts the database stays absent and the real snapshot survives.

### The undisclosed change: `knowl doctor`'s verdict and exit code

The body lists nineteen findings and mentions none of: the new 225-line `src/cli/retrieval-probe.ts`, the integrity check going `OK` → `WARN`, or `runDoctor`'s verdict moving from `every(status === 'OK')` to `every(status !== 'FAIL')`. That last one flips exit codes — `knowl doctor` and `upgrade --all` now exit 0 where they exited 1, and their own tests were rewritten to assert it.

The change itself is right: a repository that has just been initialized is not broken, and NOT READY has to mean broken or the genuinely broken rows stop standing out. But anything gating CI on those exit codes changes meaning silently, so it now has a `### Changed` section in the CHANGELOG that says so in those words.

### The trade: the query bound spent results where it could have spent bodies

`boundQueryPayload` dropped lowest-ranked results until the response fit `MAX_RESPONSE_CHARS` (12,000). Measured on a seeded store of 25 two-kilobyte atoms, a `limit: 25` query returned **5 results with 20 gone** — which an agent cannot tell from a store that only holds 5.

It now cuts bodies before it cuts results: the lowest-ranked entries are reduced to a 240-character excerpt and marked `truncated`, keeping id, title and score. Dropping remains the last resort for when every body is already an excerpt. This is the half of progressive disclosure the `id` parameter in this same PR makes possible — a shortened result can be read whole on demand, a dropped one cannot be read at all. New coverage in `tests/mcp/query-response-bound.test.ts`.

### Smaller points from the review

- `taskAlreadyFinished` called `listKnowledgeItems()` — every row in the store, mapped — on every checkpoint and every finish. Now a `SELECT 1 ... LIMIT 1` on the tag columns, following the idiom in `search.ts` and `vector.ts`. The codebase's own `listActiveSkillItems` comment names the scan as the thing to avoid on a hot path.
- `replacedPrevious: merged !== existing.handoff` was object identity, and `mergeHandoff` always allocates — so it would report a replacement for a legitimate same-session merge. It agrees with the intent today only because `recordDeliberateHandoff` never merges. Now read off the branch that decided it.
- The `contentHash` guard aborted the whole file with no way through, so an export written by a writer whose hash formula predates this build became permanently un-importable. `--repair-content-hash` recomputes rather than waives: divergence is then decided on a hash that genuinely describes the body it arrived with, which is strictly safer than the behaviour the guard replaced. Reported in the result as `hashRepaired`.
- The keyspace comments in `resume-keys.ts` and `resume-points.ts` still described six-character keys and 1,259,712 combinations after the change to eight and 136,048,896.
- CHANGELOG was missing a blank line before `## 3.2.2`.

### Checks

Run on Windows against the amended branch: `npm run typecheck`, `npm run build`, `npm test`, `npm run lint`, `git diff --check` clean. `npm run docs:generate` produces no content change.
