### PR TITLE
feat(impact): refuse the stale write at PreToolUse — shadow mode first, blocking nothing yet

### DIFF
--- a/docs/change-impact-plan.md
+++ b/docs/change-impact-plan.md
@@ -3,19 +3,17 @@
 Plan for handling the case where one actor's in-progress code change invalidates another
 agent's unfinished work. Written 2026-08-05.
 
-> **What is in this branch, and what is not.** This document describes the whole arc, including
-> the part that is *not* here. This branch is **detection only**: the read-set, certain-tier
-> findings, the card stanza and `knowl_impact`. It is off by default and it refuses nothing —
-> every path through it is advisory, and every failure path allows the turn to proceed.
+> **What is in this branch.** The **write gate** of §7.5 — the `PreToolUse` refusal — on top of
+> the detection layer. This is the first thing in knowl that can stop a user's tool call from
+> happening, so the two sections to read before the code are §7.5's four non-optional properties
+> and §10's coverage ceiling, which names four open bugs in the host's own hook implementation
+> by number.
 >
-> The **write gate** of §7.5 — the `PreToolUse` refusal that is the mechanism the evidence
-> actually supports — is deliberately proposed **separately**, so that accepting detection does
-> not commit anyone to accepting enforcement. Two reasons it is split rather than bundled: its
-> precision is not yet measured against §9's ≥95% bar, and §10 records four open bugs in the
-> host's own hook implementation that bound what a refusal can currently guarantee. Detection is
-> unaffected by all four.
->
-> Read §7.5 and §10 as design, not as shipped behaviour.
+> It is off by default (`impact.enabled`), fails open on every failure mode, and refuses at most
+> once per stale read so it can never trap an agent. §9.1 carries the precision measurement the
+> gate's bar is stated in terms of — **100% over 46 adjudicated scenarios**, against a ≥95% bar —
+> and §10 says plainly what that number does *not* establish, which is prevalence in real
+> sessions.
 
 **This is v2. It contradicts v1 (same path, earlier today) on its central design choice.** v1
 proposed *detect → notify the stale agent*. A full prior-art pass found that notification is

--- a/docs/change-impact-plan.md
+++ b/docs/change-impact-plan.md
@@ -404,6 +404,30 @@ Four properties it must have, none optional:
 
 **`knowl_task_finish` is *not* a second gate, and the build proved it cannot be one** — §15.
 
+**Shipped in shadow mode first `[C]`.** `impact.gate` takes `off` (default), `shadow` or
+`enforce`, and is separate from `impact.enabled` because the risks differ in kind: detection
+spends context, while the gate refuses a tool call. `shadow` computes the identical verdict,
+records it in `impact_gate_shadow`, and lets the write through — so §9's ≥95%-over-≥40-findings
+bar is measured against real traffic before anything is refused. Promotion to `enforce` is a
+separate decision on a stated number, not a follow-up commit.
+
+Shadow deliberately **does not release** the read-set rows it names, and this is the one place it
+departs from the third property above. Enforcing mode releases them so a retry is never blocked
+twice, which is safe there because the agent has been told to re-read; doing the same while merely
+observing would clear a belief nobody re-read, and `work_read_sets` is simultaneously the evidence
+the precision number is computed from. A diagnostic must not change the process it observes.
+
+The consequence is that the belief stays live and the same finding returns on the next write to
+that file, which is why `impact_gate_shadow` is **unique on `finding_id`**: the row count has to
+equal the denials an enforcing gate would have issued, not the writes that were attempted, and
+those differ by however many times an agent happens to edit one file. `finding_id` alone is
+sufficient because a finding's `affected_id` already *is* the read-set row id, so one finding is
+one stale belief.
+
+Precision reads `1 − false_positive / adjudicated` over the findings those rows point at
+(`shadowGatePrecision`), with unresolved findings excluded from **both** halves — counting an
+unadjudicated block as correct is how a number talks its way past the bar it was meant to clear.
+
 **The notice is a courtesy.** Added to `renderChangeCard` (`change-card.ts:21`) — the shared
 renderer, so it reaches both the hook path and the MCP path. Constraints from `[C]`: the
 mid-turn slot is **single-occupancy** with a documented priority order
@@ -444,7 +468,7 @@ Not automatic merge resolution. Not semantic conflict inference. §11.
 | **P-0** | `toolName` on hook events; `indexFile()` export; G-6 transaction fix | full suite green; single-file index p95 measured |
 | **P-1** | incremental index on write; freshness in `doctor` | index stays current through a real session; no repo walk mid-session |
 | **P-2** | `work_read_sets` + capture + release + GC | read-set matches ground truth on a scripted session; bounded growth |
-| **P-3** | certain-tier detection + `impact_findings` + **the `PreToolUse` write gate** | **≥95% precision over ≥40 findings**, adjudicated |
+| **P-3** | certain-tier detection + `impact_findings` + **the `PreToolUse` write gate, in `shadow` first** | **≥95% precision over ≥40 findings**, adjudicated — measured *from shadow rows*, and the gate stays out of `enforce` until it is met |
 | **P-4** | reference edges, tiers, `knowl_impact` | likely-tier ≥70%; misses catalogued |
 | **P-5** | test selection + replan hint | end-to-end task success improves, or it does not ship |
 | **P-6** | cross-repo impact via workspace peers | — |

