### PR TITLE
fix(retrieval): scale the semantic half correctly, and unbreak the benchmarks measuring it

### DIFF
--- a/benchmarks/memoryagentbench/results/README.md
+++ b/benchmarks/memoryagentbench/results/README.md
@@ -3,55 +3,67 @@
 MemoryAgentBench Conflict Resolution, single-hop 6k (`data/cr-sh-6k.json`, 100 questions).
 Reproduce with `npm run bench:cr -- run --instance benchmarks/memoryagentbench/data/cr-sh-6k.json`.
 
-**Compare the `retrieval` and `supersede` fields, not the filenames.** A filename says what the
-run was *for*; only those fields say what it actually did. `cr-sh-6k-vector.json` was read as a
-current vector-path measurement and its 26 stale leaks as a regression against
+**Compare the `retrieval`, `embedding` and `supersede` fields, not the filenames.** A filename says
+what the run was *for*; only those fields say what it actually did. `cr-sh-6k-vector.json` was read
+as a current vector-path measurement and its 26 stale leaks as a regression against
 `cr-sh-6k-supersede-on.json`'s 3 — but it carries `supersede: undefined`, meaning it predates the
 flag, so the two differ by code state and not by retrieval mode. There was no regression.
 
-| File | retrieval | supersede | top-1 | stale leaks | p50 | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| `cr-sh-6k-vector.json` | vector+bm25 | *(pre-flag)* | 96% | 26 | 19ms | **Historical.** Predates supersession-at-write. Not comparable to anything below. |
-| `cr-sh-6k-supersede-on.json` | vector+bm25 | on | 96% | 3 | 19ms | The real prior baseline for the shipped default. |
-| `cr-sh-6k-supersede-off.json` | vector+bm25 | off | 40% | 62 | 20ms | Ablation. Doubles as the control: if this stops looking bad, the metric has broken rather than the product improved. |
-| `cr-sh-6k-vector-2.7.0.json` | vector+bm25 | on | 96% | 3 | 22-24ms | 2.7.0, the shipped default. Unchanged from the prior baseline. |
-| `cr-sh-6k-bm25-2.7.0.json` | bm25 | on | 82% | 2 | 15ms | 2.7.0 lower bound. Vector buys 14 points of top-1 for ~8ms. |
+**`embedding` exists because the same trap recurred on a second axis.** The default preset moved
+from minilm-l6-en to granite-small-en-r2 on 2026-08-02, which moved cr-sh-6k top-1 from 96% to 98%
+and cr-sh-64k from 91% to 95% — in *opposite directions from each other*. Runs recorded before that
+field was added carry no `embedding` at all; those are minilm, and the only other thing that dates
+them is `timestamp`. Never subtract across two runs whose `embedding` differs or is absent.
 
-## What 2.7.0 measured
-
-Retrieval quality is **unchanged** by the 2.7.0 refactor: 96% top-1 and 3 stale leaks, matching
-`supersede-on` exactly. For a change that rewrote candidate selection, split scoring out of
-ranking, moved filtering above the result cap and replaced the cross-repo fusion, "no movement" is
-the result worth having — the ablation still scores 40%/62, so the benchmark can still tell good
-from bad.
-
-Latency sits at p50 22-24ms against a recorded 19ms. Three consecutive runs on identical code
-spanned p50 19-35ms on this machine, so that gap is inside the noise; treat it as unmeasured
-rather than as a regression.
+| File | retrieval | embedding | supersede | top-1 | stale leaks | p50 | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `cr-sh-6k-supersede-on.json` | vector+bm25 | granite *(unrecorded)* | on | 98% | 2 | 13ms | **Published ablation, ON arm.** The README and reference.md figures come from here. |
+| `cr-sh-6k-supersede-off.json` | vector+bm25 | granite *(unrecorded)* | off | 47% | 62 | 14ms | **Published ablation, OFF arm.** Doubles as the control: if this stops looking bad, the metric has broken rather than the product improved. |
+| `cr-sh-6k-vector-granite.json` | vector+bm25 | granite | on | 98% | 2 | 17ms | The 6k row of the scaling table below, and an independent reproduction of the ON arm. |
+| `cr-sh-6k-bm25-2.7.0.json` | bm25 | *(none)* | on | 82% | 2 | 15ms | Lower bound. No embedding is involved, so this one is unaffected by the preset change. |
+| `cr-sh-6k-vector.json` | vector+bm25 | minilm | *(pre-flag)* | 96% | 26 | 19ms | **Historical.** Predates supersession-at-write. Not comparable to anything above. |
+| `cr-sh-6k-vector-2.7.0.json` | vector+bm25 | minilm | on | 96% | 3 | 35ms | **Historical.** 2.7.0 on the old preset. |
 
 ## Scaling: where the headroom actually is
 
-Same question type (single-hop), same task, growing corpus. Run 2026-07-30 on 2.8.0, after the
-write-path segfault fix in `c59c570` made instances above ~1200 facts runnable at all — the 32k
-instance previously died during ingest and 64k was never attempted.
+Same question type (single-hop), same task, growing corpus, all three on granite-small-en-r2.
+Run 2026-08-07.
 
 | instance | facts ingested | active after ingest | top-1 | any-rank | stale leaks | p50 |
 | --- | --- | --- | --- | --- | --- | --- |
-| `cr-sh-6k` | 455 | 306 | 96% | 100% | 3 | 22ms |
-| `cr-sh-32k` | 2310 | 1537 | 97% | 98% | 1 | 50ms |
-| `cr-sh-64k` | 4580 | 3019 | **91%** | 98% | 3 | 80ms |
+| `cr-sh-6k` | 455 | 306 | 98% | 100% | 2 | 17ms |
+| `cr-sh-32k` | 2310 | 1535 | 95% | 98% | 1 | 41ms |
+| `cr-sh-64k` | 4580 | 3016 | 95% | 99% | 3 | 111ms |
 
-**top-1 falls 6 points by 64k while any-rank holds at 98%.** The correct answer is still retrieved
-into the top 5 — it is being *ranked* below something else. That is a ranking problem, not a recall
-problem, and it is the first measurable retrieval headroom this project has had: 6k is saturated at
-96/100 and cannot demonstrate an improvement, while 64k has 9 points of top-1 to win and a named set
-of failing cases to inspect.
+**top-1 falls 3 points from 6k to 32k and then stops falling.** 32k and 64k are level at 95% while
+the corpus doubles, so the curve flattens rather than degrading with scale. any-rank holds at
+98-99% throughout: the correct answer is still retrieved into the top 5 and is being *ranked* below
+something else, which is a ranking problem rather than a recall problem.
 
-Latency grows roughly linearly with the corpus (455 → 4580 facts, 22ms → 80ms p50). Worth knowing
+Latency grows roughly linearly with the corpus (455 → 4580 facts, 17ms → 111ms p50). Worth knowing
 before anything is tuned: a ranking change that costs an extra pass over candidates shows up here.
 
-**Use 64k, not 6k, to justify retrieval work.** Anything measured on 6k is measured against a
-ceiling.
+### The previous version of this section was wrong, and worth keeping as a warning
+
+Measured on minilm, the same three instances read 96% / 97% / **91%**, which supported a confident
+conclusion: "top-1 falls 6 points by 64k… 64k has 9 points of top-1 to win… **use 64k, not 6k, to
+justify retrieval work.**" All of it was an artifact of the embedding model.
+
+Swapping the preset moved 6k **up** two points and 64k **up** four, erasing the cliff that made 64k
+look special. Note the directions differ — 32k went *down* while the other two went up — so this
+was not a uniform offset that a reader could have mentally corrected for.
+
+The surviving claim is the weaker one: there are ~5 points of top-1 to win, they are a ranking
+problem, and they are available at 32k as readily as at 64k. **Prefer 32k for iteration** — same
+headroom at roughly a third of the latency.
+
+Active-after-ingest also shifted slightly (1537 → 1535 at 32k, 3019 → 3016 at 64k), so
+supersession-at-write is not fully independent of the embedding model. Small, but it means an
+ablation must hold the preset fixed too.
+
+`cr-sh-32k-vector-2.8.0.json` and `cr-sh-64k-vector-2.8.0.json` are the superseded minilm runs the
+paragraph above is about. They are kept only as the evidence for it — they carry no `embedding`
+field and must not be read as current.
 
 ## Multi-hop instances measure something else
 
@@ -72,11 +84,17 @@ retrieval signal and must not be tuned against.
 content counts, even when the item that carried it is the current one. Treat it as directional, not
 exact — 1 versus 3 leaks is noise, 3 versus 62 is a signal.
 
-**On 6k, top-1 and any-rank cannot show an improvement**, only a fall: 96% and 100% are effectively
-the ceiling. An earlier revision of this note concluded from that alone that the benchmark had no
-headroom left anywhere and that retrieval work could not be justified by measurement. That was wrong
-— it generalised from the one instance small enough to run at the time. The 32k and 64k instances
-were unrunnable because of the write-path segfault, not because they were absent, and 64k turns out
-to have 9 points of top-1 headroom. Scale was the missing axis, not difficulty of question.
+**On 6k, top-1 and any-rank cannot show an improvement**, only a fall: 98% and 100% are effectively
+the ceiling. An early revision of this note generalised from that to "the benchmark has no headroom
+anywhere", which was wrong — 6k was simply the only instance small enough to run before the
+write-path segfault fix in `c59c570`. The correction that replaced it, that 64k specifically carried
+9 points of headroom, was wrong too, for a different reason: it compared runs across two embedding
+models. **Two successive conclusions here died of comparing runs that differed in something other
+than the thing under test.** That is what the `retrieval` / `embedding` / `supersede` fields are for.
 
-Row 7 (single-hop 262k) is still unfetched and is the next step up if 64k saturates.
+**No metric here separates "the ranker improved" from "the embedding model changed".** Every figure
+is end-to-end. Before attributing a movement to a code change, confirm `embedding` matches on both
+sides — and if a run predates that field, it is minilm and cannot be compared to anything current.
+
+Row 7 (single-hop 262k) is still unfetched. It is the next step up, though the 32k/64k plateau at
+95% suggests corpus size has stopped being the interesting axis.

