### PR TITLE
feat(standing): promote on observed use, because the feedback channel never fires

### DIFF
--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -53,6 +53,7 @@ import { bootstrapAgentSession } from '../store/context-bootstrap.js';
 import { consumePendingSessionHandoff, recordPendingSessionHandoff } from './session-handoff.js';
 import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
 import { describeAutoDrift, runAutoDriftCheckBestEffort, type AutoDriftResult } from '../store/drift-auto.js';
+import { describeObservedUsePromotions, promoteByObservedUseBestEffort } from '../store/tier.js';
 
 // Emit the mid-turn continuation reminder after this many consecutive non-Knowl
 // tool calls; any Knowl tool call resets the counter to zero.
@@ -708,6 +709,9 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     await closeInactiveHostSessionBindings();
     // Detection only: names what moved and the command to review it, mutating nothing.
     const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
+    // After drift, and fed its candidates: an item whose files moved this session must not be
+    // promoted on the strength of a `freshness` column detection deliberately left alone.
+    const standing = await promoteByObservedUseBestEffort(projectId, drift?.candidateIds ?? []);
     const started = await bootstrapWithHandoff(projectId, input, 'session', true);
     // The warning is charged against the cap first — the same rule the subagent card
     // follows. Prepending it to an already-budgeted block pushed the session past the size
@@ -717,9 +721,13 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // only one survives truncation it should be the one saying the instructions on disk cannot be
     // trusted -- an agent acting on stale guidance gets the subsequent work wrong, where a missed
     // drift notice costs it a re-read.
+    // Standing last of the three: it reports something the store already did successfully,
+    // where the other two are warnings that the work ahead may be built on bad ground. If the
+    // cap drops a line, drop this one.
     const warning = truncateText([
       await staleGuidanceWarningBestEffort(input.projectRoot),
       describeAutoDrift(drift),
+      describeObservedUsePromotions(standing),
     ].filter(Boolean).join('\n\n'), DEFAULT_CONTEXT_MAX_CHARS);
     const recentBudget = warning
       ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - warning.length - 2)

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -707,11 +707,16 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // A read-set with nothing collecting it grows for as long as the repository is used.
     await sweepReadSetsBestEffort(plusHoursIso(-READ_SET_RETENTION_HOURS));
     await closeInactiveHostSessionBindings();
-    // Detection only: names what moved and the command to review it, mutating nothing.
+    // Detection only: names what moved and the command to review it, leaving `freshness` alone.
     const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
-    // After drift, and fed its candidates: an item whose files moved this session must not be
-    // promoted on the strength of a `freshness` column detection deliberately left alone.
-    const standing = await promoteByObservedUseBestEffort(projectId, drift?.candidateIds ?? []);
+    // Strictly after drift, and only when drift actually ran. `checked` is false on the run
+    // that learns a baseline and on the re-baseline after a rebase -- both skip a window of
+    // history -- and null outside a git repository or after a thrown check. In every one of
+    // those cases nothing was in a position to contradict an item this session, which is
+    // exactly the state where "nothing is drifting" must not be read as evidence of health.
+    // A project with no git history therefore never promotes on observed use, which is the
+    // same falsifiability rule as `affected_paths`, applied to the repository instead.
+    const standing = drift?.checked ? await promoteByObservedUseBestEffort(projectId) : null;
     const started = await bootstrapWithHandoff(projectId, input, 'session', true);
     // The warning is charged against the cap first — the same rule the subagent card
     // follows. Prepending it to an already-budgeted block pushed the session past the size

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -51,6 +51,7 @@ const SCHEMA_STATEMENTS = [
     confidence REAL NOT NULL DEFAULT 1.0,
     tier TEXT NOT NULL DEFAULT 'asserted',
     tier_since TEXT,
+    last_drift_at TEXT,
     provenance TEXT,
     conflict_key TEXT, conflict_scope TEXT, conflict_exclusive INTEGER NOT NULL DEFAULT 0,
     superseded_by_id TEXT,
@@ -588,6 +589,11 @@ async function ensureFreshnessColumns(client: Client): Promise<void> {
   }
   if (!columns.includes('content_hash')) {
     await client.execute('ALTER TABLE knowledge_items ADD COLUMN content_hash TEXT;');
+  }
+  if (!columns.includes('last_drift_at')) {
+    // Left NULL rather than backfilled: an existing row has no recorded drift observation,
+    // and inventing one would refuse promotion for items nothing has actually contradicted.
+    await client.execute('ALTER TABLE knowledge_items ADD COLUMN last_drift_at TEXT;');
   }
   if (!columns.includes('freshness')) {
     await client.execute(`ALTER TABLE knowledge_items ADD COLUMN freshness TEXT NOT NULL DEFAULT '${DEFAULT_FRESHNESS}';`);

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -8,12 +8,6 @@ export type AutoDriftResult = {
   candidateCount: number;
   /** Up to the first few candidate titles, for the session-start warning. */
   candidateTitles: string[];
-  /**
-   * Every candidate's id, not just the titled few. Detection does not flip `freshness`, so
-   * stored freshness alone cannot tell a later pass in this same session that an item's files
-   * just moved. Standing promotion reads this to refuse anything currently drifting.
-   */
-  candidateIds: string[];
   /** The watermark the diff ran from; absent when nothing was compared. */
   sinceCommit?: string;
 };
@@ -37,6 +31,10 @@ const WARNING_TITLE_LIMIT = 3;
  * ranking damage and a warning that cries wolf. So the automatic path names what moved
  * and the exact command to review it, and flipping freshness stays a deliberate act.
  *
+ * "Detection only" is about `freshness`, not about writing nothing: each candidate's
+ * `last_drift_at` is stamped (see `recordDriftObservation`). Nothing reads that column at
+ * retrieval time, so it costs none of the ranking damage the paragraph above refuses.
+ *
  * The watermark is the last git commit a check ran against, keyed by project root.
  * rowid-style head tracking (change-watermark.ts) does not work here: the thing that
  * moves is the git history, not the knowledge log. It advances even when candidates go
@@ -55,13 +53,13 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
   })).rows[0];
   const watermark = row ? String(row.last_checked_commit) : null;
 
-  if (watermark === current) return { checked: true, candidateCount: 0, candidateTitles: [], candidateIds: [], sinceCommit: watermark };
+  if (watermark === current) return { checked: true, candidateCount: 0, candidateTitles: [], sinceCommit: watermark };
 
   // First run learns the baseline and reports nothing: diffing from the repository's
   // root commit would announce most of the store as drift candidates in one wall.
   if (!watermark) {
     await writeWatermark(projectRoot, current);
-    return { checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] };
+    return { checked: false, candidateCount: 0, candidateTitles: [] };
   }
 
   let changedFiles: string[];
@@ -71,12 +69,11 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
     // The watermark commit no longer exists — rebase, aggressive gc, a rewritten branch.
     // Re-baseline rather than guess; the next real change is caught from the new baseline.
     await writeWatermark(projectRoot, current);
-    return { checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] };
+    return { checked: false, candidateCount: 0, candidateTitles: [] };
   }
 
   let candidateCount = 0;
   let candidateTitles: string[] = [];