--- a/docs/superpowers/plans/2026-08-08-write-gate-shadow-mode.md
+++ b/docs/superpowers/plans/2026-08-08-write-gate-shadow-mode.md
@@ -1,0 +1,957 @@
+# Write Gate (Shadow Mode First) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land issue #17's piece 3 — the `PreToolUse` write gate — in a shadow mode that logs what it would have blocked, so the false-positive rate is measured before anything refuses a write.
+
+**Architecture:** Cherry-pick William-Sommers' gate commit `cd9fc8f` to preserve authorship, relocate it from `store/` to `session/` to satisfy the enforced layer graph, then add a three-state `impact.gate` config (`off`/`shadow`/`enforce`). Shadow computes the identical verdict, records one row per finding in a new `impact_gate_shadow` table, and allows the write — crucially without releasing read-set rows, so the table being measured is not mutated by the act of measuring it.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), libSQL/SQLite via `getClient()`, vitest, tsup.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-08-write-gate-shadow-mode-design.md`. Read it before Task 1.
+- **Build before testing.** A fresh worktree has no `dist/`; CLI tests spawn the built binary. Run `npm run build` before the first `npm test` or 76 tests fail for unrelated reasons.
+- **Baseline:** 257 test files, 2257 passed, 4 skipped. Any other number means something broke.
+- **Layer graph** (`tests/architecture/module-boundaries.test.ts`): `core`→`store`→{`ai`,`workspace`,`skills`,`code`}→{`session`,`pipeline`,`transcripts`,`viewer`}→{`cli`,`mcp`}. A module may import strictly below its own layer, never above. Type-only imports are exempt.
+- **`KNOWL_SCHEMA_VERSION` stays 1.** Raising it locks out installed builds. Only `KNOWL_MIGRATION_LEVEL` moves (3 → 4).
+- **Never add `impact.gate` to `DEFAULT_CONFIG`.** `upgradeConfigDefaults` merges that object into every config on the machine, which would arm a write gate in every repo the user has initialized.
+- **Fail open, without exception.** Every error path in the gate allows the write.
+- **Comment style:** this repo comments the *why with measurements*. Match the surrounding density; it is the strongest unwritten convention here.
+- **Commit style:** lowercase `type(scope): summary`, body explains why. Do not add `Co-authored-by` to the cherry-picked commit — `git cherry-pick` already preserves its author.
+
+---
+
+### Task 1: Cherry-pick the gate and land it in the right layer
+
+The gate commit is based on `ac3ce52`, before pieces 1 and 2 merged and before `#31` moved modules into `session/`. Every conflict is a path that moved, not a semantic disagreement.
+
+**Files:**
+- Create: `src/session/write-gate.ts` (from the commit's `src/store/write-gate.ts`)
+- Create: `tests/store/write-gate.test.ts` — **stays under `tests/store/`**, only its import changes. There is no `tests/session/` directory: when #31 moved modules into `src/session/`, the tests kept their paths, which is why `tests/store/host-lifecycle.test.ts` imports `../../src/session/host-lifecycle.js`. Creating a new directory here would be a convention this repo does not have.
+- Create: `tests/cli/tool-precheck.test.ts`
+- Modify: `src/cli/agents/host-hook.ts` (add `tool-precheck` to `NormalizedHookEventName`, the normalizer branch, the validator bypass)
+- Modify: `src/cli/agents/hosts/claude.ts` (`CLAUDE_EVENT_MAP`, `CLAUDE_HOOK_EVENTS`, `denyToolCall`)
+- Modify: `src/cli/agents/hosts/profile.ts` (optional `denyToolCall` on `HostProfile`)
+- Modify: `src/cli/agents/hook-config.ts` (spread-first comment)
+- Modify: `src/cli/agent-hook.ts` (exit-0 comment)
+- Modify: `src/session/host-lifecycle.ts` (`runWriteGate`, dispatch line)
+- Modify: `src/mcp/tools.ts:1171` (comment says `store/write-gate.ts`)
+- Modify: `docs/change-impact-plan.md` (the commit's §10 additions)
+
+**Interfaces:**
+- Consumes: `IMPACT_WRITE_TOOLS` and `impactChangedPaths` (already on main, `session/host-lifecycle.ts:87,401`); `openFindingsForSession` (`session/impact.ts:448`); `activeReadSetForSession`, `repoRelativePath`, `ReadSetEntry` (`store/read-set.ts`); `ImpactCardEntry` (`session/change-card.ts`); `isImpactEnabled` (`store/impact-config.ts`).
+- Produces: `shouldRefuseWrite(root: string, sessionId: string, targetPaths: string[]): Promise<WriteGateDecision>` and `interface WriteGateDecision { deny: boolean; reason: string | null; releasedReadIds: string[] }`, both from `src/session/write-gate.ts`. `HostProfile.denyToolCall?: (reason: string) => HostOutput | undefined`. `NormalizedHookEventName` gains `'tool-precheck'`.
+
+- [ ] **Step 1: Fetch the contributor's branch**
+
+```bash
+git fetch https://github.com/William-Sommers/knowl.git \
+  'refs/heads/impact/3-write-gate:refs/remotes/contrib/impact-3-write-gate'
+git log --oneline -1 contrib/impact-3-write-gate   # expect cd9fc8f
+```
+
+- [ ] **Step 2: Cherry-pick, expecting conflicts**
+
+```bash
+git cherry-pick -x cd9fc8f
+```
+
+Expected: conflicts. `src/store/host-lifecycle.ts` and `src/store/write-gate.ts` do not exist at those paths on this branch. Do not abort.
+
+- [ ] **Step 3: Place the two moved files**
+
+`src/store/write-gate.ts` from the commit becomes `src/session/write-gate.ts`. Its import block changes — these targets all moved on main:
+
+```ts
+import type { ImpactCardEntry } from './change-card.js';
+import { loadConfig } from '../core/config.js';
+import { getClient } from '../store/database.js';
+import { isImpactEnabled } from '../store/impact-config.js';
+import { openFindingsForSession } from './impact.js';
+import { activeReadSetForSession, repoRelativePath, type ReadSetEntry } from '../store/read-set.js';
+```
+
+`normalizePathForKnowledge` and `path` are imported in the original but unused by the final file — drop both rather than carry a dead import past the linter.
+
+`src/store/host-lifecycle.ts`'s hunks apply to `src/session/host-lifecycle.ts`. The `runWriteGate` function and its dispatch line `if (input.event === 'tool-precheck') return runWriteGate(input);` go in verbatim; only `import { shouldRefuseWrite } from './write-gate.js';` differs (same directory now).
+
+```bash
+git rm --cached src/store/write-gate.ts 2>/dev/null || true
+rm -f src/store/write-gate.ts src/store/host-lifecycle.ts
+```
+
+- [ ] **Step 4: Repoint the gate's test file**
+
+`tests/store/write-gate.test.ts` stays where the cherry-pick puts it. Change only its import of the module under test to `../../src/session/write-gate.js`, matching how `tests/store/host-lifecycle.test.ts` reaches `../../src/session/host-lifecycle.js`.
+
+- [ ] **Step 5: Update the stale comment in `src/mcp/tools.ts`**
+
+At line 1171 it names the module's old home. Change `(\`store/write-gate.ts\`)` to `(\`session/write-gate.ts\`)`.
+
+- [ ] **Step 6: Verify the layer rule accepts the new placement**
+
+Run: `npx vitest run tests/architecture/module-boundaries.test.ts`
+Expected: PASS. If it fails naming `session -> cli`, an import of `ImpactCardEntry` still points at `cli/agents/change-card.js`; it is `./change-card.js` now.
+
+- [ ] **Step 7: Build and run the affected suites**
+
+```bash
+npm run build
+npx vitest run tests/store/write-gate.test.ts tests/cli/tool-precheck.test.ts tests/store/host-lifecycle.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 8: Full suite**
+
+Run: `npm test`
+Expected: 257 files, 2257 passed, 4 skipped.
+
+- [ ] **Step 9: Conclude the cherry-pick**
+
+```bash
+git add -A
+git cherry-pick --continue
+git log -1 --format='%an <%ae>'   # must still be William Sommers
+```
+
+---
+
+### Task 2: The `impact_gate_shadow` table
+
+**Files:**
+- Modify: `src/store/bootstrap.ts` (append to `SCHEMA_STATEMENTS`, after the `impact_findings` indexes ending at `:365`)
+- Modify: `src/store/schema-version.ts:54` (`KNOWL_MIGRATION_LEVEL` 3 → 4)
+- Modify: `src/store/snapshot-tables.ts:68` (add `impact_gate_shadow: 'preserved'`)
+- Test: `tests/store/schema-pin.test.ts:22` (add `SCHEMA_PINS[4]`)
+- Test: `tests/store/impact-schema.test.ts`
+
+**Interfaces:**
+- Produces: table `impact_gate_shadow(id, finding_id, session_id, target_path, observed_at)` with `UNIQUE(finding_id)`. `KNOWL_MIGRATION_LEVEL === 4`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/store/impact-schema.test.ts`:
+
+```ts
+it('records one shadow row per finding, and ignores a repeat', async () => {
+  await initDb(root);
+  const client = getClient();
+  await client.execute({
+    sql: `INSERT OR IGNORE INTO impact_gate_shadow (id, finding_id, session_id, target_path, observed_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: ['s1', 'finding-a', 'session-1', 'src/a.ts', '2026-08-08T00:00:00.000Z'],
+  });
+  // Same finding, different row id and a later write against a different file: the belief has
+  // not changed, so the table must not grow. This is what makes the row count equal the number
+  // of denials an enforcing gate would have issued rather than the number of writes attempted.
+  const repeat = await client.execute({
+    sql: `INSERT OR IGNORE INTO impact_gate_shadow (id, finding_id, session_id, target_path, observed_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: ['s2', 'finding-a', 'session-1', 'src/b.ts', '2026-08-08T00:00:01.000Z'],
+  });
+
+  expect(Number(repeat.rowsAffected ?? 0)).toBe(0);
+  const rows = await client.execute('SELECT id, target_path FROM impact_gate_shadow');
+  expect(rows.rows).toHaveLength(1);
+  // The *first* target survives, not the latest: the row answers "what was in flight when this
+  // would first have been blocked", which is the question a false-positive adjudication asks.
+  expect(String(rows.rows[0].target_path)).toBe('src/a.ts');
+});
+
+it('holds the migration level at 4 with the schema version pinned to 1', () => {
+  expect(KNOWL_MIGRATION_LEVEL).toBe(4);
+  expect(KNOWL_SCHEMA_VERSION).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/store/impact-schema.test.ts`
+Expected: FAIL — `no such table: impact_gate_shadow`.
+
+- [ ] **Step 3: Add the DDL**
+
+In `src/store/bootstrap.ts`, after the `idx_impact_findings_unique_open` statement:
+
+```ts
+  /*
+   * What an enforcing gate *would* have blocked, recorded while it is not blocking anything.
+   *
+   * Shadow mode exists because the gate is the one part of this subsystem that can cost somebody
+   * their working session, and plan §9 sets a ≥95% precision bar over ≥40 findings before it is
+   * allowed to. So the verdict is computed for real and the refusal is withheld, and this table is
+   * the record of what was withheld.
+   *
+   * The table matters because shadow mode deliberately does *not* release the read-set rows it
+   * names -- releasing a belief the agent never re-read would make `work_read_sets` stop
+   * describing what the session holds, while that table is simultaneously the evidence the
+   * precision number is computed from. Not releasing leaves the belief live, so the same finding
+   * arrives again on the next write to that file, and without the unique index below the row count
+   * would measure writes attempted rather than denials avoided.
+   */
+  `CREATE TABLE IF NOT EXISTS impact_gate_shadow (
+    id TEXT PRIMARY KEY,
+    finding_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    target_path TEXT NOT NULL,
+    observed_at TEXT NOT NULL
+  );`,
+  /*
+   * `finding_id` alone, and not `(finding_id, read_set_id)`.
+   *
+   * A finding's `affected_id` *is* the read-set row id -- `detectCertainImpact` writes
+   * `affectedId: entry.id` from the row it compared (`session/impact.ts:417`) and
+   * `openFindingsForSession` joins `work_read_sets w ON w.id = f.affected_id`. One finding is
+   * therefore already one stale belief, and a stored read-set id would be a second copy of a
+   * value that can only ever disagree with its source.
+   *
+   * `session_id` is kept even though the same join reaches it, and this is the one place the
+   * denormalization earns itself: `sweepReadSets` hard-deletes released rows, so after GC the
+   * join returns nothing and the owning session is unrecoverable. Findings are not swept by that
+   * path, so the measurement survives -- but only if the session is recorded where GC cannot
+   * reach it.
+   */
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_impact_gate_shadow_finding ON impact_gate_shadow(finding_id);`,
+```
+
+- [ ] **Step 4: Bump the migration level**
+
+`src/store/schema-version.ts:54`: `export const KNOWL_MIGRATION_LEVEL = 4;` and extend the comment above it to say level 4 adds `impact_gate_shadow` and its unique index, additive, so `KNOWL_SCHEMA_VERSION` again does not move.
+
+- [ ] **Step 5: Classify the table for snapshot restore**
+
+`src/store/snapshot-tables.ts`, beside `impact_findings: 'preserved'`:
+
+```ts
+  // Same reason as `impact_findings`' own: these rows are the measurement. A restore that rolled
+  // them back would silently reset the precision denominator to zero while leaving the findings
+  // they refer to in place.
+  impact_gate_shadow: 'preserved',
+```
+
+- [ ] **Step 6: Run the pin test to learn the new hash**
+
+Run: `npx vitest run tests/store/schema-pin.test.ts`
+Expected: FAIL, printing `Bump KNOWL_MIGRATION_LEVEL and add SCHEMA_PINS[4] = '<hash>'`. Copy the hash it prints — do not invent one.
+
+- [ ] **Step 7: Record the pin**
+
+In `tests/store/schema-pin.test.ts`, after the `3:` entry:
+
+```ts
+  // 4 adds `impact_gate_shadow` and its unique index on `finding_id`. Additive, so
+  // `KNOWL_SCHEMA_VERSION` again does not move.
+  4: '<hash printed in Step 6>',
+```
+
+- [ ] **Step 8: Verify**
+
+Run: `npx vitest run tests/store/impact-schema.test.ts tests/store/schema-pin.test.ts tests/store/portability.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/store/bootstrap.ts src/store/schema-version.ts src/store/snapshot-tables.ts \
+        tests/store/schema-pin.test.ts tests/store/impact-schema.test.ts
+git commit -m "feat(impact): impact_gate_shadow, at migration level 4
+
+What an enforcing gate would have blocked, recorded while it blocks nothing.
+One row per finding, because shadow mode does not release the read-set rows it
+names -- so the belief stays live and the same finding returns on the next
+write to that file. Without the unique index the row count would measure
+writes attempted rather than denials avoided.
+
+finding_id alone is the key: a finding's affected_id already is the read-set
+row id, so one finding is one stale belief. session_id is kept because
+sweepReadSets hard-deletes released rows and the owning session would
+otherwise be unrecoverable after GC."
+```
+
+---
+
+### Task 3: The `impact.gate` config key
+
+**Files:**
+- Modify: `src/core/types.ts:297` (add `gate` to the `impact` block)
+- Modify: `src/cli/config/schema.ts:25` (`ConfigKey` union), `:85+` (`CONFIG_FIELDS`)
+- Modify: `src/store/impact-config.ts` (add `impactGateMode`)
+- Test: `tests/core/impact-config.test.ts`
+
+**Interfaces:**
+- Produces: `type ImpactGateMode = 'off' | 'shadow' | 'enforce'` and `impactGateMode(config?: ProjectConfig): ImpactGateMode`, both from `src/store/impact-config.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/core/impact-config.test.ts` already exists on `main` (it came with piece 2). **Append** this
+block; add `impactGateMode` to its existing import of `../../src/store/impact-config.js` rather
+than writing a second import statement, and reuse whatever config helper the file already defines
+if it has one — the `config` helper below is only for the case where it does not.
+
+```ts
+const config = (impact: Record<string, unknown>): ProjectConfig =>
+  ({ impact } as unknown as ProjectConfig);
+
+describe('impactGateMode', () => {
+  it('is off when nothing is configured', () => {
+    expect(impactGateMode(undefined)).toBe('off');
+    expect(impactGateMode(config({}))).toBe('off');
+  });
+
+  it('reads shadow and enforce when detection is on', () => {
+    expect(impactGateMode(config({ enabled: true, gate: 'shadow' }))).toBe('shadow');
+    expect(impactGateMode(config({ enabled: true, gate: 'enforce' }))).toBe('enforce');
+  });
+
+  // The gate reads findings that only exist while detection is capturing, so an armed gate over
+  // a disabled detector is not a stricter configuration -- it is one that can never fire while
+  // claiming it can. Refusing it here means one place decides, rather than every call site.
+  it('is off when the gate is armed but detection is not', () => {
+    expect(impactGateMode(config({ enabled: false, gate: 'enforce' }))).toBe('off');
+    expect(impactGateMode(config({ gate: 'enforce' }))).toBe('off');
+  });
+
+  // Same rule `isImpactEnabled` follows: every failure mode of this subsystem is a failure of
+  // turning it on, and this one takes away somebody's ability to write a file.
+  it('treats an unrecognised value as off', () => {
+    expect(impactGateMode(config({ enabled: true, gate: 'yes' }))).toBe('off');
+    expect(impactGateMode(config({ enabled: true, gate: true }))).toBe('off');
+    expect(impactGateMode(config({ enabled: true }))).toBe('off');
+  });
+
+  it('leaves isImpactEnabled alone', () => {
+    expect(isImpactEnabled(config({ enabled: true, gate: 'enforce' }))).toBe(true);
+    expect(isImpactEnabled(config({ gate: 'enforce' }))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/core/impact-config.test.ts`
+Expected: FAIL — `impactGateMode is not a function`.
+
+- [ ] **Step 3: Add the type**
+
+`src/core/types.ts`, in the `impact` block:
+
+```ts
+  impact?: {
+    enabled?: boolean;
+    /**
+     * Whether the `PreToolUse` gate refuses a write whose premise has moved, and how loudly.
+     *
+     * `shadow` computes the identical verdict, records it in `impact_gate_shadow`, and lets the
+     * write through -- the state plan §9's ≥95%-over-≥40-findings bar is measured in, before
+     * anything is allowed to refuse. `enforce` denies. Separate from `enabled` because they are
+     * different risks: detection spends context, and the gate can cost somebody their session.
+     */
+    gate?: 'off' | 'shadow' | 'enforce';
+  };
+```
+
+- [ ] **Step 4: Add the resolver**
+
+`src/store/impact-config.ts`:
+
+```ts
+export type ImpactGateMode = 'off' | 'shadow' | 'enforce';
+
+const GATE_MODES: readonly ImpactGateMode[] = ['off', 'shadow', 'enforce'];
+
+/**
+ * How the write gate should behave, resolved once so no call site re-derives it.
+ *
+ * **Detection off means gate off, whatever the key says.** The gate's whole input is the open
+ * findings the detector writes, so an armed gate over a disabled detector is not a stricter
+ * configuration -- it is one that can never fire while reporting that it can.
+ *
+ * Anything unrecognised is `off`, following `isImpactEnabled`'s rule and for a sharper reason: a
+ * malformed value here does not merely switch on machinery nobody asked for, it can take away
+ * somebody's ability to write a file.
+ */
+export function impactGateMode(config?: ProjectConfig): ImpactGateMode {
+  if (!isImpactEnabled(config)) return 'off';
+  const mode = config?.impact?.gate;
+  return GATE_MODES.includes(mode as ImpactGateMode) ? mode as ImpactGateMode : 'off';
+}
+```
+
+- [ ] **Step 5: Add the config field**
+
+`src/cli/config/schema.ts` — extend the `ConfigKey` union at `:25` with `| 'impact.gate'`, add `const IMPACT_GATE_MODES = ['off', 'shadow', 'enforce'] as const;` beside the other enum tuples at `:80-83`, and append to `CONFIG_FIELDS` after `impact.enabled`:
+
+```ts
+  {
+    // `defaultValue: 'off'` lives here and nowhere else, same as `impact.enabled` above: the
+    // literal in DEFAULT_CONFIG would be merged into every config on the machine by
+    // `upgradeConfigDefaults`, which for this key means arming a write gate in every repository
+    // the user has ever initialized.
+    key: 'impact.gate', category: 'Change impact', type: 'enum', values: IMPACT_GATE_MODES,
+    parse: enumValue(IMPACT_GATE_MODES), defaultValue: 'off',
+    label: 'Write gate',
+    description: 'Before an edit lands on code this session read and has not seen since: shadow records what it would have refused and lets the write through, enforce refuses it and hands back what changed. Needs change impact detection on.',
+  },
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `npx vitest run tests/core/impact-config.test.ts tests/cli/cli.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/types.ts src/store/impact-config.ts src/cli/config/schema.ts tests/core/impact-config.test.ts
+git commit -m "feat(config): impact.gate -- off, shadow, or enforce
+
+Separate from impact.enabled because they are different risks. Detection
+spends context; the gate can cost somebody their working session, so it gets
+its own switch and its own default.
+
+Detection off resolves to gate off whatever the key says: the gate's entire
+input is the findings the detector writes, so an armed gate over a disabled
+detector cannot fire while reporting that it can. Unrecognised values are off
+for the same reason isImpactEnabled works that way, only sharper -- a
+malformed value here can take away somebody's ability to write a file."
+```
+
+---
+
+### Task 4: Shadow recording and the precision query
+
+**Files:**
+- Create: `src/store/gate-shadow.ts`
+- Test: `tests/store/gate-shadow.test.ts`
+
+**Interfaces:**
+- Consumes: `getClient` (`src/store/database.js`).
+- Produces, from `src/store/gate-shadow.ts`:
+  - `recordShadowBlock(input: { findingId: string; sessionId: string; targetPath: string }): Promise<boolean>` — true when a row was written, false when the finding was already recorded.
+  - `shadowGatePrecision(): Promise<{ adjudicated: number; falsePositives: number; precision: number | null }>` — `precision` is null when `adjudicated` is 0.
+  - `countShadowBlocks(): Promise<number>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/store/gate-shadow.test.ts`. Follow the fixture setup in `tests/store/impact-schema.test.ts` for `initDb`/root handling.
+
+```ts
+import { describe, expect, it, beforeEach } from 'vitest';
+import { getClient } from '../../src/store/database.js';
+import { countShadowBlocks, recordShadowBlock, shadowGatePrecision } from '../../src/store/gate-shadow.js';
+
+// A finding row, minimal but real: the precision query joins against it, so a fake id would
+// measure nothing and pass anyway.
+async function seedFinding(id: string, resolution: string | null): Promise<void> {
+  await getClient().execute({
+    sql: `INSERT INTO impact_findings
+            (id, cause_locator, cause_session, affected_kind, affected_id, tier, path_json, detected_at, delivered_at, resolution, resolved_at)
+          VALUES (?, 'symbol://src/a.ts#f', 'other-session', 'work', ?, 'certain', NULL, '2026-08-08T00:00:00.000Z', NULL, ?, ?)`,
+    args: [id, `read-${id}`, resolution, resolution ? '2026-08-08T01:00:00.000Z' : null],
+  });
+}
+
+describe('gate shadow log', () => {
+  it('records a finding once and reports the repeat as not written', async () => {
+    await seedFinding('f1', null);
+
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(true);
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/b.ts' })).toBe(false);
+    expect(await countShadowBlocks()).toBe(1);
+  });
+
+  it('computes precision from the findings the shadow rows point at', async () => {
+    await seedFinding('f1', 'repaired');
+    await seedFinding('f2', 'false_positive');
+    await seedFinding('f3', 'dismissed');
+    for (const id of ['f1', 'f2', 'f3']) {
+      await recordShadowBlock({ findingId: id, sessionId: 's1', targetPath: 'src/a.ts' });
+    }
+
+    const result = await shadowGatePrecision();
+    expect(result.adjudicated).toBe(3);
+    expect(result.falsePositives).toBe(1);
+    expect(result.precision).toBeCloseTo(2 / 3, 10);
+  });
+
+  // Unresolved findings leave both halves alone rather than counting as correct. Assuming an
+  // unadjudicated block was justified is how a precision number talks itself past its own bar.
+  it('excludes unresolved findings from both halves', async () => {
+    await seedFinding('f1', 'false_positive');
+    await seedFinding('f2', null);
+    await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' });
+    await recordShadowBlock({ findingId: 'f2', sessionId: 's1', targetPath: 'src/a.ts' });
+
+    const result = await shadowGatePrecision();
+    expect(result.adjudicated).toBe(1);
+    expect(result.falsePositives).toBe(1);
+    expect(result.precision).toBe(0);
+  });
+
+  it('reports null precision when nothing has been adjudicated', async () => {
+    await seedFinding('f1', null);
+    await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' });
+
+    const result = await shadowGatePrecision();
+    expect(result.adjudicated).toBe(0);
+    expect(result.precision).toBeNull();
+  });
+
+  // Same contract as recordReadBestEffort: this runs inside a hook, so a lost row beats a throw.
+  it('returns false rather than throwing when the row cannot be written', async () => {
+    expect(await recordShadowBlock({ findingId: '', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/store/gate-shadow.test.ts`
+Expected: FAIL — cannot resolve `src/store/gate-shadow.js`.
+
+- [ ] **Step 3: Write the module**
+
+Create `src/store/gate-shadow.ts`:
+
+```ts
+import crypto from 'node:crypto';
+import { getClient } from './database.js';
+
+/**
+ * What an enforcing write gate would have refused, recorded while it refuses nothing.
+ *
+ * The gate is the one part of the change-impact design that can cost somebody their working
+ * session, so plan §9 puts a ≥95% precision bar over ≥40 findings in front of it. This is the
+ * table that bar is computed from: shadow mode runs the real verdict and withholds the refusal,
+ * and every withheld refusal lands here.
+ *
+ * **One row per finding, enforced by a unique index rather than by a check here.** Shadow mode
+ * deliberately does not release the read-set rows it names -- releasing a belief the agent never
+ * re-read would make `work_read_sets` stop describing what the session holds, while that table is
+ * simultaneously the evidence this measurement rests on. Not releasing means the belief is still
+ * live on the next write to the same file, so without the index the row count would measure
+ * writes attempted rather than denials avoided, and those differ by however many times an agent
+ * happens to edit one file.
+ *
+ * No adjudication of its own. Every row names a finding, and findings already carry `resolution`
+ * through `knowl_impact({resolve})` -- which plan §15 established is the only adjudication path,
+ * precisely because the gate leaves findings open by design.
+ */
+
+const newId = (): string => crypto.randomUUID().replace(/-/g, '').substring(0, 16);
+
+export interface ShadowGatePrecision {
+  /** Shadow rows whose finding has been adjudicated. The denominator, and nothing else. */
+  adjudicated: number;
+  falsePositives: number;
+  /** `null` rather than 1 when nothing is adjudicated: no evidence is not a perfect score. */
+  precision: number | null;
+}
+
+/**
+ * Record one withheld refusal. True when this belief had not been recorded before.
+ *
+ * `INSERT OR IGNORE` against `idx_impact_gate_shadow_finding`, following `insertFinding`: the
+ * repeat is the expected case rather than an error, since the belief stays live by design and
+ * returns on every subsequent write to that file.
+ *
+ * Never throws. This runs inside the `PreToolUse` path with a host blocked on the answer, and the
+ * whole point of shadow mode is that it cannot affect the write -- so a store mid-snapshot costs
+ * one measurement, not somebody's edit.
+ */
+export async function recordShadowBlock(
+  input: { findingId: string; sessionId: string; targetPath: string },
+): Promise<boolean> {
+  const findingId = (input.findingId ?? '').trim();
+  const sessionId = (input.sessionId ?? '').trim();
+  const targetPath = (input.targetPath ?? '').trim();
+  if (!findingId || !sessionId || !targetPath) return false;
+
+  try {
+    const result = await getClient().execute({
+      sql: `INSERT OR IGNORE INTO impact_gate_shadow (id, finding_id, session_id, target_path, observed_at)
+            VALUES (?, ?, ?, ?, ?)`,
+      args: [newId(), findingId, sessionId, targetPath, new Date().toISOString()],
+    });
+    return Number(result.rowsAffected ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** How many refusals were withheld. The `≥40 findings` half of plan §9's bar. */
+export async function countShadowBlocks(): Promise<number> {
+  const rows = await getClient().execute('SELECT COUNT(*) AS total FROM impact_gate_shadow');
+  return Number(rows.rows[0]?.total ?? 0);
+}
+
+/**
+ * `1 − false_positive / adjudicated`, over the findings the shadow rows point at.
+ *
+ * Unresolved findings are excluded from **both** halves rather than counted as correct. Treating
+ * an unadjudicated block as justified is how a precision number talks its way past the bar it was
+ * meant to clear, and `resolution` exists precisely so the judgement is recorded rather than
+ * assumed.
+ */
+export async function shadowGatePrecision(): Promise<ShadowGatePrecision> {
+  const rows = await getClient().execute(
+    `SELECT COUNT(*) AS adjudicated,
+            SUM(CASE WHEN f.resolution = 'false_positive' THEN 1 ELSE 0 END) AS false_positives
+     FROM impact_gate_shadow s
+     JOIN impact_findings f ON f.id = s.finding_id
+     WHERE f.resolution IS NOT NULL`,
+  );
+  const adjudicated = Number(rows.rows[0]?.adjudicated ?? 0);
+  const falsePositives = Number(rows.rows[0]?.false_positives ?? 0);
+  return {
+    adjudicated,
+    falsePositives,
+    precision: adjudicated === 0 ? null : 1 - falsePositives / adjudicated,
+  };
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npx vitest run tests/store/gate-shadow.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/gate-shadow.ts tests/store/gate-shadow.test.ts
+git commit -m "feat(impact): the shadow log, and the precision it is there to produce
+
+One row per finding, INSERT OR IGNORE against the unique index, following
+insertFinding -- the repeat is the expected case here, not an error, because
+shadow mode leaves the belief live by design and it returns on the next write
+to that file.
+
+Precision is 1 - false_positive/adjudicated over the findings the rows point
+at, and unresolved findings are excluded from both halves rather than counted
+as correct. Treating an unadjudicated block as justified is how a number talks
+its way past the bar it was meant to clear. Null, not 1, when nothing has been
+adjudicated: no evidence is not a perfect score."
+```
+
+---
+
+### Task 5: Teach the gate its three modes
+
+**Files:**
+- Modify: `src/session/write-gate.ts`
+- Test: `tests/store/write-gate.test.ts`
+
+**Interfaces:**
+- Consumes: `impactGateMode`, `ImpactGateMode` (`src/store/impact-config.js`); `recordShadowBlock` (`src/store/gate-shadow.js`).
+- Produces: `WriteGateDecision` gains `shadowedFindingIds: string[]` — the findings this call recorded as withheld refusals. Empty in every mode but `shadow`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/store/write-gate.test.ts`. Reuse that file's existing helpers for seeding a session, a read-set row and a certain-tier finding.
+
+```ts
+describe('gate modes', () => {
+  it('off computes nothing and allows', async () => {
+    await writeConfig({ impact: { enabled: true, gate: 'off' } });
+    const decision = await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+
+    expect(decision.deny).toBe(false);
+    expect(decision.shadowedFindingIds).toEqual([]);
+    expect(await countShadowBlocks()).toBe(0);
+  });
+
+  it('shadow records the withheld refusal and lets the write through', async () => {
+    await writeConfig({ impact: { enabled: true, gate: 'shadow' } });
+    const decision = await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+
+    expect(decision.deny).toBe(false);
+    expect(decision.reason).toBeNull();
+    expect(decision.shadowedFindingIds).toEqual([findingId]);
+    expect(await countShadowBlocks()).toBe(1);
+  });
+
+  // The property the whole mode exists for. Releasing here would clear a belief the agent never
+  // re-read, so `work_read_sets` would stop describing what the session holds -- while being the
+  // evidence the precision number is computed from. A diagnostic must not change what it observes.
+  it('shadow does not release the read-set row it named', async () => {
+    await writeConfig({ impact: { enabled: true, gate: 'shadow' } });
+    await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+
+    const live = await activeReadSetForSession('session-1');
+    expect(live.map(entry => entry.id)).toContain(readSetId);
+  });
+
+  // Not releasing means the belief returns on the next write. The unique index is what keeps the
+  // count equal to the denials an enforcing gate would have issued.
+  it('shadow logs one row however many writes hit the same belief', async () => {
+    await writeConfig({ impact: { enabled: true, gate: 'shadow' } });
+    await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+    await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+    await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+
+    expect(await countShadowBlocks()).toBe(1);
+  });
+
+  it('enforce denies, releases, and writes no shadow row', async () => {
+    await writeConfig({ impact: { enabled: true, gate: 'enforce' } });
+    const decision = await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+
+    expect(decision.deny).toBe(true);
+    expect(decision.reason).toContain('KNOWL BLOCKED THIS WRITE');
+    expect(decision.releasedReadIds).toEqual([readSetId]);
+    expect(decision.shadowedFindingIds).toEqual([]);
+    expect(await countShadowBlocks()).toBe(0);
+
+    const live = await activeReadSetForSession('session-1');
+    expect(live.map(entry => entry.id)).not.toContain(readSetId);
+  });
+
+  // Detection off is gate off, decided in impactGateMode and re-asserted here because this is the
+  // call site where getting it wrong takes away somebody's edit.
+  it('allows when the gate is armed but detection is off', async () => {
+    await writeConfig({ impact: { enabled: false, gate: 'enforce' } });
+    const decision = await shouldRefuseWrite(root, 'session-1', ['src/a.ts']);
+
+    expect(decision.deny).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+Run: `npx vitest run tests/store/write-gate.test.ts`
+Expected: FAIL — `shadowedFindingIds` undefined; shadow mode denies.
+
+- [ ] **Step 3: Extend the decision type**
+
+In `src/session/write-gate.ts`:
+
+```ts
+export interface WriteGateDecision {
+  deny: boolean;
+  /** Non-null exactly when `deny` is true. */
+  reason: string | null;
+  /**
+   * The read-set rows this denial named and released. Present so the caller can see the one-shot
+   * happened rather than take it on trust; see `releaseGatedReads`. Empty in `shadow`, which
+   * withholds the refusal and therefore has no one-shot to spend.
+   */
+  releasedReadIds: string[];
+  /**
+   * The findings recorded as withheld refusals. Non-empty only in `shadow`, and it is how a
+   * caller distinguishes "the gate found nothing" from "the gate found something and said
+   * nothing" -- two outcomes that are otherwise the same `allow()`.
+   */
+  shadowedFindingIds: string[];
+}
+
+const allow = (): WriteGateDecision => ({ deny: false, reason: null, releasedReadIds: [], shadowedFindingIds: [] });
+```
+
+- [ ] **Step 4: Branch on the mode**
+
+Replace the `isImpactEnabled` check:
+
+```ts
+    const config = await loadConfig(root).catch(() => null);
+    const mode = impactGateMode(config ?? undefined);
+    if (mode === 'off') return allow();
+```
+
+Collect the finding id alongside the read-set id in the matching loop — add `const findingIds: string[] = [];` beside `ids`, and `findingIds.push(finding.id);` next to `ids.push(entry.id);`.
+
+Then, after `if (entries.length === 0) return allow();`:
+
+```ts
+    /*
+     * Shadow: the same verdict, withheld.
+     *
+     * **No release, and that is the point.** Enforcing mode releases these rows so a retry is
+     * never blocked twice, which is safe there because the agent was told to re-read. Doing it
+     * here would clear a belief nobody re-read, so `work_read_sets` would stop describing what
+     * the session holds -- while being the evidence the precision number is computed from. The
+     * belief therefore stays live and this same finding returns on the next write to the file;
+     * `idx_impact_gate_shadow_finding` is what keeps that from inflating the count.
+     *
+     * `paths[0]` because the row is written once and every later attempt is ignored, so the
+     * column answers "what was in flight when this would first have been blocked".
+     */
+    if (mode === 'shadow') {
+      const shadowedFindingIds: string[] = [];
+      for (const findingId of findingIds) {
+        if (await recordShadowBlock({ findingId, sessionId, targetPath: paths[0] })) {
+          shadowedFindingIds.push(findingId);
+        }
+      }
+      return { deny: false, reason: null, releasedReadIds: [], shadowedFindingIds };
+    }
+```
+
+Leave the `releaseGatedReads` block below it untouched, and add `shadowedFindingIds: []` to the returned denial.
+
+Imports to add:
+
+```ts
+import { impactGateMode } from '../store/impact-config.js';
+import { recordShadowBlock } from '../store/gate-shadow.js';
+```
+
+`isImpactEnabled` is no longer used here — remove it from the import list.
+
+- [ ] **Step 5: Verify**
+
+Run: `npx vitest run tests/store/write-gate.test.ts tests/store/gate-shadow.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Full suite**
+
+Run: `npm run build && npm test`
+Expected: 257 files + 2 new, all passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/session/write-gate.ts tests/store/write-gate.test.ts
+git commit -m "feat(impact): the gate ships in shadow mode first
+
+Same verdict, withheld. The gate is the one part of this subsystem that can
+cost somebody their working session, so plan §9's >=95%-over->=40-findings bar
+gets measured before anything refuses a write.
+
+Shadow does not release the read-set rows it names, which is the property the
+mode exists for. Enforcing mode releases them so a retry is never blocked
+twice -- safe there, because the agent was told to re-read. Doing the same
+here would clear a belief nobody re-read, so work_read_sets would stop
+describing what the session holds while being the evidence the precision
+number is computed from.
+
+The belief therefore stays live and the finding returns on the next write to
+that file; the unique index on finding_id keeps that from inflating the count,
+so shadow rows equal the denials an enforcing gate would have issued."
+```
+
+---
+
+### Task 6: Correct the two stale config strings
+
+Spec §5. Both describe the `knowl_task_finish` gate that plan §15 removed as unreachable by construction. Verified on `main`: `openFindingsForSession` has exactly one caller, `src/mcp/tools.ts:364`, the `knowl_impact` pull tool.
+
+**Files:**
+- Modify: `src/cli/config/schema.ts:213`
+- Modify: `src/core/types.ts:282-296`
+- Test: `tests/cli/cli.test.ts` (only if it asserts on the description text — check first)
+
+- [ ] **Step 1: Check whether anything asserts the current wording**
+
+Run: `grep -rn "task finish reports unresolved" tests/ src/`
+Expected: only the two source sites. If a test pins the string, update it in the same commit.
+
+- [ ] **Step 2: Fix the config description**
+
+`src/cli/config/schema.ts:213` — replace the trailing sentence:
+
+```ts
+    description: 'Record which code each session read, and flag work whose code changed underneath it. Findings reach the agent through the change card and knowl_impact.',
+```
+
+- [ ] **Step 3: Fix the type comment**
+
+`src/core/types.ts`, in the `impact` block's doc comment, replace *"and a gate that declines to record a clean finish while a certain-tier finding is unresolved"* with:
+
+```
+   * it, and findings an agent can pull and adjudicate. The `PreToolUse` write gate is a
+   * separate switch (`impact.gate`) for a separate risk.
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npx vitest run tests/cli/cli.test.ts tests/cli/doctor-report.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/config/schema.ts src/core/types.ts
+git commit -m "docs(config): stop promising a task-finish gate that does not exist
+
+Both strings described knowl_task_finish declining to close clean over an
+unresolved certain-tier finding. Plan §15 removed that gate as unreachable by
+construction -- reads are captured under the host session and startWorkLoop
+mints a different one, so openFindingsForSession queried an id under which no
+read was ever recorded.
+
+Verified rather than assumed: openFindingsForSession has exactly one caller on
+main, tools.ts:364, which is the knowl_impact pull tool. Nothing consults it at
+task finish.
+
+§15's own conclusion is that a description promising an enforcement that
+cannot fire is worse than no promise, and it costs guidance-card space in
+every session to say it."
+```
+
+---
+
+### Task 7: Document the mode and close out
+
+**Files:**
+- Modify: `docs/change-impact-plan.md` (§7.5 and the §8 phase table)
+
+`docs/reference.md` needs nothing — checked, it does not enumerate config keys (`grep -n
+"impact.enabled\|search.transcripts.enabled" docs/reference.md` returns no matches), so the new
+key is reachable through `knowl config` and the `CONFIG_FIELDS` entry alone.
+
+- [ ] **Step 1: Amend §7.5 of the plan doc**
+
+After the four-properties list, add:
+
+```markdown
+**Shipped in shadow mode first.** `impact.gate` takes `off` (default), `shadow` or `enforce`.
+`shadow` computes the identical verdict, records it in `impact_gate_shadow`, and allows the
+write — so §9's ≥95%-over-≥40-findings bar is measured before anything refuses anything.
+
+Shadow deliberately does **not** release the read-set rows it names. Enforcing mode does, so a
+retry is never blocked twice; doing the same while merely observing would clear a belief the
+agent never re-read, and `work_read_sets` is simultaneously the evidence the precision number is
+computed from. The belief therefore stays live and the same finding returns on the next write to
+that file, which is why `impact_gate_shadow` is unique on `finding_id`: the row count has to
+equal the denials an enforcing gate would have issued, not the writes that were attempted.
+```
+
+- [ ] **Step 2: Mark P-3 in the §8 phase table**
+
+Change the P-3 row's gate column to note that the gate ships in shadow first and that promotion to `enforce` is a separate decision on the measured number.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+npm run build
+npx tsc --noEmit
+npx eslint .
+npm test
+```
+Expected: build clean, `tsc` clean, eslint 0 errors, 259 files / 2257+new passing, 4 skipped.
+
+If `tsc --noEmit` reports pre-existing errors in files this change did not touch, note them and move on — `main` is not gated on it (see the 2.17.0 release notes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(impact): say that the gate ships in shadow mode, and why it does not release"
+```
+
+- [ ] **Step 5: Report**
+
+Summarize for the maintainer: what landed, the full-suite numbers, that nothing blocks a write yet, and that promotion to `enforce` needs ≥40 adjudicated findings at ≥95% precision — queried with `shadowGatePrecision()`.
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 → Task 1. §2 (rebase) → Task 1 Steps 1-2, 9. §2.1 layer move → Task 1 Steps 3-6. §2.1 `working-tree.ts` → not reintroduced; the commit does not contain it, verified in `git show --stat cd9fc8f`. §3.1 config → Task 3. §3.2 shadow semantics → Task 5. §3.3 table and unique index → Task 2. §3.4 precision → Task 4. §3.5 enforce unchanged → Task 5 Step 4 leaves `releaseGatedReads` untouched, pinned by the enforce test. §4 schema house rules → Task 2. §5 → Task 6. §6 testing → distributed, each task test-first. §7 non-goals → nothing in any task flips `enforce` on.
+
+**Type consistency.** `WriteGateDecision` gains `shadowedFindingIds: string[]` in Task 5 and `allow()` is updated in the same step, so every existing return path stays well-typed. `ImpactGateMode` is declared in Task 3 and consumed in Task 5. `recordShadowBlock`/`countShadowBlocks`/`shadowGatePrecision` are declared in Task 4 and consumed in Task 5's tests. `impact_gate_shadow`'s columns match between Task 2's DDL, Task 2's test, and Task 4's SQL.
+
+**Ordering note.** Task 4's tests insert into `impact_gate_shadow`, so Task 2 must land first. Task 5 consumes both. Tasks 6 and 7 are independent and may be done in either order after Task 5.

--- a/docs/superpowers/specs/2026-08-08-write-gate-shadow-mode-design.md
+++ b/docs/superpowers/specs/2026-08-08-write-gate-shadow-mode-design.md
@@ -1,0 +1,233 @@
+# The `PreToolUse` write gate, in shadow mode first
+
+Issue #17, piece 3. Pieces 1 (PR #19, `08040f9`) and 2 (PR #33, `c8fc58d`) are merged; this is
+what keeps #17 open.
+
+The design of the gate itself is not new work — it is `docs/change-impact-plan.md` §7.5, accepted
+on #17 (comment 5192096798) — and an implementation of it already exists on
+`William-Sommers:impact/3-write-gate` at `cd9fc8f`. What this spec adds is the condition the
+maintainer attached to that acceptance and which the branch does not implement: **the gate ships
+in shadow mode first, logging what it would have blocked, so the false-positive rate is measured
+before anything refuses a write.**
+
+## 1. What the gate is
+
+Two agents share a repo. Agent A reads `login.ts` and plans an edit. Agent B changes that
+function. Agent A's edit then lands on a version that is gone.
+
+Pieces 1 and 2 detect this and add a `CODE IMPACT` stanza to the change card. That is a notice,
+and notices are the intervention measured at approximately zero effect twice, independently —
+SWE-Touch finds message-plus-edit no better than the silent edit and *worse* for 3 of 4 models;
+CooperBench finds a first-turn plan halves the conflict rate while moving end-to-end success by
+an amount that is not statistically significant.
+
+The gate is the mechanism with evidence behind it. `PreToolUse` fires before `Edit`/`Write`/
+`MultiEdit`; when the write targets a file holding an unresolved `certain`-tier finding against a
+read *this session still holds*, the hook returns `permissionDecision: 'deny'` with the was/now
+pair and the host blocks the call. That is STORM's mechanism, the one intervention in the
+literature that moved a number (+18.7 on Commit0-Lite).
+
+**Nothing is discarded.** A denial costs one tool call, reissued after a re-read. That is what
+separates it from optimistic concurrency control, which aborted trajectories for 0.93× speedup at
+1.83× tokens.
+
+## 2. Base: rebase the contributor's branch
+
+`William-Sommers:impact/3-write-gate` is cut from `ac3ce52`, before pieces 1 and 2 landed, so its
+raw diff spans all three. The gate-specific content is `src/store/write-gate.ts` (307 lines),
+`src/store/working-tree.ts` (79), `tests/store/write-gate.test.ts` (333),
+`tests/cli/tool-precheck.test.ts` (190), and deltas to the hook plumbing.
+
+We rebase it onto current `main` with authorship preserved, following how #19 and #33 went and the
+2.17.0 cherry-pick precedent. The reasoning in that code is already the reasoning in the plan doc;
+rewriting it would discard validated work to no end.
+
+The wiring it brings is complete and is kept as-is:
+
+| Piece | What it does |
+|---|---|
+| `hosts/claude.ts` | `PreToolUse` → normalized `tool-precheck`, in a Claude-only event map — Codex 0.145.0's dispatcher enum has no `PreToolUse`, so teaching the shared map would mark that host gated when it is not |
+| `hosts/profile.ts` | `denyToolCall` as an optional capability; absence means the host cannot refuse |
+| `host-lifecycle.ts` | `runWriteGate`, claimed first so no other branch mistakes a pre-tool event for a session boundary |
+| `agent-hook.ts` | the deny returns on **exit 0**. Claude reads a `PreToolUse` verdict from stdout only on exit 0; a non-zero exit discards it and runs the tool anyway |
+
+### 2.1 Two corrections it needs
+
+**Layer placement.** `store/write-gate.ts` imports `ImpactCardEntry` from `cli/agents/
+change-card.js` and `openFindingsForSession` from `impact.js`. Under the layer graph #31 enforced
+(`tests/architecture/module-boundaries.test.ts`: `store` = 1, `code` = 2, `session` = 3,
+`cli`/`mcp` = 4) both are upward edges, and on current `main` both targets have moved anyway —
+the card renderer is `src/session/change-card.ts` and the detector is `src/session/impact.ts`.
+The gate moves to **`src/session/write-gate.ts`**. This is the identical correction #33 needed;
+the comment at `src/mcp/tools.ts:1171` naming `store/write-gate.ts` is updated with it.
+
+**`working-tree.ts` stays deleted.** #33's review removed it as dead code on the reasoning that it
+was the write gate's input. Checked against the contributor's own branch: `git grep working-tree`
+over its `src/` returns nothing — it has no caller there either. The gate takes its target paths
+from the hook event, not from `git status`. It is P-1 tick machinery that was never wired, and it
+comes back with the code that needs it, which is not this.
+
+## 3. Shadow mode
+
+### 3.1 Configuration
+
+A second key beside `impact.enabled`:
+
+```
+impact.gate:  'off' (default) | 'shadow' | 'enforce'
+```
+
+Both must be on for anything to happen — `impact.enabled` gates capture and detection, and a gate
+with no findings to read has nothing to say.
+
+Follows `search.transcripts.enabled` exactly: the union in `src/cli/config/schema.ts:25`, the
+`CONFIG_FIELDS` entry with `defaultValue: 'off'`, the type in `src/core/types.ts:297`, and
+**deliberately not in `DEFAULT_CONFIG`** — `upgradeConfigDefaults` merges that object into every
+config on the machine, so a default written there would arm a write gate in every repository the
+user has ever initialized, at once, with nothing recording that it happened.
+
+### 3.2 What shadow does
+
+`shouldRefuseWrite` computes the identical verdict. On a would-be denial in `shadow`:
+
+1. write one row to `impact_gate_shadow`;
+2. **do not** release the read-set rows;
+3. return `allow()`.
+
+The read-set is the thing being measured, so shadow mode must not write to it. This is the repo's
+own rule from 2.17.0 — a diagnostic must not change the process it observes — and the concrete
+harm is specific: releasing a belief the agent never re-read makes the read-set stop describing
+what the session holds, while that table is simultaneously the evidence the precision number is
+computed against.
+
+### 3.3 One row per belief
+
+```sql
+CREATE TABLE IF NOT EXISTS impact_gate_shadow (
+  id           TEXT PRIMARY KEY,
+  finding_id   TEXT NOT NULL,
+  session_id   TEXT NOT NULL,
+  target_path  TEXT NOT NULL,
+  observed_at  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_impact_gate_shadow_finding
+  ON impact_gate_shadow(finding_id);
+```
+
+The unique index is the whole design. Because shadow does not release, the same stale belief is
+still live on the next write to that file and would log again — so the row count would measure
+*writes attempted* rather than *blocks a real gate would produce*, and those differ by however
+many times an agent happens to edit one file. With `finding_id` unique, a repeat is an ignored
+constraint violation and the count of rows equals the count of denials `enforce` would have
+issued. That is what makes the shadow measurement predictive of the real one rather than merely
+suggestive.
+
+**`finding_id` alone, and not `(finding_id, read_set_id)`.** A finding's `affected_id` *is* the
+read-set row id — `detectCertainImpact` writes `affectedId: entry.id` from the read-set entry it
+compared (`session/impact.ts:417`), and `openFindingsForSession` joins
+`work_read_sets w ON w.id = f.affected_id` (`:463`). So one finding is one stale belief already,
+the pair is 1:1, and a stored `read_set_id` would be a second copy of a value that can only ever
+disagree with its source. The adjudicator reaches the read-set row through the finding.
+
+`target_path` is recorded because a finding can be reached from more than one write target and the
+adjudicator needs to see which edit was in flight. It is the *first* such target, not the latest:
+the row is written once and the unique index makes every later attempt a no-op, so the column
+answers "what was the agent doing when this first would have been blocked" — which is the question
+a false-positive adjudication actually asks.
+
+`session_id` is kept even though it is reachable through the same join, and this is the one place
+the denormalization earns itself: `sweepReadSets` **hard-deletes** released read-set rows
+(`store/read-set.ts`, `DELETE ... WHERE released_at IS NOT NULL AND released_at < ?`), so once GC
+has run the finding's join to `work_read_sets` returns nothing and the owning session is
+unrecoverable. Findings themselves are not swept by that path, so the precision measurement
+survives GC — but only if the session is recorded where GC cannot reach it. That is a different
+situation from `read_set_id`, which after the same sweep would be an id pointing at a row that no
+longer exists.
+
+### 3.4 The measurement
+
+No new adjudication path. Every shadow row names a `finding_id`, and findings already carry
+`resolution`, set through `knowl_impact({resolve})` — which §15 established is the only
+adjudication path, precisely because the gate leaves findings open by design.
+
+```
+precision = 1 − (shadow rows whose finding resolved false_positive) / (shadow rows whose finding resolved)
+```
+
+Promotion to `enforce` is a separate decision on a stated number, against plan §9's bar: **≥95%
+over ≥40 findings**. Unresolved findings are excluded from both halves rather than assumed good.
+
+### 3.5 What enforce does
+
+Unchanged from the contributor's branch: release the named read-set rows, then deny — release
+first, so a refusal that could not be recorded is abandoned rather than issued, because a denial
+the store did not remember is one that fires again on the retry. That is the "one shot per stale
+belief" property; a gate that can trap an agent is strictly worse than no gate.
+
+Fail open without exception, also unchanged: flag off, no session, unknown host, no `denyToolCall`
+capability, broken store, malformed row, failed release. A silent detector costs recall; a gate
+that wrongly blocks costs someone their working session.
+
+## 4. Schema
+
+One additive table and one index, appended to `SCHEMA_STATEMENTS` in `src/store/bootstrap.ts`.
+Per the house rules in plan §8:
+
+- `KNOWL_MIGRATION_LEVEL` **3 → 4** (`src/store/schema-version.ts:54`) — without the bump every
+  existing database skips the migration forever;
+- `KNOWL_SCHEMA_VERSION` **stays 1** (`:24`) — raising it locks out installed builds, and this
+  change is purely additive;
+- a new `SCHEMA_PINS` entry — the map lives in `tests/store/schema-pin.test.ts:22`, keyed by
+  migration level, and the test prints the hash to add when it is missing;
+- `src/store/snapshot-tables.ts` gets `impact_gate_shadow: 'preserved'`, joining
+  `work_read_sets` and `impact_findings` at `:67-68`. Same reason as `impact_findings`' own: the
+  rows are the measurement, and a snapshot restore that dropped them would silently reset the
+  precision denominator to zero.
+
+## 5. In-scope correction
+
+`src/cli/config/schema.ts:213` describes `impact.enabled` as *"While on, a task finish reports
+unresolved changes instead of closing clean"*, and `src/core/types.ts:284` calls it *"a gate that
+declines to record a clean finish while a certain-tier finding is unresolved."*
+
+Both describe the `knowl_task_finish` gate that plan §15 removed as unreachable by construction.
+Verified on current `main`: `openFindingsForSession` has exactly one caller, `src/mcp/tools.ts:364`,
+which is the `knowl_impact` pull tool — nothing consults it at task finish.
+
+Both strings are corrected as part of this change. They are in the two files this change edits to
+add `impact.gate`, and §15's own conclusion is that a description promising an enforcement that
+cannot fire is worse than no promise.
+
+## 6. Testing
+
+Written failing-first, full suite run. The baseline in this worktree is **2261 tests across 257
+files**, and it requires `npm run build` first — a fresh worktree has no `dist/`, and the CLI
+tests spawn the built binary, so an unbuilt tree fails 76 of them for reasons that have nothing to
+do with the change under test.
+
+**Kept from the branch**, retargeted to `session/write-gate.ts`: `tests/store/write-gate.test.ts`
+(the verdict — symbol granularity, self-exclusion, the fail-open matrix) and
+`tests/cli/tool-precheck.test.ts` (normalization, Claude-only mapping, the deny envelope).
+
+**New, for shadow mode:**
+
+| Test | Pins |
+|---|---|
+| shadow logs and allows | verdict identical to `enforce`, `deny: false`, tool proceeds |
+| shadow does not release | the read-set row is still live afterwards — the observer-effect rule |
+| repeat write, one row | second write to the same file adds no row; the unique index holds |
+| distinct beliefs, distinct rows | two findings on one file produce two rows |
+| `off` computes nothing | no findings query is issued at all |
+| enforce still releases | the one-shot survives the refactor |
+| precision query | mixed resolutions produce the stated ratio; unresolved excluded from both halves |
+
+The measurement itself extends `tests/store/impact-precision.test.ts`, which already carries the
+46 adjudicated scenarios from the 2026-08-05 run.
+
+## 7. Explicitly not in this change
+
+- Flipping anything to `enforce`. That is a later decision on a measured number.
+- Codex support. Its dispatcher has no `PreToolUse`; a host that cannot refuse is left alone.
+- `working-tree.ts` and the P-1 tick.
+- Any second gate at `knowl_task_finish` — §15 settled that.
+- Test selection and the replan hint (P-5).

--- a/src/cli/agent-hook.ts
+++ b/src/cli/agent-hook.ts
@@ -45,6 +45,18 @@ export async function runAgentHook(host: string, event: string): Promise<void> {
       await catchUpTranscripts(root);
     }
 
+    // **This path must exit 0, including when the output is a refusal.**
+    //
+    // Claude Code reads a `PreToolUse` verdict from stdout only on exit 0. A non-zero exit is
+    // read as the hook having crashed, and the verdict is discarded -- so a `permissionDecision:
+    // "deny"` emitted alongside a failing exit code does not block anything, it just runs the
+    // tool. That is the single most common cause of "deny is ignored" reports upstream
+    // (anthropics/claude-code#37210 was closed as exactly this, on the reporter's own diagnosis),
+    // and it fails in the direction that is hardest to notice: every test still passes, because
+    // the refusal is computed correctly and only the process's exit status throws it away.
+    //
+    // So the deny returns normally from here. Do not add a `process.exit` to this branch, and do
+    // not "signal failure" from a hook that produced a verdict.
     if (result.hostOutput) console.log(JSON.stringify(result.hostOutput));
     else if (!hostProfile(normalized.host).nativeOutput) console.log(JSON.stringify(result));
     await closeDb();

--- a/src/cli/agents/hook-config.ts
+++ b/src/cli/agents/hook-config.ts
@@ -98,6 +98,13 @@ export async function mergeNestedHookConfig(
     : {};
   const events = hostProfile(host).hookEvents;
   let hadOwnEntry = false;
+  // Spread first, so an event added to a profile after a settings.json was written appends
+  // as a new key and every event already there keeps its position and its foreign handlers.
+  // Note what this does *not* do: nothing re-runs the merge on its own. An install written by
+  // an older build stays a version behind until `knowl init <host>` or `knowl doctor --fix`
+  // runs -- `verifyNestedHookConfig` requires an entry for every declared event, so the
+  // missing one surfaces as "lifecycle hooks missing or stale" with a host-init remedy
+  // rather than as silence.
   const nextHooks = { ...hooks };
   for (const event of events) {
     const current = Array.isArray(hooks[event]) ? hooks[event] as Record<string, any>[] : [];

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -255,6 +255,29 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
   const event = profile.normalizedEvent(eventName);
   if (!event) throw new Error(`Unsupported ${normalizedHost} hook event: ${eventName}`);
   if (normalizedHost === 'generic') return normalizeGeneric(event, raw, projectRoot, ids);
+  // Checked before every other event because this one fires ahead of *every* tool call --
+  // the only branch here whose cost is paid on that path -- and because the host is blocked
+  // on the answer, so work done before recognising it is latency in front of the agent.
+  if (event === 'tool-precheck') {
+    const toolName = stringValue(raw.tool_name) ?? stringValue(raw.toolName);
+    return {
+      host: normalizedHost,
+      event,
+      ...ids,
+      ...agent,
+      projectRoot,
+      // The same `changedPaths` helper the post-tool path uses, not a second copy: a gate
+      // matches these against paths recorded by earlier events, and two spellings of one
+      // file (absolute vs relative, backslashes vs forward) miss each other silently --
+      // a gate that never fires looks exactly like a gate with nothing to report.
+      // The name keeps the post-tool field's spelling for the same reason; here it means
+      // "about to change", and only the event name says which tense applies.
+      payload: { changedPaths: changedPaths(projectRoot, { ...raw, ...toolInput(raw) }) },
+      // Spread, so a host that named no tool leaves the field absent rather than empty --
+      // see `toolName` on NormalizedHostHook.
+      ...(toolName ? { toolName } : {}),
+    };
+  }
   if (event === 'session-start' || event === 'turn-start') {
     return { host: normalizedHost, event, ...ids, projectRoot, title: event === 'turn-start' ? 'Agent turn' : 'Agent session', payload: {} };
   }
@@ -303,5 +326,12 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
 }
 
 export function normalizeHostHook(host: string, eventName: string, raw: Record<string, unknown>): NormalizedHostHook {
-  return validateNormalizedHostHook(normalizeHostHookUnchecked(host, eventName, raw));
+  const normalized = normalizeHostHookUnchecked(host, eventName, raw);
+  // A precheck is answered and thrown away, never written, so the write validator is
+  // guarding nothing here -- and it rejects on a sensitive path, which would turn "the
+  // agent is about to touch .env" into a hook error printed in front of that call and
+  // every retry of it. Anything a consumer does go on to persist passes the validator at
+  // the store, which is the door that actually protects the row.
+  if (normalized.event === 'tool-precheck') return normalized;
+  return validateNormalizedHostHook(normalized);
 }

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -22,7 +22,8 @@ export type ConfigKey =
   | 'memory.organization.path'
   | 'memory.global.enabled'
   | 'memory.global.path'
-  | 'impact.enabled';
+  | 'impact.enabled'
+  | 'impact.gate';
 
 export type ConfigCategory = 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact';
 
@@ -81,6 +82,9 @@ const VECTOR_PROVIDERS = ['local'] as const;
 const VECTOR_DTYPES = ['q4', 'q8', 'fp16', 'fp32'] as const;
 const VECTOR_POOLINGS = ['mean', 'cls'] as const;
 const AI_PROVIDERS = ['openai', 'anthropic', 'ollama', 'custom'] as const;
+// Ordered by how much they can cost the person running them, which is also the order they are
+// meant to be adopted in: nothing, then measurement, then refusal.
+const IMPACT_GATE_MODES = ['off', 'shadow', 'enforce'] as const;
 
 export const CONFIG_FIELDS: ConfigField[] = [
   // The preset leads the Search list: it is the one setting most people should touch,
@@ -211,6 +215,16 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: booleanValue, defaultValue: false,
     label: 'Change impact detection',
     description: 'Record which code each session read, and flag work whose code changed underneath it. While on, a task finish reports unresolved changes instead of closing clean.',
+  },
+  {
+    // `defaultValue: 'off'` lives here and nowhere else, for the same reason as `impact.enabled`
+    // above and with more at stake: the literal in DEFAULT_CONFIG would be merged into every
+    // config on the machine by `upgradeConfigDefaults`, which for this key means arming a write
+    // gate in every repository the user has ever initialized.
+    key: 'impact.gate', category: 'Change impact', type: 'enum', values: IMPACT_GATE_MODES,
+    parse: enumValue(IMPACT_GATE_MODES), defaultValue: 'off',
+    label: 'Write gate',
+    description: 'Before an edit lands on code this session read and has not seen since: shadow records what it would have refused and lets the write through, enforce refuses it and hands back what changed. Needs change impact detection on.',
   },
 ];
 

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -214,7 +214,7 @@ export const CONFIG_FIELDS: ConfigField[] = [
     key: 'impact.enabled', category: 'Change impact', type: 'boolean',
     parse: booleanValue, defaultValue: false,
     label: 'Change impact detection',
-    description: 'Record which code each session read, and flag work whose code changed underneath it. While on, a task finish reports unresolved changes instead of closing clean.',
+    description: 'Record which code each session read, and flag work whose code changed underneath it. Findings reach the agent through the change card and knowl_impact.',
   },
   {
     // `defaultValue: 'off'` lives here and nowhere else, for the same reason as `impact.enabled`

--- a/src/core/host-hook-types.ts
+++ b/src/core/host-hook-types.ts
@@ -20,7 +20,17 @@ export type NormalizedHookEventName =
   | 'turn-stop'
   | 'session-stop'
   | 'agent-start'
-  | 'agent-stop';
+  | 'agent-stop'
+  /**
+   * A tool call the host is asking about *before* running it, and whose answer decides
+   * whether it runs at all.
+   *
+   * Separate from `session-event` because tense is the whole point: a post-tool event
+   * records what happened and its return value is advice, while this one is a question the
+   * host is waiting on. Folding the two together would let a consumer record a write that
+   * was then refused, and answer a refusal request for a call that already executed.
+   */
+  | 'tool-precheck';
 
 export interface NormalizedHostHook {
   host: HookHost;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -296,6 +296,23 @@ export interface ProjectConfig {
    */
   impact?: {
     enabled?: boolean;
+    /**
+     * Whether the `PreToolUse` write gate refuses an edit whose premise has already moved.
+     *
+     * A second switch rather than a mode of `enabled`, because the two carry different kinds of
+     * risk. Detection spends context and can be wrong inside a card; the gate refuses a tool
+     * call, and being wrong there costs somebody their working session. Arming it is therefore a
+     * separate, deliberate act.
+     *
+     * `shadow` computes the identical verdict, records it in `impact_gate_shadow`, and lets the
+     * write through -- the state the certain tier's ≥95%-over-≥40-findings bar is measured in,
+     * before anything is permitted to block. `enforce` denies and hands back what changed.
+     *
+     * Meaningless without `enabled`, and resolved to `off` in that case rather than honoured:
+     * the gate reads the findings the detector writes, so an armed gate over a disabled detector
+     * can never fire while claiming it can.
+     */
+    gate?: 'off' | 'shadow' | 'enforce';
   };
   /**
    * This repo's half of workspace membership. The other half is the workspace manifest

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -281,13 +281,14 @@ export interface ProjectConfig {
   };
   /**
    * Live change-impact detection: what a session read, whether that code moved underneath
-   * it, and a gate that declines to record a clean finish while a certain-tier finding is
-   * unresolved. Off by default for two separate reasons.
+   * it, and findings an agent can pull and adjudicate. Off by default for two separate
+   * reasons. Refusing the write itself is a separate switch, `gate` below, for a separate
+   * risk.
    *
    * It is advisory machinery that spends context: findings reach the agent through the
    * shared change card, and tool-side noise is the channel a wrong finding damages most, so
-   * a repository that never asked for it must pay nothing -- not a card line, not a capture
-   * write, not a held-open task finish.
+   * a repository that never asked for it must pay nothing -- not a card line and not a
+   * capture write.
    *
    * Deliberately absent from DEFAULT_CONFIG for the same reason `search.transcripts` is:
    * `upgradeConfigDefaults` merges that object into every config on the machine, so a

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -130,7 +130,7 @@ const IMPACT_TOOLS: ToolDefinition[] = [
             properties: {
               scope: {
                 type: 'string', enum: ['mine', 'all'],
-                description: 'mine (default): findings against reads still held open -- the work someone can still act on. all: every open finding, including ones whose read was released when a task finished and which nobody has adjudicated yet.',
+                description: 'mine (default): findings against reads still held open -- the work someone can still act on. all: every open finding, including ones whose read was released when its session ended and which nobody has adjudicated yet.',
               },
               tier: {
                 type: 'string', enum: ['certain', 'likely', 'possible'],
@@ -352,8 +352,12 @@ const impactText = (value: unknown): string | null =>
  * the protocol stateless and removed `Mcp-Session-Id`, so a tool call carries nothing that names
  * its caller. A held read is the closest honest proxy -- it is work somebody is still standing on,
  * which is the set an agent can act on -- and `all` widens it to include findings whose read was
- * released at a task finish and which nobody has adjudicated, since an unadjudicated finding is
- * exactly what the precision denominator is missing (plan §9).
+ * released when its session ended and which nobody has adjudicated, since an unadjudicated finding
+ * is exactly what the precision denominator is missing (plan §9).
+ *
+ * Session end, not task finish: `releaseSessionReadSet` is called from the stop and failure
+ * branches of `host-lifecycle.ts` and nowhere else. The task-scoped release was removed in #33
+ * because nothing on the capture path knows a task id.
  *
  * The read-set query runs only for a session that actually has findings, so the common case --
  * every session clean -- costs one query per live session and nothing else.

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1168,7 +1168,7 @@ export function registerTools(
         // gate resolved through the task's tag queries an id under which no read exists. The
         // loose repair (any recent session) is the one thing this must not do: it would block
         // one agent's finish over another agent's stale read. The write gate
-        // (`store/write-gate.ts`) is the chokepoint instead, and it needs no such join because
+        // (`session/write-gate.ts`) is the chokepoint instead, and it needs no such join because
         // it runs inside the session that holds the read. Plan §15.
         const result = await finishWorkLoop(projectId!, taskId, summary);
         return {

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -12,6 +12,7 @@ import {
   recordReadsBestEffort, releaseReadSetBestEffort, repoRelativePath, sweepReadSetsBestEffort,
   type ReadObservation,
 } from '../store/read-set.js';
+import { shouldRefuseWrite } from './write-gate.js';
 import { KNOWL_CLAUDE_CONTINUATION_REMINDER, KNOWL_SUBAGENT_BOOTSTRAP_CARD } from '../core/knowl-guidance.js';
 import {
   ChangeSummary,
@@ -564,6 +565,49 @@ async function runToolEventImpact(input: NormalizedHostHook, sessionId: string):
   }
 }
 
+/**
+ * The pre-write branch: refuse this one call when the session is about to write over something it
+ * read and has not seen since.
+ *
+ * Ordered by cost, and the first three checks touch nothing. This fires ahead of *every* tool call
+ * with the host blocked on the answer, so the tool-name filter is what keeps it off the path of
+ * every read, grep and shell command the agent makes.
+ *
+ * The session binding is looked up, never created. A pre-tool event is an observation of something
+ * about to happen; a session that does not exist yet has read nothing, and bootstrapping one here
+ * would mint memory sessions from hook traffic.
+ *
+ * Wrapped whole, following `flagCorrectionSiblingsBestEffort`. Every failure here allows the
+ * write: the worst outcome this subsystem can produce is not a missed detection, it is a person
+ * whose agent cannot edit a file because a memory server had an opinion about it.
+ */
+async function runWriteGate(input: NormalizedHostHook): Promise<HostLifecycleResult> {
+  try {
+    if (!IMPACT_WRITE_TOOLS.has(input.toolName ?? '')) return { accepted: true };
+    const paths = impactChangedPaths(input.payload);
+    if (paths.length === 0) return { accepted: true };
+
+    // Absent on every host without a pre-tool callback of its own -- capability by return value,
+    // the rule the rest of this interface follows. A host that cannot refuse has no use for the
+    // answer, and asking anyway would spend the gate's one-shot on a refusal nobody could deliver.
+    const { denyToolCall } = hostProfile(input.host);
+    if (typeof denyToolCall !== 'function') return { accepted: true };
+
+    const session = await findHostSession(bindingKey(input, 'turn'))
+      ?? await findHostSession(bindingKey(input, 'session'));
+    if (!session) return { accepted: true };
+
+    const decision = await shouldRefuseWrite(input.projectRoot, session.id, paths);
+    if (!decision.deny || !decision.reason) return { accepted: true, sessionId: session.id };
+    // A host that declines to produce an envelope costs this one refusal: the gate has already
+    // spent its one-shot, so the write proceeds and the finding stays open for the card to carry.
+    // Silence is the right degradation -- the alternative is holding the block armed for a host
+    // that has no way to explain it, which is a refusal with no reason attached.
+    return { accepted: true, sessionId: session.id, hostOutput: denyToolCall(decision.reason) };
+  } catch {
+    return { accepted: true };
+  }
+}
 
 /**
  * Release a memory session's read-set when that session stops holding beliefs -- which is when
@@ -607,6 +651,12 @@ async function finalizeFailedStop(projectId: string, input: NormalizedHostHook, 
 }
 
 export async function handleHostLifecycleEvent(projectId: string, input: NormalizedHostHook): Promise<HostLifecycleResult> {
+  // First, and claimed before anything else can mistake it for a session boundary: every event
+  // this function does not recognise falls through to the session-stop handler at the bottom, and
+  // this one fires ahead of every tool call. It captures nothing, advances no watermark and
+  // finishes nothing -- the tool has not run yet, and the only question here is whether it should.
+  if (input.event === 'tool-precheck') return runWriteGate(input);
+
   if (input.event === 'session-start') {
     const recovered = await recoverAbandonedSessions();
     const purgedEventCount = await purgeExpiredSessionEvents();

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -62,7 +62,8 @@ const KNOWL_REMINDER_DRIFT = 12;
  * and deliberately do not.
  *
  * A read-set row asserts "this session saw this text and holds a belief about it", and the
- * certain tier spends that assertion by interrupting the agent and gating its task finish. So the
+ * certain tier spends that assertion by interrupting the agent and, once the gate is enforcing,
+ * refusing its write. So the
  * set is the tools that return *contents*: `Read`, and `NotebookRead`, whose target the host names
  * `notebook_path` rather than `file_path` -- which is why that key had to be added to `changedPaths`
  * and to the stdin allowlist in the same change, or this entry would have named a tool whose paths
@@ -412,7 +413,7 @@ function impactChangedPaths(payload: Record<string, unknown>): string[] {
  * single design difference between this and the only published system with the same shape:
  * STORM's own stated limitation is that file-level granularity makes "two agents editing
  * different functions in the same file" a false-positive rejection (plan §6). The certain tier is
- * the only tier allowed to push into an agent's context and gate a task finish, held to ≥95%
+ * the only tier allowed to push into an agent's context and refuse its write, held to ≥95%
  * precision, and file granularity spends that budget on edits that never touched anything the
  * reader saw. `file://` is recorded only when the file yields no symbols at all -- a non-code
  * file, a language with no grammar here, or a parse that produced nothing -- where the file hash

--- a/src/session/hosts/claude.ts
+++ b/src/session/hosts/claude.ts
@@ -16,6 +16,20 @@ export const PASCAL_EVENT_MAP: Record<string, NormalizedHookEventName> = {
   SessionEnd: 'session-stop',
 };
 
+/**
+ * Claude's map: the shared one plus the pre-tool event.
+ *
+ * Kept out of `PASCAL_EVENT_MAP` deliberately. Codex imports that map, and its own event
+ * list was verified against codex 0.145.0's dispatcher enum, which carries no PreToolUse --
+ * so adding it there would teach Codex to normalise an event it never registers and can
+ * never answer, and the gate downstream would treat that host as gated when it is not.
+ * A name a host does not implement has to keep being rejected.
+ */
+const CLAUDE_EVENT_MAP: Record<string, NormalizedHookEventName> = {
+  ...PASCAL_EVENT_MAP,
+  PreToolUse: 'tool-precheck',
+};
+
 /** `hookSpecificOutput` envelope used by Claude Code and Codex CLI. */
 export function hookSpecificOutput(hookEventName: string, context: string): HostOutput {
   return { hookSpecificOutput: { hookEventName, additionalContext: context } };
@@ -28,7 +42,7 @@ export function startEventName(event: NormalizedHookEventName): string {
 }
 
 export const CLAUDE_HOOK_EVENTS = [
-  'SessionStart', 'SubagentStart', 'PostToolUse', 'PostToolUseFailure',
+  'SessionStart', 'SubagentStart', 'PreToolUse', 'PostToolUse', 'PostToolUseFailure',
   'PreCompact', 'Stop', 'StopFailure', 'SubagentStop', 'SessionEnd',
 ] as const;
 
@@ -47,7 +61,7 @@ export const claudeProfile: HostProfile = {
     };
   },
   normalizedEvent(hostEvent) {
-    return PASCAL_EVENT_MAP[hostEvent];
+    return CLAUDE_EVENT_MAP[hostEvent];
   },
   isShellEvent(_hostEvent, toolName) {
     return toolNameIsShell(toolName);
@@ -57,5 +71,23 @@ export const claudeProfile: HostProfile = {
   },
   midTurnContext(text) {
     return hookSpecificOutput('PostToolUse', text);
+  },
+  // Claude Code's documented refusal: it reads the decision, blocks the tool call, and shows
+  // the model `permissionDecisionReason`. Deliberately not the `additionalContext` envelope
+  // above -- that one is advice attached to a call that already ran, and reusing it here
+  // would let the write through while the reason explains why it was stopped.
+  //
+  // The reason is passed through whole. Every other host string in this file is truncated at
+  // MAX_HOST_STRING, but this one is the recovery instruction itself: cutting it mid-sentence
+  // leaves the agent blocked and not told what to do about it, which is the one failure a
+  // gate cannot survive.
+  denyToolCall(reason) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    };
   },
 };

--- a/src/session/hosts/profile.ts
+++ b/src/session/hosts/profile.ts
@@ -43,6 +43,19 @@ export interface HostProfile {
   isShellEvent(hostEvent: string, toolName: string): boolean;
   startContext(event: NormalizedHookEventName, context: string): HostOutput | undefined;
   midTurnContext(text: string): HostOutput | undefined;
+  /**
+   * The host's own envelope for refusing the tool call this hook fired for, if it has one.
+   *
+   * Capability by return value again, and fail closed: a host whose refusal channel is not
+   * confirmed leaves this absent, so calling it yields undefined. The alternative -- assuming
+   * every host can deny -- emits an envelope the host ignores and then reports the call as
+   * blocked, so the write lands while the caller is told it did not. A gate that degrades to
+   * advisory is recoverable; one that lies about what it stopped is not.
+   *
+   * `reason` is the entire message the agent receives, because a denial has no second
+   * channel: whatever the agent needs in order to recover has to be inside this string.
+   */
+  denyToolCall?: (reason: string) => HostOutput | undefined;
 }
 
 export const hostString = (value: unknown): string | undefined =>

--- a/src/session/write-gate.ts
+++ b/src/session/write-gate.ts
@@ -1,0 +1,305 @@
+import type { ImpactCardEntry } from './change-card.js';
+import { loadConfig } from '../core/config.js';
+import { getClient } from '../store/database.js';
+import { isImpactEnabled } from '../store/impact-config.js';
+import { openFindingsForSession } from './impact.js';
+import { activeReadSetForSession, repoRelativePath, type ReadSetEntry } from '../store/read-set.js';
+
+/**
+ * Refuse one write whose premise has already moved, and hand back the diff that explains it.
+ *
+ * This is the only part of the change-impact design with a measured mechanism behind it. Telling
+ * an agent its premise is stale is measured at approximately zero effect twice, independently:
+ * SWE-Touch finds message-plus-edit no better than the silent edit and *worse* for 3 of 4 models,
+ * CooperBench finds a first-turn plan halves the conflict rate while moving end-to-end success by
+ * an amount that is not statistically significant. The one intervention that moved a number is
+ * STORM's -- reject the write, return the diff, let the agent re-read and retry (+18.7 on
+ * Commit0-Lite). So the notice is the courtesy and this is the mechanism (plan §0, §7.5).
+ *
+ * **Nothing is discarded.** What a denial costs is one tool call, which the agent reissues after
+ * re-reading. That is the whole reason this is safe where CoAgent's optimistic concurrency was not
+ * -- aborting a trajectory bought 0.93x speedup at 1.83x tokens, slower than serial while costing
+ * 83% more, and every published approach that discarded agent work underperformed (plan §6).
+ *
+ * **Symbol granularity, and that is the one improvement on STORM.** Its own stated limitation is
+ * that file-level rejection false-positives when two agents edit different functions in one file.
+ * The read-set stores `symbol://path#Name`, so a session that read `createSession` is not blocked
+ * from editing `destroySession` beside it.
+ *
+ * **The staleness verdict is not computed here.** A denial is predicated on an open certain-tier
+ * finding from `impact.ts`, which is where "did this locator move" lives. That is deliberate reuse
+ * rather than tidiness: a second copy of the comparison would drift from the first, and the two
+ * would disagree about which reads are stale -- the gate blocking writes the card never mentions,
+ * or the card naming changes the gate lets through. It also inherits, for free and by
+ * construction, the two conditions hardest to re-derive at gate time: the hash moved *since that
+ * read* (detection compares against the read-set row's own `observed_hash`), and the change was
+ * *not this session's own* (`detectCertainImpact` self-excludes on `causeSession`, without which
+ * every second edit to a file the agent itself just changed would be refused).
+ *
+ * **Fail open, without exception.** Flag off, no session, unknown host, no deny capability, a
+ * broken store, a malformed row, a failed release -- every one of them allows the write. A
+ * detector that stays silent costs recall on an advisory subsystem; a gate that wrongly blocks
+ * costs a person their working session, and this runs in front of every write in every session of
+ * every repo that turned it on.
+ */
+
+/** What the caller needs to act: whether to refuse, and the text that makes a refusal actionable. */
+export interface WriteGateDecision {
+  deny: boolean;
+  /** Non-null exactly when `deny` is true. */
+  reason: string | null;
+  /**
+   * The read-set rows this denial named and released. Present so the caller can see the one-shot
+   * happened rather than take it on trust; see `releaseGatedReads`.
+   */
+  releasedReadIds: string[];
+}
+
+/**
+ * Entries per refusal, matching `MAX_IMPACT_ENTRIES` in `change-card.ts` and for the same reason:
+ * an entry that can prove both signatures costs three lines, and past the third one the refusal
+ * has already made its case and is only spending the agent's context.
+ */
+const MAX_GATE_ENTRIES = 3;
+
+/** Paths, not entries: several changed symbols in one file are one file to re-open. */
+const MAX_REREAD_PATHS = 3;
+
+/**
+ * Matches `MAX_TITLE_LENGTH` in `change-card.ts`, which is private to it. Same channel, same
+ * one-line ceiling; a second number that is allowed to differ is a number someone has to remember
+ * to keep equal.
+ */
+const MAX_SIGNATURE_LENGTH = 90;
+
+const allow = (): WriteGateDecision => ({ deny: false, reason: null, releasedReadIds: [] });
+
+
+/**
+ * The file a locator names, or null when its shape does not name one.
+ *
+ * First `#`, matching `normalizeLocator` and `describeLocator`: a path cannot contain one, a
+ * qualified name conceivably can. An unrecognised scheme yields no path and therefore blocks
+ * nothing -- inventing a file out of a locator we cannot parse is how a gate refuses a write it
+ * has no evidence against.
+ */
+function locatorFilePath(locator: string): string | null {
+  if (locator.startsWith('symbol://')) {
+    const rest = locator.slice('symbol://'.length);
+    const hash = rest.indexOf('#');
+    const filePath = hash < 0 ? rest : rest.slice(0, hash);
+    return filePath || null;
+  }
+  if (locator.startsWith('file://')) return locator.slice('file://'.length) || null;
+  return null;
+}
+
+/** The locator as a human reads it, and what moved about it -- `change-card.ts`'s wording. */
+function describeLocator(locator: string): { display: string; phrase: string } {
+  if (locator.startsWith('symbol://')) {
+    return { display: locator.slice('symbol://'.length), phrase: 'signature changed since you read it' };
+  }
+  if (locator.startsWith('file://')) {
+    return { display: locator.slice('file://'.length), phrase: 'file changed since you read it' };
+  }
+  return { display: locator, phrase: 'changed since you read it' };
+}
+
+/**
+ * Truncation that announces itself, copied from `change-card.ts`'s private renderer.
+ *
+ * A cut-off signature still reads as a complete, valid signature, and an agent that believes one
+ * writes a call against the parameters that were sliced away -- which is the failure this whole
+ * refusal exists to prevent, reintroduced by the text meant to prevent it.
+ */
+function renderSignature(signature: string): string {
+  const flat = signature.replace(/\s+/g, ' ').trim();
+  return flat.length > MAX_SIGNATURE_LENGTH ? `${flat.slice(0, MAX_SIGNATURE_LENGTH - 1)}…` : flat;
+}
+
+/**
+ * The was/now pair a finding can prove, or nulls.
+ *
+ * `path_json` is parsed rather than recomputed because it cannot be recomputed: by the time
+ * anything renders, the only surviving record of the old state is a hash, and a hash does not
+ * render (`impact.ts:79`). A row written by a different version, or truncated, degrades to a
+ * locator with no pair rather than throwing inside a hook.
+ */
+function provenPair(pathJson: string | null): { was: string | null; now: string | null } {
+  try {
+    const payload = pathJson ? JSON.parse(pathJson) as Record<string, unknown> : {};
+    const asText = (value: unknown): string | null => typeof value === 'string' && value.length > 0 ? value : null;
+    return { was: asText(payload.observedSignature), now: asText(payload.currentSignature) };
+  } catch {
+    return { was: null, now: null };
+  }
+}
+
+/**
+ * The refusal text, which *is* the product.
+ *
+ * Three things, in STORM's order: what changed, the was/now pair, and an explicit instruction to
+ * re-read before retrying. Strip any of them and what is left is the bare announcement measured at
+ * no consistent improvement and worse than silence for 3 of 4 models -- an agent that is told "no"
+ * without being told what moved has been given an obstacle rather than information.
+ *
+ * **Both signature halves or neither**, the same rule `change-card.ts` follows. A null `was` means
+ * the detector could not prove the agent saw that text, so printing a plausible one would be a
+ * fabricated quote inside a refusal whose only value is being trustworthy. A lone `now:` goes too:
+ * it is already in the file the agent is being sent to re-read.
+ *
+ * The last line states the one-shot plainly. Hiding it would read better and would be a lie -- the
+ * block genuinely does not fire twice (see `releaseGatedReads`), and an agent that discovers that
+ * by accident learns the gate is bluffable. Stated with its consequence attached, it is the honest
+ * shape of what this is: a mandatory pause with the diff in hand, not a lock.
+ */
+function renderRefusal(entries: ImpactCardEntry[], paths: string[]): string {
+  const shown = entries.slice(0, MAX_GATE_ENTRIES);
+  const lines = shown.flatMap(entry => {
+    const { display, phrase } = describeLocator(entry.locator);
+    const head = `- ${display} — ${phrase}`;
+    if (!entry.wasSignature || !entry.nowSignature) return [head];
+    return [head, `  was: ${renderSignature(entry.wasSignature)}`, `  now: ${renderSignature(entry.nowSignature)}`];
+  });
+  const remaining = entries.length - shown.length;
+  if (remaining > 0) lines.push(`- +${remaining} more`);
+
+  const shownPaths = paths.slice(0, MAX_REREAD_PATHS);
+  const morePaths = paths.length - shownPaths.length;
+  const target = `${shownPaths.join(', ')}${morePaths > 0 ? ` (+${morePaths} more)` : ''}`;
+  const subject = entries.length === 1
+    ? '1 thing you read has changed'
+    : `${entries.length} things you read have changed`;
+
+  return [
+    `KNOWL BLOCKED THIS WRITE: ${subject}, so this edit is written against a version that is no longer there.`,
+    ...lines,
+    `Re-read ${target}, reconcile your change with what is there now, then make this edit again.`,
+    'This block fires once per stale read: retrying without re-reading is not blocked, and overwrites a version you have not seen.',
+  ].join('\n');
+}
+
+/**
+ * Release exactly the reads this refusal named, and report whether it stuck.
+ *
+ * **This is the no-deny-loop guarantee, and it is deliberately not predicated on the agent doing
+ * anything.** The natural path does close on its own: an agent that re-reads the file goes through
+ * `recordRead`, which releases the superseded row and inserts a new one carrying the current hash,
+ * so the retry finds no live stale belief and passes. But that path only exists for a re-read the
+ * capture layer sees -- `Read` and `NotebookRead`. An agent that re-reads with `cat`, `sed -n` or
+ * any other shell command updates nothing, and without this it would be refused on every retry
+ * forever, having done exactly what it was asked to do. A gate that can trap an agent is strictly
+ * worse than no gate, so the one-shot is unconditional: at most one refusal per stale belief, and
+ * the belief has to be re-observed to arm again.
+ *
+ * Released, never deleted, and the finding is left open -- both following the subsystem's own
+ * rules. The row is the evidence the refusal was justified and the denominator plan §9's precision
+ * number is computed against, and `resolution` is the adjudication that number comes from, so
+ * spending `dismissed` here to quiet a gate would corrupt the one measurement this phase exists to
+ * produce.
+ *
+ * The UPDATE is issued here rather than through `read-set.ts` because that module exports release
+ * by session and by task, not by row, and it is another lane's file. The predicate is the same one
+ * `releaseReadSet` uses.
+ *
+ * Returning false means the refusal is abandoned. That ordering is the point: a denial we could not
+ * record is a denial that would fire again on the retry, which is the loop this exists to make
+ * impossible.
+ */
+async function releaseGatedReads(ids: string[]): Promise<boolean> {
+  const releasedAt = new Date().toISOString();
+  try {
+    const client = getClient();
+    for (const id of ids) {
+      await client.execute({
+        sql: 'UPDATE work_read_sets SET released_at = ? WHERE id = ? AND released_at IS NULL',
+        args: [releasedAt, id],
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether this write should be refused, and why.
+ *
+ * Deny only when all four hold, and allow whenever any of them is merely probable:
+ *
+ * 1. the repository asked for change-impact detection;
+ * 2. this session has an *unreleased* read-set row for a locator in a file being written;
+ * 3. that row's `observed_hash` no longer matches what is there -- established by the finding,
+ *    which was recorded by comparing against that exact row;
+ * 4. the change was not this session's own -- established by the same finding, which
+ *    `detectCertainImpact` never emits against its own `causeSession`.
+ *
+ * Conditions 3 and 4 arrive together because they are the same record. A finding whose affected
+ * row is no longer live has already been superseded by a fresh read and is not a reason to refuse
+ * anything, which is why the live read-set is intersected rather than trusted from the join.
+ *
+ * `targetPaths` is what the write is about to touch, in whatever spelling the host reported.
+ *
+ * Cheapest checks first, and the order is load-bearing rather than tidy: pure string work, then
+ * the config, then the findings query -- which returns nothing in the overwhelming majority of
+ * writes and ends the call before the read-set is loaded at all. This runs in front of every write
+ * tool call in the session.
+ */
+export async function shouldRefuseWrite(
+  root: string,
+  sessionId: string,
+  targetPaths: string[],
+): Promise<WriteGateDecision> {
+  try {
+    if (!sessionId || !Array.isArray(targetPaths) || targetPaths.length === 0) return allow();
+
+    const targets = new Set<string>();
+    for (const target of targetPaths) {
+      if (typeof target !== 'string') continue;
+      const relative = repoRelativePath(root, target);
+      if (relative !== null) targets.add(relative);
+    }
+    if (targets.size === 0) return allow();
+
+    // `loadConfig` throws on a missing or unreadable config, and an unreadable config is the off
+    // case by `isImpactEnabled`'s own rule: every failure mode of this subsystem is a failure of
+    // turning it on, and this one takes away someone's ability to write a file.
+    const config = await loadConfig(root).catch(() => null);
+    if (!isImpactEnabled(config ?? undefined)) return allow();
+
+    const findings = await openFindingsForSession(sessionId, 'certain');
+    if (findings.length === 0) return allow();
+
+    const live = new Map<string, ReadSetEntry>();
+    for (const entry of await activeReadSetForSession(sessionId)) live.set(entry.id, entry);
+    if (live.size === 0) return allow();
+
+    const entries: ImpactCardEntry[] = [];
+    const paths: string[] = [];
+    const ids: string[] = [];
+    for (const finding of findings) {
+      const entry = live.get(finding.affectedId);
+      // Released since the finding was recorded: the session has re-read this locator and the
+      // belief the finding was about is no longer one it holds.
+      if (!entry) continue;
+      const filePath = locatorFilePath(entry.locator);
+      if (filePath === null || !targets.has(filePath)) continue;
+      if (ids.includes(entry.id)) continue;
+
+      const pair = provenPair(finding.pathJson);
+      ids.push(entry.id);
+      entries.push({ locator: entry.locator, wasSignature: pair.was, nowSignature: pair.now });
+      if (!paths.includes(filePath)) paths.push(filePath);
+    }
+    if (entries.length === 0) return allow();
+
+    // Refuse only once the one-shot is durable. See `releaseGatedReads`.
+    if (!await releaseGatedReads(ids)) return allow();
+
+    return { deny: true, reason: renderRefusal(entries, paths), releasedReadIds: ids };
+  } catch {
+    // Anything at all -- a store mid-snapshot, a schema older than the read-set, a row shaped by a
+    // future version. The write proceeds.
+    return allow();
+  }
+}

--- a/src/session/write-gate.ts
+++ b/src/session/write-gate.ts
@@ -1,7 +1,8 @@
 import type { ImpactCardEntry } from './change-card.js';
 import { loadConfig } from '../core/config.js';
 import { getClient } from '../store/database.js';
-import { isImpactEnabled } from '../store/impact-config.js';
+import { impactGateMode } from '../store/impact-config.js';
+import { recordShadowBlock } from '../store/gate-shadow.js';
 import { openFindingsForSession } from './impact.js';
 import { activeReadSetForSession, repoRelativePath, type ReadSetEntry } from '../store/read-set.js';
 
@@ -41,6 +42,13 @@ import { activeReadSetForSession, repoRelativePath, type ReadSetEntry } from '..
  * detector that stays silent costs recall on an advisory subsystem; a gate that wrongly blocks
  * costs a person their working session, and this runs in front of every write in every session of
  * every repo that turned it on.
+ *
+ * **And it refuses nothing until it has earned the right to.** `impact.gate` starts at `off`, and
+ * the step before `enforce` is `shadow`: the identical verdict, recorded rather than delivered, so
+ * the ≥95%-over-≥40-findings bar plan §9 sets is measured against real traffic before a single
+ * write is stopped. Shadow deliberately does not release the read-set rows it names -- see the
+ * branch in `shouldRefuseWrite` -- because the table it would be writing to is the same one the
+ * measurement is computed from.
  */
 
 /** What the caller needs to act: whether to refuse, and the text that makes a refusal actionable. */
@@ -51,8 +59,19 @@ export interface WriteGateDecision {
   /**
    * The read-set rows this denial named and released. Present so the caller can see the one-shot
    * happened rather than take it on trust; see `releaseGatedReads`.
+   *
+   * Empty in `shadow`, which withholds the refusal and therefore has no one-shot to spend.
    */
   releasedReadIds: string[];
+  /**
+   * The findings this call recorded as withheld refusals. Non-empty only in `shadow`, and only
+   * for beliefs not already on file.
+   *
+   * It exists because `shadow` and "nothing was wrong" are otherwise the same `allow()`, and a
+   * caller that cannot tell them apart cannot report what the gate is finding while it is not
+   * blocking -- which is the entire output of shadow mode.
+   */
+  shadowedFindingIds: string[];
 }
 
 /**
@@ -72,7 +91,7 @@ const MAX_REREAD_PATHS = 3;
  */
 const MAX_SIGNATURE_LENGTH = 90;
 
-const allow = (): WriteGateDecision => ({ deny: false, reason: null, releasedReadIds: [] });
+const allow = (): WriteGateDecision => ({ deny: false, reason: null, releasedReadIds: [], shadowedFindingIds: [] });
 
 
 /**
@@ -225,9 +244,16 @@ async function releaseGatedReads(ids: string[]): Promise<boolean> {
 /**
  * Whether this write should be refused, and why.
  *
+ * **Three modes, one verdict.** `impact.gate` decides what is done with the answer, never what the
+ * answer is: `off` does not compute it, `shadow` computes it and records it in
+ * `impact_gate_shadow` while letting the write through, `enforce` refuses. Shadow is the default
+ * destination rather than a debugging aid -- plan §9 requires ≥95% precision over ≥40 adjudicated
+ * findings before this is allowed to block anything, and that number cannot be measured by a gate
+ * that is already blocking.
+ *
  * Deny only when all four hold, and allow whenever any of them is merely probable:
  *
- * 1. the repository asked for change-impact detection;
+ * 1. the repository asked for change-impact detection *and* armed the gate;
  * 2. this session has an *unreleased* read-set row for a locator in a file being written;
  * 3. that row's `observed_hash` no longer matches what is there -- established by the finding,
  *    which was recorded by comparing against that exact row;
@@ -262,10 +288,11 @@ export async function shouldRefuseWrite(
     if (targets.size === 0) return allow();
 
     // `loadConfig` throws on a missing or unreadable config, and an unreadable config is the off
-    // case by `isImpactEnabled`'s own rule: every failure mode of this subsystem is a failure of
+    // case by `impactGateMode`'s own rule: every failure mode of this subsystem is a failure of
     // turning it on, and this one takes away someone's ability to write a file.
     const config = await loadConfig(root).catch(() => null);
-    if (!isImpactEnabled(config ?? undefined)) return allow();
+    const mode = impactGateMode(config ?? undefined);
+    if (mode === 'off') return allow();
 
     const findings = await openFindingsForSession(sessionId, 'certain');
     if (findings.length === 0) return allow();
@@ -277,6 +304,10 @@ export async function shouldRefuseWrite(
     const entries: ImpactCardEntry[] = [];
     const paths: string[] = [];
     const ids: string[] = [];
+    // Collected alongside `ids` rather than derived from it. The two are the same value today --
+    // `detectCertainImpact` writes `affectedId: entry.id` -- but they answer different questions,
+    // and the shadow log keys on the finding because that is what carries the adjudication.
+    const findingIds: string[] = [];
     for (const finding of findings) {
       const entry = live.get(finding.affectedId);
       // Released since the finding was recorded: the session has re-read this locator and the
@@ -288,15 +319,43 @@ export async function shouldRefuseWrite(
 
       const pair = provenPair(finding.pathJson);
       ids.push(entry.id);
+      findingIds.push(finding.id);
       entries.push({ locator: entry.locator, wasSignature: pair.was, nowSignature: pair.now });
       if (!paths.includes(filePath)) paths.push(filePath);
     }
     if (entries.length === 0) return allow();
 
+    /*
+     * Shadow: the same verdict, withheld.
+     *
+     * **Nothing is released, and that is the point.** Enforcing mode releases these rows so a
+     * retry is never blocked twice, which is safe there because the agent has been told to
+     * re-read. Doing it here would clear a belief nobody re-read, and `work_read_sets` would stop
+     * describing what the session holds -- while being the evidence the precision number is
+     * computed from. A diagnostic must not change the process it observes.
+     *
+     * The belief therefore stays live and this same finding returns on the next write to the file;
+     * `idx_impact_gate_shadow_finding` is what stops that inflating the count, so the number of
+     * rows stays equal to the number of denials `enforce` would have issued.
+     *
+     * `paths[0]` because the row is written once and every later attempt is ignored, so the column
+     * answers "what was in flight when this would first have been blocked" -- the question a
+     * false-positive adjudication actually asks.
+     */
+    if (mode === 'shadow') {
+      const shadowedFindingIds: string[] = [];
+      for (const findingId of findingIds) {
+        if (await recordShadowBlock({ findingId, sessionId, targetPath: paths[0] })) {
+          shadowedFindingIds.push(findingId);
+        }
+      }
+      return { deny: false, reason: null, releasedReadIds: [], shadowedFindingIds };
+    }
+
     // Refuse only once the one-shot is durable. See `releaseGatedReads`.
     if (!await releaseGatedReads(ids)) return allow();
 
-    return { deny: true, reason: renderRefusal(entries, paths), releasedReadIds: ids };
+    return { deny: true, reason: renderRefusal(entries, paths), releasedReadIds: ids, shadowedFindingIds: [] };
   } catch {
     // Anything at all -- a store mid-snapshot, a schema older than the read-set, a row shaped by a
     // future version. The write proceeds.

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -364,6 +364,47 @@ const SCHEMA_STATEMENTS = [
   // rather than an exception inside a best-effort path.
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_impact_findings_unique_open ON impact_findings(cause_locator, affected_id) WHERE resolution IS NULL;`,
 
+  // What an enforcing write gate *would* have refused, recorded while it is refusing nothing.
+  //
+  // The gate is the one part of this subsystem that can cost somebody their working session, so
+  // plan §9 puts a ≥95%-precision-over-≥40-findings bar in front of letting it block. Shadow mode
+  // is how that bar is measured: the verdict is computed for real, the refusal is withheld, and
+  // every withheld refusal lands here.
+  //
+  // No `resolution` column of its own, deliberately. Each row names a finding, and findings
+  // already carry the adjudication through `knowl_impact({resolve})` -- which plan §15 established
+  // is the *only* adjudication path, precisely because the gate leaves findings open by design. A
+  // second verdict column here would be a second answer to a question that already has one.
+  `CREATE TABLE IF NOT EXISTS impact_gate_shadow (
+    id TEXT PRIMARY KEY,
+    finding_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    target_path TEXT NOT NULL,
+    observed_at TEXT NOT NULL
+  );`,
+  // One row per stale belief, and this index is what makes the measurement mean anything.
+  //
+  // Shadow mode deliberately does *not* release the read-set rows it names. Enforcing mode does,
+  // so a retry is never blocked twice -- safe there, because the agent has been told to re-read.
+  // Doing it while merely observing would clear a belief nobody re-read, and `work_read_sets`
+  // would stop describing what the session holds while being the evidence this measurement rests
+  // on. So the belief stays live, and the same finding comes back on the next write to that file.
+  // Unconstrained, the row count would then measure *writes attempted* rather than *denials an
+  // enforcing gate would have issued*, and those differ by however many times an agent happens to
+  // edit one file.
+  //
+  // `finding_id` alone, not `(finding_id, read_set_id)`: a finding's `affected_id` already *is*
+  // the read-set row id -- `detectCertainImpact` writes `affectedId: entry.id` from the row it
+  // compared, and `openFindingsForSession` joins `work_read_sets w ON w.id = f.affected_id`. One
+  // finding is therefore one stale belief, and a stored read-set id would be a second copy of a
+  // value that can only ever disagree with its source.
+  //
+  // `session_id` is kept even though that same join reaches it, and this is the one place the
+  // denormalization earns itself: `sweepReadSets` hard-deletes released rows, so after GC the join
+  // returns nothing and the owning session is unrecoverable. Findings are not swept by that path,
+  // so the measurement survives -- but only if the session is recorded where GC cannot reach it.
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_impact_gate_shadow_finding ON impact_gate_shadow(finding_id);`,
+
   `CREATE TRIGGER IF NOT EXISTS knowledge_items_fts_ai AFTER INSERT ON knowledge_items BEGIN
     INSERT INTO knowledge_items_fts(item_id, category, status, title, content, reasoning, tags)
     VALUES (new.id, new.category, new.status, new.title, new.content, coalesce(new.reasoning, ''), coalesce(new.tags, ''));

--- a/src/store/gate-shadow.ts
+++ b/src/store/gate-shadow.ts
@@ -1,0 +1,121 @@
+import crypto from 'node:crypto';
+import { getClient } from './database.js';
+
+/**
+ * What an enforcing write gate *would* have refused, recorded while it refuses nothing.
+ *
+ * The gate is the one part of the change-impact design that can cost somebody their working
+ * session -- a wrong refusal does not degrade quietly, it stops a person's agent from editing a
+ * file. So plan §9 puts a bar in front of it: ≥95% precision over ≥40 findings, adjudicated. This
+ * module is the table that bar is computed from. Shadow mode runs the real verdict and withholds
+ * the refusal; every withheld refusal lands here.
+ *
+ * **One row per stale belief, and the uniqueness is the index's job rather than this module's.**
+ * Shadow mode deliberately does not release the read-set rows it names. Enforcing mode does, so a
+ * retry is never blocked twice, and that is safe there because the agent has been told to re-read.
+ * Doing the same while merely observing would clear a belief nobody re-read, and `work_read_sets`
+ * would stop describing what the session actually holds -- while being the evidence this
+ * measurement rests on. The belief therefore stays live and the same finding arrives again on
+ * every later write to that file, so without `idx_impact_gate_shadow_finding` the row count would
+ * measure *writes attempted* rather than *denials an enforcing gate would have issued*, and those
+ * differ by however many times an agent happens to edit one file.
+ *
+ * **No adjudication of its own.** Every row names a finding, and findings already carry
+ * `resolution`, set through `knowl_impact({resolve})` -- which plan §15 established is the only
+ * adjudication path, precisely because the gate leaves findings open by design. A second verdict
+ * column here would be a second answer to a question that already has one.
+ *
+ * Advisory throughout, like the rest of this lane: the write path never throws, because it runs
+ * inside `PreToolUse` with a host blocked on the answer and the entire promise of shadow mode is
+ * that it cannot affect the write.
+ */
+
+const newId = (): string => crypto.randomUUID().replace(/-/g, '').substring(0, 16);
+
+export interface ShadowGatePrecision {
+  /** Shadow rows whose finding has been adjudicated. The denominator, and nothing else. */
+  adjudicated: number;
+  falsePositives: number;
+  /**
+   * `1 − falsePositives / adjudicated`, or **null** when nothing has been adjudicated.
+   *
+   * Null rather than 1, because no evidence is not a perfect score: returning 1 would let an
+   * untouched install report that it had cleared a ≥95% bar it has never measured against.
+   */
+  precision: number | null;
+}
+
+/**
+ * Record one withheld refusal. True when this belief had not been recorded before.
+ *
+ * `INSERT OR IGNORE` against the unique index, following `insertFinding`, and for the same reason
+ * expressed differently: there, the repeat is a lost race; here, the repeat is the *designed*
+ * case, since the belief stays live and returns on every later write to the same file. Either way
+ * a duplicate means the row already exists, which is the outcome wanted.
+ *
+ * Blank input is dropped rather than stored. An empty `finding_id` is worse than a missing row --
+ * it satisfies `NOT NULL` while joining to nothing, so it would sit in the table inflating the
+ * count of blocks and contributing to no adjudication ever.
+ *
+ * Never throws, at all. A store mid-snapshot, or one on a schema older than this table, costs one
+ * measurement; an exception here would surface as a broken tool call in front of the agent, which
+ * is precisely the harm shadow mode exists to avoid while the real gate is being evaluated.
+ */
+export async function recordShadowBlock(
+  input: { findingId: string; sessionId: string; targetPath: string },
+): Promise<boolean> {
+  const findingId = (input?.findingId ?? '').trim();
+  const sessionId = (input?.sessionId ?? '').trim();
+  const targetPath = (input?.targetPath ?? '').trim();
+  if (!findingId || !sessionId || !targetPath) return false;
+
+  try {
+    const result = await getClient().execute({
+      sql: `INSERT OR IGNORE INTO impact_gate_shadow (id, finding_id, session_id, target_path, observed_at)
+            VALUES (?, ?, ?, ?, ?)`,
+      args: [newId(), findingId, sessionId, targetPath, new Date().toISOString()],
+    });
+    return Number(result.rowsAffected ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * How many refusals have been withheld -- the `≥40 findings` half of plan §9's bar.
+ *
+ * Counts rows rather than adjudicated rows on purpose: this answers "is there enough to measure
+ * yet", which is a different question from "what does the measurement say".
+ */
+export async function countShadowBlocks(): Promise<number> {
+  const rows = await getClient().execute('SELECT COUNT(*) AS total FROM impact_gate_shadow');
+  return Number(rows.rows[0]?.total ?? 0);
+}
+
+/**
+ * `1 − false_positive / adjudicated`, over the findings the shadow rows point at.
+ *
+ * **Unresolved findings are excluded from both halves rather than counted as correct.** Nothing
+ * forces adjudication, so early on the unresolved set is the larger one; treating those blocks as
+ * justified is how a precision number talks its way past the bar it was meant to clear. The
+ * denominator is deliberately the adjudicated count and not `countShadowBlocks()`.
+ *
+ * The join is on `impact_findings`, which `sweepReadSets` does not touch -- so this survives the
+ * GC that hard-deletes released read-set rows underneath it.
+ */
+export async function shadowGatePrecision(): Promise<ShadowGatePrecision> {
+  const rows = await getClient().execute(
+    `SELECT COUNT(*) AS adjudicated,
+            SUM(CASE WHEN f.resolution = 'false_positive' THEN 1 ELSE 0 END) AS false_positives
+     FROM impact_gate_shadow s
+     JOIN impact_findings f ON f.id = s.finding_id
+     WHERE f.resolution IS NOT NULL`,
+  );
+  const adjudicated = Number(rows.rows[0]?.adjudicated ?? 0);
+  const falsePositives = Number(rows.rows[0]?.false_positives ?? 0);
+  return {
+    adjudicated,
+    falsePositives,
+    precision: adjudicated === 0 ? null : 1 - falsePositives / adjudicated,
+  };
+}

--- a/src/store/impact-config.ts
+++ b/src/store/impact-config.ts
@@ -20,3 +20,31 @@ import type { ProjectConfig } from '../core/types.js';
 export function isImpactEnabled(config?: ProjectConfig): boolean {
   return config?.impact?.enabled === true;
 }
+
+export type ImpactGateMode = 'off' | 'shadow' | 'enforce';
+
+const GATE_MODES: readonly ImpactGateMode[] = ['off', 'shadow', 'enforce'];
+
+/**
+ * How the `PreToolUse` write gate should behave, resolved in one place so no call site re-derives
+ * it.
+ *
+ * **Detection off means gate off, whatever the key says.** The gate's entire input is the open
+ * findings `detectCertainImpact` writes and the read-set rows the capture path records, so an
+ * armed gate over a disabled detector is not a stricter configuration -- it is one that can never
+ * fire while reporting that it can. Answering that here rather than at each call site means one
+ * place can be wrong about it instead of three.
+ *
+ * Anything unrecognised is `off`, following `isImpactEnabled`'s rule and for a sharper reason. A
+ * malformed value there switches on machinery nobody asked for; a malformed value here can take
+ * away somebody's ability to write a file, and a `config.json` is a file people edit by hand.
+ *
+ * `shadow` is where this is expected to sit for a while: it computes the real verdict and
+ * withholds the refusal, which is how plan §9's ≥95%-over-≥40-findings bar gets measured before
+ * anything is allowed to block.
+ */
+export function impactGateMode(config?: ProjectConfig): ImpactGateMode {
+  if (!isImpactEnabled(config)) return 'off';
+  const mode = config?.impact?.gate;
+  return GATE_MODES.includes(mode as ImpactGateMode) ? mode as ImpactGateMode : 'off';
+}

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -51,7 +51,14 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * the bump buys is that a database created before them still gets them, since the gate is the
  * only thing that decides whether `SCHEMA_STATEMENTS` runs at all.
  */
-export const KNOWL_MIGRATION_LEVEL = 3;
+/*
+ * Level 4 adds `impact_gate_shadow` and its unique index on `finding_id` -- what an enforcing
+ * write gate would have refused, recorded while it refuses nothing, so the certain tier's
+ * precision can be measured before anything is allowed to block. Additive on exactly the same
+ * reasoning as level 3: one new table, no altered column, no backfill, so `KNOWL_SCHEMA_VERSION`
+ * stays at 1 and no installed build is locked out of a database it can still read completely.
+ */
+export const KNOWL_MIGRATION_LEVEL = 4;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/snapshot-tables.ts
+++ b/src/store/snapshot-tables.ts
@@ -66,6 +66,11 @@ export const SNAPSHOT_TABLE_POLICY: Readonly<Record<string, SnapshotTablePolicy>
   // a measurement, which is worse than losing it.
   work_read_sets: 'preserved',
   impact_findings: 'preserved',
+  // Same reason as `impact_findings`' own, one step further along: these rows are the measurement
+  // the write gate is not allowed to start blocking without. A restore that rolled them back would
+  // silently reset the precision denominator to zero while leaving the findings they point at in
+  // place, so the next reading would be taken over a sample that no longer matches the history.
+  impact_gate_shadow: 'preserved',
 
   // --- derived, trigger-maintained ---------------------------------------------------------
   knowledge_items_fts: 'rebuilt',

--- a/tests/cli/tool-precheck.test.ts
+++ b/tests/cli/tool-precheck.test.ts
@@ -1,0 +1,190 @@
+import path from 'node:path';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { afterAll, describe, expect, it } from 'vitest';
+import { normalizeHostHook } from '../../src/cli/agents/host-hook.js';
+import { hostProfile } from '../../src/session/hosts/index.js';
+import { mergeNestedHookConfig, verifyNestedHookConfig } from '../../src/cli/agents/hook-config.js';
+
+const ROOT = path.resolve('.knowl-tool-precheck-test');
+// Outside the repo: the settings fixtures here are written concurrently with other lanes'
+// suites, and a `.knowl-*` directory in the repo root is swept by their setup.
+const workspaces: string[] = [];
+const workspace = async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'knowl-precheck-'));
+  workspaces.push(dir);
+  return dir;
+};
+
+afterAll(async () => {
+  for (const dir of workspaces) await rm(dir, { recursive: true, force: true });
+});
+
+describe('PreToolUse normalization', () => {
+  it('carries the tool name and the path the call is about to touch', () => {
+    const result = normalizeHostHook('claude', 'PreToolUse', {
+      session_id: 'session-1',
+      cwd: ROOT,
+      tool_name: 'Edit',
+      tool_use_id: 'toolu_1',
+      tool_input: { file_path: path.join(ROOT, 'src/store/impact.ts') },
+    });
+
+    expect(result).toMatchObject({
+      host: 'claude',
+      event: 'tool-precheck',
+      externalSessionId: 'session-1',
+      projectRoot: ROOT,
+      toolName: 'Edit',
+      payload: { changedPaths: ['src/store/impact.ts'] },
+    });
+  });
+
+  it('normalizes paths the same way the post-tool event does', () => {
+    // The gate compares these against paths recorded by earlier events. Two spellings of one
+    // file would make every lookup miss, and a gate that never fires is indistinguishable
+    // from a gate with nothing to report.
+    const raw = { session_id: 's', cwd: ROOT, tool_name: 'Write', tool_input: { file_path: path.join(ROOT, 'a', 'b.ts') } };
+    const before = normalizeHostHook('claude', 'PreToolUse', raw);
+    const after = normalizeHostHook('claude', 'PostToolUse', raw);
+    expect(before.payload.changedPaths).toEqual(after.payload.changedPaths);
+  });
+
+  it('drops a target outside the project rather than inventing a relative path', () => {
+    const result = normalizeHostHook('claude', 'PreToolUse', {
+      session_id: 's', cwd: ROOT, tool_name: 'Write', tool_input: { file_path: path.resolve('/elsewhere/x.ts') },
+    });
+    expect(result.payload.changedPaths).toEqual([]);
+  });
+
+  it('degrades to an empty target list when the host names no tool and no path', () => {
+    const result = normalizeHostHook('claude', 'PreToolUse', { session_id: 's', cwd: ROOT });
+    expect(result.event).toBe('tool-precheck');
+    expect(result.toolName).toBeUndefined();
+    expect(result.payload.changedPaths).toEqual([]);
+  });
+
+  it('does not retain the body of the write it is checking', () => {
+    const result = normalizeHostHook('claude', 'PreToolUse', {
+      session_id: 's', cwd: ROOT, tool_name: 'Write',
+      tool_input: { file_path: path.join(ROOT, 'a.ts'), content: 'Private file body must not be stored' },
+    });
+    expect(JSON.stringify(result)).not.toContain('Private file body');
+  });
+
+  it('answers a sensitive target instead of erroring on it', () => {
+    // The write validator refuses `.env`, which is right for a stored atom and wrong here:
+    // a precheck is answered and discarded, and throwing would print an error in front of
+    // that tool call and every retry of it.
+    const result = normalizeHostHook('claude', 'PreToolUse', {
+      session_id: 's', cwd: ROOT, tool_name: 'Edit', tool_input: { file_path: path.join(ROOT, '.env') },
+    });
+    expect(result.payload.changedPaths).toEqual(['.env']);
+  });
+
+  it('keeps the event off hosts that do not register it', () => {
+    // Codex's event list was verified against its dispatcher enum and has no PreToolUse.
+    expect(hostProfile('codex').normalizedEvent('PreToolUse')).toBeUndefined();
+    expect(hostProfile('cursor').normalizedEvent('PreToolUse')).toBeUndefined();
+    expect(() => normalizeHostHook('codex', 'PreToolUse', { session_id: 's', cwd: ROOT }))
+      .toThrow('Unsupported codex hook event');
+  });
+
+  it('leaves the existing events byte-identical', () => {
+    const raw = {
+      session_id: 'session-2', cwd: ROOT, tool_name: 'Bash',
+      tool_input: { command: 'npm test' }, tool_response: { exit_code: 0 },
+    };
+    expect(normalizeHostHook('claude', 'PostToolUse', raw)).toEqual({
+      host: 'claude', event: 'session-event', externalSessionId: 'session-2', externalTurnId: undefined,
+      projectRoot: ROOT, type: 'command', payload: { command: 'npm test', exitCode: 0 },
+      status: undefined, toolName: 'Bash', knowlTool: false,
+    });
+    expect(normalizeHostHook('claude', 'SessionStart', { session_id: 's', cwd: ROOT }))
+      .toEqual({ host: 'claude', event: 'session-start', externalSessionId: 's', externalTurnId: undefined, projectRoot: ROOT, title: 'Agent session', payload: {} });
+  });
+});
+
+describe('tool-call denial', () => {
+  it('returns Claude Code\'s documented deny envelope', () => {
+    expect(hostProfile('claude').denyToolCall?.('re-read src/a.ts: it changed'))
+      .toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 're-read src/a.ts: it changed',
+        },
+      });
+  });
+
+  it('passes a long reason through uncut', () => {
+    // The reason carries the diff and the recovery instruction; truncating it leaves the
+    // agent blocked without being told what to do.
+    const reason = 'x'.repeat(8_000);
+    const output = hostProfile('claude').denyToolCall?.(reason) as any;
+    expect(output.hookSpecificOutput.permissionDecisionReason).toHaveLength(8_000);
+  });
+
+  it('yields undefined for every host whose refusal channel is unconfirmed', () => {
+    for (const host of ['codex', 'cursor', 'claude-desktop', 'generic'] as const) {
+      expect(hostProfile(host).denyToolCall?.('nope'), host).toBeUndefined();
+    }
+  });
+});
+
+describe('PreToolUse registration', () => {
+  it('registers with the same command shape as the other events', async () => {
+    const dir = await workspace();
+    const configPath = path.join(dir, 'settings.json');
+    expect(await mergeNestedHookConfig(configPath, 'win32', 'claude')).toBe('configured');
+
+    const config = JSON.parse(await readFile(configPath, 'utf8'));
+    expect(config.hooks.PreToolUse).toEqual([{
+      matcher: '.*',
+      hooks: [{ type: 'command', command: 'knowl.cmd agent-hook claude PreToolUse --json', timeout: 30, statusMessage: '' }],
+    }]);
+    expect(config.hooks.PreToolUse[0].hooks[0]).toEqual({
+      ...config.hooks.PostToolUse[0].hooks[0],
+      command: 'knowl.cmd agent-hook claude PreToolUse --json',
+    });
+    expect(await verifyNestedHookConfig(configPath, 'win32', 'claude')).toBe(true);
+  });
+
+  it('is idempotent on a re-run', async () => {
+    const dir = await workspace();
+    const configPath = path.join(dir, 'settings.json');
+    await mergeNestedHookConfig(configPath, 'linux', 'claude');
+    const first = await readFile(configPath, 'utf8');
+    expect(await mergeNestedHookConfig(configPath, 'linux', 'claude')).toBe('unchanged');
+    expect(await readFile(configPath, 'utf8')).toBe(first);
+  });
+
+  it('adds the event to a settings.json written before it existed, keeping foreign handlers', async () => {
+    const dir = await workspace();
+    const configPath = path.join(dir, 'settings.json');
+    const foreign = { matcher: 'Bash', hooks: [{ type: 'command', command: 'someone-elses-tool' }] };
+    await mergeNestedHookConfig(configPath, 'linux', 'claude');
+    const older = JSON.parse(await readFile(configPath, 'utf8'));
+    delete older.hooks.PreToolUse;
+    older.hooks.PostToolUse = [foreign, ...older.hooks.PostToolUse];
+    await writeFile(configPath, `${JSON.stringify(older, null, 2)}\n`);
+
+    // Stale until something re-runs the merge -- nothing does so on its own, which is why
+    // doctor has to see it as a warning with a host-init remedy.
+    expect(await verifyNestedHookConfig(configPath, 'linux', 'claude')).toBe(false);
+    expect(await mergeNestedHookConfig(configPath, 'linux', 'claude')).toBe('updated');
+
+    const config = JSON.parse(await readFile(configPath, 'utf8'));
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toBe('knowl agent-hook claude PreToolUse --json');
+    expect(config.hooks.PostToolUse[0]).toEqual(foreign);
+    expect(await verifyNestedHookConfig(configPath, 'linux', 'claude')).toBe(true);
+  });
+
+  it('leaves Codex without the event', async () => {
+    const dir = await workspace();
+    const configPath = path.join(dir, 'settings.json');
+    await mergeNestedHookConfig(configPath, 'linux', 'codex');
+    const config = JSON.parse(await readFile(configPath, 'utf8'));
+    expect(config.hooks.PreToolUse).toBeUndefined();
+  });
+});

--- a/tests/core/impact-config.test.ts
+++ b/tests/core/impact-config.test.ts
@@ -7,10 +7,13 @@ import type { ProjectConfig } from '../../src/core/types.js';
 /**
  * Change-impact detection is additive, advisory and off until someone says otherwise.
  *
- * The gate matters more than a normal feature flag because of what the subsystem does when
- * it is on: it captures read sets on every tool call and declines to record a clean task
- * finish while a certain-tier finding is unresolved. Turning that on by accident does not
- * degrade quietly -- it holds up work in a repository whose owner never heard of it.
+ * The flag matters more than a normal feature flag because of what the subsystem does when it is
+ * on: it captures read sets on every tool call and pushes findings into the agent's context
+ * through the shared change card. Turning that on by accident does not degrade quietly -- it
+ * spends context in a repository whose owner never heard of it, on the channel a wrong finding
+ * damages most.
+ *
+ * Refusing the write is a second switch, `impact.gate`, covered further down.
  */
 
 const baseConfig = (): ProjectConfig => ({

--- a/tests/core/impact-config.test.ts
+++ b/tests/core/impact-config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_CONFIG, NEW_PROJECT_CONFIG, mergeConfigDefaults } from '../../src/core/config.js';
 import { CONFIG_FIELDS, getConfigField } from '../../src/cli/config/schema.js';
-import { isImpactEnabled } from '../../src/store/impact-config.js';
+import { impactGateMode, isImpactEnabled } from '../../src/store/impact-config.js';
 import type { ProjectConfig } from '../../src/core/types.js';
 
 /**
@@ -95,5 +95,84 @@ describe('where the default is allowed to live', () => {
     expect(field.parse('false')).toBe(false);
     expect(() => field.parse('yes')).toThrow();
     expect(CONFIG_FIELDS.filter(candidate => candidate.key === 'impact.enabled')).toHaveLength(1);
+  });
+});
+
+/**
+ * The write gate's own switch, separate from detection's.
+ *
+ * They are separated because the risks differ in kind rather than degree. Detection spends
+ * context and can be wrong in a card; the gate refuses a tool call, and being wrong there costs
+ * somebody their working session. So arming it is a second, deliberate act, and it starts in
+ * `shadow` -- computing the verdict and withholding the refusal -- until plan §9's
+ * ≥95%-over-≥40-findings bar has actually been measured.
+ */
+const withGate = (impact: Record<string, unknown>): ProjectConfig =>
+  ({ ...baseConfig(), impact: impact as ProjectConfig['impact'] });
+
+describe('write gate mode', () => {
+  it('is off when nothing is configured', () => {
+    expect(impactGateMode(undefined)).toBe('off');
+    expect(impactGateMode(baseConfig())).toBe('off');
+    expect(impactGateMode(withGate({}))).toBe('off');
+  });
+
+  it('reads shadow and enforce when detection is on', () => {
+    expect(impactGateMode(withGate({ enabled: true, gate: 'shadow' }))).toBe('shadow');
+    expect(impactGateMode(withGate({ enabled: true, gate: 'enforce' }))).toBe('enforce');
+    expect(impactGateMode(withGate({ enabled: true, gate: 'off' }))).toBe('off');
+  });
+
+  /**
+   * Detection off is gate off, whatever the gate key says.
+   *
+   * The gate's entire input is the open findings the detector writes, so an armed gate over a
+   * disabled detector is not a stricter configuration -- it is one that can never fire while
+   * reporting that it can. Deciding it here means one place answers the question instead of
+   * every call site re-deriving it and one of them getting it wrong.
+   */
+  it('is off when the gate is armed but detection is not', () => {
+    expect(impactGateMode(withGate({ enabled: false, gate: 'enforce' }))).toBe('off');
+    expect(impactGateMode(withGate({ gate: 'enforce' }))).toBe('off');
+    expect(impactGateMode(withGate({ enabled: 'yes', gate: 'enforce' }))).toBe('off');
+  });
+
+  it('treats anything unrecognised as off', () => {
+    // Same rule `isImpactEnabled` follows, and for a sharper reason: a malformed value here does
+    // not merely switch on machinery nobody asked for, it can take away somebody's ability to
+    // write a file. A config.json is a file people edit by hand.
+    expect(impactGateMode(withGate({ enabled: true, gate: 'yes' }))).toBe('off');
+    expect(impactGateMode(withGate({ enabled: true, gate: 'ENFORCE' }))).toBe('off');
+    expect(impactGateMode(withGate({ enabled: true, gate: true }))).toBe('off');
+    expect(impactGateMode(withGate({ enabled: true, gate: 1 }))).toBe('off');
+    expect(impactGateMode(withGate({ enabled: true, gate: null }))).toBe('off');
+    expect(impactGateMode(withGate({ enabled: true }))).toBe('off');
+  });
+
+  it('leaves isImpactEnabled alone', () => {
+    // The two switches answer different questions, so arming the gate must not imply detection
+    // and enabling detection must not imply a gate.
+    expect(isImpactEnabled(withGate({ enabled: true, gate: 'enforce' }))).toBe(true);
+    expect(isImpactEnabled(withGate({ gate: 'enforce' }))).toBe(false);
+    expect(impactGateMode(withGate({ enabled: true }))).toBe('off');
+  });
+
+  it('stays out of DEFAULT_CONFIG, like every other key in this block', () => {
+    // The same mass-write hazard as `impact.enabled`, one step worse: a default written there
+    // would arm a write gate in every repository on the machine at the next upgrade.
+    expect(DEFAULT_CONFIG.impact).toBeUndefined();
+    expect(NEW_PROJECT_CONFIG.impact).toBeUndefined();
+  });
+
+  it('is settable from the CLI as an enum, defaulting to off', () => {
+    const field = getConfigField('impact.gate');
+    expect(field.type).toBe('enum');
+    expect(field.values).toEqual(['off', 'shadow', 'enforce']);
+    expect(field.defaultValue).toBe('off');
+    expect(field.parse('shadow')).toBe('shadow');
+    expect(field.parse('enforce')).toBe('enforce');
+    expect(() => field.parse('true')).toThrow();
+    expect(() => field.parse('ENFORCE')).toThrow();
+    expect(CONFIG_FIELDS.filter(candidate => candidate.key === 'impact.gate')).toHaveLength(1);
   });
 });

--- a/tests/store/gate-shadow.test.ts
+++ b/tests/store/gate-shadow.test.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { countShadowBlocks, recordShadowBlock, shadowGatePrecision } from '../../src/store/gate-shadow.js';
+
+/**
+ * The record of what an enforcing write gate would have refused, and the number it exists to
+ * produce.
+ *
+ * Everything here is about the *denominator*. Shadow mode's whole purpose is to let plan §9's
+ * ≥95%-over-≥40-findings bar be measured before the gate is allowed to block anything, so the two
+ * ways this could quietly lie are the two things worth pinning: counting the same stale belief
+ * more than once, and counting an unadjudicated finding as a correct one.
+ */
+
+const ROOT = path.join(os.tmpdir(), `knowl-gate-shadow-${process.pid}`);
+const AT = '2026-08-08T00:00:00.000Z';
+
+/**
+ * A finding, written directly rather than through the detector.
+ *
+ * Real rather than a bare id, because the precision query joins `impact_findings` -- a fake id
+ * would join to nothing, measure nothing, and let a broken query pass. `affected_id` carries the
+ * read-set row id the same way `detectCertainImpact` writes it.
+ */
+async function seedFinding(id: string, resolution: string | null): Promise<void> {
+  await getClient().execute({
+    sql: `INSERT INTO impact_findings
+            (id, cause_locator, cause_session, affected_kind, affected_id, tier, path_json, detected_at, delivered_at, resolution, resolved_at)
+          VALUES (?, 'symbol://src/a.ts#createSession', 'other-session', 'work', ?, 'certain', NULL, ?, NULL, ?, ?)`,
+    args: [id, `read-${id}`, AT, resolution, resolution ? '2026-08-08T01:00:00.000Z' : null],
+  });
+}
+
+describe('gate shadow log', () => {
+  // One database for the file, emptied between tests rather than recreated. Tearing the store
+  // down per test fails on Windows with EBUSY: libSQL's handle, and its -shm/-wal siblings, are
+  // not always released by the time `rm` reaches them. `impact-schema.test.ts` is shaped the same
+  // way for the same reason.
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await getClient().execute('DELETE FROM impact_gate_shadow');
+    await getClient().execute('DELETE FROM impact_findings');
+  });
+
+  it('records a belief once and reports the repeat as not written', async () => {
+    await seedFinding('f1', null);
+
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(true);
+    // The same belief, reached from a different write. Shadow mode does not release the read-set
+    // row, so this is the ordinary case rather than an error: the finding is still open and still
+    // live, and it will arrive again on every subsequent write to that file.
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/b.ts' })).toBe(false);
+    expect(await countShadowBlocks()).toBe(1);
+  });
+
+  it('records distinct beliefs separately', async () => {
+    await seedFinding('f1', null);
+    await seedFinding('f2', null);
+
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(true);
+    expect(await recordShadowBlock({ findingId: 'f2', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(true);
+    expect(await countShadowBlocks()).toBe(2);
+  });
+
+  it('computes precision from the findings the rows point at', async () => {
+    await seedFinding('f1', 'repaired');
+    await seedFinding('f2', 'false_positive');
+    await seedFinding('f3', 'dismissed');
+    for (const id of ['f1', 'f2', 'f3']) {
+      await recordShadowBlock({ findingId: id, sessionId: 's1', targetPath: 'src/a.ts' });
+    }
+
+    const result = await shadowGatePrecision();
+    expect(result.adjudicated).toBe(3);
+    expect(result.falsePositives).toBe(1);
+    expect(result.precision).toBeCloseTo(2 / 3, 10);
+  });
+
+  /**
+   * Unresolved findings leave both halves alone rather than counting as correct.
+   *
+   * Assuming an unadjudicated block was justified is exactly how a precision number talks its way
+   * past the bar it was meant to clear -- and since nothing forces adjudication, the unresolved
+   * set is the *larger* one early on.
+   */
+  it('excludes unresolved findings from both halves', async () => {
+    await seedFinding('f1', 'false_positive');
+    await seedFinding('f2', null);
+    await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' });
+    await recordShadowBlock({ findingId: 'f2', sessionId: 's1', targetPath: 'src/a.ts' });
+
+    const result = await shadowGatePrecision();
+    expect(await countShadowBlocks()).toBe(2);
+    expect(result.adjudicated).toBe(1);
+    expect(result.falsePositives).toBe(1);
+    expect(result.precision).toBe(0);
+  });
+
+  it('reports null precision rather than a perfect score when nothing is adjudicated', async () => {
+    await seedFinding('f1', null);
+    await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' });
+
+    const result = await shadowGatePrecision();
+    expect(result.adjudicated).toBe(0);
+    expect(result.falsePositives).toBe(0);
+    // No evidence is not a perfect score. Returning 1 here would let an untouched install report
+    // that it had cleared a ≥95% bar it has not measured at all.
+    expect(result.precision).toBeNull();
+  });
+
+  it('returns false rather than throwing on input it will not store', async () => {
+    // Same contract as `recordReadBestEffort`: this runs inside the PreToolUse path with a host
+    // blocked on the answer, and the entire promise of shadow mode is that it cannot affect the
+    // write. A lost measurement beats a broken tool call.
+    expect(await recordShadowBlock({ findingId: '', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(false);
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: '', targetPath: 'src/a.ts' })).toBe(false);
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: '   ' })).toBe(false);
+    expect(await countShadowBlocks()).toBe(0);
+  });
+
+  it('survives the store being closed underneath it', async () => {
+    await seedFinding('f1', null);
+    await closeDb();
+
+    expect(await recordShadowBlock({ findingId: 'f1', sessionId: 's1', targetPath: 'src/a.ts' })).toBe(false);
+
+    await initDb(ROOT);
+  });
+});

--- a/tests/store/impact-schema.test.ts
+++ b/tests/store/impact-schema.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { bootstrapSchema } from '../../src/store/bootstrap.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
-import { KNOWL_MIGRATION_LEVEL, readMigrationLevel } from '../../src/store/schema-version.js';
+import { KNOWL_MIGRATION_LEVEL, KNOWL_SCHEMA_VERSION, readMigrationLevel } from '../../src/store/schema-version.js';
 
 /**
  * The change-impact substrate: `work_read_sets` (what a session read, hashed at read time) and
@@ -269,5 +269,64 @@ describe('change-impact schema', () => {
     );
     expect(Number(rows.rows[0].reads)).toBe(1);
     expect(Number(rows.rows[0].findings)).toBe(1);
+  });
+
+  it('gives impact_gate_shadow exactly the specified columns and nullability', async () => {
+    expect(await columnsOf('impact_gate_shadow')).toEqual([
+      { name: 'id', type: 'TEXT', notnull: 0, pk: 1 },
+      { name: 'finding_id', type: 'TEXT', notnull: 1, pk: 0 },
+      { name: 'session_id', type: 'TEXT', notnull: 1, pk: 0 },
+      { name: 'target_path', type: 'TEXT', notnull: 1, pk: 0 },
+      { name: 'observed_at', type: 'TEXT', notnull: 1, pk: 0 },
+    ]);
+  });
+
+  /**
+   * The unique index is the whole design of shadow mode, so it is pinned as a *unique* index on
+   * exactly `finding_id` rather than merely as an index that exists.
+   *
+   * Shadow mode deliberately does not release the read-set rows it names -- releasing a belief the
+   * agent never re-read would make `work_read_sets` stop describing what the session holds, while
+   * that table is simultaneously the evidence the precision number is computed from. So the belief
+   * stays live and the same finding returns on the next write to that file. Without uniqueness the
+   * row count would measure writes attempted rather than denials an enforcing gate would have
+   * issued, and those differ by however many times an agent happens to edit one file.
+   */
+  it('keeps one shadow row per finding', async () => {
+    expect(await indexesOf('impact_gate_shadow')).toEqual(['idx_impact_gate_shadow_finding']);
+    expect(await indexColumns('idx_impact_gate_shadow_finding')).toEqual(['finding_id']);
+
+    const unique = await getClient().execute(
+      "SELECT \"unique\" FROM pragma_index_list('impact_gate_shadow') WHERE name = 'idx_impact_gate_shadow_finding'",
+    );
+    expect(Number(unique.rows[0].unique)).toBe(1);
+  });
+
+  it('ignores a second row for a finding already recorded, keeping the first target', async () => {
+    const insert = (id: string, target: string) => getClient().execute({
+      sql: `INSERT OR IGNORE INTO impact_gate_shadow (id, finding_id, session_id, target_path, observed_at)
+            VALUES (?, 'finding-a', 'session-1', ?, ?)`,
+      args: [id, target, AT],
+    });
+
+    await insert('shadow-1', 'src/a.ts');
+    const repeat = await insert('shadow-2', 'src/b.ts');
+
+    expect(Number(repeat.rowsAffected ?? 0)).toBe(0);
+    const rows = await getClient().execute(
+      "SELECT id, target_path FROM impact_gate_shadow WHERE finding_id = 'finding-a'",
+    );
+    expect(rows.rows).toHaveLength(1);
+    // The *first* target survives, not the latest. The row is written once and every later
+    // attempt is ignored, so the column answers "what was in flight when this would first have
+    // been blocked" -- which is the question a false-positive adjudication asks.
+    expect(String(rows.rows[0].target_path)).toBe('src/a.ts');
+  });
+
+  it('holds the migration level at 4 with the schema version pinned to 1', () => {
+    expect(KNOWL_MIGRATION_LEVEL).toBe(4);
+    // Additive tables never move the compatibility floor: raising it locks out installed builds
+    // that would otherwise read this database perfectly well.
+    expect(KNOWL_SCHEMA_VERSION).toBe(1);
   });
 });

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -28,6 +28,10 @@ const SCHEMA_PINS: Record<number, string> = {
   // index that closes the duplicate-finding window. Additive again, so `KNOWL_SCHEMA_VERSION`
   // again does not move.
   3: '627dad6b3eff5019fb2442a4a1a12a05',
+  // 4 adds `impact_gate_shadow` and its unique index on `finding_id` -- what an enforcing write
+  // gate would have refused, recorded while it refuses nothing. Additive again, so
+  // `KNOWL_SCHEMA_VERSION` again does not move.
+  4: '4592e436daefd236d1f15554d1a2db3a',
 };
 
 let root: string;

--- a/tests/store/write-gate.test.ts
+++ b/tests/store/write-gate.test.ts
@@ -1,0 +1,336 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
+import { listCodeSymbols, indexFile } from '../../src/code/symbol-index.js';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { handleHostLifecycleEvent } from '../../src/session/host-lifecycle.js';
+import { detectCertainImpact } from '../../src/session/impact.js';
+import { recordRead } from '../../src/store/read-set.js';
+import * as repo from '../../src/store/repository.js';
+import { shouldRefuseWrite } from '../../src/session/write-gate.js';
+
+/**
+ * The write gate, tested as a *refusal* claim: what it blocks, and far more often what it does not.
+ *
+ * Two thirds of these assert that a write went through. That is the shape of the thing -- a gate
+ * that wrongly refuses does not cost recall on an advisory notice, it costs a person the ability
+ * to edit a file, and the design's answer to every uncertain case is to allow. So the suite is
+ * mostly a list of ways to *not* be blocked: flag off, own change, released read, a sibling symbol,
+ * a different file, a broken store, a host that cannot refuse.
+ *
+ * The remaining claim is the one that decides whether this feature is tolerable at all: a refusal
+ * cannot repeat. An agent that is blocked, does what it was told, and is blocked again has been
+ * trapped by its memory server, which is strictly worse than never having had a gate.
+ *
+ * Real git repo, real tree-sitter index and the real detector, following `tests/store/impact.test
+ * .ts`. Every condition the gate refuses on is `impact.ts`'s verdict rather than this suite's, and
+ * a seeded finding row would test this file's idea of staleness instead of the one that ships.
+ */
+
+const SOURCE = 'src/session.ts';
+const OTHER = 'src/other.ts';
+
+/**
+ * Two symbols, neither exported -- the fixture `tests/store/impact-lifecycle.test.ts` uses, for
+ * its reason: `export function` yields two index symbols (the declaration and its `export:`
+ * wrapper), which hides exactly the per-symbol distinction the sibling-symbol case turns on.
+ */
+const V1 = `function createSession(user: User): Session {
+  return { user };
+}
+
+function destroySession(id: string): void {
+  void id;
+}
+`;
+const V2 = `function createSession(user: User, org: Organization): Session {
+  return { user, org };
+}
+
+function destroySession(id: string): void {
+  void id;
+}
+`;
+const V3 = `function createSession(user: User, org: Organization, at: number): Session {
+  return { user, org, at };
+}
+
+function destroySession(id: string): void {
+  void id;
+}
+`;
+const WAS_SIGNATURE = 'function createSession(user: User): Session';
+const NOW_SIGNATURE = 'function createSession(user: User, org: Organization): Session';
+
+const READER = 'sess-reader';
+const WRITER = 'sess-writer';
+const AT = '2026-08-05T00:00:00.000Z';
+
+// One directory per test: on Windows the previous database file can still be locked when the next
+// test starts, and a silently failed cleanup would carry read-set rows into the next case, where
+// "allowed the write" would pass or fail on the leftovers.
+let testRoot = '';
+let testIndex = 0;
+
+function git(...args: string[]): void {
+  const result = spawnSync('git', args, { cwd: testRoot, encoding: 'utf-8', stdio: 'pipe' });
+  if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr ?? ''}`);
+}
+
+async function write(relativePath: string, contents: string): Promise<void> {
+  const full = path.join(testRoot, relativePath);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, contents, 'utf8');
+}
+
+/** The real gate: the config is re-read per call, so it can be flipped mid-test. */
+async function setImpactEnabled(enabled: boolean): Promise<void> {
+  await write('.knowl/config.json', JSON.stringify({ version: 1, impact: { enabled } }));
+}
+
+async function symbolHashOf(relativePath: string, qualifiedName: string): Promise<string> {
+  const symbols = await listCodeSymbols(relativePath);
+  const hash = symbols.find(symbol => symbol.qualifiedName === qualifiedName)?.signatureHash;
+  if (!hash) throw new Error(`no indexed signature hash for ${qualifiedName} in ${relativePath}`);
+  return hash;
+}
+
+/**
+ * A read-set row written directly rather than through the capture path.
+ *
+ * The capture path is another branch of this lane and is exercised by `impact-lifecycle.test.ts`;
+ * what this suite owns is the gate's reaction to a belief that exists. The row is therefore the
+ * fixture -- but only the row: which rows still count is `activeReadSetForSession`'s answer, not
+ * this helper's, which is what makes the released case below mean anything.
+ */
+async function seedRead(id: string, sessionId: string, locator: string, observedHash: string): Promise<void> {
+  await getClient().execute({
+    // No `task_id`. The column went during #33's review: nothing on the capture path knows a task
+    // id -- `recordToolReads` runs from a hook event carrying a session and an agent and no task --
+    // so every row was written NULL and the task-scoped release could only ever match zero rows.
+    sql: `INSERT INTO work_read_sets (id, session_id, agent_id, locator, observed_hash, tool_name, read_at, released_at)
+          VALUES (?, ?, NULL, ?, ?, 'Read', ?, NULL)`,
+    args: [id, sessionId, locator, observedHash, AT],
+  });
+}
+
+const readRow = async (id: string) => (await getClient().execute({
+  sql: 'SELECT released_at FROM work_read_sets WHERE id = ?',
+  args: [id],
+})).rows[0];
+
+/**
+ * The situation the gate exists for: READER read `createSession`, somebody else changed it.
+ *
+ * Returns after asserting the detector actually produced the finding, so a fixture that stopped
+ * reproducing staleness fails here rather than as a mystery "allowed the write" three lines later.
+ */
+async function makeStale(causeSession = WRITER): Promise<void> {
+  await indexFile(testRoot, SOURCE);
+  await seedRead('read-1', READER, `symbol://${SOURCE}#createSession`, await symbolHashOf(SOURCE, 'createSession'));
+  await write(SOURCE, V2);
+  const findings = await detectCertainImpact(testRoot, [SOURCE], causeSession);
+  if (causeSession !== READER && findings.length !== 1) {
+    throw new Error(`fixture produced ${findings.length} findings, expected 1`);
+  }
+}
+
+beforeEach(async () => {
+  testRoot = path.resolve(`./.knowl-test-write-gate-${testIndex++}`);
+  await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  await fs.mkdir(path.join(testRoot, '.knowl'), { recursive: true });
+
+  git('init', '-q', '.');
+  git('config', 'user.email', 'lane-l@example.test');
+  git('config', 'user.name', 'lane l');
+  // The store lives inside the repo it indexes, so it has to be ignored.
+  await write('.gitignore', '.knowl/\n');
+  await write(SOURCE, V1);
+  await write(OTHER, 'function unrelated(): void {}\n');
+  git('add', '-A');
+  git('commit', '-qm', 'fixture');
+
+  await initDb(testRoot);
+  await setImpactEnabled(true);
+});
+
+afterEach(async () => {
+  await closeDb();
+  await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('write gate — refusing', () => {
+  it('refuses a write to a file whose read symbol moved, and says what moved', async () => {
+    await makeStale();
+
+    const decision = await shouldRefuseWrite(testRoot, READER, [path.join(testRoot, SOURCE)]);
+
+    expect(decision.deny).toBe(true);
+    const reason = decision.reason ?? '';
+    // The file, because the agent has to know where to look; the pair, because a refusal without
+    // the diff is the bare announcement measured at no consistent improvement over silence.
+    expect(reason).toContain(SOURCE);
+    expect(reason).toContain(`was: ${WAS_SIGNATURE}`);
+    expect(reason).toContain(`now: ${NOW_SIGNATURE}`);
+    // The instruction is the payload's third part: an agent told "no" with no next step retries.
+    expect(reason).toContain(`Re-read ${SOURCE}`);
+  });
+
+  it('re-arms after the belief is observed again, so the block is per stale read and not per file', async () => {
+    await makeStale();
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(true);
+
+    // The agent does what it was told: re-reads, and now holds the current signature.
+    await recordRead({
+      sessionId: READER,
+      locator: `symbol://${SOURCE}#createSession`,
+      observedHash: await symbolHashOf(SOURCE, 'createSession'),
+    });
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+
+    // A *second* foreign change to the same symbol is a new stale belief, and must block again --
+    // otherwise the one-shot would be a permanent disarm of the file it fired on.
+    await write(SOURCE, V3);
+    await detectCertainImpact(testRoot, [SOURCE], WRITER);
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(true);
+  });
+});
+
+describe('write gate — allowing', () => {
+  it('never refuses the same write twice: the retry goes through', async () => {
+    await makeStale();
+
+    const first = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+    expect(first.deny).toBe(true);
+    // The one-shot has to be durable and not merely intended: the row it named is released, which
+    // is what makes the second answer independent of the agent having re-read anything. An agent
+    // that re-reads with `cat` updates no read-set row, and without this would be refused forever
+    // for doing exactly what it was asked.
+    expect(first.releasedReadIds).toEqual(['read-1']);
+    expect((await readRow('read-1')).released_at).not.toBeNull();
+
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows when nothing this session read has moved', async () => {
+    await indexFile(testRoot, SOURCE);
+    await seedRead('read-1', READER, `symbol://${SOURCE}#createSession`, await symbolHashOf(SOURCE, 'createSession'));
+    expect(await detectCertainImpact(testRoot, [SOURCE], WRITER)).toEqual([]);
+
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows when this session made the change itself', async () => {
+    // The common case, not an exotic one: an agent reads a file and then edits it twice. Without
+    // self-exclusion every second edit in that sequence is refused.
+    await makeStale(READER);
+
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows when the repository never turned impact detection on', async () => {
+    await makeStale();
+    await setImpactEnabled(false);
+
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows when the read that justified the finding was already released', async () => {
+    await makeStale();
+    await getClient().execute({
+      sql: 'UPDATE work_read_sets SET released_at = ? WHERE id = ?',
+      args: [AT, 'read-1'],
+    });
+
+    // A finished task or session no longer holds the belief, and `openFindingsForSession`
+    // deliberately does not filter on release -- so the gate, not the query, has to decide this.
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows a write to a file this session has no stale read in', async () => {
+    await makeStale();
+
+    expect((await shouldRefuseWrite(testRoot, READER, [OTHER])).deny).toBe(false);
+    expect((await readRow('read-1')).released_at).toBeNull();
+  });
+
+  it('allows an edit to a file where a different symbol moved than the one this session read', async () => {
+    // STORM's own stated limitation, and the single reason this is symbol-granular: two agents
+    // editing different functions in one file must not block each other.
+    await indexFile(testRoot, SOURCE);
+    await seedRead('read-1', READER, `symbol://${SOURCE}#destroySession`, await symbolHashOf(SOURCE, 'destroySession'));
+    await write(SOURCE, V2);
+    expect(await detectCertainImpact(testRoot, [SOURCE], WRITER)).toEqual([]);
+
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows, rather than throwing, when the store cannot answer', async () => {
+    await makeStale();
+    await getClient().execute('DROP TABLE impact_findings');
+
+    await expect(shouldRefuseWrite(testRoot, READER, [SOURCE])).resolves.toMatchObject({ deny: false });
+  });
+});
+
+describe('write gate — on the hook path', () => {
+  /**
+   * `generic` because it is the host with no native hook protocol at all, so it has no pre-tool
+   * callback to refuse through. Pinning the degradation to a host that could later gain one would
+   * make this test flip from "degrades correctly" to "fails" the day it did.
+   */
+  const precheck = (sessionId: string, toolName: string, changedPaths: string[]): NormalizedHostHook => ({
+    host: 'generic',
+    event: 'tool-precheck',
+    externalSessionId: sessionId,
+    projectRoot: testRoot,
+    toolName,
+    payload: { changedPaths },
+  });
+
+  it('degrades to allowing on a host that cannot refuse, and spends nothing doing it', async () => {
+    const projectId = (await repo.createProject(testRoot, 'write gate')).id;
+    const started = await handleHostLifecycleEvent(projectId, {
+      host: 'generic',
+      event: 'session-start',
+      externalSessionId: 'host-session',
+      projectRoot: testRoot,
+      payload: {},
+    });
+    const sessionId = started.sessionId ?? '';
+    expect(sessionId).not.toBe('');
+
+    await indexFile(testRoot, SOURCE);
+    await seedRead('read-1', sessionId, `symbol://${SOURCE}#createSession`, await symbolHashOf(SOURCE, 'createSession'));
+    await write(SOURCE, V2);
+    await detectCertainImpact(testRoot, [SOURCE], WRITER);
+
+    const result = await handleHostLifecycleEvent(projectId, precheck('host-session', 'Edit', [SOURCE]));
+
+    expect(result.accepted).toBe(true);
+    expect(result.hostOutput).toBeUndefined();
+    // The refusal was never attempted, so the one-shot is still armed for a host that can deliver
+    // one. Asking the gate first and discarding the answer would silently disarm it here.
+    expect((await readRow('read-1')).released_at).toBeNull();
+  });
+
+  it('does not treat a pre-tool event as a session boundary', async () => {
+    const projectId = (await repo.createProject(testRoot, 'write gate')).id;
+    await handleHostLifecycleEvent(projectId, {
+      host: 'generic',
+      event: 'session-start',
+      externalSessionId: 'host-session',
+      projectRoot: testRoot,
+      payload: {},
+    });
+
+    // Every unrecognised event falls through to the session-stop handler, which finishes the
+    // memory session and promotes it. A pre-tool event arriving before every write would end the
+    // session on the agent's first edit.
+    const result = await handleHostLifecycleEvent(projectId, precheck('host-session', 'Read', [SOURCE]));
+
+    expect(result).toEqual({ accepted: true });
+  });
+});

--- a/tests/store/write-gate.test.ts
+++ b/tests/store/write-gate.test.ts
@@ -10,6 +10,7 @@ import { detectCertainImpact } from '../../src/session/impact.js';
 import { recordRead } from '../../src/store/read-set.js';
 import * as repo from '../../src/store/repository.js';
 import { shouldRefuseWrite } from '../../src/session/write-gate.js';
+import { countShadowBlocks } from '../../src/store/gate-shadow.js';
 
 /**
  * The write gate, tested as a *refusal* claim: what it blocks, and far more often what it does not.
@@ -86,8 +87,20 @@ async function write(relativePath: string, contents: string): Promise<void> {
 }
 
 /** The real gate: the config is re-read per call, so it can be flipped mid-test. */
+async function setImpact(impact: Record<string, unknown>): Promise<void> {
+  await write('.knowl/config.json', JSON.stringify({ version: 1, impact }));
+}
+
+/**
+ * Detection on and the gate *enforcing*, which is what the suite below is about.
+ *
+ * The gate mode has to be written explicitly. `impact.enabled` alone resolves to `gate: 'off'`
+ * through `impactGateMode`, so a helper that set only `enabled` would leave every refusal test
+ * here asserting against a gate that was switched off -- and they would not fail loudly, they
+ * would all quietly start allowing, which is the same shape as the feature working.
+ */
 async function setImpactEnabled(enabled: boolean): Promise<void> {
-  await write('.knowl/config.json', JSON.stringify({ version: 1, impact: { enabled } }));
+  await setImpact({ enabled, gate: 'enforce' });
 }
 
 async function symbolHashOf(relativePath: string, qualifiedName: string): Promise<string> {
@@ -332,5 +345,125 @@ describe('write gate — on the hook path', () => {
     const result = await handleHostLifecycleEvent(projectId, precheck('host-session', 'Read', [SOURCE]));
 
     expect(result).toEqual({ accepted: true });
+  });
+});
+
+/**
+ * The three modes, and the one property shadow exists for.
+ *
+ * The gate is the only part of this subsystem that can cost somebody their working session, so it
+ * is not allowed to refuse anything until plan §9's ≥95%-over-≥40-findings bar has been measured.
+ * Shadow is where that measurement happens: the identical verdict, computed for real, with the
+ * refusal withheld.
+ */
+describe('write gate — modes', () => {
+  const openFindingId = async (): Promise<string> => String((await getClient().execute(
+    'SELECT id FROM impact_findings WHERE resolution IS NULL ORDER BY detected_at, id',
+  )).rows[0].id);
+
+  it('computes nothing and allows when the gate is off', async () => {
+    await setImpact({ enabled: true, gate: 'off' });
+    await makeStale();
+
+    const decision = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    expect(decision.deny).toBe(false);
+    expect(decision.shadowedFindingIds).toEqual([]);
+    expect(await countShadowBlocks()).toBe(0);
+    // Nothing was spent: the belief is untouched and the gate is still armed for whenever
+    // somebody turns it on.
+    expect((await readRow('read-1')).released_at).toBeNull();
+  });
+
+  it('shadow records the withheld refusal and lets the write through', async () => {
+    await setImpact({ enabled: true, gate: 'shadow' });
+    await makeStale();
+    const findingId = await openFindingId();
+
+    const decision = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    expect(decision.deny).toBe(false);
+    expect(decision.reason).toBeNull();
+    expect(decision.shadowedFindingIds).toEqual([findingId]);
+    expect(await countShadowBlocks()).toBe(1);
+  });
+
+  /**
+   * The property the whole mode exists for.
+   *
+   * Releasing here would clear a belief the agent never re-read, so `work_read_sets` would stop
+   * describing what the session holds -- while being the evidence the precision number is computed
+   * from. A diagnostic must not change the process it observes.
+   */
+  it('shadow does not release the read-set row it named', async () => {
+    await setImpact({ enabled: true, gate: 'shadow' });
+    await makeStale();
+
+    await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    expect((await readRow('read-1')).released_at).toBeNull();
+  });
+
+  /**
+   * Because the belief stays live it returns on every later write to that file, so the count has
+   * to be defended by the unique index rather than by the belief going away.
+   */
+  it('shadow logs one row however many writes hit the same belief', async () => {
+    await setImpact({ enabled: true, gate: 'shadow' });
+    await makeStale();
+
+    const first = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+    const second = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+    const third = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    expect(await countShadowBlocks()).toBe(1);
+    // Only the write that actually recorded something reports it, so a caller counting these does
+    // not double-count either.
+    expect(first.shadowedFindingIds).toHaveLength(1);
+    expect(second.shadowedFindingIds).toEqual([]);
+    expect(third.shadowedFindingIds).toEqual([]);
+  });
+
+  it('shadow leaves the finding open, so it stays in the precision denominator', async () => {
+    await setImpact({ enabled: true, gate: 'shadow' });
+    await makeStale();
+
+    await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    const open = await getClient().execute('SELECT COUNT(*) AS n FROM impact_findings WHERE resolution IS NULL');
+    expect(Number(open.rows[0].n)).toBe(1);
+  });
+
+  it('enforce denies, releases, and writes no shadow row', async () => {
+    await setImpact({ enabled: true, gate: 'enforce' });
+    await makeStale();
+
+    const decision = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    expect(decision.deny).toBe(true);
+    expect(decision.reason).toContain('KNOWL BLOCKED THIS WRITE');
+    expect(decision.releasedReadIds).toEqual(['read-1']);
+    expect(decision.shadowedFindingIds).toEqual([]);
+    expect(await countShadowBlocks()).toBe(0);
+    expect((await readRow('read-1')).released_at).not.toBeNull();
+  });
+
+  it('allows when the gate is armed but detection is off', async () => {
+    // Decided in `impactGateMode`, and re-asserted here because this is the call site where
+    // getting it wrong takes away somebody's edit rather than merely logging a wrong row.
+    await setImpact({ enabled: false, gate: 'enforce' });
+    await makeStale();
+
+    expect((await shouldRefuseWrite(testRoot, READER, [SOURCE])).deny).toBe(false);
+  });
+
+  it('allows when the mode is a value nobody defined', async () => {
+    await setImpact({ enabled: true, gate: 'block' });
+    await makeStale();
+
+    const decision = await shouldRefuseWrite(testRoot, READER, [SOURCE]);
+
+    expect(decision.deny).toBe(false);
+    expect(await countShadowBlocks()).toBe(0);
   });
 });


### PR DESCRIPTION
Closes the last open piece of #17. Pieces 1 (#19) and 2 (#33) are merged; this is the `PreToolUse` write gate — **shipped in shadow mode, blocking nothing.**

The gate itself is @William-Sommers' work, cherry-picked from `impact/3-write-gate` at `cd9fc8f` so authorship is preserved. What this PR adds on top is the condition attached to accepting it on #17: it ships in shadow mode first, so the false-positive rate is measured before anything refuses a write.

## What the gate does

Agent A reads `login.ts` and plans an edit. Agent B changes that function. A's edit then lands on a version that is gone.

Pieces 1 and 2 detect that and add a `CODE IMPACT` stanza to the change card. That is a notice, and notices are the intervention measured at approximately zero effect twice, independently — SWE-Touch finds message-plus-edit no better than the silent edit and *worse* for 3 of 4 models; CooperBench finds a first-turn plan halves the conflict rate while moving end-to-end success insignificantly.

The gate is the mechanism with evidence behind it: `PreToolUse` fires before `Edit`/`Write`/`MultiEdit`, and when the write targets a file holding an unresolved `certain`-tier finding against a read *this session still holds*, the hook returns `permissionDecision: 'deny'` with the was/now pair. That is STORM's mechanism, the one intervention in the literature that moved a number (+18.7 on Commit0-Lite). A denial costs one tool call, reissued after a re-read — nothing is discarded.

## Shadow mode

`impact.gate` takes `off` (default), `shadow`, or `enforce`. It is separate from `impact.enabled` because the risks differ in kind: detection spends context, while the gate refuses a tool call. Detection off resolves to gate off whatever the key says — the gate's entire input is the findings the detector writes, so an armed gate over a disabled detector could never fire while claiming it can.

`shadow` computes the identical verdict, records it in `impact_gate_shadow`, and lets the write through. Promotion to `enforce` is a separate decision on a stated number: plan §9's ≥95% precision over ≥40 adjudicated findings, read from `shadowGatePrecision()`.

**Shadow deliberately does not release the read-set rows it names**, and this is the one place it departs from the gate's four properties. Enforcing mode releases them so a retry is never blocked twice — safe there, because the agent has been told to re-read. Doing the same while merely observing would clear a belief nobody re-read, and `work_read_sets` would stop describing what the session holds while being the evidence the precision number is computed from. A diagnostic must not change the process it observes.

The consequence is that the belief stays live and the same finding returns on the next write to that file, which is why `impact_gate_shadow` is **unique on `finding_id`**: the row count has to equal the denials an enforcing gate would have issued, not the writes that were attempted, and those differ by however many times an agent happens to edit one file. `finding_id` alone suffices because a finding's `affected_id` already *is* the read-set row id, so one finding is one stale belief. `session_id` is stored despite being reachable through that join, because `sweepReadSets` hard-deletes released rows and the owning session would otherwise be unrecoverable after GC.

Precision excludes unresolved findings from **both** halves rather than counting them correct, and returns `null` rather than `1` when nothing has been adjudicated — no evidence is not a perfect score.

## Schema

One additive table and one index. `KNOWL_MIGRATION_LEVEL` 3 → 4, `KNOWL_SCHEMA_VERSION` held at **1**, new `SCHEMA_PINS[4]`, and `impact_gate_shadow: 'preserved'` in `snapshot-tables.ts` — same reason as `impact_findings`: the rows are the measurement, and a restore that rolled them back would silently reset the denominator.

## What the cherry-pick had to change

The original is based on `ac3ce52`, before pieces 1 and 2 landed. The commit message records this too, so the diff is not mistaken for the author's:

- The gate is **`src/session/write-gate.ts`**, not `store/`. It imports the card renderer and the detector, both of which #31 placed above `store/` in the layer graph and both of which had moved to `session/` on main. Identical correction to the one #33 needed.
- `NormalizedHookEventName`'s `'tool-precheck'` variant is declared in `src/core/host-hook-types.ts`, where the hook types now live.
- Host profiles are `src/session/hosts/`, not `cli/agents/hosts/`.
- The test's `seedRead` no longer writes `task_id` — #33 dropped that column, because nothing on the capture path knows a task id.

`working-tree.ts` is **not** reintroduced. #33 removed it as dead on the reasoning that it was the gate's input; checked against the contributor's own branch, it has no caller there either — the gate takes its paths from the hook event.

## Also in here

Six comments and descriptions promised a `knowl_task_finish` gate that plan §15 removed as unreachable, or claimed read-sets release "at a task finish". Both are false and now say what actually happens. Verified rather than assumed: `openFindingsForSession` has exactly one caller (`tools.ts:364`, the `knowl_impact` pull tool), and `releaseSessionReadSet` is called only from the stop and failure branches of `host-lifecycle.ts`. `tests/mcp/impact-tool.test.ts:331` already asserts a clean finish lands with an unresolved finding outstanding.

§15's own conclusion is the reason it is worth correcting: a description promising an enforcement that cannot fire is worse than no promise, and it costs guidance-card space in every session to say it.

## Verification

- `npm run build` clean, `tsc --noEmit` clean, `eslint` **0 errors** (26 warnings, all pre-existing, none in a touched file)
- Full suite **260 files / 2310 passed / 4 skipped**, against a 257/2257 baseline
- New coverage: 12 gate tests, 8 mode tests, 7 shadow-log tests, 4 schema tests, 7 config tests

One caveat worth stating: over six full-suite runs on Windows, three were clean and three each failed a single *different* unrelated test, every one passing in isolation immediately afterwards. One named its cause — `EPERM` on an atomic-write rename. This looks like the process-spawn and file-lock contention `vitest.config.ts` already documents rather than anything in this change, but it was not proven against a six-run clean baseline, so it is flagged rather than dismissed.

## Coverage bounds

Carried from the original and unchanged: `Bash` writes are unmediated (STORM concedes the same), and `NotebookEdit` is gated only insofar as `notebook_path` reaches the stdin allowlist. The original commit message also cites four open upstream bugs, including `#78970` on `PreToolUse` and subagent tool calls — that citation has **not** been re-verified in this PR and should not be relied on without checking.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