--- a/benchmarks/memoryagentbench/results/cr-sh-32k-vector-granite.json
+++ b/benchmarks/memoryagentbench/results/cr-sh-32k-vector-granite.json
@@ -1,0 +1,1529 @@
+{
+  "instance": "D:\\coding\\knowl\\.claude\\worktrees\\fix+eval-vector-fixture-embeddings\\benchmarks\\memoryagentbench\\data\\cr-sh-32k.json",
+  "timestamp": "2026-08-07T04:30:57.810Z",
+  "retrieval": "vector+bm25",
+  "embedding": {
+    "provider": "local",
+    "model": "onnx-community/granite-embedding-small-english-r2-ONNX",
+    "dtype": "q8",
+    "pooling": "cls"
+  },
+  "supersede": true,
+  "topK": 5,
+  "facts": 2310,
+  "conflictGroups": 810,
+  "supersededAtWrite": 775,
+  "activeAfterIngest": 1535,
+  "report": {
+    "questions": 100,
+    "answered": 100,
+    "topOneAccuracy": 0.95,
+    "anyRankAccuracy": 0.98,
+    "staleLeaks": 1,
+    "emptyResults": 0,
+    "p50LatencyMs": 41,
+    "p95LatencyMs": 47
+  },
+  "cases": [
+    {
+      "question": "Which sport is Salem-Keizer Volcanoes associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "Salem-Keizer Volcanoes is associated with the sport of basketball",
+      "returnedContents": [
+        "Salem-Keizer Volcanoes is associated with the sport of basketball",
+        "goaltender is associated with the sport of pesäpallo",
+        "placekicker is associated with the sport of rugby",
+        "center is associated with the sport of basketball",
+        "cornerback is associated with the sport of field hockey"
+      ],
+      "latencyMs": 50
+    },
+    {
+      "question": "What position does Nick Rimando play?",
+      "golds": [
+        "flanker"
+      ],
+      "topContent": "Nick Rimando plays the position of flanker",
+      "returnedContents": [
+        "Nick Rimando plays the position of flanker",
+        "Hines Ward plays the position of cornerback",
+        "Freddie Freeman plays the position of linebacker",
+        "Dennis Erickson plays the position of quarterback",
+        "Regina Ip works in the field of basketball player"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "Which sport is power forward associated with?",
+      "golds": [
+        "rugby"
+      ],
+      "topContent": "power forward is associated with the sport of rugby",
+      "returnedContents": [
+        "power forward is associated with the sport of rugby",
+        "small forward is associated with the sport of rugby",
+        "Sebastian Janikowski plays the position of power forward",
+        "goaltender is associated with the sport of pesäpallo",
+        "linebacker is associated with the sport of shinty"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Which religion is Morris Iemma affiliated with?",
+      "golds": [
+        "Methodism"
+      ],
+      "topContent": "Morris Iemma is affiliated with the religion of Methodism",
+      "returnedContents": [
+        "Morris Iemma is affiliated with the religion of Methodism",
+        "Iman is affiliated with the religion of Islam",
+        "Imelda Marcos is affiliated with the religion of atheism",
+        "Niagara University is affiliated with the religion of Methodism",
+        "Common is affiliated with the religion of Christianity"
+      ],
+      "latencyMs": 46
+    },
+    {
+      "question": "Which sport is FC Slutsk associated with?",
+      "golds": [
+        "association football"
+      ],
+      "topContent": "FC Slutsk is associated with the sport of association football",
+      "returnedContents": [
+        "FC Slutsk is associated with the sport of association football",
+        "FC Irtysh Omsk is associated with the sport of association football",
+        "FC Vorskla Poltava is associated with the sport of basketball",
+        "Terrassa FC is associated with the sport of baseball",
+        "HIFK Fotboll is associated with the sport of association football"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is the capital of United Kingdom?",
+      "golds": [
+        "Rupnagar"
+      ],
+      "topContent": "The capital of United Kingdom is Rupnagar",
+      "returnedContents": [
+        "The capital of United Kingdom is Rupnagar",
+        "The capital of United States of America is Harrisville",
+        "The capital of Great Britain is London",
+        "United Kingdom is located in the continent of Oceania",
+        "The capital of England is Amposta"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "What is the country of citizenship of Dan Christensen?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Dan Christensen is a citizen of United States of America",
+      "returnedContents": [
+        "Dan Christensen is a citizen of United States of America",
+        "Dan Povenmire is a citizen of United States of America",
+        "Bryan Adams is a citizen of Canada",
+        "Dirk Nowitzki is a citizen of Canada",
+        "Hal Erickson is a citizen of United States of America"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Who founded Montanism?",
+      "golds": [
+        "Montanus of Phrygia"
+      ],
+      "topContent": "Montanism was founded by Montanus of Phrygia",
+      "returnedContents": [
+        "Montanism was founded by Montanus of Phrygia",
+        "Pedro Menéndez de Avilés is affiliated with the religion of Montanism",
+        "Mormonism was founded by Juvénal Habyarimana",
+        "Taoism was founded by Juliette Gordon Low",
+        "Methodism was founded by John Wesley"
+      ],
+      "latencyMs": 38
+    },
+    {
+      "question": "Which city did Noel Pemberton Billing work in?",
+      "golds": [
+        "London"
+      ],
+      "topContent": "Noel Pemberton Billing worked in the city of Washington, D.C.",
+      "returnedContents": [
+        "Noel Pemberton Billing worked in the city of Washington, D.C.",
+        "Christianity was founded by Noel Pemberton Billing",
+        "Lyndon B. Johnson worked in the city of London",
+        "Jesus Christ worked in the city of Galilee",
+        "John Knox worked in the city of Edinburgh"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is the capital of Papal States?",
+      "golds": [
+        "Rome"
+      ],
+      "topContent": "The capital of Papal States is Watertown",
+      "returnedContents": [
+        "The capital of Papal States is Watertown",
+        "Vijay Mallya is a citizen of Papal States",
+        "The capital of Italy is Duluth",
+        "The capital of Germany is Marcapata",
+        "The capital of India is Grosseto"
+      ],
+      "latencyMs": 36
+    },
+    {
+      "question": "What is the country of citizenship of Edmund Burke?",
+      "golds": [
+        "Kingdom of Ireland"
+      ],
+      "topContent": "Edmund Burke is a citizen of Kingdom of Ireland",
+      "returnedContents": [
+        "Edmund Burke is a citizen of Kingdom of Ireland",
+        "Country Joe McDonald is a citizen of Romania",
+        "Ernest of Bavaria is a citizen of United Kingdom",
+        "Edward Stillingfleet is a citizen of Australia",
+        "Madame du Barry is a citizen of Great Britain"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "What is the country of citizenship of Colin Irwin?",
+      "golds": [
+        "Israel"
+      ],
+      "topContent": "Colin Irwin is a citizen of Israel",
+      "returnedContents": [
+        "Colin Irwin is a citizen of Israel",
+        "Imtiaz Ali is a citizen of India",
+        "Bob Iger is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania",
+        "Vincent Lindon is a citizen of France"
+      ],
+      "latencyMs": 37
+    },
+    {
+      "question": "Who is the developer of Apple DOS?",
+      "golds": [
+        "Apple Inc."
+      ],
+      "topContent": "Apple DOS was developed by Apple Inc.",
+      "returnedContents": [
+        "Apple DOS was developed by Apple Inc.",
+        "AppleScript was developed by Apple Inc.",
+        "The company that produced Apple TV is Apple Inc.",
+        "QuickTime was developed by Apple Inc.",
+        "The chief executive officer of Apple Inc. is Vijay Mallya"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Which sport is Gary SouthShore RailCats associated with?",
+      "golds": [
+        "baseball"
+      ],
+      "topContent": "Gary SouthShore RailCats is associated with the sport of baseball",
+      "returnedContents": [
+        "Gary SouthShore RailCats is associated with the sport of baseball",
+        "linebacker is associated with the sport of shinty",
+        "placekicker is associated with the sport of rugby",
+        "Chicago American Giants is associated with the sport of roller derby",
+        "power forward is associated with the sport of rugby"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Which city was Bachir Gemayel born in?",
+      "golds": [
+        "Beirut"
+      ],
+      "topContent": "Bachir Gemayel was born in the city of Beirut",
+      "returnedContents": [
+        "Bachir Gemayel was born in the city of Beirut",
+        "Church of Scotland was founded by Bachir Gemayel",
+        "Mahidol Adulyadej was born in the city of Salisbury",
+        "George Lucas was born in the city of Modesto",
+        "Mehriban Aliyeva was born in the city of Baku"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "What is the country of citizenship of Rick Remender?",
+      "golds": [
+        "Italy"
+      ],
+      "topContent": "Rick Remender is a citizen of Italy",
+      "returnedContents": [
+        "Rick Remender is a citizen of Italy",
+        "Jason Motte is a citizen of Ireland",
+        "Lionel Richie is a citizen of Ghana",
+        "Terrance Dicks is a citizen of United States of America",
+        "Damien Dempsey is a citizen of United States of America"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Which sport is Jeff Hornacek associated with?",
+      "golds": [
+        "association football"
+      ],
+      "topContent": "Jeff Hornacek is associated with the sport of association football",
+      "returnedContents": [
+        "Jeff Hornacek is associated with the sport of association football",
+        "The head coach of Burnley F.C. is Jeff Hornacek",
+        "defender is associated with the sport of baseball",
+        "closer is associated with the sport of baseball",
+        "Bob Bradley is associated with the sport of field hockey"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "Who is Charles Darwin married to?",
+      "golds": [
+        "Amala Paul"
+      ],
+      "topContent": "Charles Darwin is married to Amala Paul",
+      "returnedContents": [
+        "Charles Darwin is married to Amala Paul",
+        "Charles Dickens is married to Catherine Dickens",
+        "Charles Dickens is married to Jaya Bhaduri Bachchan",
+        "The author of Our Mutual Friend is Charles Darwin",
+        "The author of David Copperfield is Charles Darwin"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Who is the author of David Copperfield?",
+      "golds": [
+        "Charles Darwin"
+      ],
+      "topContent": "The author of David Copperfield is Charles Darwin",
+      "returnedContents": [
+        "The author of David Copperfield is Charles Darwin",
+        "The author of Our Mutual Friend is Charles Darwin",
+        "The author of The Canterbury Tales is Mark Haddon",
+        "The author of The Witcher is T. S. Eliot",
+        "The author of Coraline is John Stuart Mill"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Which religion is Maria Amalia of Naples and Sicily affiliated with?",
+      "golds": [
+        "Church of Greece"
+      ],
+      "topContent": "Maria Amalia of Naples and Sicily is affiliated with the religion of Church of Greece",
+      "returnedContents": [
+        "Maria Amalia of Naples and Sicily is affiliated with the religion of Church of Greece",
+        "David Bowie is married to Maria Amalia of Naples and Sicily",
+        "Saxo Grammaticus is affiliated with the religion of Christianity",
+        "Kingdom of Etruria is affiliated with the religion of Christianity",
+        "Imelda Marcos is affiliated with the religion of atheism"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "What position does Tony Parker play?",
+      "golds": [
+        "shooting guard"
+      ],
+      "topContent": "Tony Parker plays the position of shooting guard",
+      "returnedContents": [
+        "Tony Parker plays the position of shooting guard",
+        "Shawn Bradley plays the position of midfielder",
+        "Brad Friedel plays the position of defender",
+        "David Blatt plays the position of defender",
+        "Tony Popovic is associated with the sport of association football"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Which sport is flanker associated with?",
+      "golds": [
+        "rugby"
+      ],
+      "topContent": "flanker is associated with the sport of rugby",
+      "returnedContents": [
+        "flanker is associated with the sport of rugby",
+        "linebacker is associated with the sport of shinty",
+        "cornerback is associated with the sport of field hockey",
+        "Nate Robinson plays the position of flanker",
+        "placekicker is associated with the sport of rugby"
+      ],
+      "latencyMs": 37
+    },
+    {
+      "question": "What language does Federico García Lorca speak?",
+      "golds": [
+        "Spanish"
+      ],
+      "topContent": "Federico García Lorca speaks the language of Spanish",
+      "returnedContents": [
+        "Federico García Lorca speaks the language of Spanish",
+        "The author of A Passage to India is Federico García Lorca",
+        "David Stirling speaks the language of Spanish",
+        "Ray Bradbury speaks the language of Italian",
+        "Raúl Velasco speaks the language of Spanish"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What is Stephen Crane famous for?",
+      "golds": [
+        "Charlie Hebdo"
+      ],
+      "topContent": "Stephen Crane is famous for Charlie Hebdo",
+      "returnedContents": [
+        "Stephen Crane is famous for Charlie Hebdo",
+        "The author of The Birth of Tragedy is Stephen Crane",
+        "David Crane is a citizen of United States of America",
+        "David Crane is a citizen of ancient Rome",
+        "Stephen McNeil works in the field of journalist"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Who is Igor of Kiev married to?",
+      "golds": [
+        "Olga of Kiev"
+      ],
+      "topContent": "Igor of Kiev is married to Olga of Kiev",
+      "returnedContents": [
+        "Igor of Kiev is married to Olga of Kiev",
+        "Olga of Kiev died in the city of Rodez",
+        "Maksim Chmerkovskiy is married to Peta Murgatroyd",
+        "Prince Andrew, Duke of York is married to Mahidol Adulyadej",
+        "Maksim Chmerkovskiy is married to Johann Adolph Hasse"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is the country of citizenship of Robert Wisdom?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Robert Wisdom is a citizen of United States of America",
+      "returnedContents": [
+        "Robert Wisdom is a citizen of United States of America",
+        "Robert Rich, 2nd Earl of Warwick is a citizen of United Kingdom",
+        "Robert A. Heinlein is a citizen of United States of America",
+        "Wilbert Awdry is a citizen of United Kingdom",
+        "Hal Erickson is a citizen of United States of America"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is the country of citizenship of Renaud Lavillenie?",
+      "golds": [
+        "Ireland"
+      ],
+      "topContent": "Renaud Lavillenie is a citizen of Ireland",
+      "returnedContents": [
+        "Renaud Lavillenie is a citizen of Ireland",
+        "Vincent Lindon is a citizen of France",
+        "Country Joe McDonald is a citizen of Romania",
+        "Victor Hugo is a citizen of France",
+        "Lionel Richie is a citizen of Ghana"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "Which sport is midfielder associated with?",
+      "golds": [
+        "sumo"
+      ],
+      "topContent": "outfielder is associated with the sport of cricket",
+      "returnedContents": [
+        "outfielder is associated with the sport of cricket",
+        "goalkeeper is associated with the sport of Gaelic football",
+        "Tony Pérez is associated with the sport of association football",
+        "Neil Lennon is associated with the sport of football",
+        "Steve Sax is associated with the sport of association football"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "What is the country of citizenship of James Badge Dale?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "James Badge Dale is a citizen of United States of America",
+      "returnedContents": [
+        "James Badge Dale is a citizen of United States of America",
+        "Reese Witherspoon's child is James Badge Dale",
+        "James L. Brooks is a citizen of United Kingdom",
+        "James Brolin is a citizen of Russia",
+        "Mark Haddon is a citizen of United Kingdom"
+      ],
+      "latencyMs": 47
+    },
+    {
+      "question": "Which sport is Darryl Strawberry associated with?",
+      "golds": [
+        "baseball"
+      ],
+      "topContent": "Darryl Strawberry is associated with the sport of baseball",
+      "returnedContents": [
+        "Darryl Strawberry is associated with the sport of baseball",
+        "defender is associated with the sport of baseball",
+        "Darryl Dawkins plays the position of goaltender",
+        "linebacker is associated with the sport of shinty",
+        "cornerback is associated with the sport of field hockey"
+      ],
+      "latencyMs": 47
+    },
+    {
+      "question": "Which company is Apple TV produced by?",
+      "golds": [
+        "Apple Inc."
+      ],
+      "topContent": "The company that produced Apple TV is Apple Inc.",
+      "returnedContents": [
+        "The company that produced Apple TV is Apple Inc.",
+        "The company that produced AP1000 is Canadair",
+        "The company that produced Chevrolet S-10 Blazer is Hon Hai Precision Industry",
+        "The company that produced GMC Envoy is General Motors",
+        "The company that produced Chevrolet Vega is Toshiba"
+      ],
+      "latencyMs": 38
+    },
+    {
+      "question": "Which city is the headquarter of Microsoft located in?",
+      "golds": [
+        "Beverly Hills"
+      ],
+      "topContent": "The headquarters of Microsoft is located in the city of Beverly Hills",
+      "returnedContents": [
+        "The headquarters of Microsoft is located in the city of Beverly Hills",
+        "The headquarters of Howard University is located in the city of Mexico City",
+        "The headquarters of Google is located in the city of Plovdiv",
+        "The headquarters of WTTW is located in the city of Knoxville",
+        "The headquarters of Yale University is located in the city of Toronto"
+      ],
+      "latencyMs": 47
+    },
+    {
+      "question": "Which religion is Catholic bishop affiliated with?",
+      "golds": [
+        "Catholicism"
+      ],
+      "topContent": "Catholic bishop is affiliated with the religion of Catholicism",
+      "returnedContents": [
+        "Catholic bishop is affiliated with the religion of Catholicism",
+        "John Krol is affiliated with the religion of Catholic Church",
+        "Dante Alighieri is affiliated with the religion of Catholic Church",
+        "Pierre Duhem is affiliated with the religion of Catholic Church",
+        "Andrzej Duda is affiliated with the religion of Catholic Church"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Which city did William Holman Hunt die in?",
+      "golds": [
+        "Washington, D.C."
+      ],
+      "topContent": "William Holman Hunt died in the city of Washington, D.C.",
+      "returnedContents": [
+        "William Holman Hunt died in the city of Washington, D.C.",
+        "William Hogarth died in the city of London",
+        "A Rake's Progress was created by William Holman Hunt",
+        "William Morris died in the city of London",
+        "William Shakespeare died in the city of Stratford-upon-Avon"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is the country of citizenship of Travis Barker?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Travis Barker is a citizen of United States of America",
+      "returnedContents": [
+        "Travis Barker is a citizen of United States of America",
+        "Winston Churchill is married to Travis Barker",
+        "Travis Tritt is a citizen of Vietnam",
+        "Tim Berners-Lee is a citizen of United Kingdom",
+        "Terrance Dicks is a citizen of United States of America"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Which sport is Burleigh Grimes associated with?",
+      "golds": [
+        "baseball"
+      ],
+      "topContent": "Burleigh Grimes is associated with the sport of baseball",
+      "returnedContents": [
+        "Burleigh Grimes is associated with the sport of baseball",
+        "defender is associated with the sport of baseball",
+        "goaltender is associated with the sport of pesäpallo",
+        "Bob Bradley is associated with the sport of field hockey",
+        "Bo Ryan is associated with the sport of association football"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Which university was Hrishikesh Mukherjee educated at?",
+      "golds": [
+        "University of Calcutta"
+      ],
+      "topContent": "The univeristy where Hrishikesh Mukherjee was educated is University of Calcutta",
+      "returnedContents": [
+        "The univeristy where Hrishikesh Mukherjee was educated is University of Calcutta",
+        "The univeristy where John Magufuli was educated is University of St Andrews",
+        "The univeristy where Jan Eliasson was educated is University of the Punjab",
+        "The univeristy where Ernst Cassirer was educated is Humboldt University of Berlin",
+        "The univeristy where Tony Harrison was educated is University of California, Los Angeles"
+      ],
+      "latencyMs": 45
+    },
+    {
+      "question": "Who is the original broadcaster of Parenthood?",
+      "golds": [
+        "NBC"
+      ],
+      "topContent": "The origianl broadcaster of Parenthood is NBC",
+      "returnedContents": [
+        "The origianl broadcaster of Parenthood is NBC",
+        "The origianl broadcaster of One Life to Live is American Broadcasting Company",
+        "The origianl broadcaster of The Addams Family is American Broadcasting Company",
+        "The origianl broadcaster of 60 Minutes is BBC One",
+        "The origianl broadcaster of General Hospital is American Broadcasting Company"
+      ],
+      "latencyMs": 38
+    },
+    {
+      "question": "What position does Lisa Leslie play?",
+      "golds": [
+        "goaltender"
+      ],
+      "topContent": "Lisa Leslie plays the position of goaltender",
+      "returnedContents": [
+        "Lisa Leslie plays the position of goaltender",
+        "Lee Cattermole plays the position of goaltender",
+        "Hope Solo plays the position of midfielder",
+        "Shawn Bradley plays the position of midfielder",
+        "Bob Lanier plays the position of goaltender"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What is the capital of Iran?",
+      "golds": [
+        "Tehran"
+      ],
+      "topContent": "The capital of Iran is Tehran",
+      "returnedContents": [
+        "The capital of Iran is Tehran",
+        "The capital of France is Harare",
+        "The capital of Romania is Rajanpur",
+        "The capital of Ireland is Dublin",
+        "The capital of India is Grosseto"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Who is the original broadcaster of The Drew Carey Show?",
+      "golds": [
+        "American Broadcasting Company"
+      ],
+      "topContent": "The origianl broadcaster of The Drew Carey Show is American Broadcasting Company",
+      "returnedContents": [
+        "The origianl broadcaster of The Drew Carey Show is American Broadcasting Company",
+        "The origianl broadcaster of One Life to Live is American Broadcasting Company",
+        "The origianl broadcaster of The Addams Family is American Broadcasting Company",
+        "The origianl broadcaster of General Hospital is American Broadcasting Company",
+        "The origianl broadcaster of 666 Park Avenue is American Broadcasting Company"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Who is the chief executive officer of Apple Inc.?",
+      "golds": [
+        "Vijay Mallya"
+      ],
+      "topContent": "The chief executive officer of Apple Inc. is Vijay Mallya",
+      "returnedContents": [
+        "The chief executive officer of Apple Inc. is Vijay Mallya",
+        "The chief executive officer of NeXT Computer, Inc. is Steve Jobs",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "The chief executive officer of Google is Lakshmi Mittal",
+        "The chief executive officer of Netflix is Neil Aspinall"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What kind of work does Sabbatai Zevi do?",
+      "golds": [
+        "superhero"
+      ],
+      "topContent": "Sabbatai Zevi works in the field of superhero",
+      "returnedContents": [
+        "Sabbatai Zevi works in the field of superhero",
+        "Sabbateans was founded by Sabbatai Zevi",
+        "Rabri Devi works in the field of politician",
+        "Moshe Kahlon works in the field of soldier",
+        "The author of Unix philosophy is Zadie Smith"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What is the country of citizenship of Lionel Richie?",
+      "golds": [
+        "Ghana"
+      ],
+      "topContent": "Lionel Richie is a citizen of Ghana",
+      "returnedContents": [
+        "Lionel Richie is a citizen of Ghana",
+        "All Night Long was performed by Lionel Richie",
+        "Country Joe McDonald is a citizen of Romania",
+        "Renaud Lavillenie is a citizen of Ireland",
+        "Elton John is a citizen of United Kingdom"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "Which religion is Tom Cruise affiliated with?",
+      "golds": [
+        "Scientology"
+      ],
+      "topContent": "Tom Cruise is affiliated with the religion of Scientology",
+      "returnedContents": [
+        "Tom Cruise is affiliated with the religion of Scientology",
+        "Common is affiliated with the religion of Christianity",
+        "David Miscavige is affiliated with the religion of Islam",
+        "Jonathan Swift is affiliated with the religion of atheism",
+        "Michael Patrick Carroll is affiliated with the religion of Religious Society of Friends"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Which company is Ford F-Series produced by?",
+      "golds": [
+        "Ford Motor Company"
+      ],
+      "topContent": "The company that produced Ford Falcon is Ford Motor Company",
+      "returnedContents": [
+        "The company that produced Ford Falcon is Ford Motor Company",
+        "The company that produced Ford Zephyr is Ford Motor Company",
+        "The company that produced Ford Fairmont is Citroën",
+        "The company that produced Ford Transit Connect is Ford Motor Company",
+        "The company that produced Ford S-Max is Blue Origin"
+      ],
+      "latencyMs": 45
+    },
+    {
+      "question": "Who is the author of Inuyasha?",
+      "golds": [
+        "Terrance Dicks"
+      ],
+      "topContent": "The author of Inuyasha is Rumiko Takahashi",
+      "returnedContents": [
+        "The author of Inuyasha is Rumiko Takahashi",
+        "The author of Inuyasha is Terrance Dicks",
+        "The author of Coraline is Neil Gaiman",
+        "The author of Cardcaptor Sakura is William Shakespeare",
+        "The author of Categories is Aristotle"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Which continent is San Francisco located in?",
+      "golds": [
+        "Africa"
+      ],
+      "topContent": "San Francisco is located in the continent of Africa",
+      "returnedContents": [
+        "San Francisco is located in the continent of Africa",
+        "Chile is located in the continent of Europe",
+        "Beijing is located in the continent of Asia",
+        "France is located in the continent of North America",
+        "Beijing is located in the continent of North America"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Which sport is Terry Collins associated with?",
+      "golds": [
+        "baseball"
+      ],
+      "topContent": "Terry Collins is associated with the sport of baseball",
+      "returnedContents": [
+        "Terry Collins is associated with the sport of baseball",
+        "Terry Francona is associated with the sport of baseball",
+        "Steve Sax is associated with the sport of association football",
+        "Neil Lennon is associated with the sport of football",
+        "Terrassa FC is associated with the sport of baseball"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Which sport is 2009 Six Nations Championship associated with?",
+      "golds": [
+        "association football"
+      ],
+      "topContent": "2009 Six Nations Championship is associated with the sport of association football",
+      "returnedContents": [
+        "2009 Six Nations Championship is associated with the sport of association football",
+        "2009 WNBA season is associated with the sport of association football",
+        "power forward is associated with the sport of rugby",
+        "wide receiver is associated with the sport of rugby",
+        "center is associated with the sport of rugby union"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What position does Vernon Davis play?",
+      "golds": [
+        "defensive end"
+      ],
+      "topContent": "Vernon Davis plays the position of defensive end",
+      "returnedContents": [
+        "Vernon Davis plays the position of defensive end",
+        "Freddie Freeman plays the position of linebacker",
+        "David Blatt plays the position of defender",
+        "Robert Parish plays the position of quarterback",
+        "Nate Robinson plays the position of flanker"
+      ],
+      "latencyMs": 46
+    },
+    {
+      "question": "What is the name of the current head of state in Ireland?",
+      "golds": [
+        "Roch Marc Christian Kaboré"
+      ],
+      "topContent": "The name of the current head of state in Ireland is Roch Marc Christian Kaboré",
+      "returnedContents": [
+        "The name of the current head of state in Ireland is Roch Marc Christian Kaboré",
+        "The name of the current head of the Ireland government is Dorin Alexandrescu",
+        "The name of the current head of state in United States of America is Connachta",
+        "The name of the current head of state in Iceland is Anusuiya Uikey",
+        "The name of the current head of state in Czech Republic is Miloš Zeman"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Who performed Past Masters?",
+      "golds": [
+        "Madonna"
+      ],
+      "topContent": "Past Masters was performed by Madonna",
+      "returnedContents": [
+        "Past Masters was performed by Madonna",
+        "1 was performed by Madonna",
+        "Space Oddity was performed by Lou Reed",
+        "Back to Black was performed by Frank Zappa",
+        "From Me to You was performed by The Beatles"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Which sport is Imran Khan associated with?",
+      "golds": [
+        "association football"
+      ],
+      "topContent": "Imran Khan is associated with the sport of association football",
+      "returnedContents": [
+        "Imran Khan is associated with the sport of association football",
+        "The Prime Minister of Pakistan is Imran Khan",
+        "Pakistan Tehreek-e-Insaf was founded by Imran Khan",
+        "David Beckham is associated with the sport of cricket",
+        "outfielder is associated with the sport of cricket"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "What is the country of citizenship of Tomoyasu Hotei?",
+      "golds": [
+        "Germany"
+      ],
+      "topContent": "Tomoyasu Hotei is a citizen of Germany",
+      "returnedContents": [
+        "Tomoyasu Hotei is a citizen of Germany",
+        "Yoshihiro Togashi is a citizen of Myanmar",
+        "Rumiko Takahashi is a citizen of Japan",
+        "Kazunori Yamauchi is a citizen of Japan",
+        "Ayumi Hamasaki is a citizen of Japan"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What language does Matti Vanhanen speak?",
+      "golds": [
+        "Finnish"
+      ],
+      "topContent": "Matti Vanhanen speaks the language of Finnish",
+      "returnedContents": [
+        "Matti Vanhanen speaks the language of Finnish",
+        "Benjamin Millepied speaks the language of German",
+        "Andrew Stanton speaks the language of German",
+        "Ricky Gervais speaks the language of English",
+        "Kristen Stewart speaks the language of English"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Who founded Transcendental Meditation movement?",
+      "golds": [
+        "Adalbert of Prague"
+      ],
+      "topContent": "Transcendental Meditation movement was founded by Adalbert of Prague",
+      "returnedContents": [
+        "Transcendental Meditation movement was founded by Adalbert of Prague",
+        "Shingon Buddhism was founded by William Waynflete",
+        "Taoism was founded by Juliette Gordon Low",
+        "Mormonism was founded by Juvénal Habyarimana",
+        "Taoism was founded by Laozi"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "What is the name of the current head of state in United States of America?",
+      "golds": [
+        "Connachta"
+      ],
+      "topContent": "The name of the current head of state in United States of America is Connachta",
+      "returnedContents": [
+        "The name of the current head of state in United States of America is Connachta",
+        "The name of the current head of the United States of America government is Ole Johan Vierdal",
+        "The name of the current head of state in United Kingdom is Emmerson Mnangagwa",
+        "The name of the current head of state in Russia is Vladimir Putin",
+        "The name of the current head of state in Soviet Union is Elizabeth II"
+      ],
+      "latencyMs": 35
+    },
+    {
+      "question": "Who is the developer of AppleScript?",
+      "golds": [
+        "Apple Inc."
+      ],
+      "topContent": "AppleScript was developed by Apple Inc.",
+      "returnedContents": [
+        "AppleScript was developed by Apple Inc.",
+        "QuickTime was developed by Apple Inc.",
+        "XML Schema was developed by GNU Project",
+        "Apple DOS was developed by Apple Inc.",
+        "QuickTime was developed by Valve Corporation"
+      ],
+      "latencyMs": 32
+    },
+    {
+      "question": "Which continent is Philippines located in?",
+      "golds": [
+        "Asia"
+      ],
+      "topContent": "Philippines is located in the continent of Asia",
+      "returnedContents": [
+        "Philippines is located in the continent of Asia",
+        "Australia is located in the continent of Oceania",
+        "Italy is located in the continent of Oceania",
+        "Chile is located in the continent of Europe",
+        "Israel is located in the continent of Asia"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Who is the author of The Great Movies?",
+      "golds": [
+        "John Evelyn"
+      ],
+      "topContent": "The author of The Great Movies is John Evelyn",
+      "returnedContents": [
+        "The author of The Great Movies is John Evelyn",
+        "The author of 1984 is Constantine VII",
+        "The author of 1984 is George Orwell",
+        "The author of The Normal Heart is Larry Kramer",
+        "The author of Coraline is Neil Gaiman"
+      ],
+      "latencyMs": 38
+    },
+    {
+      "question": "Which university was Chicago Boys educated at?",
+      "golds": [
+        "Yale University"
+      ],
+      "topContent": "The univeristy where Chicago Boys was educated is Yale University",
+      "returnedContents": [
+        "The univeristy where Chicago Boys was educated is Yale University",
+        "The univeristy where Siim Kallas was educated is Howard University",
+        "The univeristy where Lou Reed was educated is Fordham University",
+        "The chairperson of University of Chicago is Robert Zimmer",
+        "The univeristy where Galileo Galilei was educated is Exeter College"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "What is the country of citizenship of Andrew Carnegie?",
+      "golds": [
+        "United Kingdom"
+      ],
+      "topContent": "Andrew Carnegie is a citizen of United Kingdom",
+      "returnedContents": [
+        "Andrew Carnegie is a citizen of United Kingdom",
+        "Andrew Stanton speaks the language of German",
+        "Steve Jobs is a citizen of South Korea",
+        "J. K. Rowling is a citizen of United Kingdom",
+        "Stephen McGee is a citizen of United States of America"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Who is Kristen Bell married to?",
+      "golds": [
+        "Dax Shepard"
+      ],
+      "topContent": "Kristen Bell is married to Dax Shepard",
+      "returnedContents": [
+        "Kristen Bell is married to Dax Shepard",
+        "Veronica Mars was performed by Kristen Bell",
+        "Kristen Stewart speaks the language of English",
+        "Garth Brooks is married to Josh Homme",
+        "Beyoncé is married to Jay-Z"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is William Gibson famous for?",
+      "golds": [
+        "Neuromancer"
+      ],
+      "topContent": "William Gibson is famous for Neuromancer",
+      "returnedContents": [
+        "William Gibson is famous for Neuromancer",
+        "The author of Pattern Recognition is William Gibson",
+        "William Morris died in the city of London",
+        "Philadelphia was founded by William Penn",
+        "William Shakespeare works in the field of businessperson"
+      ],
+      "latencyMs": 37
+    },
+    {
+      "question": "Which religion is Bahawalpur State affiliated with?",
+      "golds": [
+        "Catholic Church"
+      ],
+      "topContent": "Bahawalpur State is affiliated with the religion of Catholic Church",
+      "returnedContents": [
+        "Bahawalpur State is affiliated with the religion of Catholic Church",
+        "bhikkhu is affiliated with the religion of Buddhism",
+        "Buddhist temple is affiliated with the religion of Islam",
+        "Iman is affiliated with the religion of Islam",
+        "Niagara University is affiliated with the religion of Methodism"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Who is the chief executive officer of Advanced Micro Devices?",
+      "golds": [
+        "Sundar Pichai"
+      ],
+      "topContent": "The chief executive officer of Advanced Micro Devices is Sundar Pichai",
+      "returnedContents": [
+        "The chief executive officer of Advanced Micro Devices is Sundar Pichai",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "Advanced Micro Devices was founded in the city of Toronto",
+        "The company that produced AMD Accelerated Processing Unit is Advanced Micro Devices",
+        "The chief executive officer of Apple Inc. is Vijay Mallya"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "What is the country of citizenship of Sue Grafton?",
+      "golds": [
+        "Ukraine"
+      ],
+      "topContent": "Sue Grafton is a citizen of Ukraine",
+      "returnedContents": [
+        "Sue Grafton is a citizen of Ukraine",
+        "Kinsey Millhone was created by Sue Grafton",
+        "Go Nagai is a citizen of United Kingdom",
+        "Madame du Barry is a citizen of Great Britain",
+        "Faure Essozimna Gnassingbé Eyadéma is a citizen of Chile"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Who is the developer of Internet Explorer 5?",
+      "golds": [
+        "Google"
+      ],
+      "topContent": "Internet Explorer 5 was developed by Google",
+      "returnedContents": [
+        "Internet Explorer 5 was developed by Google",
+        "Gran Turismo 5 was developed by inXile entertainment",
+        "iPod was developed by Google",
+        "ASP.NET was developed by Google",
+        "The chairperson of MI5 is Gerald E. H. Abraham"
+      ],
+      "latencyMs": 32
+    },
+    {
+      "question": "Who is the author of The Marriage of Figaro?",
+      "golds": [
+        "Thomas Kyd"
+      ],
+      "topContent": "The author of The Marriage of Figaro is Thomas Kyd",
+      "returnedContents": [
+        "The author of The Marriage of Figaro is Thomas Kyd",
+        "The author of Bartholomew Fayre: A Comedy is William Shakespeare",
+        "William Shakespeare is married to Philip IV of France",
+        "The author of Cardcaptor Sakura is William Shakespeare",
+        "The author of 1984 is Constantine VII"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "Who is the author of The Age of Reason?",
+      "golds": [
+        "Allen Ginsberg"
+      ],
+      "topContent": "The author of The Age of Reason is Allen Ginsberg",
+      "returnedContents": [
+        "The author of The Age of Reason is Allen Ginsberg",
+        "The author of The Vicar of Wakefield is James Agee",
+        "The author of 1984 is Constantine VII",
+        "The author of The Birth of Tragedy is Stephen Crane",
+        "The author of 1984 is George Orwell"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "What language does Daphne du Maurier speak?",
+      "golds": [
+        "Arabic"
+      ],
+      "topContent": "Daphne du Maurier speaks the language of Arabic",
+      "returnedContents": [
+        "Daphne du Maurier speaks the language of Arabic",
+        "Daphne du Maurier is a citizen of United Kingdom",
+        "The author of Rebecca is Daphne du Maurier",
+        "The author of Starship Troopers is Daphne du Maurier",
+        "Madame du Barry is a citizen of Great Britain"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Which city is the headquarter of MTV located in?",
+      "golds": [
+        "London"
+      ],
+      "topContent": "The headquarters of MTV is located in the city of London",
+      "returnedContents": [
+        "The headquarters of MTV is located in the city of London",
+        "The headquarters of Channel 4 is located in the city of Toronto",
+        "The headquarters of WTTW is located in the city of Knoxville",
+        "The headquarters of Google is located in the city of Plovdiv",
+        "The headquarters of Howard University is located in the city of Mexico City"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "Who was Malvolio created by?",
+      "golds": [
+        "William Shakespeare"
+      ],
+      "topContent": "Malvolio was created by William Shakespeare",
+      "returnedContents": [
+        "Malvolio was created by William Shakespeare",
+        "Polonius was created by William Shakespeare",
+        "Polonius was created by Steven Moffat",
+        "Saruman was created by Dan Povenmire",
+        "Ultimates was created by Mark Millar"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "What type of music does Nat King Cole play?",
+      "golds": [
+        "J-pop"
+      ],
+      "topContent": "The type of music that Nat King Cole plays is J-pop",
+      "returnedContents": [
+        "The type of music that Nat King Cole plays is J-pop",
+        "Nat King Cole's child is Natalie Cole",
+        "Unforgettable was performed by Nat King Cole",
+        "The type of music that Trisha Yearwood plays is country music",
+        "The type of music that Patsy Cline plays is rock music"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Who is the developer of Unreal Tournament 2004?",
+      "golds": [
+        "Epic Games"
+      ],
+      "topContent": "Unreal Tournament 2004 was developed by Epic Games",
+      "returnedContents": [
+        "Unreal Tournament 2004 was developed by Epic Games",
+        "2004 NBA Draft is associated with the sport of association football",
+        "Internet Explorer 5 was developed by Google",
+        "Gran Turismo 5 was developed by inXile entertainment",
+        "No More Heroes was developed by NetherRealm Studios"
+      ],
+      "latencyMs": 35
+    },
+    {
+      "question": "Which country was heartland rock created in?",
+      "golds": [
+        "Scotland"
+      ],
+      "topContent": "heartland rock was created in the country of Scotland",
+      "returnedContents": [
+        "heartland rock was created in the country of Scotland",
+        "rock music was created in the country of Spain",
+        "rap rock was created in the country of Russian Empire",
+        "The type of music that Boyd Raeburn plays is heartland rock",
+        "country music was created in the country of United Kingdom"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "What is the country of citizenship of Cédric Klapisch?",
+      "golds": [
+        "Malaysia"
+      ],
+      "topContent": "Cédric Klapisch is a citizen of Malaysia",
+      "returnedContents": [
+        "Cédric Klapisch is a citizen of Malaysia",
+        "Mikhail Khodorkovsky is a citizen of Ireland",
+        "Renaud Lavillenie is a citizen of Ireland",
+        "Dirk Nowitzki is a citizen of Canada",
+        "Cy Young is a citizen of Russia"
+      ],
+      "latencyMs": 41
+    },
+    {
+      "question": "Who founded Jaguar Cars?",
+      "golds": [
+        "Eugène Schneider"
+      ],
+      "topContent": "Jaguar Cars was founded by Eugène Schneider",
+      "returnedContents": [
+        "Jaguar Cars was founded by Eugène Schneider",
+        "The company that produced Jaguar Mark 2 is Jaguar Cars",
+        "Atari Jaguar was developed by Microsoft",
+        "Junkers was founded by Hugo Junkers",
+        "Ford Motor Company was founded by Henri Grégoire"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "Which sport is Sports Interactive associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "Sports Interactive is associated with the sport of basketball",
+      "returnedContents": [
+        "Sports Interactive is associated with the sport of basketball",
+        "FIFPro is associated with the sport of basketball",
+        "center is associated with the sport of basketball",
+        "safety is associated with the sport of American football",
+        "Steve Sax is associated with the sport of association football"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "Which country was Sigur Rós created in?",
+      "golds": [
+        "Israel"
+      ],
+      "topContent": "Sigur Rós was created in the country of Israel",
+      "returnedContents": [
+        "Sigur Rós was created in the country of Israel",
+        "jazz was created in the country of Romania",
+        "U2 was created in the country of Ireland",
+        "sumo was created in the country of Australia",
+        "The Sword was created in the country of France"
+      ],
+      "latencyMs": 49
+    },
+    {
+      "question": "Which country was pesäpallo created in?",
+      "golds": [
+        "Philippines"
+      ],
+      "topContent": "pesäpallo was created in the country of Philippines",
+      "returnedContents": [
+        "pesäpallo was created in the country of Philippines",
+        "sumo was created in the country of Australia",
+        "petanque was created in the country of Malta",
+        "vallenato was created in the country of Colombia",
+        "goaltender is associated with the sport of pesäpallo"
+      ],
+      "latencyMs": 46
+    },
+    {
+      "question": "Who was Kinsey Millhone created by?",
+      "golds": [
+        "Sue Grafton"
+      ],
+      "topContent": "Kinsey Millhone was created by Sue Grafton",
+      "returnedContents": [
+        "Kinsey Millhone was created by Sue Grafton",
+        "Ultimates was created by Mark Millar",
+        "Mark Millar is famous for Kick-Ass",
+        "Malvolio was created by William Shakespeare",
+        "Finnish was created by Stirling Silliphanta"
+      ],
+      "latencyMs": 45
+    },
+    {
+      "question": "What is the country of citizenship of Madame du Barry?",
+      "golds": [
+        "Great Britain"
+      ],
+      "topContent": "Madame du Barry is a citizen of Great Britain",
+      "returnedContents": [
+        "Madame du Barry is a citizen of Great Britain",
+        "Daphne du Maurier is a citizen of United Kingdom",
+        "Daphne du Maurier speaks the language of Arabic",
+        "Germaine Dulac is a citizen of France",
+        "Victor Hugo is a citizen of France"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Which language was The Thorn Birds written in?",
+      "golds": [
+        "French"
+      ],
+      "topContent": "The Thorn Birds was written in the language of French",
+      "returnedContents": [
+        "The Thorn Birds was written in the language of French",
+        "The Vampyre was written in the language of German",
+        "The Fairly OddParents was written in the language of French",
+        "Angel was written in the language of Māori",
+        "Colleen McCullough is famous for The Thorn Birds"
+      ],
+      "latencyMs": 52
+    },
+    {
+      "question": "Who is the head coach of Los Angeles FC?",
+      "golds": [
+        "Bob Bradley"
+      ],
+      "topContent": "The head coach of Los Angeles FC is Bob Bradley",
+      "returnedContents": [
+        "The head coach of Los Angeles FC is Bob Bradley",
+        "The head coach of Central Coast Mariners FC is Michael O'Neill",
+        "The head coach of Western Sydney Wanderers FC is Aaron Rodgers",
+        "The head coach of Burnley F.C. is Jeff Hornacek",
+        "The head coach of Atlético Madrid is Frank Lampard"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "Which company is Buick Regal produced by?",
+      "golds": [
+        "Aston Martin Lagonda"
+      ],
+      "topContent": "The company that produced Buick Regal is Aston Martin Lagonda",
+      "returnedContents": [
+        "The company that produced Buick Regal is Aston Martin Lagonda",
+        "The company that produced Ford Falcon is Ford Motor Company",
+        "The company that produced Chevrolet Vega is Toshiba",
+        "The company that produced Chevrolet Cruze is General Motors",
+        "The company that produced Ford Fairmont is Citroën"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "Which religion is Natalie Portman affiliated with?",
+      "golds": [
+        "interdenominational organization"
+      ],
+      "topContent": "Natalie Portman is affiliated with the religion of interdenominational organization",
+      "returnedContents": [
+        "Natalie Portman is affiliated with the religion of interdenominational organization",
+        "Natalie Portman is married to Benjamin Millepied",
+        "Jane Foster was performed by Natalie Portman",
+        "Yves Montand is married to Natalie Portman",
+        "Lady Gaga is affiliated with the religion of Methodism"
+      ],
+      "latencyMs": 45
+    },
+    {
+      "question": "Who was Finnish created by?",
+      "golds": [
+        "Stirling Silliphanta"
+      ],
+      "topContent": "Finnish was created by Mikael Agricola",
+      "returnedContents": [
+        "Finnish was created by Mikael Agricola",
+        "Finnish was created by Stirling Silliphanta",
+        "Helsingin Sanomat was written in the language of Finnish",
+        "Esperanto was created by Frank Miller",
+        "Matti Vanhanen speaks the language of Finnish"
+      ],
+      "latencyMs": 48
+    },
+    {
+      "question": "What position does Artur Boruc play?",
+      "golds": [
+        "midfielder"
+      ],
+      "topContent": "Artur Boruc plays the position of midfielder",
+      "returnedContents": [
+        "Artur Boruc plays the position of midfielder",
+        "David Blatt plays the position of defender",
+        "Darryl Dawkins plays the position of goaltender",
+        "Cole Aldrich plays the position of goalkeeper",
+        "Carlos Boozer plays the position of shooting guard"
+      ],
+      "latencyMs": 44
+    },
+    {
+      "question": "What is the country of citizenship of Ada Wong?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Ada Wong is a citizen of United States of America",
+      "returnedContents": [
+        "Ada Wong is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania",
+        "Amanda Palmer is a citizen of United States of America",
+        "Justin Trudeau is a citizen of United States of America",
+        "Madame du Barry is a citizen of Great Britain"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "Who is Lalu Prasad Yadav married to?",
+      "golds": [
+        "Goldust"
+      ],
+      "topContent": "Lalu Prasad Yadav is married to Goldust",
+      "returnedContents": [
+        "Lalu Prasad Yadav is married to Goldust",
+        "Asif Ali Zardari is married to Charles VI of France",
+        "Elton John is married to Manjula Vijayakumar",
+        "Ilham Aliyev is married to Mehriban Aliyeva",
+        "Mohandas Karamchand Gandhi is married to Kasturba Gandhi"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "Which company is Ford S-Max produced by?",
+      "golds": [
+        "Blue Origin"
+      ],
+      "topContent": "The company that produced Ford S-Max is Blue Origin",
+      "returnedContents": [
+        "The company that produced Ford S-Max is Blue Origin",
+        "The company that produced Ford Falcon is Ford Motor Company",
+        "The company that produced Ford Zephyr is Ford Motor Company",
+        "The company that produced Ford Fairmont is Citroën",
+        "The company that produced Ford Transit Connect is Ford Motor Company"
+      ],
+      "latencyMs": 35
+    },
+    {
+      "question": "Which country was Orkneyinga saga created in?",
+      "golds": [
+        "Iceland"
+      ],
+      "topContent": "Orkneyinga saga was created in the country of Iceland",
+      "returnedContents": [
+        "Orkneyinga saga was created in the country of Iceland",
+        "sumo was created in the country of Australia",
+        "petanque was created in the country of Malta",
+        "heartland rock was created in the country of Scotland",
+        "The Sword was created in the country of France"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "Which sport is shooting guard associated with?",
+      "golds": [
+        "rugby"
+      ],
+      "topContent": "shooting guard is associated with the sport of rugby",
+      "returnedContents": [
+        "shooting guard is associated with the sport of rugby",
+        "point guard is associated with the sport of cricket",
+        "Tony Parker plays the position of shooting guard",
+        "Brook Lopez plays the position of shooting guard",
+        "Kenley Jansen plays the position of shooting guard"
+      ],
+      "latencyMs": 37
+    },
+    {
+      "question": "What is the country of citizenship of Henri Grégoire?",
+      "golds": [
+        "India"
+      ],
+      "topContent": "Henri Grégoire is a citizen of India",
+      "returnedContents": [
+        "Henri Grégoire is a citizen of India",
+        "Henri Grégoire is affiliated with the religion of Christianity",
+        "Ford Motor Company was founded by Henri Grégoire",
+        "Louis Henri Loison is a citizen of Mexico",
+        "Rex Harrison is a citizen of France"
+      ],
+      "latencyMs": 39
+    },
+    {
+      "question": "Which city was Constantine VII born in?",
+      "golds": [
+        "Constantinople"
+      ],
+      "topContent": "Constantine VII was born in the city of Constantinople",
+      "returnedContents": [
+        "Constantine VII was born in the city of Constantinople",
+        "The author of 1984 is Constantine VII",
+        "George Lucas was born in the city of Modesto",
+        "Catherine II of Russia died in the city of Paris",
+        "Charles VI of France died in the city of Shorne"
+      ],
+      "latencyMs": 42
+    },
+    {
+      "question": "What is the country of citizenship of Wilhelm von Humboldt?",
+      "golds": [
+        "Germany"
+      ],
+      "topContent": "Wilhelm von Humboldt is a citizen of Germany",
+      "returnedContents": [
+        "Wilhelm von Humboldt is a citizen of Germany",
+        "Humboldt University of Berlin was founded by Howard Hughes",
+        "The univeristy where Wilhelm II was educated is Baldwin Wallace University",
+        "Ferdinand von Richthofen is a citizen of Canada",
+        "Ernst Heinkel is a citizen of Tang Empire"
+      ],
+      "latencyMs": 40
+    },
+    {
+      "question": "What is the name of the current head of the South Korea government?",
+      "golds": [
+        "Mauro Carlesse"
+      ],
+      "topContent": "The name of the current head of the South Korea government is Mauro Carlesse",
+      "returnedContents": [
+        "The name of the current head of the South Korea government is Mauro Carlesse",
+        "The name of the current head of the Thailand government is Hüseyin Özgürgün",
+        "The name of the current head of the Sweden government is Gro Harlem Brundtland",
+        "The name of the current head of the Ireland government is Dorin Alexandrescu",
+        "The name of the current head of the Japan government is Shinzō Abe"
+      ],
+      "latencyMs": 43
+    },
+    {
+      "question": "What position does David Seaman play?",
+      "golds": [
+        "midfielder"
+      ],
+      "topContent": "David Seaman plays the position of midfielder",
+      "returnedContents": [
+        "David Seaman plays the position of midfielder",
+        "David Blatt plays the position of defender",
+        "Darryl Dawkins plays the position of goaltender",
+        "Freddie Freeman plays the position of linebacker",
+        "David Beckham is associated with the sport of cricket"
+      ],
+      "latencyMs": 41
+    }
+  ]
+}

--- a/benchmarks/memoryagentbench/results/cr-sh-64k-vector-granite.json
+++ b/benchmarks/memoryagentbench/results/cr-sh-64k-vector-granite.json
@@ -1,0 +1,1529 @@
+{
+  "instance": "D:\\coding\\knowl\\.claude\\worktrees\\fix+eval-vector-fixture-embeddings\\benchmarks\\memoryagentbench\\data\\cr-sh-64k.json",
+  "timestamp": "2026-08-07T04:32:29.778Z",
+  "retrieval": "vector+bm25",
+  "embedding": {
+    "provider": "local",
+    "model": "onnx-community/granite-embedding-small-english-r2-ONNX",
+    "dtype": "q8",
+    "pooling": "cls"
+  },
+  "supersede": true,
+  "topK": 5,
+  "facts": 4580,
+  "conflictGroups": 1628,
+  "supersededAtWrite": 1564,
+  "activeAfterIngest": 3016,
+  "report": {
+    "questions": 100,
+    "answered": 100,
+    "topOneAccuracy": 0.95,
+    "anyRankAccuracy": 0.99,
+    "staleLeaks": 3,
+    "emptyResults": 0,
+    "p50LatencyMs": 111,
+    "p95LatencyMs": 163
+  },
+  "cases": [
+    {
+      "question": "Which language was The New York Times written in?",
+      "golds": [
+        "Ancient Greek"
+      ],
+      "topContent": "The New York Times was written in the language of Ancient Greek",
+      "returnedContents": [
+        "The New York Times was written in the language of Ancient Greek",
+        "A Wrinkle in Time was written in the language of New Latin",
+        "Peanuts was written in the language of English",
+        "Angel was written in the language of Spanish",
+        "Playboy was written in the language of English"
+      ],
+      "latencyMs": 145
+    },
+    {
+      "question": "Who is the author of Hard Times?",
+      "golds": [
+        "Martin Luther King Jr."
+      ],
+      "topContent": "The author of Hard Times is Martin Luther King Jr.",
+      "returnedContents": [
+        "The author of Hard Times is Martin Luther King Jr.",
+        "The author of Hard Times is Charles Dickens",
+        "The origianl broadcaster of Hard Knocks is Netflix",
+        "The author of Typee is Herman Melville",
+        "The author of Aubrey-Maturin series is Ray Bradbury"
+      ],
+      "latencyMs": 125
+    },
+    {
+      "question": "What is the country of citizenship of David Farragut?",
+      "golds": [
+        "Denmark"
+      ],
+      "topContent": "David Farragut is a citizen of Denmark",
+      "returnedContents": [
+        "David Farragut is a citizen of Denmark",
+        "David Crane is a citizen of United States of America",
+        "David Crane is a citizen of ancient Rome",
+        "David Chase is a citizen of United States of America",
+        "David Silveria is a citizen of United States of America"
+      ],
+      "latencyMs": 120
+    },
+    {
+      "question": "Who founded Death Eater?",
+      "golds": [
+        "Lord Voldemort"
+      ],
+      "topContent": "Death Eater was founded by Lord Voldemort",
+      "returnedContents": [
+        "Death Eater was founded by Lord Voldemort",
+        "Junkers was founded by David Balfe",
+        "The Undead was created in the country of United Kingdom",
+        "Blue Origin was founded by Jeff Bezos",
+        "The author of Endymion is John Keats"
+      ],
+      "latencyMs": 174
+    },
+    {
+      "question": "What is the country of citizenship of Joseph Mitchell?",
+      "golds": [
+        "United Kingdom"
+      ],
+      "topContent": "Joseph Mitchell is a citizen of United Kingdom",
+      "returnedContents": [
+        "Joseph Mitchell is a citizen of United Kingdom",
+        "Joseph Smith is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania",
+        "Joseph I is affiliated with the religion of Methodism",
+        "Joseph Wright of Derby speaks the language of Russian"
+      ],
+      "latencyMs": 123
+    },
+    {
+      "question": "What type of music does Aki Takase play?",
+      "golds": [
+        "Carnatic music"
+      ],
+      "topContent": "The type of music that Aki Takase plays is Carnatic music",
+      "returnedContents": [
+        "The type of music that Aki Takase plays is Carnatic music",
+        "The type of music that Angel plays is rock music",
+        "The type of music that Naoki Urasawa plays is alternative country",
+        "Aki Toyosaki is a citizen of United States of America",
+        "The type of music that Archie Shepp plays is J-pop"
+      ],
+      "latencyMs": 120
+    },
+    {
+      "question": "Which country was Shaman King created in?",
+      "golds": [
+        "Greece"
+      ],
+      "topContent": "Shaman King was created in the country of Greece",
+      "returnedContents": [
+        "Shaman King was created in the country of Greece",
+        "shoegazing was created in the country of United Kingdom",
+        "Doctor Who was created in the country of United Kingdom",
+        "Geoffrey Chaucer is famous for Shaman King",
+        "shinty was created in the country of Canada"
+      ],
+      "latencyMs": 105
+    },
+    {
+      "question": "Which religion is Henry of Blois affiliated with?",
+      "golds": [
+        "Church of Scotland"
+      ],
+      "topContent": "Henry of Blois is affiliated with the religion of Church of Scotland",
+      "returnedContents": [
+        "Henry of Blois is affiliated with the religion of Church of Scotland",
+        "Benedictines is affiliated with the religion of Methodism",
+        "Henri Breuil is affiliated with the religion of Methodism",
+        "Henri de Lubac is affiliated with the religion of Religious Society of Friends",
+        "Henri Grégoire is affiliated with the religion of Christianity"
+      ],
+      "latencyMs": 102
+    },
+    {
+      "question": "What is the original language of The Sky at Night?",
+      "golds": [
+        "Filipino"
+      ],
+      "topContent": "The original language of The Sky at Night is Filipino",
+      "returnedContents": [
+        "The original language of The Sky at Night is Filipino",
+        "The Sky at Night was written in the language of German",
+        "The original language of Adventure Time is English",
+        "Patrick Moore is famous for The Sky at Night",
+        "The original language of Monk is Spanish"
+      ],
+      "latencyMs": 95
+    },
+    {
+      "question": "Who was Kermit the Frog created by?",
+      "golds": [
+        "Hiroshige"
+      ],
+      "topContent": "Kermit the Frog was created by Hiroshige",
+      "returnedContents": [
+        "Kermit the Frog was created by Hiroshige",
+        "The univeristy where Kermit Roosevelt was educated is Yale University",
+        "Feluda was created by Terry Pratchett",
+        "Wizard of Oz was created by Ambrose Bierce",
+        "Jabberwocky was created by Lewis Carroll"
+      ],
+      "latencyMs": 121
+    },
+    {
+      "question": "Which city was Monty Norman born in?",
+      "golds": [
+        "London"
+      ],
+      "topContent": "Monty Norman was born in the city of London",
+      "returnedContents": [
+        "Monty Norman was born in the city of London",
+        "Norman Rockwell is a citizen of United Kingdom",
+        "James Brolin was born in the city of London",
+        "Arthur Conan Doyle was born in the city of Sydney",
+        "The origianl broadcaster of The Monkees is CBS"
+      ],
+      "latencyMs": 134
+    },
+    {
+      "question": "Who is Prince Andrew, Duke of York married to?",
+      "golds": [
+        "Mahidol Adulyadej"
+      ],
+      "topContent": "Prince Andrew, Duke of York is married to Mahidol Adulyadej",
+      "returnedContents": [
+        "Prince Andrew, Duke of York is married to Mahidol Adulyadej",
+        "The President of Azerbaijan is Prince Andrew, Duke of York",
+        "Andrew Carnegie is married to Louise Whitfield Carnegie",
+        "Andrew Carnegie is married to Marjorie Merriweather Post",
+        "Queen Victoria I is married to Albert, Prince Consort"
+      ],
+      "latencyMs": 106
+    },
+    {
+      "question": "Who performed Day Tripper?",
+      "golds": [
+        "Madonna"
+      ],
+      "topContent": "Day Tripper was performed by Madonna",
+      "returnedContents": [
+        "Day Tripper was performed by Madonna",
+        "Taxman was performed by Madonna",
+        "Nature Boy was performed by Donovan",
+        "All Night Long was performed by Lionel Richie",
+        "Graceland was performed by Paul Simon"
+      ],
+      "latencyMs": 92
+    },
+    {
+      "question": "Which city did Pablo Picasso work in?",
+      "golds": [
+        "Paris"
+      ],
+      "topContent": "Pablo Picasso worked in the city of Paris",
+      "returnedContents": [
+        "Pablo Picasso worked in the city of Paris",
+        "Henry Luce is married to Pablo Picasso",
+        "Victor Hugo worked in the city of London",
+        "William Blake worked in the city of Munich",
+        "Petronius worked in the city of Rome"
+      ],
+      "latencyMs": 115
+    },
+    {
+      "question": "Who is the director of CERN?",
+      "golds": [
+        "Giorgio Armani"
+      ],
+      "topContent": "The director of CERN is Giorgio Armani",
+      "returnedContents": [
+        "The director of CERN is Giorgio Armani",
+        "The director of CERN is Fabiola Gianotti",
+        "The director of Madonna is Narendra Modi",
+        "The director of The Beatles is Joe Hockey",
+        "The director of Kojima Productions is Wolfgang Anzengruber"
+      ],
+      "latencyMs": 121
+    },
+    {
+      "question": "Who performed Jane Foster?",
+      "golds": [
+        "Natalie Portman"
+      ],
+      "topContent": "Jane Foster was performed by Natalie Portman",
+      "returnedContents": [
+        "Jane Foster was performed by Natalie Portman",
+        "Sweet Caroline was performed by Janet Jackson",
+        "The origianl broadcaster of Jane the Virgin is MSNBC",
+        "Jessica Jones was performed by Krysten Ritter",
+        "Hey Jude was performed by Madonna"
+      ],
+      "latencyMs": 117
+    },
+    {
+      "question": "Who is the head coach of Burnley F.C.?",
+      "golds": [
+        "Jeff Hornacek"
+      ],
+      "topContent": "The head coach of Burnley F.C. is Jeff Hornacek",
+      "returnedContents": [
+        "The head coach of Burnley F.C. is Jeff Hornacek",
+        "The head coach of Manchester City F.C. is Warren Gatland",
+        "The head coach of Central Coast Mariners FC is Michael O'Neill",
+        "The head coach of Atlanta United FC is Nigel Pearson",
+        "The head coach of Sydney FC is Antonio Conte"
+      ],
+      "latencyMs": 106
+    },
+    {
+      "question": "Who is the original broadcaster of One Life to Live?",
+      "golds": [
+        "American Broadcasting Company"
+      ],
+      "topContent": "The origianl broadcaster of 60 Minutes is BBC One",
+      "returnedContents": [
+        "The origianl broadcaster of 60 Minutes is BBC One",
+        "The origianl broadcaster of Angels in America is Lifetime",
+        "The origianl broadcaster of The Monkees is CBS",
+        "The origianl broadcaster of Bachelor in Paradise is MTV",
+        "The origianl broadcaster of The Addams Family is American Broadcasting Company"
+      ],
+      "latencyMs": 103
+    },
+    {
+      "question": "Who is the author of Red Storm Rising?",
+      "golds": [
+        "Tom Clancy"
+      ],
+      "topContent": "The author of Red Storm Rising is Torquato Tasso",
+      "returnedContents": [
+        "The author of Red Storm Rising is Torquato Tasso",
+        "H. P. Lovecraft was born in the city of Rising Sun",
+        "The author of Gone with the Wind is Stephen Adly Guirgis",
+        "The author of Carrie is Te Rauparaha",
+        "The author of Call of the Wild is Thomas Moore"
+      ],
+      "latencyMs": 146
+    },
+    {
+      "question": "What is the official language of Soviet Union?",
+      "golds": [
+        "French"
+      ],
+      "topContent": "The official language of Soviet Union is French",
+      "returnedContents": [
+        "The official language of Soviet Union is French",
+        "The official language of Moscow is German",
+        "The capital of Soviet Union is Russellville",
+        "The official language of Russia is Russian",
+        "The official language of Sweden is German"
+      ],
+      "latencyMs": 121
+    },
+    {
+      "question": "Which continent is Great Britain located in?",
+      "golds": [
+        "Europe"
+      ],
+      "topContent": "Great Britain is located in the continent of Asia",
+      "returnedContents": [
+        "Great Britain is located in the continent of Asia",
+        "The capital of Great Britain is London",
+        "England is located in the continent of South America",
+        "England is located in the continent of Europe",
+        "United Kingdom is located in the continent of Oceania"
+      ],
+      "latencyMs": 101
+    },
+    {
+      "question": "Who founded Sōtō?",
+      "golds": [
+        "Dōgen"
+      ],
+      "topContent": "Sōtō was founded by Dōgen",
+      "returnedContents": [
+        "Sōtō was founded by Dōgen",
+        "Torquato Tasso is affiliated with the religion of Sōtō",
+        "Toyota was founded by Kiichiro Toyoda",
+        "Buddhism was founded by Gautama Buddha",
+        "Toyota was founded by Raila Odinga"
+      ],
+      "latencyMs": 96
+    },
+    {
+      "question": "Which country was The Orange County Register created in?",
+      "golds": [
+        "United Kingdom"
+      ],
+      "topContent": "The Orange County Register was created in the country of United Kingdom",
+      "returnedContents": [
+        "The Orange County Register was created in the country of United Kingdom",
+        "country music was created in the country of United States of America",
+        "country music was created in the country of United Kingdom",
+        "Mix was created in the country of Mexico",
+        "The Indianapolis Star was created in the country of Ukraine"
+      ],
+      "latencyMs": 114
+    },
+    {
+      "question": "Which sport is racing video game associated with?",
+      "golds": [
+        "Australian rules football"
+      ],
+      "topContent": "racing video game is associated with the sport of Australian rules football",
+      "returnedContents": [
+        "racing video game is associated with the sport of Australian rules football",
+        "The type of music that F-Zero plays is racing video game",
+        "Diego Simeone is associated with the sport of auto racing",
+        "Green Bay is associated with the sport of motorsport",
+        "Sports Interactive is associated with the sport of basketball"
+      ],
+      "latencyMs": 119
+    },
+    {
+      "question": "What is the country of citizenship of Philip II of Spain?",
+      "golds": [
+        "United Kingdom"
+      ],
+      "topContent": "Philip II of Spain is a citizen of United Kingdom",
+      "returnedContents": [
+        "Philip II of Spain is a citizen of United Kingdom",
+        "Vince Gill is married to Philip II of Spain",
+        "Ferdinand VI of Spain is a citizen of Spain",
+        "Philip IV of France is a citizen of Ireland",
+        "Emo Philips is a citizen of Ireland"
+      ],
+      "latencyMs": 108
+    },
+    {
+      "question": "What is Luís de Camões famous for?",
+      "golds": [
+        "Os Lusíadas"
+      ],
+      "topContent": "Luís de Camões is famous for Os Lusíadas",
+      "returnedContents": [
+        "Luís de Camões is famous for Os Lusíadas",
+        "The univeristy where Luís de Camões was educated is University of Coimbra",
+        "The author of Os Lusíadas is Luís de Camões",
+        "The univeristy where Lluís Domènech i Montaner was educated is Yale University",
+        "The capital of Portugal is Lisbon"
+      ],
+      "latencyMs": 93
+    },
+    {
+      "question": "Who is Wilma Flintstone's child?",
+      "golds": [
+        "Eric Garcetti"
+      ],
+      "topContent": "Wilma Flintstone's child is Eric Garcetti",
+      "returnedContents": [
+        "Wilma Flintstone's child is Eric Garcetti",
+        "Priscilla Presley is married to Wilma Flintstone",
+        "Allen Funt's child is Alexander Stirling Calder",
+        "Donovan's child is Donovan Leitch",
+        "A. A. Milne's child is Cosette"
+      ],
+      "latencyMs": 82
+    },
+    {
+      "question": "Who is the original broadcaster of General Hospital?",
+      "golds": [
+        "American Broadcasting Company"
+      ],
+      "topContent": "The origianl broadcaster of General Hospital is American Broadcasting Company",
+      "returnedContents": [
+        "The origianl broadcaster of General Hospital is American Broadcasting Company",
+        "The origianl broadcaster of The Addams Family is American Broadcasting Company",
+        "The origianl broadcaster of Soap is American Broadcasting Company",
+        "The origianl broadcaster of The Alcoa Hour is CBS",
+        "The origianl broadcaster of The Merv Griffin Show is CBS"
+      ],
+      "latencyMs": 93
+    },
+    {
+      "question": "Which sport is Erik Spoelstra associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "Erik Spoelstra is associated with the sport of basketball",
+      "returnedContents": [
+        "Erik Spoelstra is associated with the sport of basketball",
+        "The head coach of Miami Heat is Erik Spoelstra",
+        "Erik Spiekermann is a citizen of Germany",
+        "placekicker is associated with the sport of rugby",
+        "goaltender is associated with the sport of pesäpallo"
+      ],
+      "latencyMs": 126
+    },
+    {
+      "question": "Who is the developer of PowerBook G4?",
+      "golds": [
+        "Microsoft"
+      ],
+      "topContent": "PowerBook G4 was developed by Microsoft",
+      "returnedContents": [
+        "PowerBook G4 was developed by Microsoft",
+        "iPod was developed by Google",
+        "GarageBand was developed by Google",
+        "iPad Pro was developed by Google",
+        "iPhone 4S was developed by Valve Corporation"
+      ],
+      "latencyMs": 91
+    },
+    {
+      "question": "Which language was Os Lusíadas written in?",
+      "golds": [
+        "English"
+      ],
+      "topContent": "Os Lusíadas was written in the language of English",
+      "returnedContents": [
+        "Os Lusíadas was written in the language of English",
+        "The author of Os Lusíadas is Luís de Camões",
+        "Luís de Camões is famous for Os Lusíadas",
+        "Blue Peter was written in the language of Portuguese",
+        "Angel was written in the language of Spanish"
+      ],
+      "latencyMs": 109
+    },
+    {
+      "question": "Which country was Die Gartenlaube created in?",
+      "golds": [
+        "Austrian Empire"
+      ],
+      "topContent": "Die Gartenlaube was created in the country of Austrian Empire",
+      "returnedContents": [
+        "Die Gartenlaube was created in the country of Austrian Empire",
+        "Deutschland sucht den Superstar was created in the country of Germany",
+        "The Normal Heart was created in the country of Nazi Germany",
+        "Le Petit Parisien was created in the country of Germany",
+        "Gundam was created in the country of Sweden"
+      ],
+      "latencyMs": 99
+    },
+    {
+      "question": "Which city did Martin Luther King Jr. die in?",
+      "golds": [
+        "St Leonards-on-Sea"
+      ],
+      "topContent": "Martin Luther King Jr. died in the city of St Leonards-on-Sea",
+      "returnedContents": [
+        "Martin Luther King Jr. died in the city of St Leonards-on-Sea",
+        "Martin Luther King Jr. was born in the city of Atlanta",
+        "Martin Luther King Jr. is a citizen of Vietnam",
+        "Coretta Scott King is married to Martin Luther King Jr.",
+        "The author of Hard Times is Martin Luther King Jr."
+      ],
+      "latencyMs": 97
+    },
+    {
+      "question": "What is the country of citizenship of Sher Bahadur Deuba?",
+      "golds": [
+        "Nepal"
+      ],
+      "topContent": "Sher Bahadur Deuba is a citizen of Nepal",
+      "returnedContents": [
+        "Sher Bahadur Deuba is a citizen of Nepal",
+        "The chairperson of Foreign Affairs Council is Sher Bahadur Deuba",
+        "Richard Brinsley Sheridan is a citizen of Afghanistan",
+        "Sajid Khan is a citizen of United States of America",
+        "Bharathan is a citizen of Venezuela"
+      ],
+      "latencyMs": 110
+    },
+    {
+      "question": "Who is the chief executive officer of Toshiba?",
+      "golds": [
+        "Nobuaki Kurumatani"
+      ],
+      "topContent": "The chief executive officer of Toshiba is Nobuaki Kurumatani",
+      "returnedContents": [
+        "The chief executive officer of Toshiba is Nobuaki Kurumatani",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "The chief executive officer of Microsoft is Satya Nadella",
+        "The chief executive officer of Apple Inc. is Tim Cook",
+        "The chief executive officer of Netflix is Neil Aspinall"
+      ],
+      "latencyMs": 92
+    },
+    {
+      "question": "Which university was Ilir Meta educated at?",
+      "golds": [
+        "Montana State University - Bozeman"
+      ],
+      "topContent": "The univeristy where Ilir Meta was educated is Montana State University - Bozeman",
+      "returnedContents": [
+        "The univeristy where Ilir Meta was educated is Montana State University - Bozeman",
+        "The univeristy where Miuccia Prada was educated is University of Milan",
+        "The univeristy where Chicago Boys was educated is Yale University",
+        "The univeristy where Nicodemus Tessin the Younger was educated is University of Minnesota",
+        "The univeristy where Vladimir Tismăneanu was educated is Italia Conti Academy of Theatre Arts"
+      ],
+      "latencyMs": 108
+    },
+    {
+      "question": "What is Richard Adams famous for?",
+      "golds": [
+        "Watership Down"
+      ],
+      "topContent": "Richard Adams is famous for Watership Down",
+      "returnedContents": [
+        "Richard Adams is famous for Watership Down",
+        "John Quincy Adams is employed by Yale University",
+        "The author of Richard II is William Shakespeare",
+        "Bryan Adams is a citizen of Canada",
+        "Richard Nixon is married to Pat Nixon"
+      ],
+      "latencyMs": 93
+    },
+    {
+      "question": "Who is the chairperson of General Motors?",
+      "golds": [
+        "Yoweri Kaguta Museveni"
+      ],
+      "topContent": "The chairperson of General Motors is Yoweri Kaguta Museveni",
+      "returnedContents": [
+        "The chairperson of General Motors is Yoweri Kaguta Museveni",
+        "The chief executive officer of General Motors is Marc Benioff",
+        "General Motors was founded in the city of Los Angeles",
+        "The company that produced Cadillac Escalade is General Motors",
+        "The chairperson of MI5 is Gerald E. H. Abraham"
+      ],
+      "latencyMs": 102
+    },
+    {
+      "question": "Which continent is Zürich located in?",
+      "golds": [
+        "Antarctica"
+      ],
+      "topContent": "Zürich is located in the continent of Antarctica",
+      "returnedContents": [
+        "Zürich is located in the continent of Antarctica",
+        "The headquarters of University of Zurich is located in the city of Zürich",
+        "Israel is located in the continent of Asia",
+        "Germany is located in the continent of Europe",
+        "Germany is located in the continent of Africa"
+      ],
+      "latencyMs": 107
+    },
+    {
+      "question": "What language does Daphne du Maurier speak?",
+      "golds": [
+        "Arabic"
+      ],
+      "topContent": "Daphne du Maurier speaks the language of Arabic",
+      "returnedContents": [
+        "Daphne du Maurier speaks the language of Arabic",
+        "Daphne du Maurier is a citizen of United Kingdom",
+        "The author of Rebecca is Daphne du Maurier",
+        "The author of Starship Troopers is Daphne du Maurier",
+        "Lena Dunham speaks the language of Hungarian"
+      ],
+      "latencyMs": 112
+    },
+    {
+      "question": "Who is the author of The Andromeda Strain?",
+      "golds": [
+        "Multatuli"
+      ],
+      "topContent": "The author of The Andromeda Strain is Multatuli",
+      "returnedContents": [
+        "The author of The Andromeda Strain is Multatuli",
+        "The author of 1984 is Constantine VII",
+        "The author of Starship Troopers is Robert A. Heinlein",
+        "The author of Carrie is Stephen King",
+        "The author of The Chronicles of Amber is R. L. Stine"
+      ],
+      "latencyMs": 111
+    },
+    {
+      "question": "What is the name of the current head of the India government?",
+      "golds": [
+        "Narendra Modi"
+      ],
+      "topContent": "The name of the current head of the India government is Narendra Modi",
+      "returnedContents": [
+        "The name of the current head of the India government is Narendra Modi",
+        "The name of the current head of the Odisha government is Joseph Muscat",
+        "The name of the current head of the Scotland government is Rudi Vervoort",
+        "The name of the current head of the Israel government is Kevin Rudd",
+        "The name of the current head of the Canada government is Guy Vattier"
+      ],
+      "latencyMs": 104
+    },
+    {
+      "question": "What is the country of citizenship of Bibi Andersson?",
+      "golds": [
+        "United Kingdom"
+      ],
+      "topContent": "Bibi Andersson is a citizen of United Kingdom",
+      "returnedContents": [
+        "Bibi Andersson is a citizen of United Kingdom",
+        "Kristen Bell is married to Bibi Andersson",
+        "Władysław Anders is a citizen of England",
+        "Flo Rida is a citizen of Sweden",
+        "The official language of Sweden is German"
+      ],
+      "latencyMs": 107
+    },
+    {
+      "question": "What is the country of citizenship of Felix Aylmer?",
+      "golds": [
+        "Denmark"
+      ],
+      "topContent": "Felix Aylmer is a citizen of Denmark",
+      "returnedContents": [
+        "Felix Aylmer is a citizen of Denmark",
+        "Wilbert Awdry is a citizen of United Kingdom",
+        "Emo Philips is a citizen of Ireland",
+        "Robert A. Heinlein is a citizen of United Kingdom of Great Britain and Ireland",
+        "Władysław Anders is a citizen of England"
+      ],
+      "latencyMs": 98
+    },
+    {
+      "question": "Where was Finnair founded?",
+      "golds": [
+        "Helsinki"
+      ],
+      "topContent": "Finnair was founded in the city of Helsinki",
+      "returnedContents": [
+        "Finnair was founded in the city of Helsinki",
+        "Canadair was founded in the city of Tucson",
+        "Ford Australia was founded by Henry Ford",
+        "Sikorsky Aircraft Corporation was founded by Robert Rich, 2nd Earl of Warwick",
+        "Nissan was founded in the city of Islamorada"
+      ],
+      "latencyMs": 107
+    },
+    {
+      "question": "Who is the developer of Mortal Kombat X?",
+      "golds": [
+        "Blizzard Entertainment"
+      ],
+      "topContent": "Mortal Kombat 3 was developed by Midway Games",
+      "returnedContents": [
+        "Mortal Kombat 3 was developed by Midway Games",
+        "NeXT Computer, Inc. was founded by Mikhail Khodorkovsky",
+        "StarCraft was developed by Blizzard Entertainment",
+        "No More Heroes was developed by NetherRealm Studios",
+        "Atari Jaguar was developed by Microsoft"
+      ],
+      "latencyMs": 79
+    },
+    {
+      "question": "What is the country of citizenship of Kim Tae-hee?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Kim Tae-hee is a citizen of United States of America",
+      "returnedContents": [
+        "Kim Tae-hee is a citizen of United States of America",
+        "Stan Lee is married to Kim Tae-hee",
+        "Kim Yong-nam is a citizen of North Korea",
+        "Kim Kardashian is a citizen of United States of America",
+        "Charles the Bold is a citizen of South Korea"
+      ],
+      "latencyMs": 89
+    },
+    {
+      "question": "Who is the developer of Windows Server 2008?",
+      "golds": [
+        "BlackBerry"
+      ],
+      "topContent": "Windows Server 2008 was developed by BlackBerry",
+      "returnedContents": [
+        "Windows Server 2008 was developed by BlackBerry",
+        "Windows Server was developed by Microsoft",
+        "Windows 98 was developed by Microsoft",
+        "Windows 2000 was developed by Microsoft",
+        "Windows 10 was developed by Microsoft"
+      ],
+      "latencyMs": 90
+    },
+    {
+      "question": "What is the official language of Kingdom of the Netherlands?",
+      "golds": [
+        "Old Turkic"
+      ],
+      "topContent": "The official language of Kingdom of the Netherlands is Old Turkic",
+      "returnedContents": [
+        "The official language of Kingdom of the Netherlands is Old Turkic",
+        "The official language of Kingdom of England is English",
+        "The official language of Kingdom of Italy is Italian",
+        "The official language of Kingdom of Hungary is Hungarian",
+        "The official language of United Kingdom is English"
+      ],
+      "latencyMs": 114
+    },
+    {
+      "question": "What is Colleen McCullough famous for?",
+      "golds": [
+        "The Thorn Birds"
+      ],
+      "topContent": "Colleen McCullough is famous for The Thorn Birds",
+      "returnedContents": [
+        "Colleen McCullough is famous for The Thorn Birds",
+        "Meredith Grey was performed by Ellen Pompeo",
+        "George Colman the Elder's child is Bob Bennett",
+        "Melinda Gates is employed by WWE",
+        "The author of Clarissa is Winston Graham"
+      ],
+      "latencyMs": 101
+    },
+    {
+      "question": "Which religion is John Paul I affiliated with?",
+      "golds": [
+        "Church of Scotland"
+      ],
+      "topContent": "John Paul I is affiliated with the religion of Church of Scotland",
+      "returnedContents": [
+        "John Paul I is affiliated with the religion of Church of Scotland",
+        "First Epistle of John is affiliated with the religion of Christianity",
+        "Paul Begala is affiliated with the religion of Buddhism",
+        "John Krol is affiliated with the religion of Catholic Church",
+        "John Bosco is affiliated with the religion of Catholic Church"
+      ],
+      "latencyMs": 101
+    },
+    {
+      "question": "Who performed Taxman?",
+      "golds": [
+        "Madonna"
+      ],
+      "topContent": "Taxman was performed by Madonna",
+      "returnedContents": [
+        "Taxman was performed by Madonna",
+        "Day Tripper was performed by Madonna",
+        "Revolver was performed by Madonna",
+        "Graceland was performed by Paul Simon",
+        "Nature Boy was performed by Donovan"
+      ],
+      "latencyMs": 90
+    },
+    {
+      "question": "Which city is the headquarter of University of Manchester located in?",
+      "golds": [
+        "Manchester"
+      ],
+      "topContent": "The headquarters of University of Manchester is located in the city of Manchester",
+      "returnedContents": [
+        "The headquarters of University of Manchester is located in the city of Manchester",
+        "The headquarters of University of Oxford is located in the city of Frankfurt",
+        "The headquarters of University of Calcutta is located in the city of Kolkata",
+        "The headquarters of University of Leeds is located in the city of Leeds",
+        "The headquarters of University of Birmingham is located in the city of 888 7th Avenue"
+      ],
+      "latencyMs": 108
+    },
+    {
+      "question": "Which sport is Texas Legends associated with?",
+      "golds": [
+        "cricket"
+      ],
+      "topContent": "Texas Legends is associated with the sport of cricket",
+      "returnedContents": [
+        "Texas Legends is associated with the sport of cricket",
+        "defender is associated with the sport of baseball",
+        "Tyson Chandler is associated with the sport of basketball",
+        "THB Champions League is associated with the sport of Muay Thai",
+        "Midland Football League is associated with the sport of basketball"
+      ],
+      "latencyMs": 91
+    },
+    {
+      "question": "What is the country of citizenship of Jaime Alguersuari?",
+      "golds": [
+        "Brazil"
+      ],
+      "topContent": "Jaime Alguersuari is a citizen of Brazil",
+      "returnedContents": [
+        "Jaime Alguersuari is a citizen of Brazil",
+        "Jaime Hernandez is famous for Het Gulden Cabinet",
+        "Sugawara no Michizane is a citizen of United States of America",
+        "Adolfo Pérez Esquivel is a citizen of Argentina",
+        "Justin Trudeau is a citizen of United States of America"
+      ],
+      "latencyMs": 94
+    },
+    {
+      "question": "Which religion is Alassane Dramane Ouattara affiliated with?",
+      "golds": [
+        "Catholic Church"
+      ],
+      "topContent": "Alassane Dramane Ouattara is affiliated with the religion of Catholic Church",
+      "returnedContents": [
+        "Alassane Dramane Ouattara is affiliated with the religion of Catholic Church",
+        "The name of the current head of state in Italy is Alassane Dramane Ouattara",
+        "Uthman ibn Affan is affiliated with the religion of Islam",
+        "Afghanistan is affiliated with the religion of Latin Church",
+        "Henri Grégoire is affiliated with the religion of Christianity"
+      ],
+      "latencyMs": 87
+    },
+    {
+      "question": "What position does Andrea Pirlo play?",
+      "golds": [
+        "midfielder"
+      ],
+      "topContent": "Andrea Pirlo plays the position of midfielder",
+      "returnedContents": [
+        "Andrea Pirlo plays the position of midfielder",
+        "Andrés Iniesta plays the position of quarterback",
+        "Dele Alli plays the position of goalkeeper",
+        "Pepe Reina plays the position of midfielder",
+        "Drew Brees plays the position of quarterback"
+      ],
+      "latencyMs": 91
+    },
+    {
+      "question": "Which country was association football created in?",
+      "golds": [
+        "Italy"
+      ],
+      "topContent": "association football was created in the country of Italy",
+      "returnedContents": [
+        "association football was created in the country of Italy",
+        "Gaelic football was created in the country of India",
+        "baseball was created in the country of Japan",
+        "country music was created in the country of United Kingdom",
+        "Israel Football Association is associated with the sport of association football"
+      ],
+      "latencyMs": 107
+    },
+    {
+      "question": "What type of music does Big Sean play?",
+      "golds": [
+        "country rock"
+      ],
+      "topContent": "The type of music that Big Sean plays is country rock",
+      "returnedContents": [
+        "The type of music that Big Sean plays is country rock",
+        "The type of music that Big Pun plays is hip hop music",
+        "The type of music that Barney Bigard plays is jazz",
+        "The type of music that Dale Evans plays is country music",
+        "The type of music that Cecil Payne plays is bubblegum pop"
+      ],
+      "latencyMs": 111
+    },
+    {
+      "question": "Which country was bluegrass music created in?",
+      "golds": [
+        "Indonesia"
+      ],
+      "topContent": "bluegrass music was created in the country of Indonesia",
+      "returnedContents": [
+        "bluegrass music was created in the country of Indonesia",
+        "country music was created in the country of United States of America",
+        "country music was created in the country of United Kingdom",
+        "hip hop music was created in the country of Denmark",
+        "rock music was created in the country of Spain"
+      ],
+      "latencyMs": 111
+    },
+    {
+      "question": "Which sport is North East Stars associated with?",
+      "golds": [
+        "cricket"
+      ],
+      "topContent": "North East Stars is associated with the sport of cricket",
+      "returnedContents": [
+        "North East Stars is associated with the sport of cricket",
+        "East Midlands derby is associated with the sport of basketball",
+        "East Melbourne Cricket Ground is associated with the sport of rugby",
+        "Northwest League is associated with the sport of association football",
+        "Red Star F.C. is associated with the sport of rugby"
+      ],
+      "latencyMs": 102
+    },
+    {
+      "question": "Who is the chief executive officer of Tesla?",
+      "golds": [
+        "Adam Sandler"
+      ],
+      "topContent": "The chief executive officer of Tesla is Adam Sandler",
+      "returnedContents": [
+        "The chief executive officer of Tesla is Adam Sandler",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "The chief executive officer of Telmex is Armin Veh",
+        "The chief executive officer of Microsoft is Satya Nadella",
+        "The chief executive officer of Google is Lakshmi Mittal"
+      ],
+      "latencyMs": 92
+    },
+    {
+      "question": "Who founded Omidyar Network?",
+      "golds": [
+        "Pierre Omidyar"
+      ],
+      "topContent": "Omidyar Network was founded by Pierre Omidyar",
+      "returnedContents": [
+        "Omidyar Network was founded by Pierre Omidyar",
+        "Pierre Omidyar was born in the city of Auckland",
+        "Dravida Munnetra Kazhagam was founded by Mário Soares",
+        "Islam was founded by Raila Odinga",
+        "Glenn L. Martin Company was founded by Vijay Mallya"
+      ],
+      "latencyMs": 102
+    },
+    {
+      "question": "Which city is the headquarter of Berklee College of Music located in?",
+      "golds": [
+        "Boston"
+      ],
+      "topContent": "The headquarters of Berklee College of Music is located in the city of Boston",
+      "returnedContents": [
+        "The headquarters of Berklee College of Music is located in the city of Boston",
+        "The headquarters of Royal College of Music is located in the city of Exeter",
+        "The univeristy where John Petrucci was educated is Berklee College of Music",
+        "The headquarters of Bowdoin College is located in the city of Brunswick",
+        "The headquarters of Corpus Christi College is located in the city of Chicago"
+      ],
+      "latencyMs": 145
+    },
+    {
+      "question": "What is the capital of Czechoslovakia?",
+      "golds": [
+        "Przeworsk"
+      ],
+      "topContent": "The capital of Czechoslovakia is Przeworsk",
+      "returnedContents": [
+        "The capital of Czechoslovakia is Przeworsk",
+        "The capital of Czech Republic is Prague",
+        "The capital of Ireland is Potosi",
+        "The capital of Ukraine is Conegliano",
+        "The capital of Lithuania is Vilnius"
+      ],
+      "latencyMs": 108
+    },
+    {
+      "question": "What is the country of citizenship of Ellen Pompeo?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Ellen Pompeo is a citizen of United States of America",
+      "returnedContents": [
+        "Ellen Pompeo is a citizen of United States of America",
+        "Meredith Grey was performed by Ellen Pompeo",
+        "Elisabeth Moss is a citizen of United States of America",
+        "Miranda Otto is a citizen of Spain",
+        "Estelle Getty is a citizen of United States of America"
+      ],
+      "latencyMs": 124
+    },
+    {
+      "question": "What is the country of citizenship of Alan Blyth?",
+      "golds": [
+        "United Kingdom"
+      ],
+      "topContent": "Alan Blyth is a citizen of United Kingdom",
+      "returnedContents": [
+        "Alan Blyth is a citizen of United Kingdom",
+        "Alan Carr is a citizen of United States of America",
+        "Alan Thicke is a citizen of Japan",
+        "Alanis Morissette is a citizen of Great Britain",
+        "David Balfe is a citizen of Argentina"
+      ],
+      "latencyMs": 98
+    },
+    {
+      "question": "Who is the author of Satyricon?",
+      "golds": [
+        "William Blake"
+      ],
+      "topContent": "The author of Satyricon is William Blake",
+      "returnedContents": [
+        "The author of Satyricon is William Blake",
+        "The author of Theaetetus is Plato",
+        "The author of 1984 is Constantine VII",
+        "The author of Heroides is Ovid",
+        "The author of Heroides is William Shakespeare"
+      ],
+      "latencyMs": 108
+    },
+    {
+      "question": "Who is the original broadcaster of Revenge?",
+      "golds": [
+        "British Broadcasting Corporation"
+      ],
+      "topContent": "The origianl broadcaster of Revenge is British Broadcasting Corporation",
+      "returnedContents": [
+        "The origianl broadcaster of Revenge is British Broadcasting Corporation",
+        "The origianl broadcaster of Revenge is American Broadcasting Company",
+        "The origianl broadcaster of Perfect Strangers is MTV",
+        "The origianl broadcaster of The Muppets is American Broadcasting Company",
+        "The origianl broadcaster of The Rogues is CBS"
+      ],
+      "latencyMs": 93
+    },
+    {
+      "question": "Which university was Stewart Udall educated at?",
+      "golds": [
+        "California State University, Long Beach"
+      ],
+      "topContent": "The univeristy where Stewart Udall was educated is University of Arizona",
+      "returnedContents": [
+        "The univeristy where Stewart Udall was educated is University of Arizona",
+        "The univeristy where Stewart Udall was educated is California State University, Long Beach",
+        "The univeristy where Steven Moffat was educated is University of Glasgow",
+        "The univeristy where John Magufuli was educated is University of St Andrews",
+        "The univeristy where Howard Gardner was educated is Harvard University"
+      ],
+      "latencyMs": 94
+    },
+    {
+      "question": "Who is the chairperson of Aam Aadmi Party?",
+      "golds": [
+        "Lamar Alexander"
+      ],
+      "topContent": "The chairperson of Aam Aadmi Party is Lamar Alexander",
+      "returnedContents": [
+        "The chairperson of Aam Aadmi Party is Lamar Alexander",
+        "The chairperson of Liberal Democratic Party is Jean-Claude Juncker",
+        "The chairperson of Israeli Labor Party is Mark Carney",
+        "The chairperson of Scottish National Party is Rick Perry",
+        "The chairperson of Ontario New Democratic Party is Habib Bourguiba"
+      ],
+      "latencyMs": 102
+    },
+    {
+      "question": "Who performed Beatles for Sale?",
+      "golds": [
+        "Madonna"
+      ],
+      "topContent": "Beatles for Sale was performed by Madonna",
+      "returnedContents": [
+        "Beatles for Sale was performed by Madonna",
+        "And I Love Her was performed by The Beatles",
+        "Free as a Bird was performed by The Beatles",
+        "Abbey Road was performed by The Beatles",
+        "Please Please Me was performed by The Beatles"
+      ],
+      "latencyMs": 118
+    },
+    {
+      "question": "Which sport is Philippine Basketball Association Draft associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "Philippine Basketball Association Draft is associated with the sport of basketball",
+      "returnedContents": [
+        "Philippine Basketball Association Draft is associated with the sport of basketball",
+        "2004 NBA Draft is associated with the sport of association football",
+        "National Basketball Association is associated with the sport of field hockey",
+        "Liga Profesional de Baloncesto is associated with the sport of basketball",
+        "Washington Wizards is associated with the sport of basketball"
+      ],
+      "latencyMs": 111
+    },
+    {
+      "question": "What type of music does Archie Shepp play?",
+      "golds": [
+        "J-pop"
+      ],
+      "topContent": "The type of music that Archie Shepp plays is J-pop",
+      "returnedContents": [
+        "The type of music that Archie Shepp plays is J-pop",
+        "The type of music that Angel plays is rock music",
+        "The type of music that Bruce Springsteen plays is rock music",
+        "The type of music that George Jones plays is rock music",
+        "The type of music that Pete Townshend plays is rock music"
+      ],
+      "latencyMs": 139
+    },
+    {
+      "question": "What is the capital of El Salvador?",
+      "golds": [
+        "San Salvador"
+      ],
+      "topContent": "The capital of El Salvador is San Salvador",
+      "returnedContents": [
+        "The capital of El Salvador is San Salvador",
+        "The capital of Mexico is Mexico City",
+        "Salvador Dalí was born in the city of Figueres",
+        "The capital of Spain is Hartford",
+        "The capital of Norway is Douglas"
+      ],
+      "latencyMs": 153
+    },
+    {
+      "question": "Who is the employer of Larry Page?",
+      "golds": [
+        "University of Edinburgh"
+      ],
+      "topContent": "Larry Page is employed by University of Edinburgh",
+      "returnedContents": [
+        "Larry Page is employed by University of Edinburgh",
+        "Jabberwocky was created by Larry Page",
+        "Larry Kramer is a citizen of United States of America",
+        "Larry McMurtry is a citizen of United States of America",
+        "Laurence Olivier worked in the city of Washington, D.C."
+      ],
+      "latencyMs": 117
+    },
+    {
+      "question": "Which university was James Dashner educated at?",
+      "golds": [
+        "Brigham Young University"
+      ],
+      "topContent": "The univeristy where James Dashner was educated is Brigham Young University",
+      "returnedContents": [
+        "The univeristy where James Dashner was educated is Brigham Young University",
+        "The univeristy where Henry James was educated is Yale University",
+        "The author of The Maze Runner is James Dashner",
+        "The univeristy where Louis Zamperini was educated is University of Dublin",
+        "The univeristy where Thomas Vanek was educated is University of Michigan"
+      ],
+      "latencyMs": 157
+    },
+    {
+      "question": "Who is the author of Areopagitica?",
+      "golds": [
+        "John Milton"
+      ],
+      "topContent": "The author of Areopagitica is John Milton",
+      "returnedContents": [
+        "The author of Areopagitica is John Milton",
+        "The author of Theaetetus is Plato",
+        "The author of Endymion is John Keats",
+        "The author of 1984 is Constantine VII",
+        "The author of Heroides is Ovid"
+      ],
+      "latencyMs": 126
+    },
+    {
+      "question": "Who performed Dear Prudence?",
+      "golds": [
+        "Madonna"
+      ],
+      "topContent": "Dear Prudence was performed by Madonna",
+      "returnedContents": [
+        "Dear Prudence was performed by Madonna",
+        "Revolver was performed by Madonna",
+        "God Bless the Child was performed by Mick Jagger",
+        "Hey Jude was performed by Madonna",
+        "My Sweet Lord was performed by Kristen Bell"
+      ],
+      "latencyMs": 134
+    },
+    {
+      "question": "What language does George Boole speak?",
+      "golds": [
+        "Spanish"
+      ],
+      "topContent": "George Boole speaks the language of Spanish",
+      "returnedContents": [
+        "George Boole speaks the language of Spanish",
+        "The author of Under the Dome is George Boole",
+        "Andrew Stanton speaks the language of German",
+        "P. G. Wodehouse speaks the language of German",
+        "Arthur Conan Doyle speaks the language of Swedish"
+      ],
+      "latencyMs": 134
+    },
+    {
+      "question": "Which language was Shahnameh written in?",
+      "golds": [
+        "Persian"
+      ],
+      "topContent": "Shahnameh was written in the language of Persian",
+      "returnedContents": [
+        "Shahnameh was written in the language of Persian",
+        "Ramayana was written in the language of English",
+        "Crytek was written in the language of Arabic",
+        "Shakugan no Shana was written in the language of Scots",
+        "The author of Persian Letters is Montesquieu"
+      ],
+      "latencyMs": 136
+    },
+    {
+      "question": "Which sport is Altrincham F.C. associated with?",
+      "golds": [
+        "association football"
+      ],
+      "topContent": "Altrincham F.C. is associated with the sport of association football",
+      "returnedContents": [
+        "Altrincham F.C. is associated with the sport of association football",
+        "John Aloisi is associated with the sport of association football",
+        "Aiginiakos F.C. is associated with the sport of basketball",
+        "Worksop Town F.C. is associated with the sport of association football",
+        "Haverfordwest County A.F.C. is associated with the sport of association football"
+      ],
+      "latencyMs": 140
+    },
+    {
+      "question": "Which continent is São Paulo located in?",
+      "golds": [
+        "South America"
+      ],
+      "topContent": "São Paulo is located in the continent of South America",
+      "returnedContents": [
+        "São Paulo is located in the continent of South America",
+        "Paulo Freire died in the city of São Paulo",
+        "Brazil is located in the continent of Antarctica",
+        "Philippines is located in the continent of Asia",
+        "Italy is located in the continent of Oceania"
+      ],
+      "latencyMs": 132
+    },
+    {
+      "question": "Which sport is three-point field goal associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "three-point field goal is associated with the sport of basketball",
+      "returnedContents": [
+        "three-point field goal is associated with the sport of basketball",
+        "point guard is associated with the sport of cricket",
+        "cornerback is associated with the sport of field hockey",
+        "safety is associated with the sport of field hockey",
+        "goalkeeper is associated with the sport of Gaelic football"
+      ],
+      "latencyMs": 170
+    },
+    {
+      "question": "What is the country of citizenship of Paul Morley?",
+      "golds": [
+        "Ireland"
+      ],
+      "topContent": "Paul Morley is a citizen of Ireland",
+      "returnedContents": [
+        "Paul Morley is a citizen of Ireland",
+        "Alanis Morissette is a citizen of Great Britain",
+        "Paul Rodriguez is a citizen of United Kingdom",
+        "Amala Paul is a citizen of Belgium",
+        "Paul I of Russia is a citizen of United Kingdom"
+      ],
+      "latencyMs": 156
+    },
+    {
+      "question": "Who is Reese Witherspoon's child?",
+      "golds": [
+        "James Badge Dale"
+      ],
+      "topContent": "Reese Witherspoon's child is James Badge Dale",
+      "returnedContents": [
+        "Reese Witherspoon's child is James Badge Dale",
+        "Reese Witherspoon is a citizen of United States of America",
+        "Harry S. Truman is married to Reese Witherspoon",
+        "Wilma Flintstone's child is Eric Garcetti",
+        "Allen Funt's child is Alexander Stirling Calder"
+      ],
+      "latencyMs": 127
+    },
+    {
+      "question": "Which sport is Lisbon Lions associated with?",
+      "golds": [
+        "baseball"
+      ],
+      "topContent": "Lisbon Lions is associated with the sport of baseball",
+      "returnedContents": [
+        "Lisbon Lions is associated with the sport of baseball",
+        "Preston Lions FC is associated with the sport of association football",
+        "The capital of Portugal is Lisbon",
+        "The capital of Lithuania is Lisbon",
+        "F.C. Porto B is associated with the sport of association football"
+      ],
+      "latencyMs": 145
+    },
+    {
+      "question": "Who performed Born This Way Ball?",
+      "golds": [
+        "Lady Gaga"
+      ],
+      "topContent": "Born This Way was performed by Lady Gaga",
+      "returnedContents": [
+        "Born This Way was performed by Lady Gaga",
+        "Born in the U.S.A. was performed by Dana International",
+        "The Way We Were was performed by Barbra Streisand",
+        "Born in the U.S.A. was performed by Bruce Springsteen",
+        "Born to Run was performed by The J. Geils Band"
+      ],
+      "latencyMs": 194
+    },
+    {
+      "question": "Which religion is Denis Thatcher affiliated with?",
+      "golds": [
+        "Lutheranism"
+      ],
+      "topContent": "Denis Thatcher is affiliated with the religion of Lutheranism",
+      "returnedContents": [
+        "Denis Thatcher is affiliated with the religion of Lutheranism",
+        "Margaret Thatcher is married to Denis Thatcher",
+        "Benedictines is affiliated with the religion of Methodism",
+        "Common is affiliated with the religion of Christianity",
+        "Jonathan Swift is affiliated with the religion of atheism"
+      ],
+      "latencyMs": 169
+    },
+    {
+      "question": "Who is the author of Rerum Novarum?",
+      "golds": [
+        "Leo XIII"
+      ],
+      "topContent": "The author of Rerum Novarum is Leo XIII",
+      "returnedContents": [
+        "The author of Rerum Novarum is Leo XIII",
+        "The author of The Chronicles of Amber is R. L. Stine",
+        "The author of 1984 is Constantine VII",
+        "The author of Sidereus Nuncius is Samuel Beckett",
+        "The author of Theaetetus is Plato"
+      ],
+      "latencyMs": 160
+    },
+    {
+      "question": "What position does Manuel Neuer play?",
+      "golds": [
+        "linebacker"
+      ],
+      "topContent": "Manuel Neuer plays the position of linebacker",
+      "returnedContents": [
+        "Manuel Neuer plays the position of linebacker",
+        "Simon Mignolet plays the position of midfielder",
+        "Jacques Necker is employed by University of Geneva",
+        "Juninho Paulista plays the position of midfielder",
+        "Manute Bol plays the position of center"
+      ],
+      "latencyMs": 150
+    },
+    {
+      "question": "Who is the author of Lonesome Dove?",
+      "golds": [
+        "Robert A. Heinlein"
+      ],
+      "topContent": "The author of Lonesome Dove is Robert A. Heinlein",
+      "returnedContents": [
+        "The author of Lonesome Dove is Robert A. Heinlein",
+        "The author of The Normal Heart is Larry Kramer",
+        "The author of The Lorax is Dr. Seuss",
+        "The author of Our Town is Thornton Wilder",
+        "The author of Little Women is H. P. Lovecraft"
+      ],
+      "latencyMs": 160
+    },
+    {
+      "question": "Which city did Allan Pinkerton die in?",
+      "golds": [
+        "Pune"
+      ],
+      "topContent": "Allan Pinkerton died in the city of Pune",
+      "returnedContents": [
+        "Allan Pinkerton died in the city of Pune",
+        "Tupolev was founded by Allan Pinkerton",
+        "Edgar Allan Poe died in the city of Baltimore",
+        "Horace Walpole died in the city of Cambridge",
+        "Ian Marter died in the city of Chicago"
+      ],
+      "latencyMs": 163
+    },
+    {
+      "question": "What is the official language of Helsinki?",
+      "golds": [
+        "Esperanto"
+      ],
+      "topContent": "The official language of Helsinki is Esperanto",
+      "returnedContents": [
+        "The official language of Helsinki is Esperanto",
+        "The official language of Tampere is Esperanto",
+        "The official language of Sweden is German",
+        "The official language of Japan is Swedish",
+        "The official language of Italy is Walloon"
+      ],
+      "latencyMs": 265
+    },
+    {
+      "question": "What is the country of citizenship of Mads Mikkelsen?",
+      "golds": [
+        "Denmark"
+      ],
+      "topContent": "Mads Mikkelsen is a citizen of Denmark",
+      "returnedContents": [
+        "Mads Mikkelsen is a citizen of Denmark",
+        "Carl Jacobsen is a citizen of Denmark",
+        "Meilen Tu is a citizen of Denmark",
+        "Søren Kierkegaard is a citizen of Denmark",
+        "Doseone is a citizen of Norway"
+      ],
+      "latencyMs": 123
+    },
+    {
+      "question": "Who is the developer of iPad Pro?",
+      "golds": [
+        "Google"
+      ],
+      "topContent": "iPad Pro was developed by Google",
+      "returnedContents": [
+        "iPad Pro was developed by Google",
+        "iPad 2 was developed by Apple Inc.",
+        "iPad Mini was developed by Microsoft",
+        "iOS 9 was developed by Apple Inc.",
+        "iOS 9 was developed by NeXT Computer, Inc."
+      ],
+      "latencyMs": 149
+    },
+    {
+      "question": "Who is the author of The Vagina Monologues?",
+      "golds": [
+        "Eve Ensler"
+      ],
+      "topContent": "The author of The Vagina Monologues is Eve Ensler",
+      "returnedContents": [
+        "The author of The Vagina Monologues is Eve Ensler",
+        "Vaginal Davis is a citizen of United States of America",
+        "The author of Heroides is Ovid",
+        "The author of The Trojan Women is Euripides",
+        "The author of Heroides is William Shakespeare"
+      ],
+      "latencyMs": 124
+    },
+    {
+      "question": "Which sport is Montreal Royals associated with?",
+      "golds": [
+        "field hockey"
+      ],
+      "topContent": "Montreal Royals is associated with the sport of field hockey",
+      "returnedContents": [
+        "Montreal Royals is associated with the sport of field hockey",
+        "defender is associated with the sport of baseball",
+        "National Basketball Association is associated with the sport of field hockey",
+        "Rio Ave F.C. is associated with the sport of basketball",
+        "Boston Red Sox is associated with the sport of baseball"
+      ],
+      "latencyMs": 119
+    },
+    {
+      "question": "Where was The Kinks founded?",
+      "golds": [
+        "England"
+      ],
+      "topContent": "The Kinks was founded in the city of England",
+      "returnedContents": [
+        "The Kinks was founded in the city of England",
+        "Wonderwall was performed by The Kinks",
+        "Junkers was founded by David Balfe",
+        "The Beatles was founded in the city of Bonn",
+        "The White Stripes was founded in the city of Detroit"
+      ],
+      "latencyMs": 129
+    },
+    {
+      "question": "What is the country of citizenship of Estelle Getty?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Estelle Getty is a citizen of United States of America",
+      "returnedContents": [
+        "Estelle Getty is a citizen of United States of America",
+        "Betty Ford is a citizen of United States of America",
+        "Trudie Styler is a citizen of Italy",
+        "Elisabeth Moss is a citizen of United States of America",
+        "Ellen Pompeo is a citizen of United States of America"
+      ],
+      "latencyMs": 115
+    }
+  ]
+}

--- a/benchmarks/memoryagentbench/results/cr-sh-6k-vector-granite.json
+++ b/benchmarks/memoryagentbench/results/cr-sh-6k-vector-granite.json
@@ -1,0 +1,1529 @@
+{
+  "instance": "D:\\coding\\knowl\\.claude\\worktrees\\fix+eval-vector-fixture-embeddings\\benchmarks\\memoryagentbench\\data\\cr-sh-6k.json",
+  "timestamp": "2026-08-07T04:33:16.618Z",
+  "retrieval": "vector+bm25",
+  "embedding": {
+    "provider": "local",
+    "model": "onnx-community/granite-embedding-small-english-r2-ONNX",
+    "dtype": "q8",
+    "pooling": "cls"
+  },
+  "supersede": true,
+  "topK": 5,
+  "facts": 455,
+  "conflictGroups": 156,
+  "supersededAtWrite": 149,
+  "activeAfterIngest": 306,
+  "report": {
+    "questions": 100,
+    "answered": 100,
+    "topOneAccuracy": 0.98,
+    "anyRankAccuracy": 1,
+    "staleLeaks": 2,
+    "emptyResults": 0,
+    "p50LatencyMs": 17,
+    "p95LatencyMs": 24
+  },
+  "cases": [
+    {
+      "question": "Which sport is goaltender associated with?",
+      "golds": [
+        "pesäpallo"
+      ],
+      "topContent": "goaltender is associated with the sport of pesäpallo",
+      "returnedContents": [
+        "goaltender is associated with the sport of pesäpallo",
+        "cornerback is associated with the sport of field hockey",
+        "Alta IF is associated with the sport of baseball",
+        "Carlos Gómez is associated with the sport of basketball",
+        "point guard is associated with the sport of cricket"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "What is Nobuhiro Watsuki famous for?",
+      "golds": [
+        "The Fairly OddParents"
+      ],
+      "topContent": "Nobuhiro Watsuki is famous for The Fairly OddParents",
+      "returnedContents": [
+        "Nobuhiro Watsuki is famous for The Fairly OddParents",
+        "Vito Corleone was created by Nobuhiro Watsuki",
+        "midfielder is associated with the sport of sumo",
+        "sumo was created in the country of Japan",
+        "Mario Puzo is famous for The Godfather"
+      ],
+      "latencyMs": 24
+    },
+    {
+      "question": "Which country was rugby union created in?",
+      "golds": [
+        "India"
+      ],
+      "topContent": "rugby union was created in the country of India",
+      "returnedContents": [
+        "rugby union was created in the country of India",
+        "basketball was created in the country of Soviet Union",
+        "Club Nouveau was created in the country of Soviet Union",
+        "cricket was created in the country of Australia",
+        "baseball was created in the country of Japan"
+      ],
+      "latencyMs": 24
+    },
+    {
+      "question": "What is Ferdowsi famous for?",
+      "golds": [
+        "Shahnameh"
+      ],
+      "topContent": "Ferdowsi is famous for Shahnameh",
+      "returnedContents": [
+        "Ferdowsi is famous for Shahnameh",
+        "Rand al'Thor was created by Ferdowsi",
+        "Mario Puzo is famous for The Godfather",
+        "The chairperson of Fatah is Mahmoud Abbas",
+        "The chairperson of Fatah is Moshe Kahlon"
+      ],
+      "latencyMs": 36
+    },
+    {
+      "question": "Which university was Joan Didion educated at?",
+      "golds": [
+        "University of California, Berkeley"
+      ],
+      "topContent": "The univeristy where Joan Didion was educated is University of California, Berkeley",
+      "returnedContents": [
+        "The univeristy where Joan Didion was educated is University of California, Berkeley",
+        "Sophia Hawthorne is married to Joan Didion",
+        "The univeristy where Elena Ceaușescu was educated is University of Bucharest",
+        "The univeristy where Lou Reed was educated is Fordham University",
+        "The univeristy where Galileo Galilei was educated is University of Pisa"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "Who is the author of The Marriage of Figaro?",
+      "golds": [
+        "Thomas Kyd"
+      ],
+      "topContent": "The author of The Marriage of Figaro is Thomas Kyd",
+      "returnedContents": [
+        "The author of The Marriage of Figaro is Thomas Kyd",
+        "The author of Sidereus Nuncius is Samuel Beckett",
+        "The author of The Birth of Tragedy is Stephen Crane",
+        "The author of The Witcher is T. S. Eliot",
+        "The author of Our Mutual Friend is Charles Darwin"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Which sport is Tunisia national football team associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "Tunisia national football team is associated with the sport of basketball",
+      "returnedContents": [
+        "Tunisia national football team is associated with the sport of basketball",
+        "Slovakia national football team is associated with the sport of cricket",
+        "goalkeeper is associated with the sport of association football",
+        "Sandy Alderson is associated with the sport of association football",
+        "FC Irtysh Omsk is associated with the sport of association football"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Which sport is quarterback associated with?",
+      "golds": [
+        "Muay Thai"
+      ],
+      "topContent": "quarterback is associated with the sport of Muay Thai",
+      "returnedContents": [
+        "quarterback is associated with the sport of Muay Thai",
+        "cornerback is associated with the sport of field hockey",
+        "David Beckham is associated with the sport of cricket",
+        "placekicker is associated with the sport of rugby",
+        "wide receiver is associated with the sport of rugby"
+      ],
+      "latencyMs": 20
+    },
+    {
+      "question": "What is the official language of Japan?",
+      "golds": [
+        "Swedish"
+      ],
+      "topContent": "The official language of Japan is Swedish",
+      "returnedContents": [
+        "The official language of Japan is Swedish",
+        "The official language of England is English",
+        "Kūkai speaks the language of Japanese",
+        "The official language of Australia is Arabic",
+        "The official language of Moscow is German"
+      ],
+      "latencyMs": 15
+    },
+    {
+      "question": "What is the name of the current head of the Tucson government?",
+      "golds": [
+        "Jonathan Rothschild"
+      ],
+      "topContent": "The name of the current head of the Tucson government is Jonathan Rothschild",
+      "returnedContents": [
+        "The name of the current head of the Tucson government is Jonathan Rothschild",
+        "The name of the current head of the United States of America government is Donald Trump",
+        "The name of the current head of the Pittsburgh government is Bill Peduto",
+        "The name of the current head of the Italy government is Giuseppe Conte",
+        "The name of the current head of the Japan government is Shinzō Abe"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "What is the name of the current head of the Italy government?",
+      "golds": [
+        "Giuseppe Conte"
+      ],
+      "topContent": "The name of the current head of the Italy government is Giuseppe Conte",
+      "returnedContents": [
+        "The name of the current head of the Italy government is Giuseppe Conte",
+        "The name of the current head of the Japan government is Shinzō Abe",
+        "The name of the current head of the Pittsburgh government is Bill Peduto",
+        "The name of the current head of the Tucson government is Jonathan Rothschild",
+        "The name of the current head of the United States of America government is Donald Trump"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "Who performed Meredith Grey?",
+      "golds": [
+        "Ellen Pompeo"
+      ],
+      "topContent": "Meredith Grey was performed by Ellen Pompeo",
+      "returnedContents": [
+        "Meredith Grey was performed by Ellen Pompeo",
+        "Derek Shepherd is married to Meredith Grey",
+        "Hermione Granger was performed by Kylie Minogue",
+        "Past Masters was performed by Madonna",
+        "Blood on the Tracks was performed by Lou Reed"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "What position does Robert Parish play?",
+      "golds": [
+        "quarterback"
+      ],
+      "topContent": "Robert Parish plays the position of quarterback",
+      "returnedContents": [
+        "Robert Parish plays the position of quarterback",
+        "Blair Walsh plays the position of placekicker",
+        "Hines Ward plays the position of cornerback",
+        "Daniele De Rossi plays the position of midfielder",
+        "Rogério Ceni plays the position of flanker"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What is the country of citizenship of Cédric Klapisch?",
+      "golds": [
+        "Malaysia"
+      ],
+      "topContent": "Cédric Klapisch is a citizen of Malaysia",
+      "returnedContents": [
+        "Cédric Klapisch is a citizen of Malaysia",
+        "Charles the Bold is a citizen of France",
+        "Country Joe McDonald is a citizen of Romania",
+        "Bernard Arnault is a citizen of France",
+        "Sable is a citizen of Czech Republic"
+      ],
+      "latencyMs": 23
+    },
+    {
+      "question": "Who is the author of Sidereus Nuncius?",
+      "golds": [
+        "Samuel Beckett"
+      ],
+      "topContent": "The author of Sidereus Nuncius is Samuel Beckett",
+      "returnedContents": [
+        "The author of Sidereus Nuncius is Samuel Beckett",
+        "The author of The Marriage of Figaro is Thomas Kyd",
+        "The author of Categories is Aristotle",
+        "The author of Endymion is John Keats",
+        "The author of The Witcher is T. S. Eliot"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "Which continent is Germany located in?",
+      "golds": [
+        "Africa"
+      ],
+      "topContent": "Germany is located in the continent of Africa",
+      "returnedContents": [
+        "Germany is located in the continent of Africa",
+        "France is located in the continent of Europe",
+        "Israel is located in the continent of Asia",
+        "England is located in the continent of Europe",
+        "India is located in the continent of Africa"
+      ],
+      "latencyMs": 20
+    },
+    {
+      "question": "Which religion is Kingdom of Ireland affiliated with?",
+      "golds": [
+        "Zoroastrianism"
+      ],
+      "topContent": "Kingdom of Ireland is affiliated with the religion of Zoroastrianism",
+      "returnedContents": [
+        "Kingdom of Ireland is affiliated with the religion of Zoroastrianism",
+        "John Walsh is affiliated with the religion of Methodism",
+        "Karen Armstrong is affiliated with the religion of Church of Scotland",
+        "Edmund Burke is a citizen of Kingdom of Ireland",
+        "Maharishi Mahesh Yogi is affiliated with the religion of Hinduism"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "Which country was association football created in?",
+      "golds": [
+        "Italy"
+      ],
+      "topContent": "association football was created in the country of Italy",
+      "returnedContents": [
+        "association football was created in the country of Italy",
+        "baseball was created in the country of Japan",
+        "basketball was created in the country of Soviet Union",
+        "Club Nouveau was created in the country of Soviet Union",
+        "baseball was created in the country of United States of America"
+      ],
+      "latencyMs": 23
+    },
+    {
+      "question": "Who is the developer of Windows Phone?",
+      "golds": [
+        "Microsoft"
+      ],
+      "topContent": "Windows Phone was developed by Microsoft",
+      "returnedContents": [
+        "Windows Phone was developed by Microsoft",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "AppleScript was developed by Apple Inc.",
+        "SteamOS was developed by ABB Group",
+        "The chief executive officer of Twitter is Bernard Arnault"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Who is the chief executive officer of Microsoft?",
+      "golds": [
+        "Steve Jobs"
+      ],
+      "topContent": "The chief executive officer of Microsoft is Steve Jobs",
+      "returnedContents": [
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "The chief executive officer of Apple Inc. is Vijay Mallya",
+        "The chief executive officer of Boeing is Adel al-Jubeir",
+        "The chief executive officer of Twitter is Bernard Arnault",
+        "The chief executive officer of Lockheed Martin is Marillyn Hewson"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Who is the chairperson of Harvard University?",
+      "golds": [
+        "Peter Diamandis"
+      ],
+      "topContent": "The chairperson of Harvard University is Peter Diamandis",
+      "returnedContents": [
+        "The chairperson of Harvard University is Peter Diamandis",
+        "Joseph Story is employed by Harvard University",
+        "The chairperson of Fatah is Moshe Kahlon",
+        "The chairperson of Fatah is Mahmoud Abbas",
+        "The chairperson of Congolese Party of Labour is Stephen McNeil"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "Who founded Church of Scotland?",
+      "golds": [
+        "John Knox"
+      ],
+      "topContent": "Church of Scotland was founded by John Knox",
+      "returnedContents": [
+        "Church of Scotland was founded by John Knox",
+        "Catholic Church was founded by Jesus Christ",
+        "Karen Armstrong is affiliated with the religion of Church of Scotland",
+        "Christianity was founded in the city of Taipei",
+        "Shingon Buddhism was founded by William Waynflete"
+      ],
+      "latencyMs": 24
+    },
+    {
+      "question": "Which sport is Galwegians RFC associated with?",
+      "golds": [
+        "rugby union"
+      ],
+      "topContent": "Galwegians RFC is associated with the sport of rugby union",
+      "returnedContents": [
+        "Galwegians RFC is associated with the sport of rugby union",
+        "Gala RFC is associated with the sport of rugby union",
+        "wide receiver is associated with the sport of rugby",
+        "placekicker is associated with the sport of rugby",
+        "David Beckham is associated with the sport of cricket"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Who is the director of American Broadcasting Company?",
+      "golds": [
+        "Ernst Heinkel"
+      ],
+      "topContent": "The director of American Broadcasting Company is Ernst Heinkel",
+      "returnedContents": [
+        "The director of American Broadcasting Company is Ernst Heinkel",
+        "The origianl broadcaster of The Brady Bunch is American Broadcasting Company",
+        "The director of British Broadcasting Corporation is Narendra Modi",
+        "The origianl broadcaster of 666 Park Avenue is American Broadcasting Company",
+        "The director of Madonna is Guy Oseary"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Which city did Gennady Rozhdestvensky die in?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Gennady Rozhdestvensky died in the city of United States of America",
+      "returnedContents": [
+        "Gennady Rozhdestvensky died in the city of United States of America",
+        "Olga of Kiev died in the city of Rodez",
+        "Nadezhda Krupskaya died in the city of Moscow",
+        "John Keats died in the city of Leipzig",
+        "Frank Zappa died in the city of Berlin"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "What is the capital of Tang Empire?",
+      "golds": [
+        "Beaumont"
+      ],
+      "topContent": "The capital of Tang Empire is Beaumont",
+      "returnedContents": [
+        "The capital of Tang Empire is Beaumont",
+        "Ernst Heinkel is a citizen of Tang Empire",
+        "The capital of Japan is Tokyo",
+        "The capital of England is London",
+        "The capital of Australia is Oderzo"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who is the director of British Broadcasting Corporation?",
+      "golds": [
+        "Narendra Modi"
+      ],
+      "topContent": "The director of British Broadcasting Corporation is Narendra Modi",
+      "returnedContents": [
+        "The director of British Broadcasting Corporation is Narendra Modi",
+        "Dave Filoni is employed by British Broadcasting Corporation",
+        "The director of American Broadcasting Company is Ernst Heinkel",
+        "The director of The Beatles is Brian Epstein",
+        "The director of Madonna is Narendra Modi"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "What is the country of citizenship of Benjamin Mazar?",
+      "golds": [
+        "Israel"
+      ],
+      "topContent": "Benjamin Mazar is a citizen of Israel",
+      "returnedContents": [
+        "Benjamin Mazar is a citizen of Israel",
+        "Charles Messier is a citizen of Iran",
+        "Madame du Barry is a citizen of Great Britain",
+        "Andrew Carnegie is a citizen of United Kingdom",
+        "Brian Epstein is a citizen of United Kingdom"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "What type of music does Michael Mantler play?",
+      "golds": [
+        "post-punk"
+      ],
+      "topContent": "The type of music that Michael Mantler plays is post-punk",
+      "returnedContents": [
+        "The type of music that Michael Mantler plays is post-punk",
+        "The type of music that Bruce Springsteen plays is rock music",
+        "The type of music that John McVie plays is rap rock",
+        "The type of music that Dale Evans plays is country music",
+        "The type of music that Dana International plays is Australian hip hop"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Which city did Oscar Wilde die in?",
+      "golds": [
+        "Guangzhou"
+      ],
+      "topContent": "Oscar Wilde died in the city of Guangzhou",
+      "returnedContents": [
+        "Oscar Wilde died in the city of Guangzhou",
+        "The author of Lady Windermere's Fan is Oscar Wilde",
+        "Sigmund Freud died in the city of London",
+        "Andy Warhol died in the city of Montmélian",
+        "Frank Zappa died in the city of Berlin"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "Which country was baseball created in?",
+      "golds": [
+        "Japan"
+      ],
+      "topContent": "baseball was created in the country of Japan",
+      "returnedContents": [
+        "baseball was created in the country of Japan",
+        "baseball was created in the country of United States of America",
+        "basketball was created in the country of Soviet Union",
+        "cricket was created in the country of Australia",
+        "association football was created in the country of Italy"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What is the country of citizenship of Ernst Heinkel?",
+      "golds": [
+        "Tang Empire"
+      ],
+      "topContent": "Ernst Heinkel is a citizen of Tang Empire",
+      "returnedContents": [
+        "Ernst Heinkel is a citizen of Tang Empire",
+        "The director of American Broadcasting Company is Ernst Heinkel",
+        "Country Joe McDonald is a citizen of Romania",
+        "Robert A. Heinlein is a citizen of United States of America",
+        "Germany is located in the continent of Africa"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Which city is the headquarter of The University of the Arts located in?",
+      "golds": [
+        "Philadelphia"
+      ],
+      "topContent": "The headquarters of The University of the Arts is located in the city of Philadelphia",
+      "returnedContents": [
+        "The headquarters of The University of the Arts is located in the city of Philadelphia",
+        "The headquarters of University of Bucharest is located in the city of Ankara",
+        "The headquarters of University of California, Berkeley is located in the city of Botevgrad",
+        "The headquarters of University of Minnesota is located in the city of Minneapolis",
+        "The headquarters of Fordham University is located in the city of New York City"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Which country was rap rock created in?",
+      "golds": [
+        "Russian Empire"
+      ],
+      "topContent": "rap rock was created in the country of Russian Empire",
+      "returnedContents": [
+        "rap rock was created in the country of Russian Empire",
+        "country music was created in the country of United States of America",
+        "post-punk was created in the country of Canada",
+        "cricket was created in the country of Australia",
+        "basketball was created in the country of Soviet Union"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Where was Christianity founded?",
+      "golds": [
+        "Taipei"
+      ],
+      "topContent": "Christianity was founded in the city of Taipei",
+      "returnedContents": [
+        "Christianity was founded in the city of Taipei",
+        "Catholic Church was founded by Jesus Christ",
+        "Buddhism was founded by Mekere Morauta",
+        "Methodism was founded by Joseph Goebbels",
+        "Shingon Buddhism was founded by William Waynflete"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "What is the official language of United States of America?",
+      "golds": [
+        "German"
+      ],
+      "topContent": "The official language of United States of America is German",
+      "returnedContents": [
+        "The official language of United States of America is German",
+        "The capital of United States of America is Harrisville",
+        "Sable is a citizen of United States of America",
+        "Henry Ford is a citizen of United States of America",
+        "Tim Cook is a citizen of United States of America"
+      ],
+      "latencyMs": 25
+    },
+    {
+      "question": "Who performed Past Masters?",
+      "golds": [
+        "Madonna"
+      ],
+      "topContent": "Past Masters was performed by Madonna",
+      "returnedContents": [
+        "Past Masters was performed by Madonna",
+        "Back to Black was performed by Frank Zappa",
+        "Free as a Bird was performed by The Beatles",
+        "Hermione Granger was performed by Kylie Minogue",
+        "Viva Las Vegas was performed by Elvis Presley"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "What is the capital of Japan?",
+      "golds": [
+        "Tokyo"
+      ],
+      "topContent": "The capital of Japan is Tokyo",
+      "returnedContents": [
+        "The capital of Japan is Tokyo",
+        "The official language of Japan is Swedish",
+        "The capital of England is London",
+        "The capital of Australia is Oderzo",
+        "The capital of Germany is Berlin"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "What is the capital of France?",
+      "golds": [
+        "Harare"
+      ],
+      "topContent": "The capital of France is Harare",
+      "returnedContents": [
+        "The capital of France is Harare",
+        "France is located in the continent of Europe",
+        "The capital of England is London",
+        "The capital of Great Britain is London",
+        "The capital of Japan is Tokyo"
+      ],
+      "latencyMs": 14
+    },
+    {
+      "question": "Who is the developer of SteamOS?",
+      "golds": [
+        "ABB Group"
+      ],
+      "topContent": "SteamOS was developed by ABB Group",
+      "returnedContents": [
+        "SteamOS was developed by ABB Group",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "Windows Phone was developed by Microsoft",
+        "The chief executive officer of Twitter is Bernard Arnault",
+        "AppleScript was developed by Apple Inc."
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Which city is the headquarter of University of Bucharest located in?",
+      "golds": [
+        "Ankara"
+      ],
+      "topContent": "The headquarters of University of Bucharest is located in the city of Ankara",
+      "returnedContents": [
+        "The headquarters of University of Bucharest is located in the city of Ankara",
+        "The headquarters of University of California, Berkeley is located in the city of Botevgrad",
+        "The headquarters of University of Minnesota is located in the city of Minneapolis",
+        "The headquarters of The University of the Arts is located in the city of Philadelphia",
+        "The headquarters of Fordham University is located in the city of New York City"
+      ],
+      "latencyMs": 26
+    },
+    {
+      "question": "Which sport is wide receiver associated with?",
+      "golds": [
+        "rugby"
+      ],
+      "topContent": "wide receiver is associated with the sport of rugby",
+      "returnedContents": [
+        "wide receiver is associated with the sport of rugby",
+        "Irving Fryar plays the position of wide receiver",
+        "cornerback is associated with the sport of field hockey",
+        "placekicker is associated with the sport of rugby",
+        "Alta IF is associated with the sport of baseball"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "What position does Hines Ward play?",
+      "golds": [
+        "cornerback"
+      ],
+      "topContent": "Hines Ward plays the position of cornerback",
+      "returnedContents": [
+        "Hines Ward plays the position of cornerback",
+        "Blair Walsh plays the position of placekicker",
+        "Robert Parish plays the position of quarterback",
+        "Irving Fryar plays the position of wide receiver",
+        "Rogério Ceni plays the position of flanker"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "What is the capital of Australia?",
+      "golds": [
+        "Oderzo"
+      ],
+      "topContent": "The capital of Australia is Oderzo",
+      "returnedContents": [
+        "The capital of Australia is Oderzo",
+        "Australia is located in the continent of South America",
+        "The official language of Australia is Arabic",
+        "The capital of England is London",
+        "The capital of Great Britain is London"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Which continent is Malaysia located in?",
+      "golds": [
+        "Antarctica"
+      ],
+      "topContent": "Malaysia is located in the continent of Antarctica",
+      "returnedContents": [
+        "Malaysia is located in the continent of Antarctica",
+        "Canada is located in the continent of Asia",
+        "Australia is located in the continent of South America",
+        "Israel is located in the continent of Asia",
+        "Germany is located in the continent of Africa"
+      ],
+      "latencyMs": 14
+    },
+    {
+      "question": "Who is the author of A Wizard of Earthsea?",
+      "golds": [
+        "Pius XII"
+      ],
+      "topContent": "The author of A Wizard of Earthsea is Pius XII",
+      "returnedContents": [
+        "The author of A Wizard of Earthsea is Pius XII",
+        "The author of The Witcher is T. S. Eliot",
+        "The author of Lady Windermere's Fan is Oscar Wilde",
+        "The author of The Birth of Tragedy is Stephen Crane",
+        "The author of Categories is Aristotle"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Who performed Free as a Bird?",
+      "golds": [
+        "The Beatles"
+      ],
+      "topContent": "Free as a Bird was performed by The Beatles",
+      "returnedContents": [
+        "Free as a Bird was performed by The Beatles",
+        "Past Masters was performed by Madonna",
+        "Born in the U.S.A. was performed by Dana International",
+        "Back to Black was performed by Frank Zappa",
+        "Born in the U.S.A. was performed by Bruce Springsteen"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who is the author of Our Mutual Friend?",
+      "golds": [
+        "Charles Darwin"
+      ],
+      "topContent": "The author of Our Mutual Friend is Charles Darwin",
+      "returnedContents": [
+        "The author of Our Mutual Friend is Charles Darwin",
+        "The author of Sketches by Boz is Sigmund Freud",
+        "The author of The Witcher is T. S. Eliot",
+        "The author of The Birth of Tragedy is Stephen Crane",
+        "The author of The Marriage of Figaro is Thomas Kyd"
+      ],
+      "latencyMs": 28
+    },
+    {
+      "question": "Which country was basketball created in?",
+      "golds": [
+        "Soviet Union"
+      ],
+      "topContent": "basketball was created in the country of Soviet Union",
+      "returnedContents": [
+        "basketball was created in the country of Soviet Union",
+        "baseball was created in the country of Japan",
+        "baseball was created in the country of United States of America",
+        "cricket was created in the country of Australia",
+        "association football was created in the country of Italy"
+      ],
+      "latencyMs": 15
+    },
+    {
+      "question": "What is the country of citizenship of Hal Needham?",
+      "golds": [
+        "United States of America"
+      ],
+      "topContent": "Hal Needham is a citizen of United States of America",
+      "returnedContents": [
+        "Hal Needham is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania",
+        "Elton John is a citizen of United Kingdom",
+        "Gabe Newell is a citizen of United States of America",
+        "Colin Irwin is a citizen of Israel"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Which continent is Bengaluru located in?",
+      "golds": [
+        "Oceania"
+      ],
+      "topContent": "Bengaluru is located in the continent of Oceania",
+      "returnedContents": [
+        "Bengaluru is located in the continent of Oceania",
+        "India is located in the continent of Africa",
+        "Australia is located in the continent of South America",
+        "Germany is located in the continent of Africa",
+        "Malaysia is located in the continent of Antarctica"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Which sport is Slovakia national football team associated with?",
+      "golds": [
+        "cricket"
+      ],
+      "topContent": "Slovakia national football team is associated with the sport of cricket",
+      "returnedContents": [
+        "Slovakia national football team is associated with the sport of cricket",
+        "Tunisia national football team is associated with the sport of basketball",
+        "goalkeeper is associated with the sport of association football",
+        "Steve Sax is associated with the sport of association football",
+        "FC Irtysh Omsk is associated with the sport of association football"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "What is the name of the current head of state in United States of America?",
+      "golds": [
+        "Connachta"
+      ],
+      "topContent": "The name of the current head of state in United States of America is Connachta",
+      "returnedContents": [
+        "The name of the current head of state in United States of America is Connachta",
+        "The name of the current head of the United States of America government is Donald Trump",
+        "The name of the current head of state in United Kingdom is Emmerson Mnangagwa",
+        "The name of the current head of state in Soviet Union is Elizabeth II",
+        "The official language of United States of America is German"
+      ],
+      "latencyMs": 23
+    },
+    {
+      "question": "Which religion is Imelda Marcos affiliated with?",
+      "golds": [
+        "atheism"
+      ],
+      "topContent": "Imelda Marcos is affiliated with the religion of atheism",
+      "returnedContents": [
+        "Imelda Marcos is affiliated with the religion of atheism",
+        "Ferdinand Marcos is married to Imelda Marcos",
+        "Iman is affiliated with the religion of Islam",
+        "Sarit Thanarat is affiliated with the religion of Buddhism",
+        "Natalie Portman is affiliated with the religion of interdenominational organization"
+      ],
+      "latencyMs": 15
+    },
+    {
+      "question": "What type of music does Dana International play?",
+      "golds": [
+        "Australian hip hop"
+      ],
+      "topContent": "The type of music that Dana International plays is Australian hip hop",
+      "returnedContents": [
+        "The type of music that Dana International plays is Australian hip hop",
+        "Born in the U.S.A. was performed by Dana International",
+        "The type of music that Bruce Springsteen plays is rock music",
+        "The type of music that Dale Evans plays is country music",
+        "The type of music that Michael Mantler plays is post-punk"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What is the country of citizenship of Sable?",
+      "golds": [
+        "Czech Republic"
+      ],
+      "topContent": "Sable is a citizen of Czech Republic",
+      "returnedContents": [
+        "Sable is a citizen of Czech Republic",
+        "Sable is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania",
+        "Tim Cook is a citizen of United States of America",
+        "Edmund Burke is a citizen of Kingdom of Ireland"
+      ],
+      "latencyMs": 20
+    },
+    {
+      "question": "Which country was Charlie Hebdo created in?",
+      "golds": [
+        "Italy"
+      ],
+      "topContent": "Charlie Hebdo was created in the country of Italy",
+      "returnedContents": [
+        "Charlie Hebdo was created in the country of Italy",
+        "Stephen Crane is famous for Charlie Hebdo",
+        "Le Petit Parisien was created in the country of Germany",
+        "basketball was created in the country of Soviet Union",
+        "rap rock was created in the country of Russian Empire"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who is Elvis Presley married to?",
+      "golds": [
+        "Charles the Bold"
+      ],
+      "topContent": "Elvis Presley is married to Charles the Bold",
+      "returnedContents": [
+        "Elvis Presley is married to Charles the Bold",
+        "Viva Las Vegas was performed by Elvis Presley",
+        "Priscilla Presley is a citizen of United States of America",
+        "Yves Montand is married to Natalie Portman",
+        "Laura Bush is married to George W. Bush"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who performed Hermione Granger?",
+      "golds": [
+        "Kylie Minogue"
+      ],
+      "topContent": "Hermione Granger was performed by Kylie Minogue",
+      "returnedContents": [
+        "Hermione Granger was performed by Kylie Minogue",
+        "Past Masters was performed by Madonna",
+        "Meredith Grey was performed by Ellen Pompeo",
+        "Aladdin Sane was performed by Yves Montand",
+        "Blood on the Tracks was performed by Lou Reed"
+      ],
+      "latencyMs": 13
+    },
+    {
+      "question": "Which sport is Bo Ryan associated with?",
+      "golds": [
+        "association football"
+      ],
+      "topContent": "Bo Ryan is associated with the sport of association football",
+      "returnedContents": [
+        "Bo Ryan is associated with the sport of association football",
+        "New Firm is associated with the sport of baseball",
+        "David Beckham is associated with the sport of cricket",
+        "cornerback is associated with the sport of field hockey",
+        "Darryl Strawberry is associated with the sport of baseball"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What type of music does John McVie play?",
+      "golds": [
+        "rap rock"
+      ],
+      "topContent": "The type of music that John McVie plays is rap rock",
+      "returnedContents": [
+        "The type of music that John McVie plays is rap rock",
+        "The type of music that Bruce Springsteen plays is rock music",
+        "The type of music that Michael Mantler plays is post-punk",
+        "The type of music that Dale Evans plays is country music",
+        "Roy Rogers is married to John McVie"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What position does Rogério Ceni play?",
+      "golds": [
+        "flanker"
+      ],
+      "topContent": "Rogério Ceni plays the position of flanker",
+      "returnedContents": [
+        "Rogério Ceni plays the position of flanker",
+        "Daniele De Rossi plays the position of midfielder",
+        "Irving Fryar plays the position of wide receiver",
+        "goalkeeper is associated with the sport of association football",
+        "Hines Ward plays the position of cornerback"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "Who is the chief executive officer of Twitter?",
+      "golds": [
+        "Bernard Arnault"
+      ],
+      "topContent": "The chief executive officer of Twitter is Bernard Arnault",
+      "returnedContents": [
+        "The chief executive officer of Twitter is Bernard Arnault",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "The chief executive officer of Apple Inc. is Vijay Mallya",
+        "The chief executive officer of Boeing is Adel al-Jubeir",
+        "The chief executive officer of Lockheed Martin is Marillyn Hewson"
+      ],
+      "latencyMs": 14
+    },
+    {
+      "question": "What language does Kylie Minogue speak?",
+      "golds": [
+        "German"
+      ],
+      "topContent": "Kylie Minogue speaks the language of German",
+      "returnedContents": [
+        "Kylie Minogue speaks the language of German",
+        "Hermione Granger was performed by Kylie Minogue",
+        "Emma Watson speaks the language of English",
+        "Kūkai speaks the language of Japanese",
+        "T. S. Eliot speaks the language of French"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Which sport is Darryl Strawberry associated with?",
+      "golds": [
+        "baseball"
+      ],
+      "topContent": "Darryl Strawberry is associated with the sport of baseball",
+      "returnedContents": [
+        "Darryl Strawberry is associated with the sport of baseball",
+        "cornerback is associated with the sport of field hockey",
+        "placekicker is associated with the sport of rugby",
+        "David Beckham is associated with the sport of cricket",
+        "New Firm is associated with the sport of baseball"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Which sport is placekicker associated with?",
+      "golds": [
+        "rugby"
+      ],
+      "topContent": "placekicker is associated with the sport of rugby",
+      "returnedContents": [
+        "placekicker is associated with the sport of rugby",
+        "Blair Walsh plays the position of placekicker",
+        "cornerback is associated with the sport of field hockey",
+        "wide receiver is associated with the sport of rugby",
+        "center is associated with the sport of basketball"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "What kind of work does Stephen McNeil do?",
+      "golds": [
+        "journalist"
+      ],
+      "topContent": "Stephen McNeil works in the field of journalist",
+      "returnedContents": [
+        "Stephen McNeil works in the field of journalist",
+        "The chairperson of Congolese Party of Labour is Stephen McNeil",
+        "Stephen Crane is famous for Charlie Hebdo",
+        "Stefan Löfven worked in the city of Stockholm",
+        "Steve Jobs was born in the city of San Francisco"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Who is the employer of Dave Filoni?",
+      "golds": [
+        "British Broadcasting Corporation"
+      ],
+      "topContent": "Dave Filoni is employed by British Broadcasting Corporation",
+      "returnedContents": [
+        "Dave Filoni is employed by British Broadcasting Corporation",
+        "The company that produced Ford F-Series is Ford Motor Company",
+        "David Bowie is married to Iman",
+        "The chief executive officer of Microsoft is Steve Jobs",
+        "The chief executive officer of Valve Corporation is Gabe Newell"
+      ],
+      "latencyMs": 15
+    },
+    {
+      "question": "Which continent is San Francisco located in?",
+      "golds": [
+        "North America"
+      ],
+      "topContent": "San Francisco is located in the continent of North America",
+      "returnedContents": [
+        "San Francisco is located in the continent of North America",
+        "Steve Jobs was born in the city of San Francisco",
+        "Israel is located in the continent of North America",
+        "Australia is located in the continent of South America",
+        "France is located in the continent of Europe"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Where was Canadair founded?",
+      "golds": [
+        "Tucson"
+      ],
+      "topContent": "Canadair was founded in the city of Tucson",
+      "returnedContents": [
+        "Canadair was founded in the city of Tucson",
+        "Ford Motor Company was founded by Henri Grégoire",
+        "The company that produced AP1000 is Canadair",
+        "Chanel was founded by Andy Warhol",
+        "Philadelphia was founded by William Penn"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Which company is AP1000 produced by?",
+      "golds": [
+        "Canadair"
+      ],
+      "topContent": "The company that produced AP1000 is Canadair",
+      "returnedContents": [
+        "The company that produced AP1000 is Canadair",
+        "The company that produced Ford F-Series is Ford Motor Company",
+        "The company that produced Ford Transit Connect is Ford Motor Company",
+        "The company that produced Il-2 Shturmovik is Ilyushin",
+        "SteamOS was developed by ABB Group"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "What is the country of citizenship of Ayumi Hamasaki?",
+      "golds": [
+        "Japan"
+      ],
+      "topContent": "Ayumi Hamasaki is a citizen of Japan",
+      "returnedContents": [
+        "Ayumi Hamasaki is a citizen of Japan",
+        "Rocket Man was performed by Ayumi Hamasaki",
+        "baseball was created in the country of Japan",
+        "Ellen Pompeo is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "What position does Blair Walsh play?",
+      "golds": [
+        "placekicker"
+      ],
+      "topContent": "Blair Walsh plays the position of placekicker",
+      "returnedContents": [
+        "Blair Walsh plays the position of placekicker",
+        "Hines Ward plays the position of cornerback",
+        "Robert Parish plays the position of quarterback",
+        "Lisa Leslie plays the position of goaltender",
+        "Mike D'Antoni plays the position of point guard"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who is Tony Blair married to?",
+      "golds": [
+        "Alan Jay Lerner"
+      ],
+      "topContent": "Tony Blair is married to Cherie Blair",
+      "returnedContents": [
+        "Tony Blair is married to Cherie Blair",
+        "Tony Blair is married to Alan Jay Lerner",
+        "The name of the current head of the Council of People's Commissars government is Tony Blair",
+        "Victoria Beckham is married to David Beckham",
+        "Laura Bush is married to George W. Bush"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "Who is the author of Endymion?",
+      "golds": [
+        "John Keats"
+      ],
+      "topContent": "The author of Endymion is John Keats",
+      "returnedContents": [
+        "The author of Endymion is John Keats",
+        "The author of The Marriage of Figaro is Thomas Kyd",
+        "The author of Sidereus Nuncius is Samuel Beckett",
+        "The author of The Witcher is T. S. Eliot",
+        "The author of The Birth of Tragedy is Stephen Crane"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who is the author of Lady Windermere's Fan?",
+      "golds": [
+        "Oscar Wilde"
+      ],
+      "topContent": "The author of Lady Windermere's Fan is Oscar Wilde",
+      "returnedContents": [
+        "The author of Lady Windermere's Fan is Oscar Wilde",
+        "The author of The Witcher is T. S. Eliot",
+        "The author of A Wizard of Earthsea is Pius XII",
+        "The author of Endymion is John Keats",
+        "The author of The Marriage of Figaro is Thomas Kyd"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "What is the name of the current head of the Japan government?",
+      "golds": [
+        "Shinzō Abe"
+      ],
+      "topContent": "The name of the current head of the Japan government is Shinzō Abe",
+      "returnedContents": [
+        "The name of the current head of the Japan government is Shinzō Abe",
+        "The name of the current head of the Italy government is Giuseppe Conte",
+        "The name of the current head of the Tucson government is Jonathan Rothschild",
+        "The name of the current head of the United States of America government is Donald Trump",
+        "The name of the current head of the Council of People's Commissars government is Tony Blair"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Who is the chairperson of Congolese Party of Labour?",
+      "golds": [
+        "Stephen McNeil"
+      ],
+      "topContent": "The chairperson of Congolese Party of Labour is Stephen McNeil",
+      "returnedContents": [
+        "The chairperson of Congolese Party of Labour is Stephen McNeil",
+        "The chairperson of Fatah is Moshe Kahlon",
+        "Denis Sassou-Nguesso works in the field of politician",
+        "The name of the current head of the Council of People's Commissars government is Tony Blair",
+        "The chairperson of Fatah is Mahmoud Abbas"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Which sport is flanker associated with?",
+      "golds": [
+        "rugby union"
+      ],
+      "topContent": "flanker is associated with the sport of rugby union",
+      "returnedContents": [
+        "flanker is associated with the sport of rugby union",
+        "cornerback is associated with the sport of field hockey",
+        "placekicker is associated with the sport of rugby",
+        "point guard is associated with the sport of cricket",
+        "midfielder is associated with the sport of sumo"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What is the capital of Czech Republic?",
+      "golds": [
+        "Prague"
+      ],
+      "topContent": "The capital of Czech Republic is Prague",
+      "returnedContents": [
+        "The capital of Czech Republic is Prague",
+        "Sable is a citizen of Czech Republic",
+        "The capital of Germany is Berlin",
+        "The capital of Romania is Rajanpur",
+        "The capital of France is Harare"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What position does Lisa Leslie play?",
+      "golds": [
+        "goaltender"
+      ],
+      "topContent": "Lisa Leslie plays the position of goaltender",
+      "returnedContents": [
+        "Lisa Leslie plays the position of goaltender",
+        "Blair Walsh plays the position of placekicker",
+        "Daniele De Rossi plays the position of midfielder",
+        "Robert Parish plays the position of quarterback",
+        "Hines Ward plays the position of cornerback"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "What is the name of the current head of state in Soviet Union?",
+      "golds": [
+        "Elizabeth II"
+      ],
+      "topContent": "The name of the current head of state in Soviet Union is Elizabeth II",
+      "returnedContents": [
+        "The name of the current head of state in Soviet Union is Elizabeth II",
+        "The name of the current head of state in United States of America is Connachta",
+        "The name of the current head of state in United Kingdom is Emmerson Mnangagwa",
+        "The name of the current head of the United States of America government is Donald Trump",
+        "The name of the current head of the Italy government is Giuseppe Conte"
+      ],
+      "latencyMs": 21
+    },
+    {
+      "question": "What is the country of citizenship of Ferdinand von Richthofen?",
+      "golds": [
+        "Canada"
+      ],
+      "topContent": "Ferdinand von Richthofen is a citizen of Canada",
+      "returnedContents": [
+        "Ferdinand von Richthofen is a citizen of Canada",
+        "Charles the Bold is a citizen of France",
+        "Ernst Heinkel is a citizen of Tang Empire",
+        "Country Joe McDonald is a citizen of Romania",
+        "Bernard Arnault is a citizen of France"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "Which religion is Karen Armstrong affiliated with?",
+      "golds": [
+        "Church of Scotland"
+      ],
+      "topContent": "Karen Armstrong is affiliated with the religion of Church of Scotland",
+      "returnedContents": [
+        "Karen Armstrong is affiliated with the religion of Church of Scotland",
+        "Natalie Portman is affiliated with the religion of interdenominational organization",
+        "Princess Alice, Duchess of Gloucester is affiliated with the religion of Anglicanism",
+        "Kingdom of Ireland is affiliated with the religion of Zoroastrianism",
+        "Iman is affiliated with the religion of Islam"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Who was Vito Corleone created by?",
+      "golds": [
+        "Nobuhiro Watsuki"
+      ],
+      "topContent": "Vito Corleone was created by Nobuhiro Watsuki",
+      "returnedContents": [
+        "Vito Corleone was created by Nobuhiro Watsuki",
+        "Charlie Hebdo was created in the country of Italy",
+        "association football was created in the country of Italy",
+        "Mario Puzo is famous for The Godfather",
+        "Le Petit Parisien was created in the country of Germany"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What is the capital of Romania?",
+      "golds": [
+        "Rajanpur"
+      ],
+      "topContent": "The capital of Romania is Rajanpur",
+      "returnedContents": [
+        "The capital of Romania is Rajanpur",
+        "The capital of France is Harare",
+        "The capital of Papal States is Rome",
+        "The capital of Soviet Union is Russellville",
+        "The capital of Australia is Oderzo"
+      ],
+      "latencyMs": 14
+    },
+    {
+      "question": "Which continent is India located in?",
+      "golds": [
+        "Africa"
+      ],
+      "topContent": "India is located in the continent of Africa",
+      "returnedContents": [
+        "India is located in the continent of Africa",
+        "Canada is located in the continent of Asia",
+        "Australia is located in the continent of South America",
+        "Germany is located in the continent of Africa",
+        "Israel is located in the continent of Asia"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Which city did Olga of Kiev die in?",
+      "golds": [
+        "Rodez"
+      ],
+      "topContent": "Olga of Kiev died in the city of Rodez",
+      "returnedContents": [
+        "Olga of Kiev died in the city of Rodez",
+        "Igor of Kiev is married to Olga of Kiev",
+        "Nadezhda Krupskaya died in the city of Moscow",
+        "Gennady Rozhdestvensky died in the city of United States of America",
+        "Sigmund Freud died in the city of London"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "Who founded Sasanian Empire?",
+      "golds": [
+        "Walter Chrysler"
+      ],
+      "topContent": "Sasanian Empire was founded by Walter Chrysler",
+      "returnedContents": [
+        "Sasanian Empire was founded by Walter Chrysler",
+        "The capital of Tang Empire is Beaumont",
+        "Buddhism was founded by Mekere Morauta",
+        "Shahnameh was written in the language of Persian",
+        "Shingon Buddhism was founded by William Waynflete"
+      ],
+      "latencyMs": 25
+    },
+    {
+      "question": "Which city did Pedro Pierluisi work in?",
+      "golds": [
+        "Washington, D.C."
+      ],
+      "topContent": "Pedro Pierluisi worked in the city of Washington, D.C.",
+      "returnedContents": [
+        "Pedro Pierluisi worked in the city of Washington, D.C.",
+        "The Prime Minister of Sweden is Pedro Pierluisi",
+        "Jesus Christ worked in the city of Galilee",
+        "Joseph Goebbels worked in the city of Berlin",
+        "Andy Warhol died in the city of Montmélian"
+      ],
+      "latencyMs": 15
+    },
+    {
+      "question": "Which sport is Surrey Senior Cup associated with?",
+      "golds": [
+        "basketball"
+      ],
+      "topContent": "Surrey Senior Cup is associated with the sport of basketball",
+      "returnedContents": [
+        "Surrey Senior Cup is associated with the sport of basketball",
+        "David Beckham is associated with the sport of cricket",
+        "point guard is associated with the sport of cricket",
+        "Steve Sax is associated with the sport of association football",
+        "cornerback is associated with the sport of field hockey"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "What is the country of citizenship of Narendra Modi?",
+      "golds": [
+        "Australia"
+      ],
+      "topContent": "Narendra Modi is a citizen of Australia",
+      "returnedContents": [
+        "Narendra Modi is a citizen of Australia",
+        "The director of Madonna is Narendra Modi",
+        "The director of British Broadcasting Corporation is Narendra Modi",
+        "Country Joe McDonald is a citizen of Romania",
+        "Vijay Mallya is a citizen of Papal States"
+      ],
+      "latencyMs": 24
+    },
+    {
+      "question": "Who is Victoria Beckham married to?",
+      "golds": [
+        "David Beckham"
+      ],
+      "topContent": "Victoria Beckham is married to David Beckham",
+      "returnedContents": [
+        "Victoria Beckham is married to David Beckham",
+        "David Beckham is associated with the sport of cricket",
+        "David Bowie is married to Iman",
+        "Charles Dickens is married to Catherine Dickens",
+        "Elvis Presley is married to Charles the Bold"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What is the country of citizenship of Charles Messier?",
+      "golds": [
+        "Iran"
+      ],
+      "topContent": "Charles Messier is a citizen of Iran",
+      "returnedContents": [
+        "Charles Messier is a citizen of Iran",
+        "Charles the Bold is a citizen of France",
+        "Country Joe McDonald is a citizen of Romania",
+        "Walter Chrysler's child is Charles Frederick, Duke of Holstein-Gottorp",
+        "Madame du Barry is a citizen of Great Britain"
+      ],
+      "latencyMs": 18
+    },
+    {
+      "question": "Who was Rand al'Thor created by?",
+      "golds": [
+        "Ferdowsi"
+      ],
+      "topContent": "Rand al'Thor was created by Ferdowsi",
+      "returnedContents": [
+        "Rand al'Thor was created by Ferdowsi",
+        "rap rock was created in the country of Russian Empire",
+        "Charlie Hebdo was created in the country of Italy",
+        "Philadelphia was founded by William Penn",
+        "baseball was created in the country of United States of America"
+      ],
+      "latencyMs": 16
+    },
+    {
+      "question": "What position does Mike D'Antoni play?",
+      "golds": [
+        "point guard"
+      ],
+      "topContent": "Mike D'Antoni plays the position of point guard",
+      "returnedContents": [
+        "Mike D'Antoni plays the position of point guard",
+        "Daniele De Rossi plays the position of midfielder",
+        "Hines Ward plays the position of cornerback",
+        "Robert Parish plays the position of quarterback",
+        "Rogério Ceni plays the position of flanker"
+      ],
+      "latencyMs": 19
+    },
+    {
+      "question": "What is the country of citizenship of Colin Irwin?",
+      "golds": [
+        "Israel"
+      ],
+      "topContent": "Colin Irwin is a citizen of Israel",
+      "returnedContents": [
+        "Colin Irwin is a citizen of Israel",
+        "Bob Iger is a citizen of United States of America",
+        "Country Joe McDonald is a citizen of Romania",
+        "Elton John is a citizen of United Kingdom",
+        "Andrew Carnegie is a citizen of United Kingdom"
+      ],
+      "latencyMs": 17
+    },
+    {
+      "question": "Who is Walter Chrysler's child?",
+      "golds": [
+        "Charles Frederick, Duke of Holstein-Gottorp"
+      ],
+      "topContent": "Walter Chrysler's child is Walter Percy Chrysler Jr.",
+      "returnedContents": [
+        "Walter Chrysler's child is Walter Percy Chrysler Jr.",
+        "Walter Chrysler's child is Charles Frederick, Duke of Holstein-Gottorp",
+        "Sasanian Empire was founded by Walter Chrysler",
+        "Aristotle's child is George Alexander Kohut",
+        "Ardashir I's child is Shapur I"
+      ],
+      "latencyMs": 22
+    },
+    {
+      "question": "Who is Charles Darwin married to?",
+      "golds": [
+        "Amala Paul"
+      ],
+      "topContent": "Charles Darwin is married to Amala Paul",
+      "returnedContents": [
+        "Charles Darwin is married to Amala Paul",
+        "Charles Dickens is married to Catherine Dickens",
+        "The author of Our Mutual Friend is Charles Darwin",
+        "Elvis Presley is married to Charles the Bold",
+        "Laura Bush is married to George W. Bush"
+      ],
+      "latencyMs": 23
+    },
+    {
+      "question": "What position does Irving Fryar play?",
+      "golds": [
+        "wide receiver"
+      ],
+      "topContent": "Irving Fryar plays the position of wide receiver",
+      "returnedContents": [
+        "Irving Fryar plays the position of wide receiver",
+        "Robert Parish plays the position of quarterback",
+        "Blair Walsh plays the position of placekicker",
+        "Hines Ward plays the position of cornerback",
+        "Daniele De Rossi plays the position of midfielder"
+      ],
+      "latencyMs": 17
+    }
+  ]
+}

--- a/benchmarks/memoryagentbench/runner.ts
+++ b/benchmarks/memoryagentbench/runner.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { loadConfig } from '../../src/core/config.js';
+import { resolveVectorProfile, type VectorProfile } from '../../src/core/vector-profile.js';
 import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../../src/ai/embeddings.js';
 import { closeDb, initDb } from '../../src/store/database.js';
 import * as repo from '../../src/store/repository.js';
@@ -38,6 +39,15 @@ export type CrRunResult = {
   instance: string;
   timestamp: string;
   retrieval: 'vector+bm25' | 'bm25';
+  /**
+   * The embedding profile the vector arm actually ran on, or null for a bm25-only run.
+   *
+   * Recorded because a result was otherwise distinguishable only by `timestamp`: the default
+   * preset moved from minilm-l6-en to granite-small-en-r2 on 2026-08-02, which shifted cr-sh-6k
+   * top-1 from 96% to 98%, and the checked-in 32k/64k runs predate it. Subtracting one preset's
+   * number from another's is exactly the mistake this file's README warns about for filenames.
+   */
+  embedding: VectorProfile | null;
   supersede: boolean;
   topK: number;
   facts: number;
@@ -72,11 +82,13 @@ export async function runConflictResolution(options: CrRunOptions): Promise<CrRu
   const superseded = buildSupersededValues(facts);
 
   let embedder: Awaited<ReturnType<typeof createLocalEmbeddingProvider>> | null = null;
+  let embedding: VectorProfile | null = null;
   if (options.vector) {
     const config = await loadConfig(options.projectRoot);
     if (!isVectorSearchEnabled(config)) {
       throw new Error('Vector search is not enabled. Set search.vector.enabled true, or pass --no-vector.');
     }
+    embedding = resolveVectorProfile(config);
     embedder = await createLocalEmbeddingProvider(config, options.projectRoot);
   }
 
@@ -155,6 +167,7 @@ export async function runConflictResolution(options: CrRunOptions): Promise<CrRu
       instance: options.instancePath,
       timestamp: new Date().toISOString(),
       retrieval: options.vector ? 'vector+bm25' : 'bm25',
+      embedding,
       supersede: options.supersede,
       topK: options.topK,
       facts: facts.length,

--- a/docs/assets/benchmark-governance.svg
+++ b/docs/assets/benchmark-governance.svg
@@ -1,6 +1,6 @@
 <svg width="760" height="228" viewBox="0 0 760 228" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-labelledby="governance-title governance-desc">
   <title id="governance-title">Internal governance retrieval benchmark</title>
-  <desc id="governance-desc">Across 44 top-three cases, mean reciprocal rank was 98.9 percent. Stale active decisions appeared 28 times and caused 22 stale-trap failures. Rejected decisions appeared zero times.</desc>
+  <desc id="governance-desc">Across 44 top-three cases, mean reciprocal rank was 100 percent. Stale active decisions appeared 27 times and caused 21 stale-trap failures. Rejected decisions appeared zero times.</desc>
 
   <rect x="1" y="1" width="758" height="226" rx="16" fill="#161b22" stroke="#2c313a" stroke-width="1.5"/>
 
@@ -14,13 +14,13 @@
   </g>
 
   <g text-anchor="middle">
-    <text x="138" y="142" font-size="40" font-weight="800" fill="#3987e5">98.9<tspan font-size="20" font-weight="700" fill="#7cb0f5">%</tspan></text>
+    <text x="138" y="142" font-size="40" font-weight="800" fill="#3987e5">100<tspan font-size="20" font-weight="700" fill="#7cb0f5">%</tspan></text>
     <text x="138" y="169" font-size="13" font-weight="600" fill="#c3c2b7">mean reciprocal rank</text>
-    <text x="138" y="188" font-size="12" fill="#898781">not a top-1 percentage</text>
+    <text x="138" y="188" font-size="12" fill="#898781">expected decision ranked first</text>
 
-    <text x="380" y="142" font-size="40" font-weight="800" fill="#eda100">28</text>
+    <text x="380" y="142" font-size="40" font-weight="800" fill="#eda100">27</text>
     <text x="380" y="169" font-size="13" font-weight="600" fill="#c3c2b7">stale-active returns</text>
-    <text x="380" y="188" font-size="12" fill="#898781">22 stale-trap failures</text>
+    <text x="380" y="188" font-size="12" fill="#898781">21 stale-trap failures</text>
 
     <text x="621.5" y="142" font-size="40" font-weight="800" fill="#0ca30c">0</text>
     <text x="621.5" y="169" font-size="13" font-weight="600" fill="#c3c2b7">rejected items returned</text>

--- a/docs/assets/benchmark-retrieval-quality.svg
+++ b/docs/assets/benchmark-retrieval-quality.svg
@@ -1,4 +1,4 @@
-<svg width="760" height="392" viewBox="0 0 760 392" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-label="Retrieval quality on the 500-case suite with vector+BM25 fusion: Recall@3 98.8%, Recall@10 100%, MRR 95.3%, nDCG 96.4%">
+<svg width="760" height="392" viewBox="0 0 760 392" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-label="Retrieval quality on the 500-case suite with vector+BM25 fusion: Recall@3 98.6%, Recall@10 99.8%, MRR 95.2%, nDCG 96.4%">
   <rect x="1" y="1" width="758" height="390" rx="16" fill="#161b22" stroke="#2c313a" stroke-width="1.5"/>
 
   <text x="28" y="42" font-size="21" font-weight="700" fill="#ffffff">Retrieval quality</text>
@@ -25,17 +25,23 @@
     <text x="146" y="230">MRR</text>
     <text x="146" y="284">nDCG</text>
   </g>
+  <!--
+    Bar width is the value: the axis puts 0% at x=160 and 100% at x=660, so 5px per point.
+    Change a label and the width with it. These four decoded to 98.9 / 99.4 / 96.1 / 96.9 while
+    their labels read 98.8 / 100 / 95.3 / 96.4, because two rounds of label edits left the
+    geometry on the original minilm-era figures.
+  -->
   <g>
-    <rect x="160" y="104" width="494.5" height="24" rx="6" fill="#3987e5"/>
-    <rect x="160" y="158" width="497" height="24" rx="6" fill="#3987e5"/>
-    <rect x="160" y="212" width="480.5" height="24" rx="6" fill="#3987e5"/>
-    <rect x="160" y="266" width="484.5" height="24" rx="6" fill="#3987e5"/>
+    <rect x="160" y="104" width="493" height="24" rx="6" fill="#3987e5"/>
+    <rect x="160" y="158" width="499" height="24" rx="6" fill="#3987e5"/>
+    <rect x="160" y="212" width="476" height="24" rx="6" fill="#3987e5"/>
+    <rect x="160" y="266" width="481.8" height="24" rx="6" fill="#3987e5"/>
   </g>
   <g font-size="14" font-weight="700" fill="#ffffff" text-anchor="start">
-    <text x="666.5" y="122">98.8%</text>
-    <text x="669" y="176">100%</text>
-    <text x="652.5" y="230">95.3%</text>
-    <text x="656.5" y="284">96.4%</text>
+    <text x="659.5" y="122">98.6%</text>
+    <text x="665.5" y="176">99.8%</text>
+    <text x="642.5" y="230">95.2%</text>
+    <text x="648.3" y="284">96.4%</text>
   </g>
 
   <g transform="translate(28,352)" font-size="13" font-weight="600">

--- a/docs/evals/semantic-suite.json
+++ b/docs/evals/semantic-suite.json
@@ -1643,6 +1643,260 @@
         "password-policy"
       ],
       "limit": 10
+    },
+    {
+      "id": "soft-delete-b3",
+      "tier": "basic",
+      "query": "deleted_at timestamp so an accidental delete can be undone",
+      "expectedItemIds": [
+        "soft-delete"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "db-postgres-b3",
+      "tier": "basic",
+      "query": "postgresql primary transactional datastore system of record",
+      "expectedItemIds": [
+        "db-postgres"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "auth-jwt-b3",
+      "tier": "basic",
+      "query": "jwt access token valid fifteen minutes signed rs256",
+      "expectedItemIds": [
+        "auth-jwt"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "rate-limit-api-b3",
+      "tier": "basic",
+      "query": "hundred requests per minute sliding window per api key",
+      "expectedItemIds": [
+        "rate-limit-api"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "deploy-canary-b3",
+      "tier": "basic",
+      "query": "canary release five percent traffic thirty minutes error rate",
+      "expectedItemIds": [
+        "deploy-canary"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "config-env-b3",
+      "tier": "basic",
+      "query": "runtime settings read from environment variables at boot",
+      "expectedItemIds": [
+        "config-env"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "logs-structured-b3",
+      "tier": "basic",
+      "query": "structured json log lines carrying a request id",
+      "expectedItemIds": [
+        "logs-structured"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "retention-audit-b3",
+      "tier": "basic",
+      "query": "audit events retained seven years for compliance",
+      "expectedItemIds": [
+        "retention-audit"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "queue-retry-b3",
+      "tier": "basic",
+      "query": "failed job retries six times exponential backoff jitter",
+      "expectedItemIds": [
+        "queue-retry"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "tests-unit-b3",
+      "tier": "basic",
+      "query": "unit suite runs on every commit under two minutes",
+      "expectedItemIds": [
+        "tests-unit"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "secrets-vault-b3",
+      "tier": "basic",
+      "query": "credentials fetched from the managed vault at boot",
+      "expectedItemIds": [
+        "secrets-vault"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "pagination-cursor-b3",
+      "tier": "basic",
+      "query": "cursor pagination keeps results steady while rows are inserted",
+      "expectedItemIds": [
+        "pagination-cursor"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "idempotency-keys-b3",
+      "tier": "basic",
+      "query": "repeated request with the same idempotency key returns the original response",
+      "expectedItemIds": [
+        "idempotency-keys"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "timezone-utc-b3",
+      "tier": "basic",
+      "query": "timestamps stored in utc converted in the presentation layer",
+      "expectedItemIds": [
+        "timezone-utc"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "uploads-s3-b3",
+      "tier": "basic",
+      "query": "clients upload directly to object storage with a presigned url",
+      "expectedItemIds": [
+        "uploads-s3"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "hard-purge-m2",
+      "tier": "moderate",
+      "query": "permanent removal of expired records by a scheduled overnight job",
+      "expectedItemIds": [
+        "hard-purge"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "auth-refresh-m2",
+      "tier": "moderate",
+      "query": "detecting a reused token and revoking the whole chain",
+      "expectedItemIds": [
+        "auth-refresh"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "deploy-blue-green-m2",
+      "tier": "moderate",
+      "query": "two identical stacks swapping traffic at the load balancer",
+      "expectedItemIds": [
+        "deploy-blue-green"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "feature-flags-m2",
+      "tier": "moderate",
+      "query": "shipping unfinished code dark behind a per request toggle",
+      "expectedItemIds": [
+        "feature-flags"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "migrations-expand-m2",
+      "tier": "moderate",
+      "query": "renaming a column by backfilling then switching reads over",
+      "expectedItemIds": [
+        "migrations-expand"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "alerting-pager-m2",
+      "tier": "moderate",
+      "query": "which failures are allowed to wake a human at night",
+      "expectedItemIds": [
+        "alerting-pager"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "cdn-assets-m2",
+      "tier": "moderate",
+      "query": "hashed static filenames cached for a year at the edge",
+      "expectedItemIds": [
+        "cdn-assets"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "webhooks-signing-m2",
+      "tier": "moderate",
+      "query": "verifying an incoming callback came from us before trusting it",
+      "expectedItemIds": [
+        "webhooks-signing"
+      ],
+      "mustNotReturn": [],
+      "limit": 10
+    },
+    {
+      "id": "cache-redis-x2",
+      "tier": "extreme",
+      "query": "storage tier that can vanish without any data harm",
+      "expectedItemIds": [
+        "cache-redis"
+      ],
+      "mustNotReturn": [
+        "uploads-s3"
+      ],
+      "limit": 10
+    },
+    {
+      "id": "password-policy-x2",
+      "tier": "extreme",
+      "query": "no symbol or capital requirement for sign in credentials",
+      "expectedItemIds": [
+        "password-policy"
+      ],
+      "mustNotReturn": [
+        "rate-limit-login"
+      ],
+      "limit": 10
     }
   ]
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1033,22 +1033,28 @@ decision fixtures: 22 current decisions, 22 stale predecessors, and 12 rejected 
 defines 44 top-3 cases.
 
 <div align="center">
-<img src="assets/benchmark-governance.svg" alt="Internal governance regression suite: MRR 98.9 percent, 28 stale-active returns with 22 stale-trap failures, and zero rejected items returned" width="82%" />
+<img src="assets/benchmark-governance.svg" alt="Internal governance regression suite: MRR 100 percent, 27 stale-active returns with 21 stale-trap failures, and zero rejected items returned" width="82%" />
 </div>
 
 | Recall@3 | MRR | nDCG | Stale-active returns | Stale-trap failures | Rejected items returned |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 100% | 98.86% | 99.16% | 28 | 22 | 0 |
+| 100% | 100% | 100% | 27 | 21 | 0 |
 
-MRR is reciprocal rank, not top-1 accuracy. Stale predecessors remain active, so all 22 stale
-traps failed and produced 28 stale-active returns; rejected items test a separate status filter
+MRR is reciprocal rank, not top-1 accuracy, and at 100% it means the expected current decision
+ranked first in every one of the 44 cases. Stale predecessors remain active, so 21 stale traps
+still failed and produced 27 stale-active returns; rejected items test a separate status filter
 and never appeared. Recall@3 means every top three contained the expected current decision, not
 that every result was current.
 
-Re-measured 2026-08-06 with the `granite-small-en-r2` default. The previous figures — MRR
-94.3182%, 43 stale-active returns — were taken on the `minilm-l6-en` default this repository
-shipped before 2026-08-02, so the model is part of the result and is named here rather than
-left to the reader's config.
+**This suite is now saturated and cannot show an improvement**, only a regression. Every ranking
+metric is at ceiling, so the only figures left that can move are the two stale counts. Use
+`semantic-suite.json` for anything that has to discriminate.
+
+Measured on the `granite-small-en-r2` default. Two earlier sets of figures are worth knowing
+about, because both differed by something other than the ranker: MRR 94.3182% with 43
+stale-active returns was taken on the `minilm-l6-en` default this repository shipped before
+2026-08-02, and MRR 98.86% with 28 stale-active returns predates the semantic rescale in
+`scoreCandidates`. The model and the scoring are both part of the result.
 
 ```bash
 knowl eval retrieval \
@@ -1063,16 +1069,23 @@ The checked-in [`retrieval-suite.json`](evals/retrieval-suite.json) contains 500
 items; it is not third-party evidence.
 
 <div align="center">
-<img src="assets/benchmark-retrieval-quality.svg" alt="Internal retrieval regression suite: vector plus BM25 Recall at 3 98.8 percent, Recall at 10 100 percent, MRR 95.26 percent, and nDCG 96.44 percent" width="82%" />
+<img src="assets/benchmark-retrieval-quality.svg" alt="Internal retrieval regression suite: vector plus BM25 Recall at 3 98.6 percent, Recall at 10 99.8 percent, MRR 95.21 percent, and nDCG 96.36 percent" width="82%" />
 </div>
 
 | Retrieval path | Recall@3 | Recall@10 | MRR | nDCG | Stale hits | Forbidden hits | Failed criteria |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Vector + BM25 | 98.8% | 100% | 95.26% | 96.44% | 5 | 3 | 3 |
+| Vector + BM25 | 98.6% | 99.8% | 95.21% | 96.36% | 11 | 2 | 3 |
 
-Re-measured 2026-08-06 with the `granite-small-en-r2` default, stable across two runs; no result
-snapshot is checked in. The run passed 497 of 500 evaluator cases, including expected, stale, and
-forbidden conditions rather than only search hits.
+Measured on the `granite-small-en-r2` default, byte-identical across two runs; no result snapshot
+is checked in. The run passed 497 of 500 evaluator cases, including expected, stale, and forbidden
+conditions rather than only search hits.
+
+This suite is near its ceiling too, and the numbers moved slightly *down* when the semantic
+rescale in `scoreCandidates` landed — Recall@3 98.8% to 98.6% and Recall@10 100% to 99.8%, one
+case each. That change was kept because it wins where these suites cannot discriminate: on
+`semantic-suite.json` it moved Recall@3 89.6% to 91.9% and the hardest tier's MRR 33.3% to 38.1%,
+and it left the external MemoryAgentBench result unchanged. A suite at ceiling reports the cost of
+a change and not its benefit, which is the reason not to tune against this one.
 
 Fresh BM25-only runs varied under equal-score ordering, including their failure counts. Exact
 BM25 outcome and rank values are therefore not published; rerun the command below in the target

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "db:migrate": "drizzle-kit migrate",
     "test:bench": "vitest run --config benchmarks/vitest.config.ts",
     "typecheck:bench": "tsc -p benchmarks/tsconfig.json",
-    "bench:cr:build": "tsup benchmarks/memoryagentbench/cli.ts --format esm --outDir .benchmark-dist",
+    "bench:cr:build": "tsup benchmarks/memoryagentbench/cli.ts --format esm --outDir .benchmark-dist --no-dts",
     "bench:cr": "npm run bench:cr:build --silent && node .benchmark-dist/cli.js",
     "docs:generate": "tsx scripts/generate-docs.ts",
     "docs:check": "tsx scripts/generate-docs.ts --check",

--- a/scripts/benchmark-embedding-models.mjs
+++ b/scripts/benchmark-embedding-models.mjs
@@ -82,8 +82,24 @@ for (const preset of [...presets, null]) {
 const TIERS = ['basic', 'moderate', 'extreme'];
 const cell = value => String(value).padEnd(9);
 
-console.log(`\n${['model'.padEnd(26), ...TIERS.map(tier => cell(tier)), cell('overall'), 'p50 ms'].join(' ')}`);
-console.log('-'.repeat(26 + 4 * 10 + 7));
+/**
+ * MRR leads, Recall@10 trails.
+ *
+ * This table reported Recall@10 alone and, on 2026-08-07, that stopped being able to rank
+ * anything: granite-small-en-r2 and minilm-l6-en both scored 0.9852 overall and 1.0000 on two of
+ * three tiers, while MemoryAgentBench separated the same two models by two points of top-1. The
+ * suite had not become useless -- the metric had saturated. Recall@10 asks "is the answer on the
+ * page", which every real model now satisfies; MRR asks where on the page, which is what an agent
+ * reading the top result actually experiences.
+ *
+ * Keep Recall@10 in view: a model can win MRR while dropping answers entirely, and that trade is
+ * one a reader has to be able to see.
+ */
+const primary = metrics => metrics?.mrr;
+const secondary = metrics => metrics?.recallAt10;
+
+console.log(`\n${['model'.padEnd(26), ...TIERS.map(tier => cell(`${tier} MRR`)), cell('MRR'), cell('R@10'), 'p50 ms'].join(' ')}`);
+console.log('-'.repeat(26 + 5 * 10 + 7));
 
 for (const row of rows) {
   if (row.error) {
@@ -91,17 +107,19 @@ for (const row of rows) {
     continue;
   }
   const cells = TIERS.map(tier => {
-    const metrics = row.result.byTier?.[tier];
-    return cell(metrics ? metrics.recallAt10.toFixed(4) : '-');
+    const value = primary(row.result.byTier?.[tier]);
+    return cell(value === undefined ? '-' : value.toFixed(4));
   });
   console.log([
     row.label.padEnd(26),
     ...cells,
-    cell(row.result.metrics?.recallAt10?.toFixed(4) ?? '-'),
+    cell(primary(row.result.metrics)?.toFixed(4) ?? '-'),
+    cell(secondary(row.result.metrics)?.toFixed(4) ?? '-'),
     String(row.result.metrics?.p50LatencyMs ?? '-'),
   ].join(' '));
 }
 
-console.log('\nRecall@10 per tier. Basic is the deciding column: it predicts day-to-day quality.');
+console.log('\nMRR per tier, then overall MRR and Recall@10. Rank models on MRR: Recall@10 is');
+console.log('saturated on this suite and ties models that other benchmarks separate.');
 console.log('Extreme is a stress signal. A model that wins there while losing on basic is the wrong pick.');
 console.log('If bm25-only matches the models across every tier, the suite is not discriminating.');

--- a/scripts/diagnose-cosine-spread.ts
+++ b/scripts/diagnose-cosine-spread.ts
@@ -1,0 +1,79 @@
+/**
+ * How much ranking signal does the semantic half actually carry?
+ *
+ * Fusion is `alpha * semantic + (1 - alpha) * lexical` at alpha 0.8, so the semantic term holds
+ * four fifths of the weight. That is only four fifths of the *signal* if cosines actually spread
+ * out across candidates. If a model packs every cosine into a narrow band, the semantic term is
+ * nearly constant, and the 0.2-weighted lexical term decides the order despite its small weight.
+ *
+ * Usage: npx tsx scripts/diagnose-cosine-spread.ts [preset]
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { findProjectRoot, loadConfig } from '../src/core/config.js';
+import { createLocalEmbeddingProvider } from '../src/ai/embeddings.js';
+
+const datasetPath = path.resolve('docs/evals/semantic-suite.json');
+const dataset = JSON.parse(await fs.readFile(datasetPath, 'utf-8')) as {
+  cases: Array<{ id: string; tier?: string; query: string; expectedItemIds: string[] }>;
+  fixtures: Array<{ id: string; title: string; content: string; tags?: string[] }>;
+};
+
+const root = await findProjectRoot(process.cwd());
+const config = await loadConfig(root);
+const embedder = await createLocalEmbeddingProvider(config, root);
+
+const cosine = (a: number[], b: number[]) => {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+};
+
+// Embed the fixtures the same way the index does: title, content and tags together.
+const fixtureText = (f: typeof dataset.fixtures[number]) =>
+  `${f.title}\n${f.content}\n${(f.tags ?? []).join(' ')}`;
+const fixtureVectors: number[][] = [];
+for (const f of dataset.fixtures) fixtureVectors.push((await embedder.embed([fixtureText(f)]))[0] as number[]);
+
+console.log(`model: ${embedder.profileFingerprint}`);
+console.log(`fixtures: ${dataset.fixtures.length}  cases: ${dataset.cases.length}\n`);
+
+const gaps: number[] = [];
+const spreads: number[] = [];
+for (const testCase of dataset.cases) {
+  const q = (await embedder.embed([testCase.query]))[0] as number[];
+  const scores = fixtureVectors
+    .map((v, i) => ({ id: dataset.fixtures[i].id, cos: cosine(q, v) }))
+    .sort((a, b) => b.cos - a.cos);
+  // The margin the fusion has to work with: how far rank 1 stands above rank 2.
+  gaps.push(scores[0].cos - scores[1].cos);
+  // The whole usable range across the candidate page.
+  spreads.push(scores[0].cos - scores[9].cos);
+}
+
+const stat = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const at = (p: number) => s[Math.min(s.length - 1, Math.floor(p * s.length))];
+  return `min=${s[0].toFixed(4)} p25=${at(0.25).toFixed(4)} median=${at(0.5).toFixed(4)} p75=${at(0.75).toFixed(4)} max=${s[s.length - 1].toFixed(4)}`;
+};
+
+console.log('cosine gap, rank1 - rank2 (the margin fusion must not overturn):');
+console.log(`  ${stat(gaps)}`);
+console.log('\ncosine spread, rank1 - rank10 (the whole semantic signal on a page):');
+console.log(`  ${stat(spreads)}`);
+
+/**
+ * The comparison that matters. The lexical half is a normalised [0,1] score, so its contribution
+ * spans up to (1 - alpha) * 1.0 = 0.2. The semantic half contributes alpha * (its actual spread).
+ * If alpha * spread is smaller than 0.2, lexical decides the ranking whatever the weights say.
+ */
+const ALPHA = 0.8;
+const median = (xs: number[]) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+const semanticSwing = ALPHA * median(spreads);
+console.log(`\nmedian semantic swing across a page: ${ALPHA} x ${median(spreads).toFixed(4)} = ${semanticSwing.toFixed(4)}`);
+console.log(`maximum lexical swing:               ${(1 - ALPHA).toFixed(1)} x 1.0000 = ${(1 - ALPHA).toFixed(4)}`);
+console.log(
+  semanticSwing < (1 - ALPHA)
+    ? '=> lexical can overturn any semantic ordering on this model.'
+    : '=> semantic dominates, as the weights intend.',
+);

--- a/scripts/diagnose-floor-threshold.ts
+++ b/scripts/diagnose-floor-threshold.ts
@@ -1,0 +1,85 @@
+/**
+ * What floor value, if any, separates real questions from junk on THIS store?
+ *
+ * The shipped per-model floors were fitted against a 50-fixture corpus. This reports the raw
+ * best-cosine the floor actually tests, for on-topic and off-topic queries, against the live
+ * store -- so the question "is 0.76 too high, would 0.3 be better" is answered with the two
+ * distributions rather than with intuition about what a cosine ought to look like.
+ *
+ * Usage: npx tsx scripts/diagnose-floor-threshold.ts
+ */
+import { findProjectRoot, loadConfig } from '../src/core/config.js';
+import { createLocalEmbeddingProvider } from '../src/ai/embeddings.js';
+import { closeDb, initDb } from '../src/store/database.js';
+import { getProjectByRootPath } from '../src/store/repository.js';
+import { searchKnowledgeEmbeddings } from '../src/store/vector.js';
+
+const OFF_TOPIC = [
+  'best hiking trails in patagonia',
+  'how to make sourdough starter',
+  'premier league fixtures this weekend',
+  'symptoms of vitamin d deficiency',
+  'cheapest flights to reykjavik',
+  'who won the 1998 world cup',
+  'recipe for lemon drizzle cake',
+  'when did the roman empire fall',
+];
+
+const ON_TOPIC = [
+  'supersession retires the predecessor at write time',
+  'embedding profile fingerprint provider model dtype pooling',
+  'memoryagentbench conflict resolution benchmark',
+  'relevance floor per model calibration',
+  'knowl eval retrieval vector fixtures',
+  'transcript search opt in off by default',
+  'what does knowl store about a decision',
+  'how are stale atoms handled',
+];
+
+const root = await findProjectRoot(process.cwd());
+const config = await loadConfig(root);
+const embedder = await createLocalEmbeddingProvider(config, root);
+await initDb(root);
+const project = await getProjectByRootPath(root);
+if (!project) throw new Error('Project not found in database.');
+
+async function bestCosine(query: string): Promise<number> {
+  const hits = await searchKnowledgeEmbeddings(project!.id, {
+    vector: await embedder.embedQuery(query),
+    status: 'active',
+    profileFingerprint: embedder.profileFingerprint,
+    limit: 1,
+  } as any);
+  const top: any = hits[0];
+  if (!top) return 0;
+  // Whatever the row calls it, the floor compares a similarity in [0,1].
+  return Number(top.score ?? top.similarity ?? (top.distance !== undefined ? 1 - top.distance : 0));
+}
+
+const off: number[] = [];
+const on: number[] = [];
+console.log(`model floor as shipped: ${embedder.relevanceFloor}\n`);
+console.log('OFF-TOPIC best cosine:');
+for (const q of OFF_TOPIC) {
+  const c = await bestCosine(q);
+  off.push(c);
+  console.log(`  ${c.toFixed(4)}  "${q}"`);
+}
+console.log('\nON-TOPIC best cosine:');
+for (const q of ON_TOPIC) {
+  const c = await bestCosine(q);
+  on.push(c);
+  console.log(`  ${c.toFixed(4)}  "${q}"`);
+}
+
+const offMax = Math.max(...off);
+const onMin = Math.min(...on);
+console.log(`\noff-topic highest: ${offMax.toFixed(4)}`);
+console.log(`on-topic lowest:   ${onMin.toFixed(4)}`);
+console.log(
+  onMin > offMax
+    ? `=> separable. Any floor between ${offMax.toFixed(4)} and ${onMin.toFixed(4)} works.`
+    : `=> NOT separable. Junk scores as high as ${offMax.toFixed(4)} while a real question scores as low as ${onMin.toFixed(4)}, so no single number can split them: every floor either answers junk or silences real questions.`,
+);
+
+await closeDb();

--- a/scripts/diagnose-offtopic-floor.ts
+++ b/scripts/diagnose-offtopic-floor.ts
@@ -1,0 +1,86 @@
+/**
+ * The check the eval suites structurally cannot perform.
+ *
+ * A ranking change that lifts scores can push an off-topic query over MIN_VECTOR_RELEVANCE, so
+ * the store answers a question it has nothing to say about. No suite sees this: every suite case
+ * has a correct answer, so none of them asks "should this have returned anything at all". The
+ * recorded precedent is BM25_LEXICAL_WEIGHT, where 8.0 beat 3.0 on every suite metric and broke
+ * the floor on one of six off-topic probes.
+ *
+ * Run against the real store, before and after any scoring change.
+ *
+ * Usage: npx tsx scripts/diagnose-offtopic-floor.ts
+ */
+import { findProjectRoot, loadConfig } from '../src/core/config.js';
+import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../src/ai/embeddings.js';
+import { closeDb, initDb } from '../src/store/database.js';
+import { getProjectByRootPath } from '../src/store/repository.js';
+import { rankKnowledge } from '../src/store/agent-query.js';
+
+/** Nothing in a project-memory store should answer any of these. */
+const OFF_TOPIC = [
+  'best hiking trails in patagonia',
+  'how to make sourdough starter',
+  'premier league fixtures this weekend',
+  'symptoms of vitamin d deficiency',
+  'cheapest flights to reykjavik',
+  'who won the 1998 world cup',
+];
+
+/** Real questions this store genuinely can answer. These must keep answering. */
+const ON_TOPIC = [
+  'supersession retires the predecessor at write time',
+  'embedding profile fingerprint provider model dtype pooling',
+  'memoryagentbench conflict resolution benchmark',
+  'relevance floor per model calibration',
+  'knowl eval retrieval vector fixtures',
+  'transcript search opt in off by default',
+];
+
+const root = await findProjectRoot(process.cwd());
+const config = await loadConfig(root);
+if (!isVectorSearchEnabled(config)) throw new Error('Vector search is not enabled.');
+const embedder = await createLocalEmbeddingProvider(config, root);
+await initDb(root);
+const project = await getProjectByRootPath(root);
+if (!project) throw new Error('Project not found in database.');
+
+async function probe(query: string) {
+  const items = await rankKnowledge(project!.id, {
+    query,
+    status: 'active',
+    limit: 3,
+    vector: {
+      enabled: true,
+      profileFingerprint: embedder.profileFingerprint,
+      embedding: await embedder.embedQuery(query),
+      relevanceFloor: embedder.relevanceFloor,
+    },
+  });
+  const top: any = items[0];
+  return { count: items.length, top: top ? Number(top.explanation?.finalScore ?? 0) : 0 };
+}
+
+console.log(`floor for this model: ${embedder.relevanceFloor}\n`);
+
+let answeredOffTopic = 0;
+console.log('OFF-TOPIC (want 0 results each):');
+for (const query of OFF_TOPIC) {
+  const { count, top } = await probe(query);
+  if (count > 0) answeredOffTopic++;
+  console.log(`  ${count > 0 ? 'ANSWERED' : 'silent  '}  n=${count} top=${top.toFixed(4)}  "${query}"`);
+}
+
+let silentOnTopic = 0;
+console.log('\nON-TOPIC (want results each):');
+for (const query of ON_TOPIC) {
+  const { count, top } = await probe(query);
+  if (count === 0) silentOnTopic++;
+  console.log(`  ${count === 0 ? 'SILENT  ' : 'answered'}  n=${count} top=${top.toFixed(4)}  "${query}"`);
+}
+
+console.log(`\noff-topic answered: ${answeredOffTopic}/${OFF_TOPIC.length} (want 0)`);
+console.log(`on-topic silent:    ${silentOnTopic}/${ON_TOPIC.length} (want 0)`);
+console.log(answeredOffTopic === 0 && silentOnTopic === 0 ? 'FLOOR HOLDS' : 'FLOOR REGRESSED');
+
+await closeDb();

--- a/scripts/diagnose-semantic-suite.ts
+++ b/scripts/diagnose-semantic-suite.ts
@@ -1,0 +1,200 @@
+/**
+ * Per-case diagnostic for a fixture-backed retrieval suite.
+ *
+ * `knowl eval retrieval` reports pooled and per-tier metrics plus `failedCaseIds`, which says
+ * *that* a case failed but not what outranked the answer. This mirrors that command's store
+ * setup exactly -- same fixtures, same reindex, same `rankKnowledge` call -- and dumps the
+ * ranking for every case so a failure can be attributed.
+ *
+ * Usage: npx tsx scripts/diagnose-semantic-suite.ts [dataset.json]
+ */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { findProjectRoot, loadConfig } from '../src/core/config.js';
+import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../src/ai/embeddings.js';
+import { closeDb, initDb } from '../src/store/database.js';
+import * as repo from '../src/store/repository.js';
+import { rankKnowledge } from '../src/store/agent-query.js';
+import { reindexKnowledgeEmbeddings } from '../src/store/vector-index.js';
+
+const datasetPath = path.resolve(process.argv[2] ?? 'docs/evals/semantic-suite.json');
+
+type Fixture = { id: string; category: any; title: string; content: string; tags?: string[] };
+type Case = {
+  id: string;
+  tier?: string;
+  query: string;
+  expectedItemIds: string[];
+  mustNotReturn: string[];
+  limit?: number;
+};
+
+const dataset = JSON.parse(await fs.readFile(datasetPath, 'utf-8')) as {
+  cases: Case[];
+  fixtures: Fixture[];
+};
+
+// Walk up for the config, exactly as `knowl eval retrieval` does: a git worktree has no
+// `.knowl/` of its own, so the embedding profile comes from the checkout above it.
+const root = await findProjectRoot(process.cwd());
+const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-diag-'));
+await fs.mkdir(path.join(fixtureRoot, '.knowl'), { recursive: true });
+await initDb(fixtureRoot);
+const project = await repo.createProject(fixtureRoot, 'Suite diagnostic');
+
+/** fixture id -> real row id, and the reverse so a returned row can be named. */
+const toRowId = new Map<string, string>();
+const toFixtureId = new Map<string, string>();
+const titleOf = new Map<string, string>();
+for (const fixture of dataset.fixtures) {
+  const item = await repo.createKnowledgeItem(project.id, fixture);
+  toRowId.set(fixture.id, item.id);
+  toFixtureId.set(item.id, fixture.id);
+  titleOf.set(item.id, fixture.title);
+}
+
+const config = await loadConfig(root);
+if (!isVectorSearchEnabled(config)) throw new Error('Vector search is not enabled.');
+const embedder = await createLocalEmbeddingProvider(config, root);
+const indexed = await reindexKnowledgeEmbeddings(project.id, embedder);
+console.log(`Embedded ${indexed.indexed} fixtures · ${dataset.cases.length} cases\n`);
+
+const rows: Array<{
+  id: string;
+  tier: string;
+  query: string;
+  rank: number;
+  forbidden: string[];
+  top3: string[];
+  vectorRank: number | null;
+  bm25Rank: number | null;
+}> = [];
+
+for (const testCase of dataset.cases) {
+  const expected = new Set(testCase.expectedItemIds.map(id => toRowId.get(id) ?? id));
+  const banned = new Set(testCase.mustNotReturn.map(id => toRowId.get(id) ?? id));
+  const items = await rankKnowledge(project.id, {
+    query: testCase.query,
+    status: 'active',
+    limit: testCase.limit ?? 10,
+    vector: {
+      enabled: true,
+      profileFingerprint: embedder.profileFingerprint,
+      embedding: await embedder.embedQuery(testCase.query),
+      relevanceFloor: embedder.relevanceFloor,
+    },
+  });
+  const ids = items.map(item => item.id);
+  const expectedItem: any = items.find(item => expected.has(item.id));
+  rows.push({
+    id: testCase.id,
+    tier: testCase.tier ?? '-',
+    query: testCase.query,
+    // 1-indexed position of the expected answer; 0 means it never appeared.
+    rank: ids.findIndex(id => expected.has(id)) + 1,
+    forbidden: ids.filter(id => banned.has(id)).map(id => toFixtureId.get(id) ?? id),
+    top3: ids.slice(0, 3).map(id => `${toFixtureId.get(id) ?? id}`),
+    vectorRank: expectedItem?.explanation?.vectorRank ?? null,
+    bm25Rank: expectedItem?.explanation?.bm25Rank ?? null,
+  });
+}
+
+const notFirst = rows.filter(r => r.rank !== 1);
+const withForbidden = rows.filter(r => r.forbidden.length > 0);
+
+console.log(`=== ${notFirst.length} cases where the expected answer is not rank 1 ===`);
+for (const r of notFirst) {
+  console.log(
+    `[${r.tier.padEnd(8)}] ${r.id.padEnd(22)} rank=${r.rank === 0 ? 'ABSENT' : r.rank}  "${r.query}"\n` +
+    `${' '.repeat(12)}top3: ${r.top3.join(' > ')}`,
+  );
+}
+
+console.log(`\n=== ${withForbidden.length} cases returning a forbidden item ===`);
+for (const r of withForbidden) {
+  console.log(
+    `[${r.tier.padEnd(8)}] ${r.id.padEnd(22)} rank=${r.rank === 0 ? 'ABSENT' : r.rank}  forbidden: ${r.forbidden.join(', ')}\n` +
+    `${' '.repeat(12)}"${r.query}"  top3: ${r.top3.join(' > ')}`,
+  );
+}
+
+/**
+ * Score forensics for the worst cases.
+ *
+ * The question a rank alone cannot answer: did the embedding fail to find the item, or did it
+ * find it and fusion bury it? `vectorRank` and `bm25Rank` separate those. A good vectorRank
+ * beside a bad final position is a fusion problem and fixable in the ranker; a bad vectorRank
+ * is the embedding model and is not.
+ */
+const WORST = [
+  'alerting-pager-x1', 'migrations-forward-m1', 'cdn-assets-m1', 'soft-delete-x1', 'hard-purge-m1',
+];
+console.log('\n=== score forensics for the worst cases ===');
+for (const caseId of WORST) {
+  const testCase = dataset.cases.find(c => c.id === caseId);
+  if (!testCase) continue;
+  const expectedRows = new Set(testCase.expectedItemIds.map(id => toRowId.get(id) ?? id));
+  const explained = await rankKnowledge(project.id, {
+    query: testCase.query,
+    status: 'active',
+    limit: testCase.limit ?? 10,
+    vector: {
+      enabled: true,
+      profileFingerprint: embedder.profileFingerprint,
+      embedding: await embedder.embedQuery(testCase.query),
+      relevanceFloor: embedder.relevanceFloor,
+    },
+  });
+  console.log(`\n${caseId}  "${testCase.query}"`);
+  explained.forEach((item: any, index: number) => {
+    const mark = expectedRows.has(item.id) ? ' <-- EXPECTED' : '';
+    const e = item.explanation;
+    console.log(
+      `  ${String(index + 1).padStart(2)}. ${(toFixtureId.get(item.id) ?? item.id).padEnd(22)}` +
+      ` score=${Number(e.finalScore).toFixed(4)}` +
+      ` bm25Rank=${e.bm25Rank ?? '-'}`.padEnd(16) +
+      ` vectorRank=${e.vectorRank ?? '-'}`.padEnd(17) + mark,
+    );
+  });
+}
+
+const byTier: Record<string, { n: number; first: number; absent: number }> = {};
+for (const r of rows) {
+  const t = (byTier[r.tier] ??= { n: 0, first: 0, absent: 0 });
+  t.n++;
+  if (r.rank === 1) t.first++;
+  if (r.rank === 0) t.absent++;
+}
+/**
+ * The claim under test: fusion demotes items the embedding ranked well, because *having* a BM25
+ * match outweighs *being* the best vector hit. If true, the fix is in the ranker, not the model.
+ */
+const found = rows.filter(r => r.rank > 0);
+const vectorNailedIt = found.filter(r => r.vectorRank !== null && r.vectorRank <= 3);
+const buried = vectorNailedIt.filter(r => r.rank > 3);
+const buriedNoBm25 = buried.filter(r => r.bm25Rank === null);
+console.log('\n=== does fusion bury good vector hits? ===');
+console.log(`cases where the answer was a top-3 vector hit:      ${vectorNailedIt.length}`);
+console.log(`  ...but finished outside the top 3 overall:        ${buried.length}`);
+console.log(`  ...and of those, had NO bm25 match at all:        ${buriedNoBm25.length}`);
+for (const r of buried) {
+  console.log(`    ${r.id.padEnd(22)} vectorRank=${r.vectorRank} bm25Rank=${r.bm25Rank ?? '-'} -> final ${r.rank}`);
+}
+
+const vectorBest = found.filter(r => r.vectorRank === 1);
+const vectorBestLost = vectorBest.filter(r => r.rank !== 1);
+const lostNoBm25 = vectorBestLost.filter(r => r.bm25Rank === null);
+console.log(`\nanswer was the #1 vector hit:                        ${vectorBest.length}`);
+console.log(`  ...but did not finish #1 overall:                 ${vectorBestLost.length}`);
+console.log(`  ...and of those, had NO bm25 match:               ${lostNoBm25.length}`);
+const rank1 = found.filter(r => r.rank === 1).length;
+console.log(`\nvector alone would put ${vectorBest.length}/110 first; fusion delivers ${rank1}/110.`);
+
+console.log('\n=== per tier ===');
+for (const [tier, t] of Object.entries(byTier)) {
+  console.log(`${tier.padEnd(9)} n=${String(t.n).padStart(3)} rank1=${t.first} absent=${t.absent}`);
+}
+
+await closeDb();
+await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => {});

--- a/scripts/diagnose-write-compliance.ts
+++ b/scripts/diagnose-write-compliance.ts
@@ -1,0 +1,66 @@
+/**
+ * Does low `supersedes` / `provenance` compliance actually cost anything?
+ *
+ * The agent-surface study measured 752 real knowl_store calls: `supersedes` supplied on 3.5%,
+ * `provenance` on 9.8%. Those look like alarming compliance gaps. Whether they are depends on
+ * what the write path and the ranker do when the fields are absent, which is what this measures
+ * against the live store rather than against intuition.
+ *
+ * Usage: npx tsx scripts/diagnose-write-compliance.ts
+ */
+import { findProjectRoot } from '../src/core/config.js';
+import { closeDb, initDb } from '../src/store/database.js';
+import { getProjectByRootPath } from '../src/store/repository.js';
+import { queryKnowledgeBase } from '../src/store/queries.js';
+
+const root = await findProjectRoot(process.cwd());
+await initDb(root);
+const project = await getProjectByRootPath(root);
+if (!project) throw new Error('Project not found in database.');
+
+const active = await queryKnowledgeBase(project.id, { status: 'active', limit: 100_000 });
+const superseded = await queryKnowledgeBase(project.id, { status: 'superseded', limit: 100_000 });
+
+console.log(`active:     ${active.length}`);
+console.log(`superseded: ${superseded.length}`);
+const total = active.length + superseded.length;
+console.log(`supersession fired on ${(superseded.length / total * 100).toFixed(1)}% of all items written\n`);
+
+/**
+ * The comparison that settles it. Explicit `supersedes` was supplied on 3.5% of writes. If the
+ * share of items actually retired is far above that, the retiring is being done by the write
+ * path's own title-subset inference and the caller's field is close to decoration.
+ */
+const EXPLICIT_SUPERSEDES_RATE = 0.035;
+const observed = superseded.length / total;
+console.log(`explicit supersedes supplied on:  ${(EXPLICIT_SUPERSEDES_RATE * 100).toFixed(1)}% of writes`);
+console.log(`items actually retired:           ${(observed * 100).toFixed(1)}%`);
+console.log(
+  observed > EXPLICIT_SUPERSEDES_RATE * 2
+    ? `=> inference is doing the work, roughly ${(observed / EXPLICIT_SUPERSEDES_RATE).toFixed(1)}x what callers ask for.`
+    : '=> retirement tracks caller-supplied ids; the compliance gap is real.',
+);
+
+const provenanceCounts: Record<string, number> = {};
+for (const item of active) {
+  provenanceCounts[(item as any).provenance ?? '(unset)'] = (provenanceCounts[(item as any).provenance ?? '(unset)'] ?? 0) + 1;
+}
+console.log('\nprovenance on active items:');
+for (const [value, count] of Object.entries(provenanceCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${value.padEnd(12)} ${String(count).padStart(4)}  ${(count / active.length * 100).toFixed(1)}%`);
+}
+
+/**
+ * `scoreCandidates` applies PROVENANCE_INFERRED_PRIOR only when provenance === 'inferred'.
+ * Unset takes the same multiplier as 'observed' and 'user_stated', so omitting the field is
+ * scored identically to claiming first-hand evidence.
+ */
+const inferred = provenanceCounts['inferred'] ?? 0;
+const unset = provenanceCounts['(unset)'] ?? 0;
+console.log(`\nitems the provenance prior can demote: ${inferred} of ${active.length} (${(inferred / active.length * 100).toFixed(1)}%)`);
+console.log(`items scored as if first-hand by default: ${unset} (${(unset / active.length * 100).toFixed(1)}%)`);
+console.log('Omitting provenance takes the same prior as "observed", so the field only ever costs');
+console.log('the writer who marks "inferred" honestly. Non-compliance is not merely tolerated, it');
+console.log('is rewarded, which is why asking for it more loudly would not raise it.');
+
+await closeDb();

--- a/src/store/agent-query.ts
+++ b/src/store/agent-query.ts
@@ -465,6 +465,43 @@ export async function selectCandidates(
  *
  * and the floor judges `cosine` before any of it.
  */
+/**
+ * Below this, the page's cosines are treated as one flat value rather than rescaled.
+ *
+ * Rescaling a range narrower than this turns rounding noise into a full-strength ranking signal.
+ * The measured median page range is 0.1075, so this only fires when the candidates really are
+ * indistinguishable -- and where they are, their order is not worth manufacturing.
+ */
+const MIN_SEMANTIC_RANGE = 0.02;
+
+/**
+ * Put the semantic half on the same scale as the lexical half, so `alpha` means what it says.
+ *
+ * The lexical term is normalised against the corpus best, so it spans very nearly the whole
+ * [0,1] range on any page with a decent match. A cosine does not: measured over the 135-case
+ * semantic suite on granite-small-en-r2, the gap between rank 1 and rank 10 has a median of
+ * **0.1075**, and rank 1 to rank 2 a median of 0.0649. Fusion at alpha 0.8 therefore hands the
+ * semantic half a median swing of 0.086 while the lexical half can swing the full 0.2 -- so the
+ * term holding 20% of the weight carries roughly 2.3x the ranking authority, and a lexical
+ * match routinely overturns the best semantic hit. Measured consequence on the same suite: of
+ * the five cases where the #1 vector hit failed to finish first, all five had no lexical match
+ * at all (`scripts/diagnose-semantic-suite.ts`).
+ *
+ * Min-max rather than divide-by-best, which is the opposite of the choice made for lexical just
+ * above, and for a reason that does not apply there: dividing 0.76 by 0.80 gives 0.95 and leaves
+ * the range as compressed as it was, because cosines do not start near zero. Only the
+ * differences between them carry ranking information.
+ *
+ * This is safe for the abstention floor specifically because the floor judges the **raw** cosine
+ * on its own, before any of this, so rescaling for ranking cannot make an off-topic query look
+ * answerable.
+ */
+function rescaleSemantic(value: number, floor: number, ceiling: number): number {
+  const range = ceiling - floor;
+  if (range < MIN_SEMANTIC_RANGE) return value;
+  return (value - floor) / range;
+}
+
 export function scoreCandidates<T extends Candidate & { repo?: string }>(
   candidates: T[],
   options: {
@@ -526,6 +563,20 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
     corpusBest.set(corpus, Math.max(corpusBest.get(corpus) ?? 0, raw));
   }
   const anyLexical = corpusBest.size > 0;
+  // Semantic range across this candidate page, for the rescale below.
+  //
+  // Folded rather than spread: `Math.max(...values)` passes one argument per candidate and blows
+  // the stack on a large page. The candidate set is bounded by `limit * OVERFETCH` in the normal
+  // path but not in every caller, and a ranking helper must not carry a size ceiling nobody
+  // states.
+  let semanticCeiling = 0;
+  let semanticFloor = 1;
+  for (const candidate of candidates) {
+    const value = Math.min(Math.max(candidate.vectorScore ?? 0, 0), 1);
+    if (value > semanticCeiling) semanticCeiling = value;
+    if (value < semanticFloor) semanticFloor = value;
+  }
+  if (!candidates.length) semanticFloor = 0;
   // Alpha renormalises over the signals that exist, and does so globally rather than per
   // corpus: two repos scored under different alphas would not be comparable, which is the
   // whole reason scoring runs over the union.
@@ -555,7 +606,9 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
       const coverage = Math.min(Math.max(result.lexicalCoverage ?? 1, 0), 1);
       const lexical = raw === undefined ? 0 : (best > 0 ? Math.min(raw / best, 1) * coverage : coverage);
       const semantic = Math.min(Math.max(result.vectorScore ?? 0, 0), 1);
-      const relevance = usingVector ? alpha * semantic + (1 - alpha) * lexical : lexical;
+      const relevance = usingVector
+        ? alpha * rescaleSemantic(semantic, semanticFloor, semanticCeiling) + (1 - alpha) * lexical
+        : lexical;
 
       const recency = normalizedRecencyScore(result.item, timestamps);
       // Clamped, not trusted. `confidence` is unvalidated at the write boundary and a model

--- a/tests/benchmark/semantic-suite.test.ts
+++ b/tests/benchmark/semantic-suite.test.ts
@@ -23,9 +23,9 @@ function fixtureText(id: string): string {
 }
 
 describe('semantic suite shape', () => {
-  it('has 100 to 120 cases', () => {
+  it('has 100 to 140 cases', () => {
     expect(suite.cases.length).toBeGreaterThanOrEqual(100);
-    expect(suite.cases.length).toBeLessThanOrEqual(120);
+    expect(suite.cases.length).toBeLessThanOrEqual(140);
   });
 
   it('gives every case a tier and a resolvable expected item', () => {
@@ -37,11 +37,37 @@ describe('semantic suite shape', () => {
     }
   });
 
-  it('keeps queries to the 2-6 keywords agents actually send', () => {
+  /**
+   * This assertion used to cap every query at 6 words, which baked a refuted rule into the one
+   * suite meant to discriminate. The ground-truth ablation in docs/evals/agent-surface.md found
+   * truncating to six words costs 4.7-7.2pp hit@1 while off-subject padding costs 24-37pp: count
+   * is not the variable, on-subject-ness is. The cap also made the suite unrepresentative --
+   * 921 real knowl_query calls average 5.75 words with 26.6% over 6 and a max of 12, while the
+   * suite averaged 3.5 and topped out at 6, so no case exercised the length agents actually send.
+   *
+   * What replaces it is a floor and a distribution, not a ceiling.
+   */
+  it('carries queries at the length agents really send, with no upper cap', () => {
+    const lengths = suite.cases.map((c: any) => String(c.query).trim().split(/\s+/).length);
+    for (const length of lengths) expect(length).toBeGreaterThanOrEqual(2);
+    // Representativeness: real traffic is 26.6% over six words. Well under that and the suite
+    // has drifted back to the short-query regime the cap created.
+    const overSix = lengths.filter((n: number) => n > 6).length;
+    expect(overSix / lengths.length).toBeGreaterThan(0.15);
+  });
+
+  /**
+   * Agents do not end a query with a question mark: 0 of 921 real calls did. A suite of
+   * natural-language questions would measure a phrasing nobody sends.
+   *
+   * Only the punctuation is asserted. The same measurement also found no query *leading* with an
+   * interrogative, but enforcing that here fails `where secrets live` -- a relative clause, not a
+   * question, and perfectly plausible agent phrasing. The blunt version of this rule flags good
+   * queries, which is how the word-count cap it replaced went wrong in the first place.
+   */
+  it('never phrases a case as an explicit question', () => {
     for (const testCase of suite.cases) {
-      const words = String(testCase.query).trim().split(/\s+/);
-      expect(words.length).toBeGreaterThanOrEqual(2);
-      expect(words.length).toBeLessThanOrEqual(6);
+      expect(String(testCase.query).trim()).not.toMatch(/\?$/);
     }
   });
 


### PR DESCRIPTION
Six commits. Five are measurement and documentation and are low risk. **One changes core ranking and is the reason this is a PR rather than a fast-forward** — please read `9f0fc13` on its own.

## The one that needs review: `9f0fc13` semantic rescale

Fusion is `alpha * semantic + (1 - alpha) * lexical` at alpha 0.8, so the semantic term is meant to hold four fifths of the ranking authority. It did not. The lexical term is normalised against the corpus best and spans nearly the whole [0,1] range; a cosine does not, because cosines do not start near zero.

Measured on the 135-case semantic suite, granite-small-en-r2:

| | |
| --- | --- |
| cosine gap, rank1 − rank2 (median) | 0.0649 |
| cosine spread, rank1 − rank10 (median) | 0.1075 |
| semantic swing available, 0.8 × 0.1075 | **0.0860** |
| lexical swing available, 0.2 × 1.0 | **0.2000** |

The term holding 20% of the weight carried roughly 2.3× the authority. Measured consequence: of five cases where the #1 vector hit failed to finish first, **all five had no lexical match at all**. `alerting-pager-x1` is the clearest — the best semantic match in the store landed 8th behind seven lexically-matched items.

The fix min-max rescales the semantic term, with a guard leaving pages narrower than 0.02 unscaled so rounding noise is not amplified.

**Measured on every suite, not only the one that motivated it:**

| suite | metric | before | after |
| --- | --- | ---: | ---: |
| semantic (135) | Recall@3 | 0.896 | **0.919** |
| | MRR | 0.858 | **0.870** |
| | extreme MRR | 0.3329 | **0.3810** |
| | Recall@10 | 0.985 | 0.978 |
| governance (56) | MRR | 0.9886 | **1.0000** |
| retrieval (500) | Recall@3 | 0.988 | 0.986 |
| | Recall@10 | 1.000 | 0.998 |
| MemoryAgentBench cr-sh-6k | top-1 | 98% | 98% (unchanged) |

Wins on the two suites that can discriminate, costs one case each on the two that are saturated, leaves the independent corpus untouched. `tests/store/rank-knowledge.test.ts` still passes, so lexical agreement remains a tie-breaker rather than a veto.

**Floor check.** `BM25_LEXICAL_WEIGHT`'s doc comment warns that the suites cannot observe a floor regression, so the live off-topic check was run before and after: identical, 6/6 off-topic answered and 6/6 on-topic answered on both sides. This change is floor-neutral — it rescales for ranking, while the floor judges the raw cosine beforehand.

**What I am least sure about:** the semantic suite is partly authored in this repo, and I extended it in `d97c8ec` in the same branch. The independent evidence is MemoryAgentBench (unchanged) and governance (improved), and neither moved the wrong way — but a second opinion on whether min-max is the right normalisation is the thing worth spending review time on.

## The other five

**`0406a91`** — `npm run bench:cr` could not run at all: `bench:cr:build` invokes tsup on a benchmark entry, inherits `dts: true` and `rootDir: src` from `tsup.config.ts`, and dies on TS6059. Results now record the embedding profile, because a run was previously distinguishable only by `timestamp` — and that mattered: the default preset moved from minilm-l6-en to granite-small-en-r2 on 2026-08-02, while the checked-in 32k/64k runs predated it. Re-ran all three scaling instances on granite, which killed the standing conclusion:

| instance | minilm | granite |
| --- | ---: | ---: |
| cr-sh-6k | 96% | 98% |
| cr-sh-32k | 97% | 95% |
| cr-sh-64k | 91% | 95% |

"64k has 9 points of top-1 to win, use 64k not 6k to justify retrieval work" was an artifact of the embedding model. The directions differ, so no reader could have corrected for it mentally.

**`d97c8ec`** — the semantic suite capped every query at six words, enforced by its own shape test: the rule `docs/evals/agent-surface.md` refuted. Replaced with a floor and a distribution, plus 25 long-form cases. Adds `scripts/diagnose-semantic-suite.ts`, which is where the fusion finding above came from. Known cost, stated in the commit: minilm now ties granite on Recall@10, because long on-subject queries are easy for every model — this trades discrimination for representativeness, which is why `9f0fc13` also makes the model comparison lead with MRR.

**`2577d26`** — measures the `supersedes` (3.5%) and `provenance` (9.8%) compliance gaps that `agent-surface.md` left open. Supersession: harmless, 10.9% of items are retired against 3.5% explicit because the write path infers it from a title-subset match. Provenance: zero `inferred` items exist so the prior never fires, and unset scores identically to `observed` — the only way to lose rank is to mark `inferred` honestly. No fix applied; this measures rather than decides.

**`ba8fbcb`** — re-measures the two published internal suites after the rescale. **`benchmark-retrieval-quality.svg` was lying and not because of this branch**: bar width is the value at 5px per point, and the four bars decoded to 98.9 / 99.4 / 96.1 / 96.9 while their labels read 98.8 / 100 / 95.3 / 96.4. Two prior rounds of label edits had left the geometry on the original minilm-era figures.

**`3331326`** — measures the relevance floor against a real store. On 627 items the floor sits at 0.76 while off-topic tops out at 0.7738 and on-topic bottoms at 0.7908, so every off-topic probe answers: it is too low, not too high. **Deliberately does not change the number** — the gap is 0.017 on eight samples a side, and the probes are absurd ones no agent would send. The case that decides whether any threshold helps is the near-miss, which is not measured yet.

## README

Untouched. Its only numeric claim is the 98%-vs-47% MemoryAgentBench headline, and the CR run is unchanged at 98% top-1 / 100% any-rank / 2 stale leaks.

## Verification

- `npm test` — 240 files, 2009 passed, 4 skipped
- `npm run test:bench` — 9 files, 74 passed
- `npm run build` — clean; `npx tsc --noEmit` — clean
- `git diff --check` — clean
- Both edited SVGs parse with balanced tags
- Published figures byte-identical across two runs

Two tests flaked during the work and pass in isolation and on re-run: `tests/cli/eval-vector-fixtures.test.ts` (loads the embedding model inside a 30s timeout; also times out on clean HEAD under load) and `tests/mcp/foreign-item-refusal.test.ts`. Neither is caused by this branch — both were checked against a clean tree.
