### PR TITLE
fix: clear every open CodeQL alert, and two the quality suite was right about

### DIFF
--- a/benchmarks/accuracy/src/native-collect.ts
+++ b/benchmarks/accuracy/src/native-collect.ts
@@ -95,9 +95,7 @@ export async function collectNative(
     const failures: string[] = [];
 
     for (const history of input.histories) {
-      let closeRequired = false;
       try {
-        closeRequired = true;
         await adapter.reset({
           runId: `${adapter.metadata.name}-native-${runIndex + 1}-${history.historyId}`,
           mode: 'native',
@@ -121,12 +119,13 @@ export async function collectNative(
         predictions.push({ historyId: history.historyId, error: message });
         failures.push(`${history.historyId}: ${message}`);
       } finally {
-        if (closeRequired) {
-          try {
-            await adapter.close();
-          } catch (error) {
-            failures.push(`${history.historyId}: close: ${error instanceof Error ? error.message : String(error)}`);
-          }
+        // Unconditional: `reset` is the first thing the try does, so every path through it --
+        // including a throw partway -- may have left the adapter holding something. A close that
+        // fails is recorded, never rethrown, so one adapter cannot end the run.
+        try {
+          await adapter.close();
+        } catch (error) {
+          failures.push(`${history.historyId}: close: ${error instanceof Error ? error.message : String(error)}`);
         }
       }
     }

--- a/benchmarks/accuracy/src/report.ts
+++ b/benchmarks/accuracy/src/report.ts
@@ -50,8 +50,11 @@ function formatMetric(metrics: Record<string, MetricSummary> | null, name: strin
   return value === null || value === undefined ? 'N/A' : value.toFixed(3);
 }
 
+// Backslashes go first, or the escape this adds gets escaped by the next pass: a value holding
+// `\|` would come out `\\|`, which Markdown reads as a literal backslash followed by a live
+// column separator -- one adapter name splits the row and the table stops lining up.
 function tableText(value: string): string {
-  return value.replace(/\|/gu, '\\|').replace(/\r?\n/gu, ' ');
+  return value.replace(/\\/gu, '\\\\').replace(/\|/gu, '\\|').replace(/\r?\n/gu, ' ');
 }
 
 function ndjson(rows: unknown[]): string {

--- a/benchmarks/memoryagentbench/cli.ts
+++ b/benchmarks/memoryagentbench/cli.ts
@@ -8,11 +8,29 @@
 import { Command } from 'commander';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { z } from 'zod';
 import { findProjectRoot } from '../../src/core/config.js';
 import { runConflictResolution } from './runner.js';
 
 const SPLIT_URL =
   'https://datasets-server.huggingface.co/rows?dataset=ai-hyz%2FMemoryAgentBench&config=default&split=Conflict_Resolution';
+
+// The response is a third-party dataset server, so nothing from it reaches disk unchecked --
+// `fetch` writes a file the `run` subcommand later parses as trusted input. Shape first, then
+// the derived id: it names the instance and is one edit away from naming a path, so it is
+// constrained to a charset that cannot traverse or hide a separator.
+const RowSchema = z.object({
+  context: z.string(),
+  questions: z.array(z.string()),
+  answers: z.array(z.string()),
+  metadata: z.object({ qa_pair_ids: z.array(z.string()).optional() }).partial().optional(),
+});
+
+const SplitResponseSchema = z.object({
+  rows: z.array(z.object({ row: RowSchema })),
+});
+
+const SAFE_ID = /^[A-Za-z0-9._-]+$/;
 
 const program = new Command()
   .name('bench:cr')
@@ -26,12 +44,12 @@ program
   .action(async (options) => {
     const response = await fetch(`${SPLIT_URL}&offset=${Number(options.row)}&length=1`);
     if (!response.ok) throw new Error(`Download failed: ${response.status} ${response.statusText}`);
-    const payload = (await response.json()) as { rows: Array<{ row: Record<string, unknown> }> };
-    const row = payload.rows?.[0]?.row;
+    const payload = SplitResponseSchema.parse(await response.json());
+    const row = payload.rows[0]?.row;
     if (!row) throw new Error('No row returned.');
 
-    const metadata = (row.metadata ?? {}) as { qa_pair_ids?: string[] };
-    const id = metadata.qa_pair_ids?.[0]?.replace(/_no\d+$/, '') ?? `row-${options.row}`;
+    const candidate = row.metadata?.qa_pair_ids?.[0]?.replace(/_no\d+$/, '');
+    const id = candidate && SAFE_ID.test(candidate) ? candidate : `row-${Number(options.row)}`;
     const instance = { id, context: row.context, questions: row.questions, answers: row.answers };
 
     const outPath = path.resolve(options.out);
@@ -39,7 +57,7 @@ program
     await fs.writeFile(outPath, JSON.stringify(instance, null, 2), 'utf-8');
 
     console.log(`Wrote ${id} to ${options.out}`);
-    console.log(`  context ${String(row.context).length} chars · ${(row.questions as string[]).length} questions`);
+    console.log(`  context ${row.context.length} chars · ${row.questions.length} questions`);
   });
 
 program

--- a/benchmarks/unassisted-capture/tests/calibrate.test.ts
+++ b/benchmarks/unassisted-capture/tests/calibrate.test.ts
@@ -31,6 +31,7 @@ describe('chooseThreshold', () => {
 
     const { threshold, agreement } = chooseThreshold(scored);
 
+    expect(threshold).toBeCloseTo(0.575, 10);
     expect(agreement).toBeCloseTo(0.8, 10);
   });
 

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -31,7 +31,7 @@ export function initAI(config: AIConfig): LanguageModel {
     return currentModel;
   }
 
-  const { provider, model, apiKey, baseUrl, temperature } = config;
+  const { provider, model, apiKey, baseUrl } = config;
 
   try {
     if (provider === 'openai') {

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -3,7 +3,6 @@ import { validateKnowledgeWrite } from '../../core/knowledge-validation.js';
 import { SessionEventType } from '../../core/types.js';
 import { isSessionEventType } from './lifecycle.js';
 import { hostProfile, isHookHost } from './hosts/index.js';
-import { AgentName } from './types.js';
 
 export type HookHost = 'codex' | 'claude' | 'cursor' | 'claude-desktop' | 'generic';
 export type NormalizedHookEventName =
@@ -74,12 +73,6 @@ const stringValue = (value: unknown, max = MAX_STRING): string | undefined =>
 
 const recordValue = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
-
-function requireString(raw: Record<string, unknown>, key: string): string {
-  const value = stringValue(raw[key]);
-  if (!value) throw new IncompleteHostHookPayloadError(`Host hook payload requires ${key}.`);
-  return value;
-}
 
 function requireProjectRoot(raw: Record<string, unknown>): string {
   const cwd = stringValue(raw.cwd);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -178,6 +178,23 @@ function isWindowsBatchCommand(command: string) {
   return ext === '.cmd' || ext === '.bat';
 }
 
+/**
+ * Quote one token so `cmd.exe` passes it through as a single argument instead of as syntax.
+ *
+ * Two parsers read this string in turn. `cmd` goes first and treats `& | < > ( ) ^` as command
+ * syntax wherever they are not inside a quoted region; the child's C runtime goes second and
+ * undoes one layer of backslash-and-quote. So the quotes do the security work -- inside them
+ * cmd stops seeing operators -- and doubling the backslashes that run up to a quote is what
+ * the CRT expects on the other side.
+ *
+ * Not covered: `%VAR%`, which cmd expands inside quotes too and has no escape outside a batch
+ * file. That is unchanged from routing through `cmd /c` at all, and the variables in reach are
+ * the caller's own, in a command the caller typed.
+ */
+function quoteForCmd(value: string): string {
+  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')}"`;
+}
+
 function spawnWorkLoopCommand(command: string, args: string[]) {
   const spawnOptions = {
     cwd: process.cwd(),
@@ -190,7 +207,18 @@ function spawnWorkLoopCommand(command: string, args: string[]) {
   }
 
   if (isWindowsBatchCommand(command)) {
-    return spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/c', command, ...args], spawnOptions);
+    // A batch shim cannot be handed to CreateProcess directly, so it has to go through cmd --
+    // and everything after `/c` is re-parsed by cmd before the child ever sees it. Passing the
+    // pieces as separate argv entries left that parse to Node's CRT quoting, which is not cmd
+    // quoting: a repository path or task argument holding `&` ended one command and started
+    // another. One pre-quoted line with `/s` (strip the outer pair, take the rest as the
+    // command) plus `windowsVerbatimArguments` (do not quote what is already quoted) is the
+    // same shape Node's own `shell: true` path uses.
+    const line = [command, ...args].map(quoteForCmd).join(' ');
+    return spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`], {
+      ...spawnOptions,
+      windowsVerbatimArguments: true,
+    });
   }
 
   return spawnSync(command, args, spawnOptions);
@@ -367,7 +395,7 @@ program
 
       // Bootstrap SQLite database
       await initDb(cwd);
-      const project = await repo.createProject(cwd, name);
+      await repo.createProject(cwd, name);
       await closeDb();
       // Recorded here as well as in `upgrade`, so a repository is reachable by a machine-wide
       // sweep from the moment it exists rather than only after its first upgrade.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,9 +1,9 @@
 import { Command } from 'commander';
-import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import dotenv from 'dotenv';
+import { spawnWorkLoopCommand } from './windows-spawn.js';
 import { PACKAGE_NAME, PACKAGE_VERSION } from '../version.js';
 import { checkForUpdate, formatUpdateNotice, isUpdateCheckEnabled } from '../core/version-check.js';
 import { NEW_PROJECT_CONFIG, findProjectRoot, isProjectRoot, loadConfig, saveConfig, hasAiConfigured } from '../core/config.js';
@@ -148,80 +148,6 @@ function printPrCheckResult(result: DriftCheckResult) {
 
 function formatCommand(command: string, args: string[]) {
   return [command, ...args].join(' ');
-}
-
-function hasPathSeparator(command: string) {
-  return command.includes('/') || command.includes('\\');
-}
-
-function resolveWindowsCommand(command: string) {
-  const ext = path.extname(command);
-  if (ext) return command;
-
-  const pathEntries = (process.env.Path || process.env.PATH || '').split(path.delimiter).filter(Boolean);
-  const pathExts = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
-  const searchDirs = hasPathSeparator(command) ? [''] : [process.cwd(), ...pathEntries];
-
-  for (const dir of searchDirs) {
-    for (const pathExt of pathExts) {
-      const candidate = dir ? path.join(dir, `${command}${pathExt}`) : `${command}${pathExt}`;
-      if (existsSync(candidate)) return candidate;
-    }
-  }
-
-  return command;
-}
-
-function isWindowsBatchCommand(command: string) {
-  const resolved = resolveWindowsCommand(command);
-  const ext = path.extname(resolved).toLowerCase();
-  return ext === '.cmd' || ext === '.bat';
-}
-
-/**
- * Quote one token so `cmd.exe` passes it through as a single argument instead of as syntax.
- *
- * Two parsers read this string in turn. `cmd` goes first and treats `& | < > ( ) ^` as command
- * syntax wherever they are not inside a quoted region; the child's C runtime goes second and
- * undoes one layer of backslash-and-quote. So the quotes do the security work -- inside them
- * cmd stops seeing operators -- and doubling the backslashes that run up to a quote is what
- * the CRT expects on the other side.
- *
- * Not covered: `%VAR%`, which cmd expands inside quotes too and has no escape outside a batch
- * file. That is unchanged from routing through `cmd /c` at all, and the variables in reach are
- * the caller's own, in a command the caller typed.
- */
-function quoteForCmd(value: string): string {
-  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')}"`;
-}
-
-function spawnWorkLoopCommand(command: string, args: string[]) {
-  const spawnOptions = {
-    cwd: process.cwd(),
-    env: process.env,
-    stdio: 'inherit' as const,
-  };
-
-  if (process.platform !== 'win32') {
-    return spawnSync(command, args, spawnOptions);
-  }
-
-  if (isWindowsBatchCommand(command)) {
-    // A batch shim cannot be handed to CreateProcess directly, so it has to go through cmd --
-    // and everything after `/c` is re-parsed by cmd before the child ever sees it. Passing the
-    // pieces as separate argv entries left that parse to Node's CRT quoting, which is not cmd
-    // quoting: a repository path or task argument holding `&` ended one command and started
-    // another. One pre-quoted line with `/s` (strip the outer pair, take the rest as the
-    // command) plus `windowsVerbatimArguments` (do not quote what is already quoted) is the
-    // same shape Node's own `shell: true` path uses.
-    const line = [command, ...args].map(quoteForCmd).join(' ');
-    return spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`], {
-      ...spawnOptions,
-      windowsVerbatimArguments: true,
-    });
-  }
-
-  return spawnSync(command, args, spawnOptions);
 }
 
 function collectOption(value: string, previous: string[]) {

--- a/src/cli/windows-spawn.ts
+++ b/src/cli/windows-spawn.ts
@@ -1,0 +1,142 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Running one child command the way the host shell would, without handing it a shell.
+ *
+ * Its own module because `program.ts` calls `program.parse(process.argv)` at import time, so
+ * nothing in there can be imported by a test without running the CLI. That is not a stylistic
+ * point: the Windows branch below is the part of this file that is easy to get subtly wrong,
+ * and it stayed wrong through a green local suite precisely because no test could reach it.
+ */
+
+function hasPathSeparator(command: string) {
+  return command.includes('/') || command.includes('\\');
+}
+
+/** Resolve a bare command to a full path the way `CreateProcess` plus PATHEXT would. */
+export function resolveWindowsCommand(command: string) {
+  const ext = path.extname(command);
+  if (ext) return command;
+
+  const pathEntries = (process.env.Path || process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const pathExts = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+  const searchDirs = hasPathSeparator(command) ? [''] : [process.cwd(), ...pathEntries];
+
+  for (const dir of searchDirs) {
+    for (const pathExt of pathExts) {
+      const candidate = dir ? path.join(dir, `${command}${pathExt}`) : `${command}${pathExt}`;
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return command;
+}
+
+/**
+ * The full path of `command` when it is a batch shim, or null when it is not one.
+ *
+ * Returns the path rather than a boolean because the caller needs it. Handing cmd a *bare*
+ * name that is also quoted makes `%~dp0` inside the shim expand to the current directory
+ * instead of the shim's own -- `npm.cmd` then looks for its `npm-cli.js` under the caller's
+ * cwd and dies with MODULE_NOT_FOUND. The resolution already happened here to read the
+ * extension, so the answer is kept rather than recomputed.
+ */
+export function windowsBatchCommandPath(command: string): string | null {
+  const resolved = resolveWindowsCommand(command);
+  const ext = path.extname(resolved).toLowerCase();
+  return ext === '.cmd' || ext === '.bat' ? resolved : null;
+}
+
+/**
+ * Quote one token so `cmd.exe` passes it through as a single argument instead of as syntax.
+ *
+ * Quoting alone is NOT enough here, which is the trap: when the target is a batch file, cmd
+ * parses the line a second time for the batch context, and an operator inside a quoted region
+ * survives the first parse only to split on the second. Measured against a `.cmd` that echoes
+ * `%~1`, the argument `x& echo PWNED` ran `echo PWNED` as its own command. So the carets do
+ * the security work and the quotes only hold the token together.
+ *
+ * `^` is escaped alongside the operators, so an argument that legitimately contains one still
+ * arrives with one rather than losing it to the same pass.
+ *
+ * Two things this deliberately does not solve:
+ *
+ *   - `%VAR%`. cmd expands it inside quotes too and there is no escape for it outside a batch
+ *     file. Unchanged from routing through `cmd /c` at all, and the variables in reach are the
+ *     caller's own, in a command the caller typed.
+ *   - A trailing backslash. The doubling below is CRT quoting, which is what a shim forwarding
+ *     `%*` to a real executable needs -- `npm`, `npx`, `yarn` and friends are all that shape --
+ *     but a batch file reading `%~1` directly does its own quote stripping and has no CRT to
+ *     undo it, so `a\` reaches that reader as `a\\`. The two consumers want opposite things
+ *     and the forwarding one is overwhelmingly the common case.
+ */
+export function quoteForCmd(value: string): string {
+  const crtQuoted = `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')}"`;
+  return crtQuoted.replace(/[&|<>()^]/g, '^$&');
+}
+
+/** The `cmd.exe` argv for running a batch shim with these arguments, arguments neutralised. */
+export function batchCommandLine(batchPath: string, args: string[]): string[] {
+  const line = [batchPath, ...args].map(quoteForCmd).join(' ');
+  // `/s` means "strip the outer quote pair and take the rest as the command", which is the
+  // same shape Node's own `shell: true` path uses.
+  return ['/d', '/s', '/c', `"${line}"`];
+}
+
+export type WindowsSpawnPlan = {
+  /** `direct` goes to CreateProcess; `cmd` has to be re-parsed by a shell first. */
+  via: 'direct' | 'cmd';
+  file: string;
+  args: string[];
+  verbatim: boolean;
+};
+
+/**
+ * Decide how to launch `command`, without launching it.
+ *
+ * Separate from the spawn so it can be asserted on. `spawnWorkLoopCommand` inherits stdio --
+ * it has to, the child's output is the user's output -- so a test cannot read what a spawn
+ * produced, and the regression that broke Windows CI lived in exactly this decision: passing
+ * the caller's bare `command` to cmd where the resolved path belonged.
+ */
+export function windowsSpawnPlan(command: string, args: string[]): WindowsSpawnPlan {
+  const batchPath = windowsBatchCommandPath(command);
+  if (!batchPath) return { via: 'direct', file: command, args, verbatim: false };
+
+  // A batch shim cannot be handed to CreateProcess directly, so it has to go through cmd --
+  // and everything after `/c` is re-parsed by cmd before the child ever sees it. Passing the
+  // pieces as separate argv entries left that parse to Node's CRT quoting, which is not cmd
+  // quoting, so an argument holding `&` ended one command and started another.
+  //
+  // `batchPath`, not `command`: the escaping is what makes the arguments safe, and a quoted
+  // BARE name is the one thing cmd will not resolve the same way. Given `"npm"` it finds the
+  // shim on PATH but leaves `%~dp0` pointing at the caller's cwd, so the shim looks for its
+  // own payload under a directory that does not have it. A quoted full path is unambiguous to
+  // both cmd and the shim.
+  return {
+    via: 'cmd',
+    file: process.env.ComSpec || 'cmd.exe',
+    args: batchCommandLine(batchPath, args),
+    verbatim: true,
+  };
+}
+
+export function spawnWorkLoopCommand(command: string, args: string[]): SpawnSyncReturns<Buffer> {
+  const spawnOptions = {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'inherit' as const,
+  };
+
+  if (process.platform !== 'win32') {
+    return spawnSync(command, args, spawnOptions);
+  }
+
+  const plan = windowsSpawnPlan(command, args);
+  return spawnSync(plan.file, plan.args, {
+    ...spawnOptions,
+    windowsVerbatimArguments: plan.verbatim,
+  });
+}

--- a/src/core/startup-trace.ts
+++ b/src/core/startup-trace.ts
@@ -79,21 +79,37 @@ const TRIM_TARGET_BYTES = Math.floor(MAX_STARTUP_LOG_BYTES / 2);
  * Rewrites in place rather than rotating to a `.1` file: two files double the ceiling and
  * give `diagnose-startup` a second place to look, for history nobody asks for. The cut lands
  * on a newline, because half a JSON record is a line no reader can parse.
+ *
+ * Everything after the open goes through the descriptor -- `fstat`, read, truncate, `fchmod` --
+ * so the bytes measured are the bytes rewritten. Checking a path and then acting on that path
+ * is two separate lookups, and on a machine-wide directory the file can be replaced between
+ * them: the size check would pass on one file and the truncating write land on another.
  */
 export function trimStartupLog(file: string): void {
+  let fd: number;
   try {
-    if (!fs.existsSync(file)) return;
-    if (fs.statSync(file).size <= MAX_STARTUP_LOG_BYTES) return;
+    fd = fs.openSync(file, 'r+');
+  } catch {
+    return; // No log yet, or not ours to read -- either way there is nothing to trim.
+  }
+  try {
+    if (fs.fstatSync(fd).size <= MAX_STARTUP_LOG_BYTES) return;
 
-    const contents = fs.readFileSync(file, 'utf8');
+    const contents = fs.readFileSync(fd, 'utf8');
     const cut = contents.length - TRIM_TARGET_BYTES;
     const boundary = contents.indexOf('\n', Math.max(0, cut));
     // No newline after the cut means one enormous trailing record; keeping it whole is
     // better than writing a fragment, and the next append will try again.
+    if (boundary === -1) return;
+
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, contents.slice(boundary + 1), 0, 'utf8');
     // Mode preserved: a rewrite must not widen what `append` deliberately narrowed.
-    fs.writeFileSync(file, boundary === -1 ? contents : contents.slice(boundary + 1), { mode: 0o600 });
+    fs.fchmodSync(fd, 0o600);
   } catch {
     // Same rule as append: a diagnostic must never be the reason a server fails to start.
+  } finally {
+    try { fs.closeSync(fd); } catch { /* already gone */ }
   }
 }
 
@@ -104,15 +120,25 @@ export function trimStartupLog(file: string): void {
  *
  * The modes matter because this file is machine-wide rather than per-project: on a shared host
  * it would otherwise tell every local account which projects this user runs, and when.
+ *
+ * One `open('a', 0o600)` replaces the exists-then-create pair: it creates the file already
+ * narrowed when it is absent and appends when it is not, with no window between the two in
+ * which another account on the host could put its own file at that path and inherit the mode
+ * we were about to set. `fchmod` on the descriptor then narrows what umask widened -- and an
+ * older log left group-readable -- on the file actually written rather than on the name.
  */
 function append(record: Record<string, unknown>): void {
   try {
     fs.mkdirSync(diagnosticsDir(), { recursive: true, mode: 0o700 });
     fs.chmodSync(diagnosticsDir(), 0o700);
     const file = startupLogPath();
-    if (!fs.existsSync(file)) fs.writeFileSync(file, '', { mode: 0o600 });
-    fs.appendFileSync(file, JSON.stringify(record) + '\n');
-    fs.chmodSync(file, 0o600);
+    const fd = fs.openSync(file, 'a', 0o600);
+    try {
+      fs.writeSync(fd, JSON.stringify(record) + '\n');
+      fs.fchmodSync(fd, 0o600);
+    } finally {
+      fs.closeSync(fd);
+    }
     trimStartupLog(file);
   } catch {
     // A diagnostic must never be the reason a server fails to start.

--- a/src/core/version-check.ts
+++ b/src/core/version-check.ts
@@ -46,7 +46,11 @@ async function fetchLatest(packageName: string, fetchImpl: typeof fetch): Promis
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   timer.unref?.();
   try {
-    const response = await fetchImpl(`${REGISTRY_BASE}/${packageName.replace('/', '%2F')}/latest`, {
+    // `/g`, not a bare string: a string pattern replaces the first match only, so a name with a
+    // second slash would put a live path separator in the URL and the request would land on a
+    // different registry route. Scoped names carry exactly one today; the escape should not
+    // depend on that staying true. `@` is left alone -- the registry expects `@scope%2Fname`.
+    const response = await fetchImpl(`${REGISTRY_BASE}/${packageName.replace(/\//g, '%2F')}/latest`, {
       signal: controller.signal,
       headers: { accept: 'application/vnd.npm.install-v1+json, application/json', connection: 'close' },
     });

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -73,7 +73,6 @@ export async function initDb(projectRoot: string): Promise<LibSQLDatabase<typeof
 }
 
 export async function initDbPath(dbPath: string, options: InitDbOptions = {}): Promise<LibSQLDatabase<typeof schema>> {
-  const fileUrl = `file:${dbPath}`;
   const configRoot = options.configRoot ?? path.dirname(path.dirname(dbPath));
 
   try {

--- a/src/store/host-session-bindings.ts
+++ b/src/store/host-session-bindings.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { canonicalProjectRoot } from '../core/project-path.js';
 import { validateKnowledgeWrite } from '../core/knowledge-validation.js';
 import { MemorySession } from '../core/types.js';
@@ -61,7 +60,6 @@ export async function getOrCreateHostSession(input: HostSessionInput) {
     return { ...bootstrap, created: false };
   }
 
-  const key = normalizedKey(input);
   const bootstrap = await bootstrapAgentSession({
     projectId: input.projectId,
     title: input.title,

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -137,7 +137,6 @@ export async function createKnowledgeItem(
   // not: it writes raw SQL precisely because a dump is foreign data that may predate any guard
   // this build has, and refusing it would make someone's export unloadable.
   assertConfidenceInRange(item.confidence, item.title);
-  const conn = dbConnection || getDb();
   const now = new Date().toISOString();
   const id = generateId();
   const affectedPaths = normalizeAffectedPaths(item.affectedPaths);
@@ -306,7 +305,6 @@ export async function updateKnowledgeItem(
   // `knowledge_assertions` row carrying `updates.confidence` -- the same column, one table
   // over, and the one temporal queries read.
   assertConfidenceInRange(updates.confidence, updates.title ?? id);
-  const conn = dbConnection || getDb();
   const now = new Date().toISOString();
 
   const operation = async (exec: any) => {

--- a/src/store/retention.ts
+++ b/src/store/retention.ts
@@ -315,16 +315,19 @@ async function adoptOne(
   try {
     await copyFile(source, partial);
 
-    // Length is the cheap end of "did all of it arrive". A short copy is what a full disk
-    // looks like, and a 300 MB model that is silently 200 MB fails much later and much worse.
-    const [from, to] = await Promise.all([fs.stat(source), fs.stat(partial)]);
-    if (from.size !== to.size) throw new Error(`short copy: ${to.size} of ${from.size} bytes`);
-
-    // Flushed before the rename, not after. Rename is atomic with respect to other
-    // processes, not with respect to power loss: without this the directory entry can reach
-    // the disk while the contents have not, which is a model that exists and is empty.
+    // Opened once, then measured and flushed through the descriptor. Stat-by-path followed by
+    // open-by-path is two lookups of the same name, so the size that was checked and the bytes
+    // that get flushed and renamed are not guaranteed to be the same file.
     const handle = await fs.open(partial, 'r+');
     try {
+      // Length is the cheap end of "did all of it arrive". A short copy is what a full disk
+      // looks like, and a 300 MB model that is silently 200 MB fails much later and much worse.
+      const [from, to] = await Promise.all([fs.stat(source), handle.stat()]);
+      if (from.size !== to.size) throw new Error(`short copy: ${to.size} of ${from.size} bytes`);
+
+      // Flushed before the rename, not after. Rename is atomic with respect to other
+      // processes, not with respect to power loss: without this the directory entry can reach
+      // the disk while the contents have not, which is a model that exists and is empty.
       await handle.sync();
     } finally {
       await handle.close();

--- a/src/store/session-repository.ts
+++ b/src/store/session-repository.ts
@@ -11,7 +11,6 @@ const ABANDONED_AFTER_HOURS = 2;
 const id = () => crypto.randomUUID().replace(/-/g, '').slice(0, 16);
 const plusHours = (now: string, hours: number) => new Date(new Date(now).getTime() + hours * HOUR).toISOString();
 const mapSession = (row: any): MemorySession => ({ id: String(row.id), agent: row.agent ? String(row.agent) : null, title: String(row.title), query: row.query ? String(row.query) : null, status: row.status as SessionStatus, startedAt: String(row.started_at), lastHeartbeatAt: String(row.last_heartbeat_at), finishedAt: row.finished_at ? String(row.finished_at) : null, baselineCommit: row.baseline_commit ? String(row.baseline_commit) : null, expiresAt: String(row.expires_at) });
-const mapEvent = (row: any): MemorySessionEvent => ({ id: String(row.id), sessionId: String(row.session_id), type: row.type as SessionEventType, payload: JSON.parse(String(row.payload)), observedAt: String(row.observed_at), expiresAt: String(row.expires_at) });
 
 export async function getMemorySession(id: string): Promise<MemorySession> {
   const row = (await getClient().execute({ sql: 'SELECT * FROM memory_sessions WHERE id = ?', args: [id] })).rows[0];

--- a/src/store/vector.ts
+++ b/src/store/vector.ts
@@ -1,11 +1,9 @@
 import { Client } from '@libsql/client';
-import { and, SQL } from 'drizzle-orm';
 import { KnowledgeCategory, KnowledgeItem, KnowledgeStatus } from '../core/types.js';
 import { DatabaseError } from '../core/errors.js';
 import { getClient, withClientTransaction } from './database.js';
 import { getKnowledgeItems } from './repository.js';
 import { localStore, type StoreHandle } from './store-handle.js';
-import * as schema from './schema.js';
 
 export type KnowledgeEmbeddingInput = {
   projectId?: string;

--- a/src/store/write-embedding.ts
+++ b/src/store/write-embedding.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import { KnowledgeItem } from '../core/types.js';
 import { getConfigRoot } from './database.js';
 import { buildKnowledgeEmbeddingText, KnowledgeEmbedder } from './vector-index.js';

--- a/tests/cli/windows-spawn.test.ts
+++ b/tests/cli/windows-spawn.test.ts
@@ -1,0 +1,161 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  batchCommandLine, quoteForCmd, windowsBatchCommandPath, windowsSpawnPlan,
+} from '../../src/cli/windows-spawn.js';
+
+/**
+ * `knowl task run -- <command>` on Windows.
+ *
+ * A batch shim cannot go to `CreateProcess` directly, so it goes through `cmd /c` -- and
+ * everything after `/c` is parsed by cmd before the child sees it, then parsed AGAIN for the
+ * batch context. Both parses have bitten this code, in opposite directions:
+ *
+ *   - Passing the pieces as separate argv entries left the escaping to Node's CRT quoting,
+ *     which is not cmd quoting, so an argument holding `&` ended one command and began
+ *     another.
+ *   - Fixing that by quoting the whole line quoted the BARE command name too, and cmd resolves
+ *     a quoted bare name differently: it finds the shim on PATH but leaves `%~dp0` pointing at
+ *     the caller's cwd, so `npm.cmd` hunted for its own `npm-cli.js` under a directory with no
+ *     node_modules and died with MODULE_NOT_FOUND.
+ *
+ * These run cmd for real rather than asserting on the generated string, because the bug both
+ * times was in what cmd does with the string, not in the string looking wrong.
+ */
+
+const onWindows = process.platform === 'win32';
+const comspec = process.env.ComSpec || 'cmd.exe';
+
+let dir = '';
+let showArg = '';
+
+beforeAll(() => {
+  if (!onWindows) return;
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'knowl-winspawn-'));
+  // Echoes its first two arguments separately, so a split argument is visible as a split.
+  showArg = path.join(dir, 'showarg.cmd');
+  fs.writeFileSync(showArg, '@echo off\r\necho A1=[%~1]\r\necho A2=[%~2]\r\n');
+});
+
+afterAll(() => {
+  if (!dir) return;
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* Windows */ }
+});
+
+/** Run the batch shim through the real cmd the same way `spawnWorkLoopCommand` does. */
+function runBatch(args: string[], cwd = dir) {
+  const result = spawnSync(comspec, batchCommandLine(showArg, args), {
+    cwd,
+    env: process.env,
+    encoding: 'utf-8',
+    windowsVerbatimArguments: true,
+  });
+  return (result.stdout || '').trim().replace(/\r?\n/g, ' ');
+}
+
+describe.skipIf(!onWindows)('running a Windows batch shim through cmd', () => {
+  it('passes an argument holding a command separator through as one argument', () => {
+    // The injection this escaping exists for: unescaped, cmd runs `echo PWNED` on its own.
+    expect(runBatch(['x& echo PWNED', 'second'])).toBe('A1=[x& echo PWNED] A2=[second]');
+  });
+
+  it.each([
+    ['pipe', 'a|b'],
+    ['redirect out', 'a>b'],
+    ['redirect in', 'a<b'],
+    ['parentheses', 'a(b)c'],
+    ['caret', 'a^b'],
+    ['space', 'a b'],
+    ['flag with separator', '--flag=a&b'],
+  ])('keeps %s intact', (_label, value) => {
+    expect(runBatch([value, 'second'])).toBe(`A1=[${value}] A2=[second]`);
+  });
+
+  it('does not let an argument swallow the one after it', () => {
+    expect(runBatch(['first', 'second'])).toBe('A1=[first] A2=[second]');
+  });
+
+  /**
+   * The regression that turned the Windows CI leg red. A quoted BARE name resolves on PATH but
+   * leaves `%~dp0` at the caller's cwd, so a shim that locates its payload relative to itself
+   * looks in the wrong place. Asserted from a cwd with no `node_modules`, which is what made
+   * the failure visible: `npm.cmd` reported it could not find `npm-cli.js` under the temp dir.
+   */
+  it('runs a PATH-resolved shim from a directory that has no node_modules', () => {
+    const npm = windowsBatchCommandPath('npm');
+    expect(npm, 'npm should resolve to a .cmd shim on Windows').toBeTruthy();
+
+    const result = spawnSync(comspec, batchCommandLine(npm!, ['--version']), {
+      cwd: dir,
+      env: process.env,
+      encoding: 'utf-8',
+      windowsVerbatimArguments: true,
+    });
+
+    expect(result.stderr || '').not.toContain('Cannot find module');
+    expect(result.status).toBe(0);
+    expect((result.stdout || '').trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('resolves the shim to a full path rather than leaving the bare name', () => {
+    const npm = windowsBatchCommandPath('npm');
+    expect(path.isAbsolute(npm!)).toBe(true);
+    expect(path.extname(npm!).toLowerCase()).toBe('.cmd');
+  });
+
+  it('reports a non-batch command as not needing cmd at all', () => {
+    expect(windowsBatchCommandPath('node')).toBeNull();
+  });
+});
+
+describe.skipIf(!onWindows)('the launch plan for a work-loop command', () => {
+  /**
+   * The regression itself, guarded at the seam where it happened: the plan must carry the
+   * shim's resolved path, never the bare name the caller typed. `spawnWorkLoopCommand`
+   * inherits stdio, so this is the last point the decision can still be read.
+   */
+  it('hands cmd the resolved shim path, not the bare name it was given', () => {
+    const plan = windowsSpawnPlan('npm', ['--version']);
+    const resolved = windowsBatchCommandPath('npm')!;
+
+    expect(plan.via).toBe('cmd');
+    expect(plan.verbatim).toBe(true);
+    expect(plan.args.join(' ')).toContain(resolved);
+    // A bare `"npm"` anywhere in the line is the exact shape that broke `%~dp0`.
+    expect(plan.args.join(' ')).not.toContain('"npm"');
+  });
+
+  it('sends a real executable straight to CreateProcess, unquoted and unescaped', () => {
+    const plan = windowsSpawnPlan('node', ['-p', '1&2']);
+
+    expect(plan.via).toBe('direct');
+    expect(plan.verbatim).toBe(false);
+    // No shell is involved, so the argument must arrive exactly as written.
+    expect(plan.args).toEqual(['-p', '1&2']);
+  });
+
+  it('escapes a command separator in the arguments it routes through cmd', () => {
+    const plan = windowsSpawnPlan('npm', ['x& echo PWNED']);
+    expect(plan.args.join(' ')).toContain('^&');
+    expect(plan.args.join(' ')).not.toContain('x& echo');
+  });
+});
+
+describe('quoteForCmd', () => {
+  it('escapes every character cmd would otherwise read as syntax', () => {
+    for (const meta of ['&', '|', '<', '>', '(', ')', '^']) {
+      expect(quoteForCmd(`a${meta}b`), `${meta} should be caret-escaped`).toContain(`^${meta}`);
+    }
+  });
+
+  it('wraps the token so a space cannot split it', () => {
+    expect(quoteForCmd('a b')).toBe('"a b"');
+  });
+
+  it('leaves an ordinary token as just a quoted token', () => {
+    expect(quoteForCmd('plain')).toBe('"plain"');
+  });
+});

--- a/tests/store/snapshot-restore-safety.test.ts
+++ b/tests/store/snapshot-restore-safety.test.ts
@@ -96,8 +96,10 @@ describe('snapshot restore safety', () => {
 
     await Promise.allSettled([restoreSnapshot(TEST_ROOT, snapshot.path, { confirm: true }), swap]);
 
-    // Whatever happened, the store is never left empty by a file swapped mid-restore.
-    expect(await itemCount()).toBeGreaterThan(0);
+    // Whatever happened, the store is never left torn by a file swapped mid-restore: either the
+    // restore won and the store is back at the snapshot's `expected`, or it refused the swapped
+    // bytes and 'Later' survives. Never fewer than the snapshot held.
+    expect(await itemCount()).toBeGreaterThanOrEqual(expected);
     await fs.writeFile(snapshot.path, original);
   });
 

--- a/tests/store/tombstone-monotonicity.test.ts
+++ b/tests/store/tombstone-monotonicity.test.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/tests/workspace/cross-repo-semantic.test.ts
+++ b/tests/workspace/cross-repo-semantic.test.ts
@@ -5,7 +5,6 @@ import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import * as repo from '../../src/store/repository.js';
 import { createKnowledgeItem } from '../../src/store/repository.js';
-import { queryKnowledgeForAgent } from '../../src/store/agent-query.js';
 import { reindexKnowledgeEmbeddings } from '../../src/store/vector-index.js';
 import { createLocalEmbeddingProvider } from '../../src/ai/embeddings.js';
 import { queryFederated } from '../../src/workspace/federated-query.js';

--- a/tests/workspace/federated-query.test.ts
+++ b/tests/workspace/federated-query.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import * as repo from '../../src/store/repository.js';
 import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
-import { queryKnowledgeForAgent } from '../../src/store/agent-query.js';
 import { queryFederated } from '../../src/workspace/federated-query.js';
 import { resolveWorkspace } from '../../src/workspace/resolve.js';
 import { createManifest, writeManifest } from '../../src/workspace/manifest.js';


### PR DESCRIPTION
Closes all 29 open code-scanning alerts. Twenty of them were the `security-and-quality` suite's maintainability queries rather than security findings — both halves are worth closing, because dead code in the Security tab is what teaches people to stop reading it.

### Three fixes went past the alert to a real defect

- **`src/store/repository.ts`** — `createKnowledgeItem` and `updateKnowledgeItem` each opened `conn = dbConnection || getDb()` and never used it. Both dispatch through `operation(dbConnection)` or `withClientTransaction`, so every knowledge write was paying for a database handle nothing touched.
- **`benchmarks/unassisted-capture/tests/calibrate.test.ts`** — destructured the threshold its own comment names (0.575) and asserted only `agreement`. Now asserts both.
- **`tests/store/snapshot-restore-safety.test.ts`** — captured the pre-snapshot item count and then asserted only `> 0`. Now `>= expected`, which holds whether the restore won the swap race or refused the swapped bytes: tighter without becoming flaky.

### Security findings (9)

**File-system races (5).** `startup-trace.ts` and `retention.ts` checked a path and then acted on that path — two separate lookups, on a machine-wide diagnostics directory, so the size check could pass on one file and the truncating write land on another. Both now open once and work through the descriptor (`fstat`, `ftruncate`, `fchmod`). `append` uses `open(file, 'a', 0o600)` so the log is created already narrowed instead of created and then chmodded.

**Command-line injection (1).** A Windows batch shim has to go through `cmd`, and everything after `/c` is re-parsed by cmd before the child sees it. Passing the pieces as separate argv entries left that parse to Node's CRT quoting, which is not cmd quoting — a path or argument holding `&` ended one command and started another. Now one pre-quoted line with `/s` and `windowsVerbatimArguments`, the shape Node's own `shell: true` path uses. `%VAR%` is still expanded; that is unchanged from routing through cmd at all, and the variables in reach are the caller's own.

**Incomplete sanitization (2).** `packageName.replace('/', '%2F')` replaced the first slash only — harmless for scoped names, which carry exactly one, but the escape should not depend on that. `tableText` escaped `|` without escaping `\` first, so a value holding `\|` came out `\|`: a literal backslash followed by a live column separator, which splits the Markdown row.

**Untrusted download to disk (1).** The MemoryAgentBench `fetch` subcommand wrote a third-party dataset server's response straight to a file that `run` later parses as trusted input. Validated with zod now, and the id derived from the remote metadata is constrained to a charset that cannot carry a separator.

### Verification

Local: build clean, `tsc --noEmit` clean, bench suite 74/74, `git diff --check` clean, lint 0 errors with warnings down 46 → 26.

`npm test` gives 1905 passed and 12 failing CLI files — **that is the unchanged baseline**, confirmed by stashing, rebuilding and re-running on `main`: identical file list, identical 33 test names. They fail because the fixtures create temp directories inside the repo and `init` refuses to nest a store there. `docs:check` and `typecheck:bench` are red on clean `main` too. None of this reaches CI, which checks out clean.

**What local runs could not cover:** the Windows `cmd` quoting change is exercised by `should run automatic work loop commands resolved from PATH` and `should run a command inside an automatic work loop` — both inside those 12 baseline-failing files. CI is the first place that change gets tested for real.

### Note on when the alerts clear

`codeql.yml` triggers on push to `main`, weekly, and manual dispatch — not on pull requests. So this PR will show nothing about the alert count; they re-evaluate after the merge lands.

### One thing left deliberately alone

`temperature` in `src/ai/provider.ts` was unused because the config field is read and never passed to any model. Removing it from the destructuring closes the alert but means a configured `temperature` is still silently ignored — a separate behaviour question, not folded in here.