### PR TITLE
The guidance currency check must ignore line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+### The guidance check is line-ending agnostic
+
+Found by running `knowl doctor` on this repository immediately after the change below: it reported
+**NOT READY** on a checkout whose guidance was perfectly current. Everything in
+`knowl-guidance.ts` composes with `\n`, `core.autocrlf` hands back `\r\n`, and the comparison was
+exact — so every Windows clone was stale by definition, with no action that fixed it, because the
+next checkout restored CRLF. Survivable while staleness was advisory; not once it blocks the
+verdict.
+
+The check now ignores line endings, and a refresh writes back in whichever endings the file
+already used rather than converting it. Both halves matter: the second is what stops a guidance
+refresh rewriting every line of a CRLF file as a side effect.
+
+Includes one bug introduced by the first attempt at that fix and caught by the same manual run:
+composing without normalising to LF first expands each `\n` of an already-CRLF prefix into
+`\r\r\n`, so the file never compares equal to itself again. Normalise, compose, convert back — the
+order `scripts/generate-docs.ts` already used.
+
 ### Stale guidance is NOT READY, and the session says so
 
 `knowl doctor` detected stale `KNOWL.md` / `AGENTS.md` and reported it as a `WARN`. The verdict

--- a/src/core/agents-guidance.ts
+++ b/src/core/agents-guidance.ts
@@ -26,15 +26,39 @@ export function stripManagedKnowlGuidance(source: string): string {
   }
 }
 
+/**
+ * Line endings are not guidance.
+ *
+ * Everything here composes with `\n`, and a checkout with `core.autocrlf` holds `\r\n` — so an
+ * exact comparison calls a perfectly current file stale on Windows, forever, with no action that
+ * fixes it: writing LF makes the check pass until the next checkout restores CRLF. That is
+ * survivable while staleness is advisory and not once it blocks `doctor`'s verdict, which is how
+ * it was found — `doctor` reported NOT READY on this repository minutes after the severity
+ * changed, while `docs:check`, which already normalised, called the same files current.
+ */
+function sameIgnoringLineEndings(left: string, right: string): boolean {
+  return left.replaceAll('\r\n', '\n') === right.replaceAll('\r\n', '\n');
+}
+
 function normalizeManagedFile(source: string, managed: string): string {
-  const unmanaged = stripManagedKnowlGuidance(source).trimEnd();
-  return unmanaged.length > 0 ? `${unmanaged}\n\n${managed}` : managed;
+  // Normalised to LF before anything is composed, and converted back once at the end.
+  //
+  // Skipping the first half turns `\r\n` into `\r\r\n`: the unmanaged half of a CRLF file already
+  // carries `\r\n`, and re-expanding every `\n` doubles the carriage return on each of its lines.
+  // The file then never compares equal to itself and `doctor` calls it stale forever. Same order
+  // `scripts/generate-docs.ts` uses, for the same reason.
+  const unmanaged = stripManagedKnowlGuidance(source.replaceAll('\r\n', '\n')).trimEnd();
+  const next = unmanaged.length > 0 ? `${unmanaged}\n\n${managed}` : managed;
+  // Written back in the endings the file already used, so refreshing guidance never rewrites
+  // every line of a CRLF file as a side effect of touching the managed block.
+  return source.includes('\r\n') ? next.replaceAll('\n', '\r\n') : next;
 }
 
 function isManagedFileCurrent(source: string, managed: string): boolean {
   const startCount = source.split(KNOWL_GUIDANCE_START_MARKER).length - 1;
   const endCount = source.split(KNOWL_GUIDANCE_END_MARKER).length - 1;
-  return startCount === 1 && endCount === 1 && normalizeManagedFile(source, managed) === source;
+  return startCount === 1 && endCount === 1
+    && sameIgnoringLineEndings(normalizeManagedFile(source, managed), source);
 }
 
 async function installManagedFile(
@@ -53,7 +77,9 @@ async function installManagedFile(
     return 'created';
   }
   const next = normalizeManagedFile(existing, managed);
-  if (next === existing) return 'unchanged';
+  // Same rule as the check: a file that differs only in line endings is already current, and
+  // rewriting it would churn every line to no effect.
+  if (sameIgnoringLineEndings(next, existing)) return 'unchanged';
   await fs.writeFile(filePath, next, 'utf8');
   return 'updated';
 }

--- a/tests/core/agents-guidance.test.ts
+++ b/tests/core/agents-guidance.test.ts
@@ -64,6 +64,43 @@ describe('project guidance files', () => {
     expect(await installKnowlProjectGuidance(ROOT)).toEqual({ knowl: 'unchanged', agents: 'unchanged' });
   });
 
