### PR TITLE
feat(workspace): a repo joining a linked workspace shares by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 
 - When this repo is in a workspace, `knowl_query` results carry a `repo` field naming the repo that produced each item. A fact from another repo describes **that** repo unless it says otherwise; do not apply it here without checking.
 - Restrict a search to one repo with `knowl_query` `repos: ["<name>"]`. It matches the repo that owns an item.
-- Knowledge stays private to its repo until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
+- Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
+- Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
 
 ### Safety and freshness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ is written now because `visibility` is one column on the item, not a per-workspa
 "another person". Rows written under this default predate any counterparty, so a future `shared`
 migration must ask again rather than inherit them as consent.
 
+Everything that told an agent or a reader the opposite moved with it. The "N existing items are
+still private" notice suggested re-running `add --promote-existing`, which the guard above now
+refuses — it names `--default-visibility workspace --promote-existing`, and a test parses the line
+the tool prints and runs it rather than asserting its wording. The guidance installed into every
+repo's `KNOWL.md` said knowledge stays private until someone promotes it; it now says visibility is
+the repo's recorded default and names the command that prints it, because that sentence is what an
+agent consults before deciding a write is safe. The README and `docs/reference.md` said the same
+thing on the front page and did not document the flag at all.
+
 ### A cross-repo evaluation suite that spans more than one workspace shape
 
 `cross-repo-suite.json` held **three** cases over a single two-repo fixture. That is not enough to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+### `workspace add` shares by default in a linked workspace
+
+**Breaking-ish, for new links only.** A repo joining a `linked` workspace now gets
+`defaultVisibility: workspace` unless it passes `--default-visibility repo`. The command says a
+default decided it and how to decline.
+
+`'repo'` was the *compatibility* default — it preserved pre-workspace behaviour when the columns
+landed and nothing read them, which was right at the time. Once workspaces shipped it became a
+*policy* default nobody chose, and since promotion has no inverse it only drifts one way: measured
+on a real three-repo workspace, to 95% private, with the same rule shared from one repo and
+private in its sibling purely by where someone happened to be standing.
+
+Sharing costs little and loses nothing — across 92 cases and five workspace archetypes, pooled MRR
+moves 0.9837 → 0.9674 while recall@3 is unchanged to four decimal places
+([measurement](docs/evals/share-everything.md)). Answers get reordered, never dropped.
+
+Two limits, both deliberate:
+
+- **Repos already in a manifest do not move.** An absent `defaultVisibility` still resolves to
+  `'repo'`. Changing that would publish every linked repo's next write on account of a release
+  rather than a decision, and no `--default-visibility repo` could undo it — the bulk publish
+  `tests/cli/upgrade.test.ts` already forbids. The new default applies only where a person ran a
+  command and read the notice.
+- **The default does not satisfy `--promote-existing`.** That still requires an explicit
+  `--default-visibility workspace`. Defaulting future writes is small and announced; publishing
+  everything a repo already knows is the largest irreversible action here, and a default must not
+  stand in for saying it out loud.
+
+The `linked`-mode condition ships unconditional today, since nothing constructs `'shared'` yet. It
+is written now because `visibility` is one column on the item, not a per-workspace grant: under
+`linked` a shared row means "me, in another directory", and under `shared` the same bit would mean
+"another person". Rows written under this default predate any counterparty, so a future `shared`
+migration must ask again rather than inherit them as consent.
+
 ### A cross-repo evaluation suite that spans more than one workspace shape
 
 `cross-repo-suite.json` held **three** cases over a single two-repo fixture. That is not enough to

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -35,7 +35,8 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 
 - When this repo is in a workspace, `knowl_query` results carry a `repo` field naming the repo that produced each item. A fact from another repo describes **that** repo unless it says otherwise; do not apply it here without checking.
 - Restrict a search to one repo with `knowl_query` `repos: ["<name>"]`. It matches the repo that owns an item.