-  let candidateIds: string[] = [];
   if (changedFiles.length > 0) {
     const result = await checkKnowledgeDrift(projectId, {
       sinceCommit: watermark,
@@ -86,11 +83,41 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
     });
     candidateCount = result.candidates.length;
     candidateTitles = result.candidates.slice(0, WARNING_TITLE_LIMIT).map(candidate => candidate.title);
-    candidateIds = result.candidates.map(candidate => candidate.itemId);
+    await recordDriftObservation(result.candidates.map(candidate => candidate.itemId));
   }
 
   await writeWatermark(projectRoot, current);
-  return { checked: true, candidateCount, candidateTitles, candidateIds, sinceCommit: watermark };
+  return { checked: true, candidateCount, candidateTitles, sinceCommit: watermark };
+}
+
+/** Ids per `UPDATE`, so one window cannot outgrow the driver's bound-parameter limit. */
+const DRIFT_STAMP_CHUNK = 250;
+
+/**
+ * Record that these items' files moved, so a later pass can still tell.
+ *
+ * This is the one thing detection has to leave behind, and it is why the watermark advancing
+ * is survivable. `freshness` stays untouched for the measured reason above; `last_drift_at`
+ * is a separate column nothing reads at retrieval time, so recording an observation costs no
+ * ranking and no warning volume. Without it the only trace of a window is the one warning
+ * line, and the very next session — which finds `watermark === current` and computes no
+ * candidates at all — has no way to know that an item reading `fresh` is a claim about files
+ * that changed this morning and that nobody has looked at since.
+ *
+ * Chunked because a single window can match a third of the store, and the candidate list is
+ * bound by the corpus rather than by anything this function controls.
+ */
+async function recordDriftObservation(itemIds: string[]): Promise<void> {
+  if (itemIds.length === 0) return;
+  const now = new Date().toISOString();
+  const client = getClient();
+  for (let start = 0; start < itemIds.length; start += DRIFT_STAMP_CHUNK) {
+    const chunk = itemIds.slice(start, start + DRIFT_STAMP_CHUNK);
+    await client.execute({
+      sql: `UPDATE knowledge_items SET last_drift_at = ? WHERE id IN (${chunk.map(() => '?').join(', ')})`,
+      args: [now, ...chunk],
+    });
+  }
 }
 
 /** Hooks must never fail the host: any error reads as "no drift information this session". */

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -8,6 +8,12 @@ export type AutoDriftResult = {
   candidateCount: number;
   /** Up to the first few candidate titles, for the session-start warning. */
   candidateTitles: string[];
+  /**
+   * Every candidate's id, not just the titled few. Detection does not flip `freshness`, so
+   * stored freshness alone cannot tell a later pass in this same session that an item's files
+   * just moved. Standing promotion reads this to refuse anything currently drifting.
+   */
+  candidateIds: string[];
   /** The watermark the diff ran from; absent when nothing was compared. */
   sinceCommit?: string;
 };
@@ -49,13 +55,13 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
   })).rows[0];
   const watermark = row ? String(row.last_checked_commit) : null;
 
-  if (watermark === current) return { checked: true, candidateCount: 0, candidateTitles: [], sinceCommit: watermark };
+  if (watermark === current) return { checked: true, candidateCount: 0, candidateTitles: [], candidateIds: [], sinceCommit: watermark };
 
   // First run learns the baseline and reports nothing: diffing from the repository's
   // root commit would announce most of the store as drift candidates in one wall.
   if (!watermark) {
     await writeWatermark(projectRoot, current);
-    return { checked: false, candidateCount: 0, candidateTitles: [] };
+    return { checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] };
   }
 
   let changedFiles: string[];
@@ -65,11 +71,12 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
     // The watermark commit no longer exists — rebase, aggressive gc, a rewritten branch.
     // Re-baseline rather than guess; the next real change is caught from the new baseline.
     await writeWatermark(projectRoot, current);
-    return { checked: false, candidateCount: 0, candidateTitles: [] };
+    return { checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] };
   }
 
   let candidateCount = 0;
   let candidateTitles: string[] = [];
+  let candidateIds: string[] = [];
   if (changedFiles.length > 0) {
     const result = await checkKnowledgeDrift(projectId, {
       sinceCommit: watermark,
@@ -79,10 +86,11 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
     });
     candidateCount = result.candidates.length;
     candidateTitles = result.candidates.slice(0, WARNING_TITLE_LIMIT).map(candidate => candidate.title);
+    candidateIds = result.candidates.map(candidate => candidate.itemId);
   }
 
   await writeWatermark(projectRoot, current);