+  /**
+   * A CRLF checkout is current, and stays current.
+   *
+   * Everything here composes with `\n` and `core.autocrlf` hands back `\r\n`, so an exact
+   * comparison calls a perfectly good file stale on every Windows clone — with no action that
+   * fixes it, because the next checkout restores CRLF. Survivable while staleness was advisory;
+   * not once it blocks `doctor`'s verdict, which is how it was caught: `doctor` reported NOT
+   * READY on this repository minutes after the severity changed.
+   */
+  it('treats a CRLF checkout as current, and does not rewrite it', async () => {
+    await fs.mkdir(ROOT, { recursive: true });
+    await installKnowlProjectGuidance(ROOT);
+    for (const name of ['KNOWL.md', 'AGENTS.md']) {
+      const file = path.join(ROOT, name);
+      await fs.writeFile(file, (await fs.readFile(file, 'utf8')).replaceAll('\n', '\r\n'), 'utf8');
+    }
+
+    expect(await isKnowlProjectGuidanceCurrent(ROOT)).toBe(true);
+    // And a reinstall leaves it alone rather than churning every line back to LF.
+    expect(await installKnowlProjectGuidance(ROOT)).toEqual({ knowl: 'unchanged', agents: 'unchanged' });
+    expect(await fs.readFile(path.join(ROOT, 'AGENTS.md'), 'utf8')).toContain('\r\n');
+  });
+
+  it('does not double the carriage return when refreshing a CRLF file', async () => {
+    // The bug the check above would otherwise hide: composing without normalising first expands
+    // each `\n` of an already-CRLF prefix into `\r\r\n`, so the file never equals itself again.
+    await fs.mkdir(ROOT, { recursive: true });
+    await fs.writeFile(path.join(ROOT, 'AGENTS.md'), '# Agent Instructions\r\n\r\nHand-written.\r\n', 'utf8');
+    await installKnowlProjectGuidance(ROOT);
+
+    const agents = await fs.readFile(path.join(ROOT, 'AGENTS.md'), 'utf8');
+
+    expect(agents).not.toContain('\r\r');
+    expect(agents).toContain('Hand-written.');
+    expect(await isKnowlProjectGuidanceCurrent(ROOT)).toBe(true);
+  });
+
   it('is not current when either file is missing or stale', async () => {
     await fs.mkdir(ROOT, { recursive: true });
     await installKnowlProjectGuidance(ROOT);


### PR DESCRIPTION
Follow-up to #42, found by running `knowl doctor` on this repository immediately after merging it.

**It reported NOT READY on a checkout whose guidance was perfectly current.**

```
[FAIL] KNOWL.md or AGENTS.md Knowl guidance missing or stale;
       agents are reading instructions this version did not write. Run knowl init
Result: NOT READY
```

Everything in `knowl-guidance.ts` composes with `\n`. `core.autocrlf` hands back `\r\n`. The comparison in `isManagedFileCurrent` was exact — so **every Windows clone is stale by definition**, and nothing fixes it: running `knowl init` writes LF, and the next checkout restores CRLF.

That was survivable while staleness was a `WARN`. #42 made it block the verdict, which turned a cosmetic mismatch into a permanently broken `doctor` for a whole platform. `docs:check` already normalised and kept calling the same files current, which is what made the disagreement obvious.

## The fix

- The currency check ignores line endings.
- A refresh writes back in whichever endings the file already used, rather than converting it. Without this second half, refreshing guidance rewrites every line of a CRLF file as a side effect.

## And a bug the first attempt introduced

Caught by re-running `doctor`, not by the suite — it still said FAIL after the "fix".

Composing without normalising to LF first expands each `\n` of an **already-CRLF** prefix into `\r\r\n`. The file then never compares equal to itself, so the check fails forever regardless of content. The diff made it plain:

```
line 1
  expected: "# AGENTS.md\r"
  actual  : "# AGENTS.md"
```

Normalise → compose → convert back. The order `scripts/generate-docs.ts` already used, and now the reason that script was written that way is recorded in the product path too.

## Verification

266 files / 2359 tests, `tsc --noEmit` clean, lint 0 errors, `docs:check` current.

`knowl doctor` on this repository now reports `[OK] KNOWL.md and AGENTS.md guidance current` and `Result: READY`, verified against a real build rather than only in tests.

Two new tests: a CRLF checkout is current and is not rewritten by a reinstall; a refresh never doubles the carriage return.