-- Knowledge stays private to its repo until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
+- Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
+- Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
 
 ### Safety and freshness
 

--- a/README.md
+++ b/README.md
@@ -307,8 +307,9 @@ candidates. Park a workstream under a key and pick it up in any session, from an
 **🔗 Workspaces**
 
 Your API repo learned something the frontend repo needs. Link them and a query fans out,
-while each repository keeps its own database and its own ownership boundary. Nothing is
-shared until you promote it, and only the owner can retire its own atoms.
+while each repository keeps its own database and its own ownership boundary. Knowledge a
+repo already holds is shared only when you promote it, and only the owner can retire its
+own atoms.
 
 `workspace init` · `workspace add` · `workspace promote --apply`
 
@@ -426,7 +427,7 @@ knowl doctor                           # setup, retrieval, and registration
 </details>
 
 <details>
-<summary><b>Workspaces: many repos, one shared memory</b> — nothing is shared until you promote it</summary>
+<summary><b>Workspaces: many repos, one shared memory</b> — you decide what each repo shares</summary>
 <br>
 
 Your API repo learned something the frontend repo needs. Link them, and a query fans out — while
@@ -435,15 +436,17 @@ each repository keeps its own database and its own ownership boundary.
 ```bash
 knowl workspace init product      # create the workspace
 knowl workspace add product       # run inside each repo that joins it
+                                  # ...or --default-visibility repo to keep its writes private
 
 knowl workspace promote --category decision           # preview what would be shared
 knowl workspace promote --category decision --apply   # publish it
 ```
 
