### PR TITLE
Stale guidance is NOT READY, and the session says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+### Stale guidance is NOT READY, and the session says so
+
+`knowl doctor` detected stale `KNOWL.md` / `AGENTS.md` and reported it as a `WARN`. The verdict
+gates on `FAIL`, so **doctor said READY while agents were reading instructions this version did not
+write** — which is exactly what happened on 2026-08-08, when a `knowl` command run against a stale
+`dist/` reverted guidance that had just landed and nothing anywhere said so.
+
+That severity is now `FAIL`. Every other `WARN` here means an optional thing is not configured — no
+vector provider, no work loop, `.knowl` not gitignored. Guidance staleness is not optional-anything:
+the block between the markers is owned by Knowl and rewritten wholesale, while anything outside it
+is preserved, so a difference there is never a preference. The obvious objection — that this flips
+installs which upgraded without re-initialising — does not hold: `knowl upgrade` and `knowl init`
+both reinstall guidance, so staleness survives neither, and `doctor --fix` already had the remedy
+wired.
+
+**The lifecycle hook now warns too, and this is the case that actually bites.** The hook injects its
+guidance card rendered from the *running build* while the host reads `KNOWL.md` from *disk*, so a
+stale file does not merely under-inform the agent — it contradicts the card inside the same session,
+with nothing to break the tie. Session start now leads with a `KNOWL GUIDANCE STALE` line naming
+which source is wrong, charged against the context budget rather than stacked on top of it.
+
+The hook warns only when the files are **present and different**, where `doctor` fails on missing or
+stale alike. The two are opposite findings: an absent file is one the host never read, so there is
+no second version of the guidance to contradict, and "written by a different version" would simply
+be false. A project that never ran `knowl init` is `doctor`'s to report, not something to repeat at
+every session start.
+
 ### `knowl doctor` asks the registry every time
 
 The update check caches for a day, which is right for `knowl status` — run in passing, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ it look again. A diagnostic that cannot be refreshed is one you stop believing.
 is already deliberate and slow, fails silently offline like every other caller, and still writes
 the shared cache so the next `knowl status` benefits from the fresh answer. `status` is unchanged.
 
+A non-positive TTL now disables the cache before any clock is read. The age comparison alone did
+not deliver that: `age > ttlMs` at `ttlMs: 0` still served the cache when the write and the read
+landed in the same millisecond, so `doctor` could quietly return the cached answer it passed 0 to
+avoid. Caught by CI on macOS, where the runner was fast enough to share a tick; ubuntu and windows
+both passed and hid it.
+
 ### `docs:check` catches drift in KNOWL.md and AGENTS.md
 
 Both files are generated from `src/core/knowl-guidance.ts` by `installKnowlProjectGuidance`, and

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -52,13 +52,33 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         : 'Config missing vector search defaults; run knowl upgrade',
     });
 
+    // FAIL, not WARN, and this is the one check where that distinction is worth arguing.
+    //
+    // Every other WARN here means an optional thing is not configured -- no vector provider, no
+    // work loop, `.knowl` not gitignored. Guidance staleness is not optional-anything: the block
+    // between the markers is owned by Knowl and rewritten wholesale by `installKnowlProjectGuidance`,
+    // while anything outside it is preserved. So a difference there is never a preference. It is
+    // always this project holding instructions some other version of Knowl wrote.
+    //
+    // Which makes READY a lie in the case that matters most. The lifecycle hook injects its
+    // guidance card from the RUNNING build while the host reads KNOWL.md from disk, so a stale
+    // file does not merely under-inform the agent -- it contradicts the card in the same session.
+    // Measured 2026-08-08: a `knowl` command run against a stale `dist/` reverted guidance that
+    // had just landed, and `doctor` went on reporting READY while agents were told to look for a
+    // per-row `repo` field the response shape no longer had.
+    //
+    // The obvious objection -- that this flips every install that upgraded the CLI without
+    // re-initialising -- was checked: `knowl upgrade` and `knowl init` both call
+    // `installKnowlProjectGuidance`, so staleness survives neither. What is left is a project
+    // nobody has upgraded, where NOT READY is the honest answer, and the remedy is already wired
+    // here as `{ kind: 'guidance' }` for `doctor --fix`.
     const guidanceCurrent = await isKnowlProjectGuidanceCurrent(root);
     checks.push({
-      status: guidanceCurrent ? 'OK' : 'WARN',
+      status: guidanceCurrent ? 'OK' : 'FAIL',
       message: guidanceCurrent
         ? 'KNOWL.md and AGENTS.md guidance current'
-        : 'KNOWL.md or AGENTS.md Knowl guidance missing or stale; run knowl init',
-      fix: guidanceCurrent ? undefined : 'run `knowl init`',
+        : 'KNOWL.md or AGENTS.md Knowl guidance missing or stale; agents are reading instructions this version did not write. Run knowl init',
+      fix: guidanceCurrent ? undefined : 'run `knowl init` (or `knowl doctor --fix`)',
       remedy: guidanceCurrent ? undefined : { kind: 'guidance' },
     });
 