-  return { checked: true, candidateCount, candidateTitles, sinceCommit: watermark };
+  return { checked: true, candidateCount, candidateTitles, candidateIds, sinceCommit: watermark };
 }
 
 /** Hooks must never fail the host: any error reads as "no drift information this session". */

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -387,6 +387,22 @@ export async function updateKnowledgeItem(
     const tierIsReset = !tierIsSetExplicitly
       && (updates.content !== undefined || updates.title !== undefined);
 
+    // `last_drift_at` records that the automatic check saw this item's files move and that
+    // nobody has looked at it since; this is the "since". Any of these five means somebody
+    // did look: the claim was rewritten, the paths it cites were changed, it was re-anchored
+    // to a commit, or its freshness was deliberately set -- which is what `knowl pr check`
+    // and `knowl_update` do at the two ends of a review.
+    //
+    // Deliberately NOT every update. `updated_at` moves on visibility promotion, supersession
+    // and status changes too, and clearing on those would let a workspace-promote silently
+    // discharge a drift observation nobody reviewed. It is also not `tierSince`: a review that
+    // only refreshes freshness leaves that alone, which would leave the item blocked forever.
+    const reviewed = updates.title !== undefined
+      || updates.content !== undefined
+      || updates.affectedPaths !== undefined
+      || updates.sourceCommit !== undefined
+      || updates.freshness !== undefined;
+
     const dbUpdates = {
       ...updates,
       ...(updates.affectedPaths !== undefined ? { affectedPaths } : {}),
@@ -401,6 +417,7 @@ export async function updateKnowledgeItem(
       ...((tierIsSetExplicitly || tierIsReset) && updates.tierSince === undefined
         ? { tierSince: now }
         : {}),
+      ...(reviewed ? { lastDriftAt: null } : {}),
       ...(updates.conflictKey !== undefined ? { conflictKey } : {}),
       ...(updates.conflictScope !== undefined ? { conflictScope } : {}),
       version: nextVersion,

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -58,7 +58,16 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * reasoning as level 3: one new table, no altered column, no backfill, so `KNOWL_SCHEMA_VERSION`
  * stays at 1 and no installed build is locked out of a database it can still read completely.
  */
-export const KNOWL_MIGRATION_LEVEL = 4;
+/*
+ * Level 5 adds `knowledge_items.last_drift_at` -- when the automatic drift check last saw an
+ * item's cited files move, and NULL once somebody revisited it. One nullable column, no
+ * backfill (an existing row has no recorded observation, and inventing one would refuse
+ * promotion for items nothing has actually contradicted), so `KNOWL_SCHEMA_VERSION` stays at
+ * 1. The bump is what makes `ensureFreshnessColumns` run on databases that already exist:
+ * without it, every installed store would skip the column and standing promotion there would
+ * fall back to the ungated behaviour this column was added to prevent.
+ */
+export const KNOWL_MIGRATION_LEVEL = 5;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -40,6 +40,17 @@ export const knowledgeItems = sqliteTable('knowledge_items', {
    * standing reset, so their whole history is still theirs to count.
    */
   tierSince: text('tier_since'),
+  /**
+   * When the automatic drift check last saw this item's cited files move, and NULL once
+   * somebody has revisited the item since. Deliberately NOT `freshness`: flipping that would
+   * do the corpus-wide ranking damage `drift-auto.ts` measured and refused, whereas this
+   * column changes nothing an agent reads. Standing promotion is its only consumer.
+   *
+   * Store-internal, so it is absent from `KnowledgeItem` and from every export: it records
+   * what THIS machine's git history did to the item, which is not a portable property of the
+   * claim. An imported copy starts unstamped and earns its own observation here.
+   */
+  lastDriftAt: text('last_drift_at'),
   /** 'observed' | 'user_stated' | 'inferred'; NULL on rows written before the column existed. */
   provenance: text('provenance'),
   conflictKey: text('conflict_key'), conflictScope: text('conflict_scope', { mode: 'json' }).$type<Record<string, unknown>>(), conflictExclusive: integer('conflict_exclusive', { mode: 'boolean' }).notNull().default(false),

--- a/src/store/tier.ts
+++ b/src/store/tier.ts
@@ -104,11 +104,11 @@ export const OBSERVED_USE_MIN_DAYS = 3;
 export const OBSERVED_USE_MIN_QUESTIONS = 3;
 
 /**
- * Ceiling on promotions per run. Measured on a real 748-item store, the gate below selects
- * roughly 69 items on its first pass over an unpromoted corpus; applying all of them at one
- * session start is the corpus-wide standing change that `drift-auto.ts` deliberately refused
- * to make. Ten a run drains a backlog over a week of sessions and keeps any single run's
- * blast radius reviewable.
+ * Ceiling on promotions per run. Measured 2026-08-09 on this project's own store (697 active
+ * items), the gate below selects 85 on its first pass over an unpromoted corpus; applying all
+ * of them at one session start is the corpus-wide standing change that `drift-auto.ts`
+ * deliberately refused to make. Ten a run drains a backlog over a week of sessions and keeps
+ * any single run's blast radius reviewable.
  */
 export const OBSERVED_USE_MAX_PER_RUN = 10;
 
@@ -122,12 +122,17 @@ export type ObservedUseResult = {
  * Promote items the store has watched earn their place, without waiting for anyone to say so.
  *
  * WHY THIS EXISTS. `applyFeedbackToTier` is reachable only from `knowl_feedback`, a voluntary
- * call an agent has to choose to make. Measured 2026-08-09 on this project's own store: the
- * standing feature shipped 2026-07-31, every feedback event on record predates it (19 rows,
- * last one 2026-07-23), and in the nine days since it shipped the store served roughly 1,800
- * retrievals and received zero feedback events. 748 items, all `asserted`, zero promotions
- * ever recorded. The ladder was not too steep; its only input never arrived. Standing has to
- * be derived from what the store observes, not from what a caller volunteers.
+ * call an agent has to choose to make, and it is called at a rate that cannot clear its own
+ * threshold. Measured 2026-08-09 on this project's own store: 31 feedback events in total
+ * against 4,432 retrievals, 6 of them in the nine days since the standing feature shipped on
+ * 2026-07-31, spread across six different items. VERIFY_THRESHOLD is 2, and exactly one item
+ * in the corpus has ever accumulated two confirmations against a single standing — that one
+ * on 2026-07-30, before this code existed. 697 active items, all `asserted`, and not one
+ * `Promote to verified` commit in 788.
+ *
+ * So the mechanism is not broken and the ladder is not too steep: at roughly one confirmation
+ * per 143 retrievals, scattered one-per-item, a two-event threshold is essentially never met.
+ * Standing has to be derived from what the store observes, not from what a caller volunteers.
  *
  * WHY IT CANNOT BE RECURRENCE ALONE. Retrieval count is not ground truth — an item can be
  * surfaced a hundred times and be wrong, and promoting on that is precisely the confidence
@@ -140,20 +145,23 @@ export type ObservedUseResult = {
  * to fail and has not. Anything that ever caused a correction is excluded outright, on the
  * same "one proof of wrongness outweighs any history of usefulness" rule applied above.
  *
- * `driftingItemIds` closes the hole stored freshness leaves. The session-start drift check is
- * detection only — by deliberate design, it names what moved without flipping anything — so
- * an item whose files changed this morning still reads `fresh` until somebody runs
- * `knowl pr check` by hand. Resting the gate on that would make this feature depend on the
- * same voluntary act it exists to stop depending on, so the caller passes the live detection
- * result and anything currently drifting is refused regardless of what the column says.
+ * `last_drift_at` closes the hole stored freshness leaves, and it has to be a stored column
+ * rather than the live candidate list. The session-start drift check is detection only — by
+ * deliberate design it names what moved without flipping `freshness` — so an item whose files
+ * changed this morning still reads `fresh` until somebody runs `knowl pr check` by hand, which
+ * is the same voluntary act this feature exists to stop depending on. But the live list only
+ * covers the one session that happened to straddle the commit: the watermark then advances,
+ * the next session computes no candidates at all, and an item refused an hour ago sails
+ * through unchanged. Measured on this store, 12 of the 85 items the recurrence gate selects
+ * cite `package.json`, `CHANGELOG.md` or `.github/workflows/cd.yml`, all reading `fresh`
+ * immediately after a release commit touched exactly those files. So the observation is
+ * persisted when it is made and cleared when somebody revisits the item (see
+ * `updateKnowledgeItem`), and a stamped item is refused for as long as it stays unexamined.
  *
  * Demotion is untouched and stays immediate, unconditional and uncapped. This path only
  * ever moves items up, and only ever by one step.
  */
-export async function promoteByObservedUse(
-  projectId: string,
-  driftingItemIds: readonly string[] = [],
-): Promise<ObservedUseResult> {
+export async function promoteByObservedUse(projectId: string): Promise<ObservedUseResult> {
   // Counted from `tier_since` for the same reason the feedback path counts from it: a reset
   // means the item no longer makes the claim its earlier retrievals were about.
   const rows = (await getClient().execute({
@@ -168,6 +176,7 @@ export async function promoteByObservedUse(
             AND ki.freshness = 'fresh'
             AND ki.affected_paths IS NOT NULL
             AND ki.affected_paths != '[]'
+            AND ki.last_drift_at IS NULL
             AND NOT EXISTS (
               SELECT 1 FROM knowledge_access bad
               WHERE bad.knowledge_item_id = ki.id
@@ -185,12 +194,9 @@ export async function promoteByObservedUse(
   // Ordered here rather than in SQL so the cap and the deferred count read off one list.
   // Most-recurring first, id as the tiebreak, so a run is deterministic and a backlog drains
   // in a stable order instead of reshuffling every session.
-  const drifting = new Set(driftingItemIds);
   const ranked = rows
     .map(row => ({ id: String(row.id), days: Number(row.days) }))
-    .filter(candidate => !drifting.has(candidate.id))
     .sort((a, b) => b.days - a.days || a.id.localeCompare(b.id));
-  if (ranked.length === 0) return { promoted: [], deferred: 0 };
   const selected = ranked.slice(0, OBSERVED_USE_MAX_PER_RUN);
 
   const promoted: TierChange[] = [];
@@ -220,16 +226,16 @@ export async function promoteByObservedUse(
     }
   });
 
-  return { promoted, deferred: ranked.length - promoted.length };
+  // Against `selected`, not `promoted`. An item the re-read disqualified was retired or
+  // edited under us -- it is not eligible and no later run will take it, so counting it here
+  // would have the session line promise a backlog that does not exist.
+  return { promoted, deferred: ranked.length - selected.length };
 }
 
 /** Hooks must never fail the host: a failed promotion pass reads as "nothing promoted". */
-export async function promoteByObservedUseBestEffort(
-  projectId: string,
-  driftingItemIds: readonly string[] = [],
-): Promise<ObservedUseResult | null> {
+export async function promoteByObservedUseBestEffort(projectId: string): Promise<ObservedUseResult | null> {
   try {
-    return await promoteByObservedUse(projectId, driftingItemIds);
+    return await promoteByObservedUse(projectId);
   } catch {
     return null;
   }

--- a/src/store/tier.ts
+++ b/src/store/tier.ts
@@ -1,5 +1,6 @@
-import { getClient } from './database.js';
+import { getClient, withClientTransaction } from './database.js';
 import * as repo from './repository.js';
+import type { CommitChange } from '../core/types.js';
 
 /**
  * Confirmed-useful feedback events required before an asserted item is promoted. One use
@@ -87,4 +88,162 @@ export async function applyFeedbackToTierBestEffort(
   } catch {
     return null;
   }
+}
+
+/**
+ * Distinct days an item must be retrieved on, and distinct questions it must have answered,
+ * before use alone earns it `verified`.
+ *
+ * Days rather than hits: twenty retrievals inside one session are one agent circling one
+ * problem, which is the coincidence VERIFY_THRESHOLD's comment warns about, restated at a
+ * different scale. Surviving three separate days means three separate occasions found it
+ * worth surfacing. Distinct `query_fingerprint` adds the second axis — an item that only
+ * ever answers the same question has been retrieved repeatedly, not confirmed repeatedly.
+ */
+export const OBSERVED_USE_MIN_DAYS = 3;
+export const OBSERVED_USE_MIN_QUESTIONS = 3;
+
+/**
+ * Ceiling on promotions per run. Measured on a real 748-item store, the gate below selects
+ * roughly 69 items on its first pass over an unpromoted corpus; applying all of them at one
+ * session start is the corpus-wide standing change that `drift-auto.ts` deliberately refused
+ * to make. Ten a run drains a backlog over a week of sessions and keeps any single run's
+ * blast radius reviewable.
+ */
+export const OBSERVED_USE_MAX_PER_RUN = 10;
+
+export type ObservedUseResult = {
+  promoted: TierChange[];
+  /** Eligible items the per-run cap left behind. Reported, never silently dropped. */
+  deferred: number;
+};
+
+/**
+ * Promote items the store has watched earn their place, without waiting for anyone to say so.
+ *
+ * WHY THIS EXISTS. `applyFeedbackToTier` is reachable only from `knowl_feedback`, a voluntary
+ * call an agent has to choose to make. Measured 2026-08-09 on this project's own store: the
+ * standing feature shipped 2026-07-31, every feedback event on record predates it (19 rows,
+ * last one 2026-07-23), and in the nine days since it shipped the store served roughly 1,800
+ * retrievals and received zero feedback events. 748 items, all `asserted`, zero promotions
+ * ever recorded. The ladder was not too steep; its only input never arrived. Standing has to
+ * be derived from what the store observes, not from what a caller volunteers.
+ *
+ * WHY IT CANNOT BE RECURRENCE ALONE. Retrieval count is not ground truth — an item can be
+ * surfaced a hundred times and be wrong, and promoting on that is precisely the confidence
+ * accumulating without ground truth that `applyFeedbackToTier` was written to prevent. So
+ * recurrence only nominates. The gate is FALSIFIABILITY: an item qualifies only if it carries
+ * `affected_paths`, which is what makes it reachable by the drift checker. An item with no
+ * paths can never be marked `needs_review` by drift, so `freshness: 'fresh'` on it is not
+ * evidence of anything — nothing was ever in a position to contradict it. Requiring paths
+ * means every promotion is backed by a claim about the codebase that has had the opportunity
+ * to fail and has not. Anything that ever caused a correction is excluded outright, on the
+ * same "one proof of wrongness outweighs any history of usefulness" rule applied above.
+ *
+ * `driftingItemIds` closes the hole stored freshness leaves. The session-start drift check is
+ * detection only — by deliberate design, it names what moved without flipping anything — so
+ * an item whose files changed this morning still reads `fresh` until somebody runs
+ * `knowl pr check` by hand. Resting the gate on that would make this feature depend on the
+ * same voluntary act it exists to stop depending on, so the caller passes the live detection
+ * result and anything currently drifting is refused regardless of what the column says.
+ *
+ * Demotion is untouched and stays immediate, unconditional and uncapped. This path only
+ * ever moves items up, and only ever by one step.
+ */
+export async function promoteByObservedUse(
+  projectId: string,
+  driftingItemIds: readonly string[] = [],
+): Promise<ObservedUseResult> {
+  // Counted from `tier_since` for the same reason the feedback path counts from it: a reset
+  // means the item no longer makes the claim its earlier retrievals were about.
+  const rows = (await getClient().execute({
+    sql: `SELECT ki.id AS id, COUNT(DISTINCT substr(ka.retrieved_at, 1, 10)) AS days
+          FROM knowledge_items ki
+          JOIN knowledge_access ka
+            ON ka.knowledge_item_id = ki.id
+           AND ka.surface != 'feedback'
+           AND ka.retrieved_at >= COALESCE(ki.tier_since, '')
+          WHERE ki.status = 'active'
+            AND ki.tier = 'asserted'
+            AND ki.freshness = 'fresh'
+            AND ki.affected_paths IS NOT NULL
+            AND ki.affected_paths != '[]'
+            AND NOT EXISTS (
+              SELECT 1 FROM knowledge_access bad
+              WHERE bad.knowledge_item_id = ki.id
+                AND bad.caused_correction = 1
+                AND bad.retrieved_at >= COALESCE(ki.tier_since, '')
+            )
+          GROUP BY ki.id
+          HAVING COUNT(DISTINCT substr(ka.retrieved_at, 1, 10)) >= ?
+             AND COUNT(DISTINCT ka.query_fingerprint) >= ?`,
+    args: [OBSERVED_USE_MIN_DAYS, OBSERVED_USE_MIN_QUESTIONS],
+  })).rows;
+
+  if (rows.length === 0) return { promoted: [], deferred: 0 };
+
+  // Ordered here rather than in SQL so the cap and the deferred count read off one list.
+  // Most-recurring first, id as the tiebreak, so a run is deterministic and a backlog drains
+  // in a stable order instead of reshuffling every session.
+  const drifting = new Set(driftingItemIds);
+  const ranked = rows
+    .map(row => ({ id: String(row.id), days: Number(row.days) }))
+    .filter(candidate => !drifting.has(candidate.id))
+    .sort((a, b) => b.days - a.days || a.id.localeCompare(b.id));
+  if (ranked.length === 0) return { promoted: [], deferred: 0 };
+  const selected = ranked.slice(0, OBSERVED_USE_MAX_PER_RUN);
+
+  const promoted: TierChange[] = [];
+  const changes: CommitChange[] = [];
+
+  // Client-level for the same reason drift.ts gives: this runs on the session hook inside the
+  // long-lived MCP server.
+  await withClientTransaction(async tx => {
+    for (const candidate of selected) {
+      const item = await repo.getKnowledgeItem(candidate.id, tx);
+      // Re-read inside the transaction: the query above ran outside it, and an item can be
+      // edited, retired or corrected between selection and application.
+      if (!item || item.status !== 'active' || item.tier !== 'asserted') continue;
+
+      const updated = await repo.updateKnowledgeItem(candidate.id, { tier: 'verified' }, undefined, tx);
+      changes.push({ itemId: candidate.id, action: 'update', before: item, after: updated });
+      promoted.push({ itemId: candidate.id, tier: 'verified', reason: 'promoted' });
+    }
+
+    if (changes.length > 0) {
+      await repo.createKnowledgeCommit(
+        projectId,
+        `Promote to verified by observed use: ${changes.length} item(s)`,
+        changes,
+        tx,
+      );
+    }
+  });
+
+  return { promoted, deferred: ranked.length - promoted.length };
+}
+
+/** Hooks must never fail the host: a failed promotion pass reads as "nothing promoted". */
+export async function promoteByObservedUseBestEffort(
+  projectId: string,
+  driftingItemIds: readonly string[] = [],
+): Promise<ObservedUseResult | null> {
+  try {
+    return await promoteByObservedUse(projectId, driftingItemIds);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The session-start line. Silent when nothing moved — standing changes are routine, and a
+ * line every session would train the reader to skip the block that also carries drift.
+ */
+export function describeObservedUsePromotions(result: ObservedUseResult | null): string | undefined {
+  if (!result || result.promoted.length === 0) return undefined;
+  const more = result.deferred > 0 ? ` ${result.deferred} more are eligible and will follow on later sessions.` : '';
+  // No review command is named on purpose: nothing in the CLI lists items by tier today, and
+  // pointing at a flag that does not exist is worse than pointing at nothing. The audit trail
+  // is the knowledge commit each run writes.
+  return `STANDING: ${result.promoted.length} knowledge item(s) promoted to verified on observed use — retrieved across ${OBSERVED_USE_MIN_DAYS}+ days for ${OBSERVED_USE_MIN_QUESTIONS}+ distinct questions, with their cited files still clean.${more} A correction demotes immediately.`;
 }

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -8,6 +8,8 @@ import { DEFAULT_CONTEXT_MAX_CHARS } from '../../src/core/token-budget.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { describeAutoDrift, runAutoDriftCheck } from '../../src/store/drift-auto.js';
 import { handleHostLifecycleEvent } from '../../src/session/host-lifecycle.js';
+import { recordKnowledgeAccess } from '../../src/store/access-feedback.js';
+import { OBSERVED_USE_MIN_DAYS } from '../../src/store/tier.js';
 import * as repo from '../../src/store/repository.js';
 
 const ROOT = path.resolve('.knowl-drift-auto-test');
@@ -54,7 +56,7 @@ describe('automatic drift check', () => {
 
   it('learns the baseline on first run and reports nothing', async () => {
     const first = await runAutoDriftCheck(projectId, ROOT);
-    expect(first).toEqual({ checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] });
+    expect(first).toEqual({ checked: false, candidateCount: 0, candidateTitles: [] });
 
     const second = await runAutoDriftCheck(projectId, ROOT);
     expect(second?.checked).toBe(true);
@@ -79,20 +81,59 @@ describe('automatic drift check', () => {
     expect(result?.checked).toBe(true);
     expect(result?.candidateCount).toBe(1);
     expect(result?.candidateTitles).toEqual(['Billing module']);
-    // Ids carry every candidate, not just the titled few — standing promotion consumes this
-    // list to refuse an item whose files moved, and a truncated list would let one slip past.
-    expect(result?.candidateIds).toEqual([item.id]);
 
     // Detection only: freshness is untouched on both candidate and bystander.
     const rows = await getClient().execute({
-      sql: 'SELECT id, freshness FROM knowledge_items WHERE id IN (?, ?)',
-      args: [item.id, bystander.id],
+      sql: 'SELECT id, freshness, last_drift_at FROM knowledge_items WHERE id IN (?, ?) ORDER BY id = ? DESC',
+      args: [item.id, bystander.id, item.id],
     });
     for (const row of rows.rows) expect(String(row.freshness)).toBe('fresh');
+    // ...but the observation itself is recorded, on the candidate only. This is the whole
+    // difference between a warning and a fact a later pass can act on.
+    expect(rows.rows[0].last_drift_at).toBeTruthy();
+    expect(rows.rows[1].last_drift_at).toBeNull();
 
     // Watermark advanced: the same window is not reported twice.
     const repeat = await runAutoDriftCheck(projectId, ROOT);
     expect(repeat?.candidateCount).toBe(0);
+
+    // And the stamp survives that advance. The window is gone, the warning was said once,
+    // and the only remaining trace that this item's files moved is the column.
+    const after = (await getClient().execute({
+      sql: 'SELECT last_drift_at FROM knowledge_items WHERE id = ?',
+      args: [item.id],
+    })).rows[0];
+    expect(after.last_drift_at).toBeTruthy();
+  });
+
+  it('clears the stamp when the item is reviewed, and not when it is merely touched', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Reviewable fact',
+      content: 'Something about src/reviewable.ts.',
+      affectedPaths: ['src/reviewable.ts'],
+    });
+    const stamp = async (): Promise<unknown> => (await getClient().execute({
+      sql: 'SELECT last_drift_at FROM knowledge_items WHERE id = ?',
+      args: [item.id],
+    })).rows[0].last_drift_at;
+
+    await commitFile('src/reviewable.ts', 'export const a = 1;\n', 'add reviewable');
+    await runAutoDriftCheck(projectId, ROOT); // baseline past creation
+    await commitFile('src/reviewable.ts', 'export const a = 2;\n', 'change reviewable');
+    await runAutoDriftCheck(projectId, ROOT);
+    expect(await stamp()).toBeTruthy();
+
+    // A lifecycle-only write is not a review. Visibility, status and supersession all move
+    // `updated_at`, and discharging a drift observation on one of those would clear the block
+    // without anybody having read the item.
+    await repo.updateKnowledgeItem(item.id, { visibility: 'workspace' });
+    expect(await stamp()).toBeTruthy();
+
+    // Setting freshness is the review verb at both ends: `pr check` flags, `knowl_update`
+    // clears. Either way somebody has now looked.
+    await repo.updateKnowledgeItem(item.id, { freshness: 'fresh' });
+    expect(await stamp()).toBeNull();
   });
 
   it('re-baselines quietly when the watermark commit no longer resolves', async () => {
@@ -101,7 +142,7 @@ describe('automatic drift check', () => {
       args: ['0000000000000000000000000000000000000000', ROOT],
     });
     const result = await runAutoDriftCheck(projectId, ROOT);
-    expect(result).toEqual({ checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] });
+    expect(result).toEqual({ checked: false, candidateCount: 0, candidateTitles: [] });
   });
 
   it('returns null outside a git repository', async () => {
@@ -119,16 +160,54 @@ describe('automatic drift check', () => {
 
   it('renders the warning with the pinned review command, only when something matched', () => {
     expect(describeAutoDrift(null)).toBeUndefined();
-    expect(describeAutoDrift({ checked: true, candidateCount: 0, candidateTitles: [], candidateIds: [], sinceCommit: 'abc' })).toBeUndefined();
+    expect(describeAutoDrift({ checked: true, candidateCount: 0, candidateTitles: [], sinceCommit: 'abc' })).toBeUndefined();
     const warning = describeAutoDrift({
       checked: true, candidateCount: 4, candidateTitles: ['Billing module', 'Rate limits'],
-      candidateIds: ['a', 'b', 'c', 'd'],
       sinceCommit: 'abcdef0123456789',
     });
     expect(warning).toContain('4 knowledge item(s)');
     expect(warning).toContain('"Billing module"');
     expect(warning).toContain('…');
     expect(warning).toContain('knowl pr check --since abcdef012345');
+  });
+
+  // The other half of the same rule. `affected_paths` is required because an item with none
+  // can never be contradicted; a run where drift could not be computed is that same state one
+  // level up — nothing this session was in a position to contradict anything — so "no
+  // candidates" must not be read as "everything is clean".
+  it('promotes nothing on a session where the drift check could not compare anything', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Otherwise eligible fact',
+      content: 'A claim about src/eligible.ts.',
+      affectedPaths: ['src/eligible.ts'],
+    });
+    const since = Date.parse((await repo.getKnowledgeItem(item.id))!.tierSince!);
+    for (let day = 0; day < OBSERVED_USE_MIN_DAYS; day++) {
+      await recordKnowledgeAccess({
+        itemId: item.id,
+        query: `question ${day}`,
+        surface: 'mcp',
+        rank: 0,
+        retrievedAt: new Date(since + day * 86_400_000 + 60_000).toISOString(),
+      });
+    }
+
+    // Drop the watermark: the next check re-baselines and reports `checked: false`, exactly
+    // as it does after a rebase rewrites the commit it was pinned to.
+    await getClient().execute({ sql: 'DELETE FROM drift_state WHERE project_root = ?', args: [ROOT] });
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: `drift-baseline-${Date.now()}`,
+      title: 'Agent session',
+    }));
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    // The very next session has a watermark to compare against, so the same item now earns it.
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: `drift-baselined-${Date.now()}`,
+      title: 'Agent session',
+    }));
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
   });
 
   it('charges the drift warning against the context budget instead of overflowing it', async () => {

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -54,7 +54,7 @@ describe('automatic drift check', () => {
 
   it('learns the baseline on first run and reports nothing', async () => {
     const first = await runAutoDriftCheck(projectId, ROOT);
-    expect(first).toEqual({ checked: false, candidateCount: 0, candidateTitles: [] });
+    expect(first).toEqual({ checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] });
 
     const second = await runAutoDriftCheck(projectId, ROOT);
     expect(second?.checked).toBe(true);
@@ -79,6 +79,9 @@ describe('automatic drift check', () => {
     expect(result?.checked).toBe(true);
     expect(result?.candidateCount).toBe(1);
     expect(result?.candidateTitles).toEqual(['Billing module']);
+    // Ids carry every candidate, not just the titled few — standing promotion consumes this
+    // list to refuse an item whose files moved, and a truncated list would let one slip past.
+    expect(result?.candidateIds).toEqual([item.id]);
 
     // Detection only: freshness is untouched on both candidate and bystander.
     const rows = await getClient().execute({
@@ -98,7 +101,7 @@ describe('automatic drift check', () => {
       args: ['0000000000000000000000000000000000000000', ROOT],
     });
     const result = await runAutoDriftCheck(projectId, ROOT);
-    expect(result).toEqual({ checked: false, candidateCount: 0, candidateTitles: [] });
+    expect(result).toEqual({ checked: false, candidateCount: 0, candidateTitles: [], candidateIds: [] });
   });
 
   it('returns null outside a git repository', async () => {
@@ -116,9 +119,10 @@ describe('automatic drift check', () => {
 
   it('renders the warning with the pinned review command, only when something matched', () => {
     expect(describeAutoDrift(null)).toBeUndefined();
-    expect(describeAutoDrift({ checked: true, candidateCount: 0, candidateTitles: [], sinceCommit: 'abc' })).toBeUndefined();
+    expect(describeAutoDrift({ checked: true, candidateCount: 0, candidateTitles: [], candidateIds: [], sinceCommit: 'abc' })).toBeUndefined();
     const warning = describeAutoDrift({
       checked: true, candidateCount: 4, candidateTitles: ['Billing module', 'Rate limits'],
+      candidateIds: ['a', 'b', 'c', 'd'],
       sinceCommit: 'abcdef0123456789',
     });
     expect(warning).toContain('4 knowledge item(s)');

--- a/tests/store/impact-schema.test.ts
+++ b/tests/store/impact-schema.test.ts
@@ -323,8 +323,12 @@ describe('change-impact schema', () => {
     expect(String(rows.rows[0].target_path)).toBe('src/a.ts');
   });
 
-  it('holds the migration level at 4 with the schema version pinned to 1', () => {
-    expect(KNOWL_MIGRATION_LEVEL).toBe(4);
+  it('keeps this schema at or above its migration level with the schema version pinned to 1', () => {
+    // `>=`, not `===`. The impact tables arrived at level 4 and every later additive change
+    // moves the level past it, so an equality here fails on the next unrelated column and
+    // teaches whoever adds it to edit this line rather than read it. What is actually being
+    // guarded is that level 4 still runs, which an equality does not say any better.
+    expect(KNOWL_MIGRATION_LEVEL).toBeGreaterThanOrEqual(4);
     // Additive tables never move the compatibility floor: raising it locks out installed builds
     // that would otherwise read this database perfectly well.
     expect(KNOWL_SCHEMA_VERSION).toBe(1);

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -32,6 +32,9 @@ const SCHEMA_PINS: Record<number, string> = {
   // gate would have refused, recorded while it refuses nothing. Additive again, so
   // `KNOWL_SCHEMA_VERSION` again does not move.
   4: '4592e436daefd236d1f15554d1a2db3a',
+  // 5 adds `knowledge_items.last_drift_at`, the stored drift observation standing promotion
+  // reads. One nullable column, no backfill, so `KNOWL_SCHEMA_VERSION` again does not move.
+  5: 'b4aceb35414d23bf1240b4b1679bee78',
 };
 
 let root: string;

--- a/tests/store/tier.test.ts
+++ b/tests/store/tier.test.ts
@@ -5,7 +5,15 @@ import { sql } from 'drizzle-orm';
 import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
 import { scoreCandidates } from '../../src/store/agent-query.js';
 import { recordKnowledgeFeedback } from '../../src/store/access-feedback.js';
-import { applyFeedbackToTier, VERIFY_THRESHOLD } from '../../src/store/tier.js';
+import {
+  applyFeedbackToTier,
+  OBSERVED_USE_MAX_PER_RUN,
+  OBSERVED_USE_MIN_DAYS,
+  OBSERVED_USE_MIN_QUESTIONS,
+  promoteByObservedUse,
+  VERIFY_THRESHOLD,
+} from '../../src/store/tier.js';
+import { recordKnowledgeAccess } from '../../src/store/access-feedback.js';
 import * as repo from '../../src/store/repository.js';
 import type { KnowledgeItem } from '../../src/core/types.js';
 
@@ -208,5 +216,185 @@ describe('evidence tier and provenance', () => {
     const mapped = await repo.getKnowledgeItem(item.id);
     expect(mapped?.tier).toBe('verified');
     expect(mapped?.provenance).toBe('inferred');
+  });
+});
+
+// Its own root: the suite above holds an open handle on its database for the whole file, and
+// on Windows re-initialising the same path fails with EBUSY rather than silently reopening.
+const OBSERVED_ROOT = path.resolve('.knowl-observed-use-test');
+
+describe('standing earned by observed use', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(OBSERVED_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(OBSERVED_ROOT, '.knowl'), { recursive: true });
+    await initDb(OBSERVED_ROOT);
+    projectId = (await repo.createProject(OBSERVED_ROOT, 'Observed use test')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_access`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+    // Commits too, unlike the suite above: this one asserts on the commit log itself, and a
+    // commit left by the previous test reads as a second promotion from this one.
+    // knowledge_commit_items cascades, so the index clears with it.
+    await db.run(sql`DELETE FROM knowledge_commits`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(OBSERVED_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function seedItem(title: string, options: { paths?: string[] | null } = {}) {
+    return repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title,
+      content: `${title} — content.`,
+      affectedPaths: options.paths === undefined ? ['src/store/tier.ts'] : options.paths,
+    });
+  }
+
+  /**
+   * One retrieval per day, each asking a different question, anchored to the item's CURRENT
+   * `tier_since` rather than to the wall clock. The pass counts only from that boundary, and
+   * an edit moves it — so wall-clock offsets would leave the pre-edit rows sitting after the
+   * new boundary and the reset test would pass an item it should have refused. Reading the
+   * boundary each call is what makes "an edit restarts the climb" actually testable.
+   */
+  async function seedRetrievals(itemId: string, days: number, options: { query?: string } = {}) {
+    const since = Date.parse((await repo.getKnowledgeItem(itemId))!.tierSince!);
+    for (let day = 0; day < days; day++) {
+      await recordKnowledgeAccess({
+        itemId,
+        query: options.query ?? `distinct question ${day}`,
+        surface: 'mcp',
+        rank: 0,
+        retrievedAt: new Date(since + day * 86_400_000 + 60_000).toISOString(),
+      });
+    }
+  }
+
+  it('promotes an item the store watched answer distinct questions across distinct days', async () => {
+    const item = await seedItem('Recurring fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+
+    const result = await promoteByObservedUse(projectId);
+    expect(result.promoted).toEqual([{ itemId: item.id, tier: 'verified', reason: 'promoted' }]);
+    expect(result.deferred).toBe(0);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
+  });
+
+  it('writes a knowledge commit, so every automatic promotion stays auditable', async () => {
+    const item = await seedItem('Audited fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    await promoteByObservedUse(projectId);
+
+    const row = (await getClient().execute({
+      sql: `SELECT COUNT(*) AS n FROM knowledge_commits WHERE message LIKE 'Promote to verified by observed use%'`,
+    })).rows[0];
+    expect(Number(row.n)).toBe(1);
+  });
+
+  // The falsifiability gate, and the reason the whole feature is defensible. An item with no
+  // affected paths is unreachable by the drift checker, so nothing was ever in a position to
+  // contradict it — promoting it on use alone would be confidence accumulating without ground
+  // truth, which is the failure the feedback path was built to avoid.
+  it('refuses an item with no affected paths, however often it is retrieved', async () => {
+    const item = await seedItem('Unfalsifiable fact', { paths: null });
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS + 3);
+
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  it('refuses a burst inside one day — recurrence is days, not hits', async () => {
+    const item = await seedItem('Bursty fact');
+    const oneMoment = new Date(Date.parse(item.tierSince!) + 60_000).toISOString();
+    for (let hit = 0; hit < 20; hit++) {
+      await recordKnowledgeAccess({
+        itemId: item.id, query: `question ${hit}`, surface: 'mcp', rank: 0, retrievedAt: oneMoment,
+      });
+    }
+
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+  });
+
+  it('refuses an item that only ever answered one question', async () => {
+    const item = await seedItem('One-question fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS + 2, { query: 'the only question ever asked' });
+
+    expect(OBSERVED_USE_MIN_QUESTIONS).toBeGreaterThan(1);
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+  });
+
+  it('refuses anything that ever caused a correction', async () => {
+    const item = await seedItem('Once-wrong fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    await recordKnowledgeFeedback({ itemId: item.id, used: true, causedCorrection: true });
+
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+  });
+
+  it('refuses an item whose files moved this session, whatever the freshness column says', async () => {
+    const item = await seedItem('Drifting fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    // Detection does not flip freshness, so the column still reads fresh — which is exactly
+    // the state that would wrongly promote if the live drift result were not consulted.
+    expect((await repo.getKnowledgeItem(item.id))?.freshness).toBe('fresh');
+
+    expect((await promoteByObservedUse(projectId, [item.id])).promoted).toEqual([]);
+    expect((await promoteByObservedUse(projectId, [])).promoted).toHaveLength(1);
+  });
+
+  it('refuses an item already flagged needs_review', async () => {
+    const item = await seedItem('Stale fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    await repo.updateKnowledgeItem(item.id, { freshness: 'needs_review' });
+
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+  });
+
+  it('caps a run and reports the remainder rather than silently dropping it', async () => {
+    const overflow = 3;
+    for (let n = 0; n < OBSERVED_USE_MAX_PER_RUN + overflow; n++) {
+      const item = await seedItem(`Eligible fact ${n}`);
+      await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    }
+
+    const first = await promoteByObservedUse(projectId);
+    expect(first.promoted).toHaveLength(OBSERVED_USE_MAX_PER_RUN);
+    expect(first.deferred).toBe(overflow);
+
+    // The backlog drains on later runs instead of stranding.
+    const second = await promoteByObservedUse(projectId);
+    expect(second.promoted).toHaveLength(overflow);
+    expect(second.deferred).toBe(0);
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+  });
+
+  it('counts only from tier_since, so an edit restarts the climb', async () => {
+    const item = await seedItem('Reworded recurring fact');
+    // The climb has to sit in the PAST for this to test anything. An edit moves `tier_since`
+    // forward by milliseconds, so rows seeded from the original boundary would still clear the
+    // new one and the test would pass an item it is supposed to refuse — which is exactly how
+    // it failed the first time it ran.
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET tier_since = ? WHERE id = ?',
+      args: [new Date(Date.now() - 30 * 86_400_000).toISOString(), item.id],
+    });
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    expect((await promoteByObservedUse(projectId)).promoted).toHaveLength(1);
+
+    await repo.updateKnowledgeItem(item.id, { content: 'A materially different claim.' });
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+    // The retrievals above confirmed wording this edit replaced; they must not carry over.
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+
+    // Use of the new wording earns it back.
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    expect((await promoteByObservedUse(projectId)).promoted).toHaveLength(1);
   });
 });

--- a/tests/store/tier.test.ts
+++ b/tests/store/tier.test.ts
@@ -338,15 +338,40 @@ describe('standing earned by observed use', () => {
     expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
   });
 
-  it('refuses an item whose files moved this session, whatever the freshness column says', async () => {
+  it('refuses an item whose files have moved, whatever the freshness column says', async () => {
     const item = await seedItem('Drifting fact');
     await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET last_drift_at = ? WHERE id = ?',
+      args: [new Date().toISOString(), item.id],
+    });
     // Detection does not flip freshness, so the column still reads fresh — which is exactly
-    // the state that would wrongly promote if the live drift result were not consulted.
+    // the state that would wrongly promote if the drift observation were not consulted.
     expect((await repo.getKnowledgeItem(item.id))?.freshness).toBe('fresh');
 
-    expect((await promoteByObservedUse(projectId, [item.id])).promoted).toEqual([]);
-    expect((await promoteByObservedUse(projectId, [])).promoted).toHaveLength(1);
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+  });
+
+  // The regression the live-candidate-list version could not catch. Auto-drift advances its
+  // watermark as soon as it has reported a window, so the session after the one that saw the
+  // change computes no candidates at all — and the item still reads `fresh`, because
+  // detection deliberately never flipped it. Anything reading the in-session list promotes
+  // here; only a stored observation still refuses.
+  it('keeps refusing after the drift window has passed, until someone reviews the item', async () => {
+    const item = await seedItem('Long-drifting fact');
+    await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET last_drift_at = ? WHERE id = ?',
+      args: [new Date().toISOString(), item.id],
+    });
+
+    // Sessions later. No drift candidates anywhere, nothing flagged, freshness untouched.
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+    expect((await promoteByObservedUse(projectId)).promoted).toEqual([]);
+
+    // A review discharges the observation, and only then does use count again.
+    await repo.updateKnowledgeItem(item.id, { freshness: 'fresh' });
+    expect((await promoteByObservedUse(projectId)).promoted).toHaveLength(1);
   });
 
   it('refuses an item already flagged needs_review', async () => {


### PR DESCRIPTION
## The problem, measured

`applyFeedbackToTier` is the only path that can promote an item, and it is reachable only from `knowl_feedback` — a voluntary call an agent has to choose to make.

Measured on a real 748-item store:

| | |
|---|---|
| standing feature shipped | 2026-07-31 |
| feedback events on record | 19, all from 2026-07-12 and 2026-07-23 |
| feedback events since the feature shipped | **0** |
| ordinary retrievals in that same window | ~1,800 |
| items at `verified` | **0 of 748** |
| `Promote to verified` commits ever written | **0** |

The threshold was never the problem. The mechanism has been alive for nine days of heavy use and has received zero eligible inputs, because its only input channel is one nobody calls. Meanwhile 2,964 involuntary access rows accumulated next to it, feeding nothing but GC.

## What this adds

`promoteByObservedUse`, run on the session-start hook beside the drift check. An item is promoted when it was retrieved across `OBSERVED_USE_MIN_DAYS` (3) distinct days answering `OBSERVED_USE_MIN_QUESTIONS` (3) distinct questions, counted from `tier_since` exactly as the feedback path counts.

Days rather than hits, deliberately: twenty retrievals inside one session are one agent circling one problem, which is the coincidence `VERIFY_THRESHOLD`'s comment warns about at a different scale.

### Why it is not recurrence alone

Retrieval count is not ground truth. An item can be surfaced a hundred times and be wrong, and promoting on that is precisely the *confidence accumulating without ground truth* that `applyFeedbackToTier` was written to prevent. So recurrence only nominates.

The gate is **falsifiability**: an item qualifies only if it carries `affected_paths`, which is what makes it reachable by the drift checker. An item with no paths can never be marked `needs_review`, so `freshness: 'fresh'` on it is not evidence — nothing was ever in a position to contradict it. Requiring paths means every promotion is backed by a claim about the codebase that has had the opportunity to fail and has not. Anything that ever caused a correction is excluded outright.

### The freshness hole, and why `AutoDriftResult` changed

Auto-drift is detection only by deliberate design — it names what moved without flipping anything. So an item whose files changed this morning still reads `fresh` until someone runs `knowl pr check` by hand. Resting the gate on the stored column would make this feature depend on the same voluntary act it exists to stop depending on.

The hook therefore passes the live drift candidate list in, and anything currently drifting is refused regardless of what the column says. That is the only reason `AutoDriftResult` now carries `candidateIds` — the titled few were capped at 3, and a truncated list would let candidates through.

### Blast radius

Capped at `OBSERVED_USE_MAX_PER_RUN` (10). On that same store the gate selects 64 items on a first pass, and applying all of them at one session start is exactly the corpus-wide standing change `drift-auto.ts` refused to make for measured reasons. Ten a run drains a backlog over a week of sessions. The remainder is reported in the session line, never silently dropped.

Every run writes a knowledge commit, so promotions are auditable and revertible. **Demotion is untouched** — immediate, unconditional, uncapped. This path only ever moves items up, and only by one step.

## Verification

- Full suite: **266 files, 2,369 tests, 0 failures**. `npm run lint` 0 errors; `npm run typecheck` clean.
- 10 new tests covering each refusal: no `affected_paths`, single-day burst, single-question repetition, prior correction, currently drifting, already `needs_review`, the cap and its remainder, and `tier_since` reset on edit.
- Run against a copy of the real store: `0 -> 64` verified across seven runs, then idempotent, 7 commits written.

## Worth your call

The thresholds (3 days / 3 questions / 10 per run) are tuned against one store. If you want promotion to stay strictly human-confirmed I would rather hear that now than have it merged and quietly disliked — but the counter-argument is in the table at the top: the human-confirmed path has produced zero promotions in its lifetime.