-Nothing is shared until you promote it — private knowledge stays private, peer results are
-read-only and labeled with the repo that owns them, and only the owner can retire its own atoms. A
-peer that is missing or unreadable is skipped and disclosed, never a reason for your local search
-to fail.
+Joining a workspace shares what the repo writes **from then on**, and says so when it does; pass
+`--default-visibility repo` to decline. What the repo already knows is shared only when you
+promote it. Peer results are read-only and labeled with the repo that owns them, and only the
+owner can retire its own atoms. A peer that is missing or unreadable is skipped and disclosed,
+never a reason for your local search to fail.
 
 → [Workspaces](docs/reference.md#workspaces)
 

--- a/docs/evals/share-everything.md
+++ b/docs/evals/share-everything.md
@@ -42,6 +42,37 @@ rules were shared from one repo and private in its sibling.
 The comparison is therefore: a measured −0.016 MRR and no recall loss, against an unmeasured but
 demonstrably large volume of knowledge that is never retrieved at all.
 
+## It is not capture noise
+
+The obvious suspicion, raised on review: workspaces accumulate auto-captured `fact` and `state`
+entries — per-commit resolutions, transient test failures — and that mass is what moves the number
+when the default flips. If so, the recommendation would narrow to "flip the default, keep the
+noise categories out".
+
+It does not hold. Tested by adding the missing variable rather than removing a category: 120
+capture-noise items of exactly that shape (`Resolved failure in src/session/impact.ts: readFile on
+a directory -> EISDIR`, half `fact`, half `state`, private), roughly doubling the corpus, then
+re-measuring the same delta.
+
+| corpus | curated MRR | shared MRR | Δ | forbidden shown |
+| --- | --- | --- | --- | --- |
+| clean (121 items) | 0.9837 | 0.9674 | −0.0163 | 8 → 35 |
+| +120 noise items | 0.9837 | 0.9674 | −0.0163 | 8 → 35 |
+
+Identical to four decimal places, same forbidden count. **Capture noise never competes**: it does
+not rank for a real question, so it never enters the per-repo candidate pool, and
+`DEFAULT_PER_REPO_CAP` means the pool is what matters rather than the corpus. Noise is dead weight
+in the store, not a rival in the ranking. The −0.016 is substantive items competing.
+
+Excluding `fact` and `state` from the flip *does* recover about a third of it (0.9674 → 0.9728) —
+but by sharing fewer substantive items, not by withholding noise, since the noisy and clean runs
+of that arm are also identical. "Share less" moving the number toward "share nothing" is
+mechanical, and does not support a category rule.
+
+Note this suite cannot answer the question by holding `fact` and `state` private outright: **47 of
+its 92 expected answers are in those two categories**, because the fixture authors used them for
+substance rather than for capture. That measures fixture composition, not the hypothesis.
+
 ## Why the cost is structurally bounded
 
 `DEFAULT_PER_REPO_CAP = 10`. Only ten candidates per repo ever enter scoring, however many are

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -549,6 +549,15 @@ knowl workspace promote --category decision
 knowl workspace promote --category decision --apply
 ```
 
+A repository joining a `linked` workspace records `defaultVisibility: workspace`, so the knowledge
+it writes from then on is readable by its peers. The command prints that a default decided it and
+how to decline; `--default-visibility repo` opts out, and `knowl workspace set` with no flags
+prints the current value. Repositories already listed in a manifest are never moved: an absent
+`defaultVisibility` still resolves to `repo`, because changing what omission means would publish
+every linked repository's next write on account of an upgrade rather than a decision, and there is
+no demote. Knowledge written before the default, or under `--default-visibility repo`, stays
+private until it is promoted.
+
 For another checkout or machine, copy the workspace manifest and join from each repository:
 
 ```bash
@@ -560,7 +569,7 @@ The shipped workspace commands are:
 | Command | Purpose |
 | --- | --- |
 | `knowl workspace init <name>` | Create a workspace outside its member repositories |
-| `knowl workspace add <name> [--name <repo-name>] [--force]` | Link the current repository |
+| `knowl workspace add <name> [--name <repo-name>] [--default-visibility <repo\|workspace>] [--promote-existing] [--force]` | Link the current repository; shares its new writes by default in a `linked` workspace |
 | `knowl workspace join <manifest> [--name <repo-name>] [--force]` | Adopt a copied manifest and map this checkout |
 | `knowl workspace list` | List workspaces known to this machine |
 | `knowl workspace status [--verbose]` | Show this repository's membership and peer health |
@@ -1114,7 +1123,7 @@ knowl eval retrieval --dataset docs/evals/retrieval-suite.json --json
 | Command | Description |
 | --- | --- |
 | `knowl workspace init <name>` | Create a workspace |
-| `knowl workspace add <name> [--name <repo-name>] [--force]` | Link the current repository |
+| `knowl workspace add <name> [--name <repo-name>] [--default-visibility <repo\|workspace>] [--promote-existing] [--force]` | Link the current repository; shares its new writes by default in a `linked` workspace |
 | `knowl workspace join <manifest> [--name <repo-name>]` | Join from a copied manifest |
 | `knowl workspace list` | List machine-local workspaces |
 | `knowl workspace status [--verbose]` | Show membership and resolved peers |

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -639,7 +639,7 @@ workspaceCommand
         .then(manifest => manifest.mode)
         .catch(() => null);
       const defaultedToWorkspace = requested === undefined && manifestMode === 'linked';
-      const visibility = requested ?? (defaultedToWorkspace ? 'workspace' : undefined);
+      const visibility = defaultedToWorkspace ? 'workspace' : requested;
 
       // Rejected rather than ignored. A flag that silently does nothing is how you end up
       // believing a whole repo was shared when none of it was -- the same rule `knowl upgrade`
@@ -671,6 +671,10 @@ workspaceCommand
           console.log('New writes here default to workspace visibility, because every repo in a linked');
           console.log('workspace is on this machine and read by you. Pass --default-visibility repo to');
           console.log('keep this repo\'s writes private instead.');
+          // Blank line because the two say different things: one explains why this is happening
+          // without a flag, the other what workspace visibility costs. Run together they read as
+          // one paragraph and the irreversibility warning stops looking like a warning.
+          console.log('');
         }
         for (const line of visibilityGateNotice(repoName)) console.log(line);
         console.log('');

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -605,7 +605,7 @@ workspaceCommand
   .description('Link this repo into a workspace')
   .option('--name <repo-name>', 'Name this repo carries inside the workspace; defaults to the directory name')
   .option('--role <text>', 'What this repo is, for agents that have only the manifest')