--- a/src/core/version-check.ts
+++ b/src/core/version-check.ts
@@ -29,6 +29,14 @@ export function isUpdateCheckEnabled(config?: { updateCheck?: { enabled?: boolea
 }
 
 async function readCache(cacheFile: string, ttlMs: number): Promise<string | null> {
+  // A non-positive TTL means "do not use the cache", decided before any clock is read.
+  //
+  // The age comparison alone does not deliver that. `age > ttlMs` at `ttlMs: 0` still serves the
+  // cache when both calls land in the same millisecond, because 0 is not greater than 0 -- so
+  // `knowl doctor`, which passes 0 precisely to force a fresh answer, could quietly return the
+  // cached one. Caught by CI on macOS, where the runner was fast enough for the write and the
+  // read to share a tick; ubuntu and windows both passed and hid it.
+  if (ttlMs <= 0) return null;
   try {
     const entry = JSON.parse(await fs.readFile(cacheFile, 'utf-8')) as CacheEntry;
     const age = Date.now() - new Date(entry.checkedAt).getTime();

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -14,6 +14,7 @@ import {
 } from '../store/read-set.js';
 import { shouldRefuseWrite } from './write-gate.js';
 import { KNOWL_CLAUDE_CONTINUATION_REMINDER, KNOWL_SUBAGENT_BOOTSTRAP_CARD } from '../core/knowl-guidance.js';
+import { isKnowlProjectGuidanceCurrent } from '../core/agents-guidance.js';
 import {
   ChangeSummary,
   loadChangesInRange,
@@ -651,6 +652,45 @@ async function finalizeFailedStop(projectId: string, input: NormalizedHostHook, 
   return { promotion, handoff };
 }
 
+/**
+ * Whether this project's KNOWL.md and AGENTS.md still say what this build writes.
+ *
+ * The reason it belongs at session start and not only in `doctor`: the guidance card in this
+ * context block is rendered from the RUNNING build, while the host reads KNOWL.md from disk. A
+ * stale file therefore does not merely under-inform the agent, it **contradicts** the card in the
+ * same session, and nothing said which one to believe. Measured 2026-08-08: a `knowl` command run
+ * against a stale `dist/` reverted guidance that had just landed, and every session afterwards
+ * carried both versions at once.
+ *
+ * So the warning names the winner rather than just reporting drift -- an agent that knows the file
+ * is wrong can act on the card and tell the user, which is the whole point of saying it here.
+ *
+ * Two file reads and a string compare, once per session. Not on the per-tool-call path, where the
+ * write gate's process cost was the objection. Best-effort throughout: a missing or unreadable
+ * instruction file is not a reason to fail a session bootstrap.
+ */
+async function staleGuidanceWarningBestEffort(projectRoot: string): Promise<string | null> {
+  try {
+    // Present AND different, not merely "not current" -- `isKnowlProjectGuidanceCurrent` reports
+    // false for both, and the two mean opposite things here. A file that does not exist is one
+    // the host never read, so there is no second version of the guidance and nothing to
+    // contradict; saying "written by a different version of Knowl" about an absent file is just
+    // false. That case is `doctor`'s to raise, where "this project was never set up" is the
+    // finding. Narrowing to drift also keeps this quiet for every project that uses Knowl through
+    // MCP without the markdown files.
+    const present = await Promise.all(['KNOWL.md', 'AGENTS.md'].map(name =>
+      fs.access(path.join(projectRoot, name)).then(() => true, () => false)));
+    if (!present.every(Boolean)) return null;
+    if (await isKnowlProjectGuidanceCurrent(projectRoot)) return null;
+  } catch {
+    return null;
+  }
+  return 'KNOWL GUIDANCE STALE: this project\'s KNOWL.md / AGENTS.md were written by a different '
+    + 'version of Knowl than the one running, so they may contradict the guidance in this block. '
+    + 'Where they disagree, the file is the stale one. Run `knowl init` (or `knowl doctor --fix`) '
+    + 'to refresh them.';
+}
+
 export async function handleHostLifecycleEvent(projectId: string, input: NormalizedHostHook): Promise<HostLifecycleResult> {
   // First, and claimed before anything else can mistake it for a session boundary: every event
   // this function does not recognise falls through to the session-stop handler at the bottom, and
@@ -673,7 +713,14 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // follows. Prepending it to an already-budgeted block pushed the session past the size
     // the host was promised, and the warning is the part that must survive: the watermark
     // has already advanced, so this line is the only record of the window.
-    const warning = truncateText(describeAutoDrift(drift) ?? '', DEFAULT_CONTEXT_MAX_CHARS);
+    // Guidance first, then drift. Both are charged against the cap before recent context, and if
+    // only one survives truncation it should be the one saying the instructions on disk cannot be
+    // trusted -- an agent acting on stale guidance gets the subsequent work wrong, where a missed
+    // drift notice costs it a re-read.
+    const warning = truncateText([
+      await staleGuidanceWarningBestEffort(input.projectRoot),
+      describeAutoDrift(drift),
+    ].filter(Boolean).join('\n\n'), DEFAULT_CONTEXT_MAX_CHARS);
     const recentBudget = warning
       ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - warning.length - 2)
       : DEFAULT_CONTEXT_MAX_CHARS;

--- a/tests/cli/doctor-report.test.ts
+++ b/tests/cli/doctor-report.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import * as repo from '../../src/store/repository.js';
 import { runDoctor } from '../../src/cli/doctor-report.js';
+import { installKnowlProjectGuidance } from '../../src/core/agents-guidance.js';
 import { fingerprintProfile, resolveVectorProfile } from '../../src/core/vector-profile.js';
 import { DEFAULT_CONFIG } from '../../src/core/config.js';
 import type { ProjectConfig } from '../../src/core/types.js';
@@ -125,6 +126,11 @@ describe('doctor retrieval self-test', () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-probe-'));
     await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
     await fs.writeFile(path.join(root, '.knowl', 'config.json'), JSON.stringify(DEFAULT_CONFIG), 'utf-8');
+    // Guidance too, because `knowl init` writes it and this fixture is standing in for an
+    // initialised repository. Building `.knowl` by hand without it produced a state no real
+    // install reaches -- and once stale guidance became a FAIL, that artificial gap was what
+    // these tests were measuring instead of the probe they are named for.
+    await installKnowlProjectGuidance(root);
     await initDb(root);
     return (await repo.createProject(root, 'doctor-probe')).id;
   }
@@ -190,6 +196,39 @@ describe('doctor retrieval self-test', () => {
     expect(probeCheck(result.checks).status).toBe('WARN');
     expect(result.ready).toBe(true);
     expect(result.checks.some(check => check.status === 'FAIL')).toBe(false);
+  });
+
+  it('is NOT READY when the guidance on disk is stale', async () => {
+    // The gap this closes: guidance staleness was a WARN and the verdict gates on FAIL, so
+    // `doctor` said READY while the lifecycle hook injected a card rendered from the running
+    // build and the host read a contradicting KNOWL.md from disk. Measured 2026-08-08 -- a knowl
+    // command run against a stale dist/ reverted guidance that had just landed and nothing said so.
+    await bareRepo();
+    const knowlMd = path.join(root, 'KNOWL.md');
+    const current = await fs.readFile(knowlMd, 'utf-8');
+    await fs.writeFile(knowlMd, current.replace('### Linked repositories', '### Linked repos (from an older build)'), 'utf-8');
+    await closeDb();
+
+    const result = await runDoctor(root);
+    const guidance = result.checks.find(check => check.message.includes('KNOWL.md'));
+
+    expect(guidance?.status).toBe('FAIL');
+    expect(result.ready).toBe(false);
+    // The remedy stays wired, so `doctor --fix` can still repair what the verdict now blocks on.
+    expect(guidance?.remedy).toEqual({ kind: 'guidance' });
+  });
+
+  it('is READY once that guidance matches the running build', async () => {
+    // The control. Without it the assertion above would pass on any repository at all, and the
+    // fixture change that installs guidance would be untested.
+    await bareRepo();
+    await closeDb();
+
+    const result = await runDoctor(root);
+    const guidance = result.checks.find(check => check.message.includes('KNOWL.md'));
+
+    expect(guidance?.status).toBe('OK');
+    expect(result.ready).toBe(true);
   });
 
   it('re-finds a stored item by its own title words', async () => {

--- a/tests/core/version-check.test.ts
+++ b/tests/core/version-check.test.ts
@@ -56,11 +56,16 @@ describe('npm update check', () => {
     expect(result?.latest).toBe('1.5.0');
   });
 
-  it('always refetches at ttlMs 0, which is what makes doctor a diagnostic', async () => {
+  it('always refetches at ttlMs 0, even within the same millisecond', async () => {
     // `knowl doctor` passes 0 where `status` takes the day-long default. Measured 2026-08-08:
     // 3.4.0 published five hours after the cache was written, and doctor went on reporting a
     // healthy 3.3.0 for the rest of the day. A diagnostic that cannot be made to look again is
     // one you stop believing.
+    //
+    // "Even within the same millisecond" is the whole assertion. Age alone does not deliver it:
+    // `age > ttlMs` at 0 serves the cache when both calls share a tick, because 0 is not greater
+    // than 0. This test failed exactly that way on the macOS CI runner while ubuntu and windows
+    // passed, which is how the gap was found rather than shipped.
     await checkForUpdate({ packageName: PKG, currentVersion: '1.3.1', projectRoot: root, fetchImpl: okFetch('1.4.0') });
     const result = await checkForUpdate({
       packageName: PKG, currentVersion: '1.3.1', projectRoot: root, ttlMs: 0, fetchImpl: okFetch('1.6.0'),
@@ -68,6 +73,18 @@ describe('npm update check', () => {
 
     expect(result?.latest).toBe('1.6.0');
     expect(result?.updateAvailable).toBe(true);
+  });
+
+  it('serves a same-millisecond cache at a positive ttl, so status is unaffected', async () => {
+    // The control for the rule above. `ttlMs <= 0` must be what disables the cache, not a change
+    // to how age is compared -- `status` still wants the day-long cache and must keep getting it
+    // whatever the clock resolution is.
+    await checkForUpdate({ packageName: PKG, currentVersion: '1.3.1', projectRoot: root, fetchImpl: okFetch('1.4.0') });
+    const result = await checkForUpdate({
+      packageName: PKG, currentVersion: '1.3.1', projectRoot: root, ttlMs: 60_000, fetchImpl: okFetch('1.7.0'),
+    });
+
+    expect(result?.latest).toBe('1.4.0');
   });
 
   it('still writes the shared cache when it bypasses it, so the next status benefits', async () => {

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -51,6 +51,42 @@ describe('host lifecycle orchestration', () => {
     await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
   });
 
+  /**
+   * The contradiction this warning exists for.
+   *
+   * The card in this context block is rendered from the running build; the host reads KNOWL.md
+   * from disk. When the file is stale the agent is handed both versions in one session and given
+   * nothing to break the tie, so the warning names which one is wrong rather than merely
+   * reporting drift.
+   */
+  it('warns at session start when the guidance on disk is stale', async () => {
+    const { installKnowlProjectGuidance } = await import('../../src/core/agents-guidance.js');
+    await installKnowlProjectGuidance(ROOT);
+    const knowlMd = path.join(ROOT, 'KNOWL.md');
+    const current = await fs.readFile(knowlMd, 'utf-8');
+    await fs.writeFile(knowlMd, current.replace('### Required workflow', '### Required workflow (older build)'), 'utf-8');
+
+    const result = await handleHostLifecycleEvent(projectId, hook({
+      host: 'codex', event: 'session-start', externalSessionId: 'stale-guidance', externalTurnId: undefined,
+    }));
+
+    expect(result.context).toContain('KNOWL GUIDANCE STALE');
+    expect(result.context).toContain('the file is the stale one');
+    // Recent context survives beside it: the warning is charged against the cap, not stacked on it.
+    expect(result.context!.length).toBeLessThanOrEqual(3_000);
+  });
+
+  it('says nothing at session start when the guidance matches the build', async () => {
+    const { installKnowlProjectGuidance } = await import('../../src/core/agents-guidance.js');
+    await installKnowlProjectGuidance(ROOT);
+
+    const result = await handleHostLifecycleEvent(projectId, hook({
+      host: 'codex', event: 'session-start', externalSessionId: 'fresh-guidance', externalTurnId: undefined,
+    }));
+
+    expect(result.context ?? '').not.toContain('KNOWL GUIDANCE STALE');
+  });
+
   it('bootstraps bounded context at host session start', async () => {
     const result = await handleHostLifecycleEvent(projectId, hook({
       host: 'codex',


### PR DESCRIPTION
`knowl doctor` already detected stale `KNOWL.md` / `AGENTS.md`. It reported it as a `WARN`, and the verdict is `checks.every(check => check.status !== 'FAIL')` — so **doctor said READY while agents were reading instructions this version did not write.** The lifecycle hook never checked at all.

That is not hypothetical. On 2026-08-08 a `knowl` command run against a stale `dist/` rewrote both files from an older build, silently reverting guidance that had just landed. Doctor kept saying READY, and every session afterwards told agents to look for a per-row `repo` field that the shipped response shape no longer had.

## Why `WARN` was the wrong severity here specifically

Every other `WARN` in doctor means an optional thing is not configured — no vector provider, no work loop, `.knowl` not gitignored. Guidance staleness is not optional-anything: the block between the markers is **owned** by Knowl and rewritten wholesale by `installKnowlProjectGuidance`, while anything outside it is preserved. A difference there is never a preference. It is always this project holding instructions some other version of Knowl wrote.

I checked the obvious objection — that this flips every install which upgraded the CLI without re-initialising. It does not hold: `knowl upgrade` and `knowl init` both call `installKnowlProjectGuidance`, so staleness survives neither. What is left is a project nobody has upgraded, where NOT READY is the honest answer, and `doctor --fix` already had `{ kind: 'guidance' }` wired.

## The hook is the case that actually bites

The hook injects its guidance card rendered from the **running build**. The host reads `KNOWL.md` from **disk**. When the file is stale those two disagree inside the same session, and nothing said which to believe — so the agent gets fresh instructions and contradicting stale ones at once.

Session start now leads with:

```
KNOWL GUIDANCE STALE: this project's KNOWL.md / AGENTS.md were written by a different
version of Knowl than the one running, so they may contradict the guidance in this block.
Where they disagree, the file is the stale one. Run `knowl init` (or `knowl doctor --fix`).
```

It names the winner rather than merely reporting drift, because an agent that knows the file is wrong can act on the card and tell the user. Charged against the context budget ahead of the drift notice, not stacked on top of it — if only one warning survives truncation it should be the one saying the instructions on disk cannot be trusted.

Cost is two file reads and a string compare, once per session. Not the per-tool-call path where the write gate's process cost was the objection.

## Present-and-different, not merely "not current"

The hook fires only when both files **exist** and differ; doctor fails on missing or stale alike. These are opposite findings and `isKnowlProjectGuidanceCurrent` returns `false` for both:

- **Absent** — the host never read the file, so there is no second version of the guidance and nothing to contradict. Saying "written by a different version of Knowl" about a file that does not exist is simply false. That is doctor's finding: *this project was never set up*.
- **Stale** — the contradiction the warning exists for.

The narrowing also keeps the hook quiet for projects using Knowl through MCP without the markdown files. Found by the drift suite, whose fixtures build `.knowl` by hand and would otherwise have been told their missing files were stale.

## Fixture correction

`bareRepo()` in the doctor tests now installs guidance. `knowl init` writes it, and that fixture stands in for an initialised repository — building `.knowl` by hand without it produced a state no real install reaches. Once staleness became a FAIL, those tests would have been measuring that artificial gap rather than the retrieval probe they are named for.

Also repairs mixed line endings in `AGENTS.md` — residue of `installKnowlProjectGuidance` writing LF into a CRLF file. Content-identical to git.

## Verification

266 files / 2356 tests, `tsc --noEmit` clean, lint 0 errors, `docs:check` current and stable across consecutive runs.

Four new tests: doctor FAILs and blocks READY on stale guidance while keeping the remedy wired; doctor is READY when it matches; the hook warns on stale; the hook stays silent when current.
