### PR TITLE
Make doctor re-check, catch guidance drift, stop linting bundled output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+### `knowl doctor` asks the registry every time
+
+The update check caches for a day, which is right for `knowl status` — run in passing, and a
+day-old answer costs nothing. It is wrong for `doctor`, whose entire job is to report what is true
+right now. Measured on the day 3.4.0 shipped: the cache was written at 05:14Z, 3.4.0 published at
+10:18Z, and `doctor` went on reporting a healthy 3.3.0 for the rest of the day with no way to make
+it look again. A diagnostic that cannot be refreshed is one you stop believing.
+
+`doctor` now passes `ttlMs: 0`. It costs at most the existing 2s fetch timeout on a command that
+is already deliberate and slow, fails silently offline like every other caller, and still writes
+the shared cache so the next `knowl status` benefits from the fresh answer. `status` is unchanged.
+
+### `docs:check` catches drift in KNOWL.md and AGENTS.md
+
+Both files are generated from `src/core/knowl-guidance.ts` by `installKnowlProjectGuidance`, and
+nothing verified them: the region check covered `README.md` and `docs/reference.md` only. The gap
+let two separate stale-guidance commits through in one day. One was a `knowl` command run against
+a stale `dist/`, which rewrote both files from an older build and silently reverted bullets that
+had just landed; the other edited `KNOWL.md` and left `AGENTS.md` behind, with `docs:check`
+reporting "regions are current" while the two files disagreed with each other and with the source.
+
+`npm run docs:check` now fails on that drift and `npm run docs:generate` repairs it. Compared from
+`src/`, never from `dist/` — a stale build is the failure being caught, so trusting the build to
+detect it would close the loop on itself. The comparison and the write both match each file's own
+line endings, because `installKnowlProjectGuidance` writes LF unconditionally and a checkout with
+`core.autocrlf` would otherwise report drift on every run that git cannot see.
+
 ## 3.4.0 — 2026-08-08
 
 ### Retrieved text renders as data, not as live markdown

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,12 @@ export default tseslint.config(
   // every finding is reported once per worktree -- 52 warnings became 78 with two present, all
   // of them duplicates against code the developer has not touched. Same reason
   // `vitest.config.ts` excludes it.
-  { ignores: ['dist/**', 'node_modules/**', '.benchmark-dist/**', 'benchmarks/**/dist/**', '.tmp/**', '.claude/**'] },
+  // `.bridge-dist/**` is bundled output like `dist/**` and was the one build directory missing
+  // here, so `npm run lint` reported 29 errors -- `no-this-alias`, control characters in regexes,
+  // empty catch blocks -- against generated third-party code nobody can fix. It is gitignored, so
+  // CI's fresh checkout never has it and only local runs went red, which is the worst shape for a
+  // signal to fail in: contributors learn the lint output is wrong and stop reading it.
+  { ignores: ['dist/**', 'node_modules/**', '.benchmark-dist/**', '.bridge-dist/**', 'benchmarks/**/dist/**', '.tmp/**', '.claude/**'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -22,6 +22,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
 import { DEFAULT_PRESET_ID, VECTOR_PRESETS } from '../src/core/vector-profile.js';
+import { stripManagedKnowlGuidance } from '../src/core/agents-guidance.js';
+import { renderManagedKnowlGuidanceSection } from '../src/core/knowl-guidance.js';
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const check = process.argv.includes('--check');
@@ -121,6 +123,51 @@ if (check && stale) {
   console.error('Generated documentation regions are stale. Run: npm run docs:generate');
 } else if (!check) {
   console.log(stale ? 'Generated documentation regions updated.' : 'Generated documentation regions already current.');
+}
+
+/**
+ * This repository's own KNOWL.md and AGENTS.md, against the guidance they are generated from.
+ *
+ * Both files are written by `installKnowlProjectGuidance` from `renderManagedKnowlGuidanceSection`,
+ * and nothing verified them — the region check above covers README.md and docs/reference.md only.
+ * The gap is not theoretical: on 2026-08-08 it let two separate stale-guidance commits through in
+ * one day. One was a `knowl` command run against a stale `dist/`, which rewrote both files from an
+ * older build and silently reverted bullets that had just landed; the other was a change that
+ * edited KNOWL.md and left AGENTS.md behind, with `docs:check` reporting "regions are current"
+ * while the two files disagreed with each other and with the source.
+ *
+ * Checked from `src/`, never from `dist/`, which is the whole point: a stale build is exactly the
+ * failure being caught, so trusting the build to detect it would close the loop on itself.
+ *
+ * `installKnowlProjectGuidance` is deliberately NOT reused here even though it composes the same
+ * text. It writes LF unconditionally, which is right for a user's project and wrong for this one:
+ * a checkout with `core.autocrlf` holds CRLF, so it rewrites every line of both files on every
+ * run and reports drift that git cannot see. Same trap the region writer above documents, so the
+ * comparison normalises and the write matches the file's own endings.
+ */
+const managedGuidance = renderManagedKnowlGuidanceSection();
+let guidanceStale = false;
+for (const name of ['KNOWL.md', 'AGENTS.md']) {
+  const file = path.join(root, name);
+  const current = fs.readFileSync(file, 'utf8');
+  const eol = current.includes('\r\n') ? '\r\n' : '\n';
+  const unmanaged = stripManagedKnowlGuidance(current.replaceAll('\r\n', '\n')).trimEnd();
+  const expected = (unmanaged.length > 0 ? `${unmanaged}\n\n${managedGuidance}` : managedGuidance)
+    .replaceAll('\n', eol);
+  if (expected === current) continue;
+  guidanceStale = true;
+  if (!check) fs.writeFileSync(file, expected);
+}
+
+if (check && guidanceStale) {
+  failures.push(
+    'KNOWL.md / AGENTS.md do not match src/core/knowl-guidance.ts. '
+    + 'Run: npm run docs:generate (a knowl command run against a stale dist/ is the usual cause)',
+  );
+} else if (!check) {
+  console.log(guidanceStale
+    ? 'Project guidance rewritten from src/core/knowl-guidance.ts.'
+    : 'Project guidance already matches src/core/knowl-guidance.ts.');
 }
 
 for (const failure of failures) console.error(`✗ ${failure}`);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2501,7 +2501,20 @@ program
       const root = await findProjectRoot(process.cwd());
       const config = await loadConfig(root);
       if (isUpdateCheckEnabled(config)) {
-        const update = await checkForUpdate({ packageName: PACKAGE_NAME, currentVersion: PACKAGE_VERSION, projectRoot: root });
+        // `ttlMs: 0`, unlike `status`, so this always asks the registry.
+        //
+        // The day-long cache is right for a command run in passing and wrong for the one command
+        // whose entire job is to report what is true right now. Measured 2026-08-08: 3.4.0
+        // published at 10:18Z against a cache written at 05:14Z, and `doctor` went on reporting
+        // a healthy 3.3.0 for the rest of the day -- a diagnostic that cannot be made to look
+        // again is one you stop believing.
+        //
+        // Costs at most `FETCH_TIMEOUT_MS` (2s) on a deliberate, already-slow command, fails
+        // silently offline like every other caller, and still refreshes the shared cache so the
+        // next `knowl status` benefits.
+        const update = await checkForUpdate({
+          packageName: PACKAGE_NAME, currentVersion: PACKAGE_VERSION, projectRoot: root, ttlMs: 0,
+        });
         if (update?.updateAvailable) console.log(formatUpdateNotice(update, PACKAGE_NAME));
       }
     } catch {

--- a/tests/core/version-check.test.ts
+++ b/tests/core/version-check.test.ts
@@ -56,6 +56,29 @@ describe('npm update check', () => {
     expect(result?.latest).toBe('1.5.0');
   });
 
+  it('always refetches at ttlMs 0, which is what makes doctor a diagnostic', async () => {
+    // `knowl doctor` passes 0 where `status` takes the day-long default. Measured 2026-08-08:
+    // 3.4.0 published five hours after the cache was written, and doctor went on reporting a
+    // healthy 3.3.0 for the rest of the day. A diagnostic that cannot be made to look again is
+    // one you stop believing.
+    await checkForUpdate({ packageName: PKG, currentVersion: '1.3.1', projectRoot: root, fetchImpl: okFetch('1.4.0') });
+    const result = await checkForUpdate({
+      packageName: PKG, currentVersion: '1.3.1', projectRoot: root, ttlMs: 0, fetchImpl: okFetch('1.6.0'),
+    });
+
+    expect(result?.latest).toBe('1.6.0');
+    expect(result?.updateAvailable).toBe(true);
+  });
+
+  it('still writes the shared cache when it bypasses it, so the next status benefits', async () => {
+    await checkForUpdate({
+      packageName: PKG, currentVersion: '1.3.1', projectRoot: root, ttlMs: 0, fetchImpl: okFetch('1.6.0'),
+    });
+    const raw = JSON.parse(await fs.readFile(path.join(root, '.knowl', 'cache', 'update-check.json'), 'utf-8'));
+
+    expect(raw.latest).toBe('1.6.0');
+  });
+
   it('honours config and environment opt-outs', () => {
     expect(isUpdateCheckEnabled({})).toBe(true);
     expect(isUpdateCheckEnabled({ updateCheck: { enabled: false } })).toBe(false);


### PR DESCRIPTION
Three things the 3.4.0 release surfaced. None is in the released code; all three are tooling or diagnostics that were quietly wrong.

## `knowl doctor` could not be made to look again

The update check caches for a day. That is right for `knowl status` — run in passing, a day-old answer costs nothing — and wrong for the one command whose entire job is to report what is true right now.

Measured on release day: the cache was written at **05:14Z**, 3.4.0 published at **10:18Z**, and `doctor` went on reporting a healthy 3.3.0 for the rest of the day with no way to refresh it. A diagnostic that cannot be made to look again is one you stop believing.

`doctor` now passes `ttlMs: 0`. Costs at most the existing 2s fetch timeout on an already-deliberate command, fails silently offline like every other caller, and still writes the shared cache so the next `status` benefits. `status` is unchanged.

## Nothing verified `KNOWL.md` or `AGENTS.md`

Both are generated from `src/core/knowl-guidance.ts` by `installKnowlProjectGuidance`. The region check covered `README.md` and `docs/reference.md` only, so nothing compared the two guidance files against their source — or against each other.

That gap let **two** stale-guidance commits through in one day:

- A `knowl` command run against a stale `dist/` rewrote both files from an older build, silently reverting bullets that had just landed on `main`. This is what caused the local merge conflict after #39.
- A separate change edited `KNOWL.md` and left `AGENTS.md` behind — with `docs:check` reporting *"regions are current"* while the two files disagreed with each other **and** with the source.

`npm run docs:check` now fails on that drift; `npm run docs:generate` repairs it.

Two deliberate choices worth calling out:

- **Compared from `src/`, never `dist/`.** A stale build is the failure being caught, so trusting the build to detect it would close the loop on itself.
- **`installKnowlProjectGuidance` is not reused**, despite composing the same text. It writes LF unconditionally — right for a user's project, wrong for this one, where a `core.autocrlf` checkout would report drift on every run that git cannot see. The comparison and the write both match each file's own line endings, the same trap the region writer above already documents.

Verified both directions: injecting drift makes `docs:check` fail, and `docs:generate` restores the file to a clean `git status`.

## `.bridge-dist/**` was being linted

The one build directory missing from eslint's ignore list, so `npm run lint` reported **29 errors** — `no-this-alias`, control characters in regexes, empty catch blocks — against generated third-party code nobody can fix.

It is gitignored, so CI's fresh checkout never has it and only local runs went red. That is the worst shape for a signal to fail in: contributors learn the lint output is wrong and stop reading it. Local lint goes 29 errors → 0.

## Verification

266 files / 2352 tests, `tsc --noEmit` clean, lint 0 errors, `docs:check` current.

Two new tests cover the `ttlMs: 0` path — that it always refetches, and that it still writes the shared cache.