-  .option('--default-visibility <repo|workspace>', 'Visibility stamped on new writes here (default: repo)')
+  .option('--default-visibility <repo|workspace>', 'Visibility stamped on new writes here (default: workspace in a linked workspace)')
   .option('--kin <group>', 'Group name shared with repos of the same lineage')
   .option('--promote-existing', 'Also share knowledge already in this repo; requires --default-visibility workspace')
   .option('--force', 'Link even though .knowl/config.json is tracked by git')
@@ -613,13 +613,47 @@ workspaceCommand
     try {
       const root = await findProjectRoot(process.cwd());
       const repoName = options.name ?? path.basename(root).toLowerCase().replace(/[^a-z0-9-]+/g, '-');
-      const visibility = parseDefaultVisibility(options.defaultVisibility);
+      const requested = parseDefaultVisibility(options.defaultVisibility);
+
+      /**
+       * A repo joining a `linked` workspace shares by default.
+       *
+       * `'repo'` was the compatibility default: it preserved pre-workspace behaviour, which was
+       * right when the columns landed and nothing read them. Once workspaces shipped it became a
+       * policy default nobody chose, and because promotion has no inverse it only ever drifts one
+       * way -- measured on a real three-repo workspace, to 95% private, with the same rule shared
+       * from one repo and private in its sibling purely by where someone was standing.
+       *
+       * Sharing costs little and loses nothing: over 92 cases across five workspace archetypes,
+       * pooled MRR moves 0.9837 -> 0.9674 while recall@3 is unchanged to four decimal places
+       * (docs/evals/share-everything.md). Answers are reordered, never dropped.
+       *
+       * Applied ONLY on an explicit `workspace add`, and only to the entry being created. A
+       * person is at the terminal, reads the notice below, and can pass `--default-visibility
+       * repo`. Existing entries are untouched and absent still means `'repo'` -- changing what
+       * omission resolves to would publish every linked repo's next write on account of a
+       * release rather than a decision, which is the bulk publish `tests/cli/upgrade.test.ts`
+       * already forbids and which no `--default-visibility repo` could undo.
+       */
+      const manifestMode = await readManifest(workspaceManifestPath(workspaceName))
+        .then(manifest => manifest.mode)
+        .catch(() => null);
+      const defaultedToWorkspace = requested === undefined && manifestMode === 'linked';
+      const visibility = requested ?? (defaultedToWorkspace ? 'workspace' : undefined);
 
       // Rejected rather than ignored. A flag that silently does nothing is how you end up
       // believing a whole repo was shared when none of it was -- the same rule `knowl upgrade`
       // applies to its --all-only flags.
-      if (options.promoteExisting && visibility !== 'workspace') {
-        throw new Error('--promote-existing only applies with --default-visibility workspace, because it publishes everything this repo already knows.');
+      //
+      // Checked against `requested`, NOT the resolved value: the new default must not stand in
+      // for saying it out loud here. Defaulting a repo's FUTURE writes to workspace is a small,
+      // announced, per-command decision. Publishing everything the repo already knows is the
+      // largest irreversible action this tool has, and letting a default satisfy its
+      // precondition would mean `workspace add ws --promote-existing` quietly bulk-publishes an
+      // entire history -- exactly the shape of unrequested publish this default was scoped to
+      // avoid. The two must not be merged just because they name the same enum.
+      if (options.promoteExisting && requested !== 'workspace') {
+        throw new Error('--promote-existing only applies with an explicit --default-visibility workspace, because it publishes everything this repo already knows.');
       }
 
       await joinWorkspace({
@@ -630,6 +664,14 @@ workspaceCommand
 
       if (visibility === 'workspace') {
         console.log('');
+        // Said before the gate notice, not instead of it. Someone who did not pass a flag needs
+        // to know a default decided this and how to decline it; someone who passed
+        // `--default-visibility workspace` already knows and is not told twice.
+        if (defaultedToWorkspace) {
+          console.log('New writes here default to workspace visibility, because every repo in a linked');
+          console.log('workspace is on this machine and read by you. Pass --default-visibility repo to');
+          console.log('keep this repo\'s writes private instead.');
+        }
         for (const line of visibilityGateNotice(repoName)) console.log(line);
         console.log('');
 

--- a/src/cli/workspace-visibility-notice.ts
+++ b/src/cli/workspace-visibility-notice.ts
@@ -30,6 +30,12 @@ export function visibilityGateNotice(repoName: string): string[] {
  * The category list is quoted because `knowl.cmd` runs through `cmd.exe`, which splits an
  * unquoted comma list on the commas. Guidance that prints a command must print one that works
  * on the platform reading it.
+ *
+ * `--default-visibility workspace` is spelled out alongside `--promote-existing` because this
+ * notice is now reachable with no flags at all: a linked workspace defaults the visibility, but
+ * `--promote-existing` deliberately still demands the explicit flag. Printing the shorter form
+ * would hand the reader a command that fails -- and the one place that must not happen is the
+ * text that fires precisely when someone did not type a visibility.
  */
 export function existingItemsNotice(count: number): string[] {
   if (count <= 0) return [];
@@ -37,6 +43,6 @@ export function existingItemsNotice(count: number): string[] {
     `${count} existing item${count === 1 ? '' : 's'} ${count === 1 ? 'is' : 'are'} still private.`,
     'Share them with:',
     `  knowl workspace promote --category "${KNOWLEDGE_CATEGORIES.join(',')}" --apply`,
-    'Or re-run add with --promote-existing to do it in one step.',
+    'Or re-run add with --default-visibility workspace --promote-existing to do it in one step.',
   ];
 }

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -83,7 +83,8 @@ const WORKSPACE = `### Linked repositories
 
 - When this repo is in a workspace, \`knowl_query\` results carry a \`repo\` field naming the repo that produced each item. A fact from another repo describes **that** repo unless it says otherwise; do not apply it here without checking.
 - Restrict a search to one repo with \`knowl_query\` \`repos: ["<name>"]\`. It matches the repo that owns an item.
-- Knowledge stays private to its repo until someone runs \`knowl workspace promote\`. Only the owning repo can promote, update, or retire its own items.`;
+- Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while \`--default-visibility repo\` keeps writes private. \`knowl workspace set\` with no flags prints the current value.
+- Knowledge already written privately stays private until someone runs \`knowl workspace promote\`. Only the owning repo can promote, update, or retire its own items.`;
 
 export function renderFullKnowlGuidance(): string {
   const table = [

--- a/tests/cli/workspace-add-default-visibility.test.ts
+++ b/tests/cli/workspace-add-default-visibility.test.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { createManifest, readManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+
+const HOME = path.resolve('./.knowl-addvis-home');
+const A = path.resolve('./.knowl-addvis-a');
+const B = path.resolve('./.knowl-addvis-b');
+const CLI = path.resolve('./dist/index.js');
+
+function knowl(cwd: string, ...args: string[]) {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, KNOWL_HOME: HOME },
+  });
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
+}
+
+async function seed(root: string, name: string) {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  await repo.createProject(root, name);
+  await closeDb();
+}
+
+/**
+ * A repo joining a `linked` workspace shares by default; a repo already in one never moves.
+ *
+ * The second half is the load-bearing one. Changing what an ABSENT `defaultVisibility` resolves
+ * to would publish every linked repo's next write on account of a release rather than a decision,
+ * and `workspace set --default-visibility repo` only stops future writes -- there is no demote.
+ * So the new default is applied at the moment a person runs `add`, to the entry that command
+ * creates, and nowhere else.
+ */
+describe('workspace add default visibility', () => {
+  beforeEach(async () => {
+    // In-process too, not only in the spawned CLI's env. `workspaceManifestPath` resolves
+    // through `knowlHome()`, so without this the manifest is written under vitest's global
+    // scratch home while the child process looks for it under HOME -- and every case fails with
+    // "not a member of workspace", which reads like the feature is broken rather than the
+    // fixture. (vitest.config.ts pins KNOWL_HOME suite-wide precisely so that mismatch lands in
+    // a scratch directory instead of the developer's real ~/.knowl.)
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await seed(A, 'a');
+    await seed(B, 'b');
+    await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('defaults a new linked member to workspace visibility', () => {
+    expect(knowl(A, 'workspace', 'add', 'ws', '--name', 'a').status).toBe(0);
+
+    return readManifest(workspaceManifestPath('ws')).then(manifest => {
+      expect(manifest.repos.find(entry => entry.name === 'a')?.defaultVisibility).toBe('workspace');
+    });
+  });
+
+  it('says a default decided it, and how to decline', () => {
+    // A default that publishes must announce itself. Someone who passed no flag has to learn both
+    // that the choice was made for them and what the opt-out is, in the same breath.
+    const { stdout } = knowl(A, 'workspace', 'add', 'ws', '--name', 'a');
+
+    expect(stdout).toContain('default to workspace visibility');
+    expect(stdout).toContain('--default-visibility repo');
+  });
+
+  it('does not repeat the notice when the flag was passed explicitly', () => {
+    const { stdout } = knowl(A, 'workspace', 'add', 'ws', '--name', 'a', '--default-visibility', 'workspace');
+
+    expect(stdout).not.toContain('default to workspace visibility');
+  });
+
+  it('still honours --default-visibility repo', async () => {
+    expect(knowl(A, 'workspace', 'add', 'ws', '--name', 'a', '--default-visibility', 'repo').status).toBe(0);
+
+    const manifest = await readManifest(workspaceManifestPath('ws'));
+    // Written as undefined, which is how a manifest spells 'repo'.
+    expect(manifest.repos.find(entry => entry.name === 'a')?.defaultVisibility).toBeUndefined();
+  });
+
+  it('leaves an already-linked entry exactly as it was', async () => {
+    // The invariant Dat's review turns on: linking a DIFFERENT repo must not change what an
+    // already-linked repo's omitted defaultVisibility resolves to. `a` joins declining the
+    // default, which writes the field as absent -- the same shape every pre-existing manifest
+    // entry has -- and then `b` joins and takes it.
+    expect(knowl(A, 'workspace', 'add', 'ws', '--name', 'a', '--default-visibility', 'repo').status).toBe(0);
+    expect(knowl(B, 'workspace', 'add', 'ws', '--name', 'b').status).toBe(0);
+
+    const after = await readManifest(workspaceManifestPath('ws'));
+    expect(after.repos.find(entry => entry.name === 'a')?.defaultVisibility).toBeUndefined();
+    expect(after.repos.find(entry => entry.name === 'b')?.defaultVisibility).toBe('workspace');
+  });
+
+  it('does not let the default stand in for saying --promote-existing out loud', () => {
+    // The two decisions differ by orders of magnitude and must not be merged because they name
+    // the same enum. Defaulting FUTURE writes to workspace is small, announced and per-command.
+    // Publishing everything the repo ALREADY knows is the largest irreversible action here, and
+    // if the default satisfied its precondition then `workspace add ws --promote-existing` would
+    // bulk-publish an entire history with nobody having typed a visibility at all.
+    const refused = knowl(A, 'workspace', 'add', 'ws', '--name', 'a', '--promote-existing');
+
+    expect(refused.status).toBe(1);
+    expect(refused.stderr).toMatch(/explicit --default-visibility workspace/);
+  });
+
+  it('does not default when the workspace is not in linked mode', async () => {
+    // The branch ships unconditional today -- nothing constructs 'shared' -- so this pins intent
+    // rather than a reachable path. Under 'shared' a workspace row would mean "another person",
+    // and consent recorded before any counterparty existed cannot be inherited.
+    const manifestPath = workspaceManifestPath('sharedws');
+    await writeManifest(manifestPath, { ...createManifest('sharedws', null), mode: 'shared' });
+
+    expect(knowl(B, 'workspace', 'add', 'sharedws', '--name', 'b').status).toBe(0);
+
+    const manifest = await readManifest(manifestPath);
+    expect(manifest.repos.find(entry => entry.name === 'b')?.defaultVisibility).toBeUndefined();
+  });
+});

--- a/tests/cli/workspace-add-default-visibility.test.ts
+++ b/tests/cli/workspace-add-default-visibility.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeDb, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
 import { createManifest, readManifest, writeManifest } from '../../src/workspace/manifest.js';
 import { workspaceManifestPath } from '../../src/workspace/paths.js';
 import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
@@ -23,11 +24,19 @@ function knowl(cwd: string, ...args: string[]) {
   return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
 }
 
+/**
+ * Seeded with one item on purpose. An empty repo never prints `existingItemsNotice`, so a
+ * fixture with nothing in it cannot see what that notice tells someone to type next -- and that
+ * notice is now reachable with no flags at all.
+ */
 async function seed(root: string, name: string) {
   await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
   await saveConfig(root, { ...DEFAULT_CONFIG });
   await initDb(root);
-  await repo.createProject(root, name);
+  const project = await repo.createProject(root, name);
+  await storeKnowledgeItemDeduped(project.id, {
+    category: 'fact', title: `${name} knows something`, content: `Written by ${name} before it linked.`,
+  });
   await closeDb();
 }
 
@@ -118,6 +127,24 @@ describe('workspace add default visibility', () => {
 
     expect(refused.status).toBe(1);
     expect(refused.stderr).toMatch(/explicit --default-visibility workspace/);
+  });
+
+  it('prints a follow-up command that the --promote-existing guard actually accepts', () => {
+    // The two halves of this change pull against each other, and this is where they meet.
+    // Defaulting the visibility makes `existingItemsNotice` reachable with no flags typed;
+    // requiring an EXPLICIT --default-visibility workspace for --promote-existing makes the
+    // short form of its advice fail. So the notice is not asserted as a string here -- the line
+    // it prints is parsed and run, and the test fails if the tool contradicts itself.
+    const linked = knowl(A, 'workspace', 'add', 'ws', '--name', 'a');
+    expect(linked.status).toBe(0);
+
+    const suggestion = linked.stdout.split('\n').find(line => line.includes('re-run add with'));
+    expect(suggestion, 'the existing-items notice did not print').toBeDefined();
+    const flags = suggestion!.trim().replace(/^Or re-run add with /, '').replace(/ to do it in one step\.$/, '').split(' ');
+
+    const followed = knowl(B, 'workspace', 'add', 'ws', '--name', 'b', ...flags);
+    expect(followed.status, `following "${suggestion!.trim()}" failed: ${followed.stderr}`).toBe(0);
+    expect(followed.stdout).toMatch(/Promoted \d+ existing item/);
   });
 
   it('does not default when the workspace is not in linked mode', async () => {

--- a/tests/cli/workspace-cli.test.ts
+++ b/tests/cli/workspace-cli.test.ts
@@ -242,7 +242,10 @@ describe('knowl workspace CLI', { timeout: 120_000 }, () => {
     const shown = knowl(settable, 'workspace', 'set');
     expect(shown.status).toBe(0);
     expect(shown.stdout).toMatch(/role:\s+\(none\)/i);
-    expect(shown.stdout).toMatch(/default visibility:\s+repo/i);
+    // `workspace` because this repo joined a LINKED workspace without naming a visibility, and
+    // that now defaults to sharing rather than to `repo`. Was `repo`, which was the
+    // pre-workspace compatibility value left in place after workspaces shipped.
+    expect(shown.stdout).toMatch(/default visibility:\s+workspace/i);
 
     const changed = knowl(settable, 'workspace', 'set', '--role', 'the main app', '--default-visibility', 'workspace');
     expect(changed.status).toBe(0);


### PR DESCRIPTION
Closes the half of #35 you agreed to. Branched off `main` after #34 merged.

`workspace add` on a **`linked`** workspace stamps `defaultVisibility: workspace` unless told
otherwise, and prints one line above the existing gate notice saying a default decided it and how
to decline.

## Why

`'repo'` was the *compatibility* default — it preserved pre-workspace behaviour when the columns
landed and nothing read them, exactly as `4328408` says. Once workspaces shipped it became a
*policy* default nobody chose, and since promotion has no inverse it only drifts one way: measured
on a real three-repo workspace, to 95% private, with the same rule shared from one repo and
private in its sibling purely by where someone happened to be standing when they thought to run
`promote`.

Sharing costs little and loses nothing. Across the 92-case archetype suite, pooled MRR moves
0.9837 → 0.9674 while **recall@3 is unchanged to four decimal places** — answers get reordered,
never dropped, and three of five workspace shapes do not move at all
([`docs/evals/share-everything.md`](docs/evals/share-everything.md)).

That doc also gains the result from your review: the suspicion that per-commit capture noise
drives the delta, tested by injecting 120 such items and re-measuring. Identical to four decimals,
same forbidden count — noise never ranks for a real question, so it never enters the per-repo
candidate pool, and `DEFAULT_PER_REPO_CAP` means the pool is what matters rather than the corpus.
Excluding `fact`/`state` does recover about a third, but by sharing fewer *substantive* items, not
by withholding noise. So the narrower "keep the noise categories out" claim is not supported and
the doc says so.

## What it deliberately does not do

**Repos already in a manifest do not move.** An absent `defaultVisibility` still resolves to
`'repo'`. Changing what omission means would publish every linked repo's next write on account of
a release rather than a decision, with no demote to undo it — the bulk publish
`tests/cli/upgrade.test.ts` already forbids. The default applies only where a person ran a command
and read the notice. Pinned by a test that links one repo declining the default (which writes the
field absent, the same shape every pre-existing entry has) and then links another.

**The default does not satisfy `--promote-existing`.** That still requires an explicit
`--default-visibility workspace`.

This one is worth calling out because I got it wrong first. Resolving the default before the guard
made `workspace add ws --promote-existing` succeed silently — the guard compared the resolved
value, the new default satisfied it, and the largest irreversible action here would have run with
nobody having typed a visibility at all. The existing test caught it, which is the argument for
encoding a rule as behaviour rather than prose. It now checks the *requested* value, with its own
test so the two cannot be merged again for naming the same enum.

## The `linked` condition

Ships unconditional today — nothing constructs `'shared'` — and the CHANGELOG says so rather than
describing it as a limit. It is written now because `visibility` is one column on the item, not a
per-workspace grant: under `linked` a shared row means "me, in another directory"; under `shared`
the identical bit would mean "another person". Rows written under this default predate any
counterparty, so a future `shared` migration has to ask again rather than inherit them as consent.
A test pins the intent.

## Verification

`vitest` 663 files / 2217 tests green on the pre-rebase run and re-verified here, `tsc --noEmit`
clean, `eslint` 26 warnings (main's number), `docs:check`, `check:lockfile`, `audit:prod` and
`git diff --check` clean.

One expectation moved with the default: `workspace-cli`'s settings readout now shows `workspace`
after a plain `add`, annotated with why.
