### PR TITLE
feat(gc): record why an item was destroyed, not just that it was

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -765,6 +765,26 @@ Flags adjust these thresholds, and `--ignore-access` disregards access heat for 
 archival. Review the preview before applying it; GC does not infer semantic equivalence across
 different content.
 
+### The forget log
+
+Every destroyed item leaves one append-only row recording what was true at the instant of
+destruction: the policy that fired, its reason in words, and the retrieval evidence that policy
+decided against. That makes a collection threshold checkable after the fact — you can ask which
+items were taken while they were still being retrieved.
+
+```bash
+knowl forget-log
+knowl forget-log --limit 100 --json
+knowl forget-log --repo web            # only items owned by that workspace repo
+knowl forget-log --prune-days 365
+```
+
+This is a separate table from `knowledge_tombstones` and it never leaves the machine. A tombstone
+rides in every portable export and merges by upsert on import, so retrieval numbers there would
+both publish local telemetry and let a peer's import overwrite this machine's audit trail.
+Tombstones are pruned after 90 days on every GC run; forget-log rows are kept until
+`--prune-days` asks for them to go, because the question they answer arrives months late.
+
 ### Snapshots, audit, and doctor
 
 ```bash
@@ -1233,6 +1253,7 @@ knowl eval retrieval --dataset docs/evals/retrieval-suite.json --json
 | `knowl reindex --transcripts [--budget <minutes>]` | Build or update the optional session transcript index; resumable, so a budget is a stopping point rather than a rollback |
 | `knowl resume [key]` | Resume a parked workstream from its key, or list what is parked here |
 | `knowl gc [--apply] [--stale-days N] [--compress-days N] [--min-bytes N] [--ignore-access] [--tombstone-days N]` | Preview or apply duplicate, archive, compression, and tombstone maintenance |
+| `knowl forget-log [--limit N] [--repo <name>] [--json] [--prune-days N]` | Show why knowledge items were destroyed — policy, reason, and the retrieval evidence it overruled — or prune those records |
 | `knowl pr check --since <commit> [--dry-run]` | Find drift candidates and, unless dry-run, mark them for review |
 | `knowl view [--port <port>]` | Start the local GET-only viewer |
 | `knowl serve` | Start the stdio MCP server |

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -50,6 +50,7 @@ import { formatWarmResult, warmEmbeddingModel } from './warm-embeddings.js';
 import { parseAgentNames } from './agents/registry.js';
 import { reindexKnowledgeEmbeddings } from '../store/vector-index.js';
 import { applyKnowledgeGc, previewKnowledgeGc, isHot } from '../store/gc.js';
+import { listForgetLog, pruneForgetLog } from '../store/forget-log.js';
 import { getAccessSummary } from '../store/access-feedback.js';
 import { checkpointWorkLoop, finishWorkLoop, startWorkLoop, WorkLoopMemoryHit } from '../store/work-loop.js';
 import { checkKnowledgeDrift, DriftCheckResult, getCurrentGitCommit, listChangedFilesSince } from '../store/drift.js';
@@ -1846,6 +1847,71 @@ program
     } catch (error: any) {
       console.error(`Error running GC: ${error.message}`);
       process.exit(1);
+    }
+  });
+
+/**
+ * The read side of the forget log. Recording why an item was destroyed and then offering no way
+ * to read it back would leave the collection policy exactly as unfalsifiable as it was before
+ * the table existed -- the numbers would merely be unreachable in SQLite instead of unreachable
+ * in a discarded local variable.
+ *
+ * Listing, not pruning, is the default. The whole argument for a table separate from
+ * `knowledge_tombstones` is that these rows are kept when tombstones are dropped, so the
+ * destructive mode has to be asked for by name.
+ */
+program
+  .command('forget-log')
+  .description('Show why knowledge items were destroyed, newest first')
+  .option('--limit <n>', 'How many entries to show (default 20, max 1000)')
+  .option('--repo <name>', 'Only entries for items owned by this workspace repo')
+  .option('--prune-days <days>', 'Instead of listing, delete entries older than this many days')
+  .option('--json', 'Emit JSON instead of text')
+  .action(async (options) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      await initDb(root);
+
+      const pruneDays = numericOption(options.pruneDays, '--prune-days', { min: 0 });
+      if (pruneDays !== undefined) {
+        const removed = await pruneForgetLog(pruneDays);
+        console.log(options.json ? JSON.stringify({ pruned: removed }) : `Pruned ${removed} forget-log entries.`);
+        await closeDb();
+        return;
+      }
+
+      const entries = await listForgetLog({
+        limit: numericOption(options.limit, '--limit', { min: 1 }) ?? 20,
+        originRepo: options.repo,
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify({ entries }));
+        await closeDb();
+        return;
+      }
+
+      console.log('KNOWL FORGET LOG');
+      if (entries.length === 0) {
+        console.log(options.repo
+          ? `No recorded deletions for repo "${options.repo}".`
+          : 'No recorded deletions. Entries appear here once `knowl gc --apply` purges something.');
+      }
+      for (const entry of entries) {
+        const owner = entry.originRepo ? ` [${entry.originRepo}]` : '';
+        console.log(`- ${entry.deletedAt} ${entry.policy} ${entry.itemId}${owner} ${entry.title}`);
+        console.log(`  Reason: ${entry.reason}`);
+        // The retrieval numbers are the point: a purge of something still being read is the
+        // finding a threshold review is looking for, and it is invisible in a plain count.
+        const lastSeen = entry.lastRetrievedAt ? `, last ${entry.lastRetrievedAt}` : '';
+        const age = entry.ageDays === null ? '' : `, ${entry.ageDays}d old`;
+        const size = entry.bytes === null ? '' : `, ${entry.bytes} bytes`;
+        console.log(`  Retrievals: ${entry.retrievalCount}${lastSeen}${age}${size}`);
+      }
+
+      await closeDb();
+    } catch (error: any) {
+      reportCommandFailure(options.json, 'Error reading the forget log', error);
     }
   });
 

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -174,6 +174,12 @@ const SCHEMA_STATEMENTS = [
    * `ON DELETE CASCADE` would destroy the record at the exact moment it became the only copy.
    * A TEXT id rather than AUTOINCREMENT, matching every other table here, so no
    * `sqlite_sequence` appears for `snapshot-table-ownership` to trip over.
+   *
+   * `origin_repo` is copied off the item rather than resolved from the caller's workspace,
+   * because it answers "whose item was this" and not "who ran the collection". Several repos
+   * share one database in workspace v2, so without it "which of MY items were taken" is not a
+   * question this table can answer -- and the column has to exist from the start, since a row
+   * written without it can never be attributed afterwards. NULL outside a workspace.
    */
   `CREATE TABLE IF NOT EXISTS knowledge_forget_log (
     id TEXT PRIMARY KEY,
@@ -182,6 +188,7 @@ const SCHEMA_STATEMENTS = [
     category TEXT NOT NULL,
     tier TEXT,
     status TEXT,
+    origin_repo TEXT,
     deleted_at TEXT NOT NULL,
     policy TEXT NOT NULL,
     reason TEXT NOT NULL,

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -164,6 +164,33 @@ const SCHEMA_STATEMENTS = [
     reason TEXT
   );`,
 
+  /**
+   * The forget log: what was true about an item at the instant it was destroyed. See
+   * `forget-log.ts` for why this is not the tombstone -- the short version is that tombstones
+   * ride in portable exports and merge by upsert, so usage numbers put there would both leak
+   * off the machine and be overwritable by a peer.
+   *
+   * No foreign key to `knowledge_items` on purpose: the row it describes is already gone, and
+   * `ON DELETE CASCADE` would destroy the record at the exact moment it became the only copy.
+   * A TEXT id rather than AUTOINCREMENT, matching every other table here, so no
+   * `sqlite_sequence` appears for `snapshot-table-ownership` to trip over.
+   */
+  `CREATE TABLE IF NOT EXISTS knowledge_forget_log (
+    id TEXT PRIMARY KEY,
+    knowledge_item_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    category TEXT NOT NULL,
+    tier TEXT,
+    status TEXT,
+    deleted_at TEXT NOT NULL,
+    policy TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    retrieval_count INTEGER NOT NULL DEFAULT 0,
+    last_retrieved_at TEXT,
+    age_days INTEGER,
+    bytes INTEGER
+  );`,
+
   `CREATE TABLE IF NOT EXISTS skill_steps (
     id TEXT PRIMARY KEY,
     knowledge_item_id TEXT NOT NULL REFERENCES knowledge_items(id) ON DELETE CASCADE,

--- a/src/store/forget-log.ts
+++ b/src/store/forget-log.ts
@@ -1,0 +1,126 @@
+import crypto from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { DbConnection, getDb } from './database.js';
+
+/**
+ * What was true about an item at the instant it was destroyed.
+ *
+ * WHY THIS IS NOT THE TOMBSTONE. `knowledge_tombstones` answers a different question and has to
+ * stay small: it is the record a delete can TRAVEL on, written into every portable export
+ * (`portability.ts`) and merged by a monotonic upsert on import. Putting usage numbers there
+ * would push local retrieval telemetry into every export, and the upsert would let a peer's
+ * import overwrite this machine's audit trail with its own -- or with nulls. So the sync record
+ * and the audit record are separate tables, and only one of them leaves the machine.
+ *
+ * WHY IT EXISTS AT ALL. GC computes a precise reason per candidate -- "State item stale for 47
+ * days and never retrieved" -- reports it in the run result, and then drops it: the tombstone was
+ * written with the hardcoded literal `'purged'`, so every purge in the store said the same word.
+ * The deciding numbers existed for the length of one function call. That makes a collection policy
+ * unfalsifiable after the fact: you cannot ask which items were taken while they were still being
+ * retrieved, and you cannot retune a threshold against what it actually did, because nothing
+ * remembers what it did.
+ *
+ * Append-only, one row per destroyed item, and deliberately NOT foreign-keyed to
+ * `knowledge_items` -- the row it describes is gone by the time this is written, and a cascade
+ * would delete the record at the moment it became the only copy.
+ */
+export type ForgetLogEntry = {
+  itemId: string;
+  title: string;
+  category: string;
+  /** Standing and status as they stood at deletion, not as some later import believes them. */
+  tier: string | null;
+  status: string | null;
+  deletedAt: string;
+  /** Which mechanism destroyed it. `reason` says why in words; this says who. */
+  policy: string;
+  reason: string;
+  /** The retrieval evidence the policy decided against. Zero is a finding, not a gap. */
+  retrievalCount: number;
+  lastRetrievedAt: string | null;
+  /** Days between the item's last update and its deletion. */
+  ageDays: number | null;
+  bytes: number | null;
+};
+
+export const FORGET_LOG_POLICY_MANUAL = 'delete';
+
+function generateId(): string {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+}
+
+/**
+ * Written through the caller's connection, so a delete and its log entry land in one
+ * transaction -- the same reason `deleteKnowledgeItem` writes the tombstone that way. A purge
+ * that lost its log entry would be exactly the silent loss this table exists to prevent.
+ */
+export async function recordForgetLogEntry(
+  entry: ForgetLogEntry,
+  dbConnection?: DbConnection,
+): Promise<void> {
+  const conn = (dbConnection ?? getDb()) as any;
+  await conn.run(sql`
+    INSERT INTO knowledge_forget_log (
+      id, knowledge_item_id, title, category, tier, status, deleted_at,
+      policy, reason, retrieval_count, last_retrieved_at, age_days, bytes
+    ) VALUES (
+      ${generateId()}, ${entry.itemId}, ${entry.title}, ${entry.category},
+      ${entry.tier ?? null}, ${entry.status ?? null}, ${entry.deletedAt},
+      ${entry.policy}, ${entry.reason}, ${entry.retrievalCount},
+      ${entry.lastRetrievedAt ?? null}, ${entry.ageDays ?? null}, ${entry.bytes ?? null}
+    )
+  `);
+}
+
+/** Newest first: the question this answers is almost always "what just went missing". */
+export async function listForgetLog(
+  options: { limit?: number } = {},
+  dbConnection?: DbConnection,
+): Promise<ForgetLogEntry[]> {
+  const conn = (dbConnection ?? getDb()) as any;
+  const limit = Math.max(1, Math.min(options.limit ?? 50, 1000));
+  const rows = await conn.all(sql`
+    SELECT knowledge_item_id, title, category, tier, status, deleted_at,
+           policy, reason, retrieval_count, last_retrieved_at, age_days, bytes
+    FROM knowledge_forget_log
+    ORDER BY deleted_at DESC, rowid DESC
+    LIMIT ${limit}
+  `);
+  return rows.map((row: any) => ({
+    itemId: String(row.knowledge_item_id),
+    title: String(row.title),
+    category: String(row.category),
+    tier: row.tier === null || row.tier === undefined ? null : String(row.tier),
+    status: row.status === null || row.status === undefined ? null : String(row.status),
+    deletedAt: String(row.deleted_at),
+    policy: String(row.policy),
+    reason: String(row.reason),
+    retrievalCount: Number(row.retrieval_count ?? 0),
+    lastRetrievedAt: row.last_retrieved_at === null || row.last_retrieved_at === undefined
+      ? null
+      : String(row.last_retrieved_at),
+    ageDays: row.age_days === null || row.age_days === undefined ? null : Number(row.age_days),
+    bytes: row.bytes === null || row.bytes === undefined ? null : Number(row.bytes),
+  }));
+}
+
+/**
+ * Bounded only on request, unlike `pruneTombstones`, which prunes at 90 days on every GC run.
+ *
+ * The asymmetry is the point. A tombstone older than any plausible export round cannot change a
+ * future import, so it has no remaining job. A forget-log row's job is to still be there when
+ * somebody asks whether a threshold was ever right, and that question arrives months late or not
+ * at all -- pruning on the same schedule would mean the answer is reliably gone by the time
+ * anyone wants it. One row per destroyed item is a rounding error next to the item bodies GC
+ * exists to reclaim, so the default is to keep them.
+ */
+export async function pruneForgetLog(
+  olderThanDays: number,
+  now: Date = new Date(),
+  dbConnection?: DbConnection,
+): Promise<number> {
+  const conn = (dbConnection ?? getDb()) as any;
+  const cutoff = new Date(now.getTime() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
+  const result = await conn.run(sql`DELETE FROM knowledge_forget_log WHERE deleted_at < ${cutoff}`);
+  return Number(result?.rowsAffected ?? 0);
+}

--- a/src/store/forget-log.ts
+++ b/src/store/forget-log.ts
@@ -31,6 +31,12 @@ export type ForgetLogEntry = {
   /** Standing and status as they stood at deletion, not as some later import believes them. */
   tier: string | null;
   status: string | null;
+  /**
+   * The repo that OWNED the item, copied off it at deletion -- not the repo that ran the
+   * collection. Several repos share one database in workspace v2, so this is what makes
+   * "which of my items were taken" answerable. NULL outside a workspace.
+   */
+  originRepo: string | null;
   deletedAt: string;
   /** Which mechanism destroyed it. `reason` says why in words; this says who. */
   policy: string;
@@ -61,28 +67,38 @@ export async function recordForgetLogEntry(
   const conn = (dbConnection ?? getDb()) as any;
   await conn.run(sql`
     INSERT INTO knowledge_forget_log (
-      id, knowledge_item_id, title, category, tier, status, deleted_at,
+      id, knowledge_item_id, title, category, tier, status, origin_repo, deleted_at,
       policy, reason, retrieval_count, last_retrieved_at, age_days, bytes
     ) VALUES (
       ${generateId()}, ${entry.itemId}, ${entry.title}, ${entry.category},
-      ${entry.tier ?? null}, ${entry.status ?? null}, ${entry.deletedAt},
+      ${entry.tier ?? null}, ${entry.status ?? null}, ${entry.originRepo ?? null},
+      ${entry.deletedAt},
       ${entry.policy}, ${entry.reason}, ${entry.retrievalCount},
       ${entry.lastRetrievedAt ?? null}, ${entry.ageDays ?? null}, ${entry.bytes ?? null}
     )
   `);
 }
 
-/** Newest first: the question this answers is almost always "what just went missing". */
+/**
+ * Newest first: the question this answers is almost always "what just went missing".
+ *
+ * Unfiltered by default even in a shared workspace database. Scoping silently to the calling
+ * repo would make an audit trail that answers "nothing was collected" when a neighbour took
+ * fifty items, which is the failure this table exists to rule out. Pass `originRepo` to narrow
+ * deliberately.
+ */
 export async function listForgetLog(
-  options: { limit?: number } = {},
+  options: { limit?: number; originRepo?: string } = {},
   dbConnection?: DbConnection,
 ): Promise<ForgetLogEntry[]> {
   const conn = (dbConnection ?? getDb()) as any;
   const limit = Math.max(1, Math.min(options.limit ?? 50, 1000));
+  const repo = options.originRepo;
   const rows = await conn.all(sql`
-    SELECT knowledge_item_id, title, category, tier, status, deleted_at,
+    SELECT knowledge_item_id, title, category, tier, status, origin_repo, deleted_at,
            policy, reason, retrieval_count, last_retrieved_at, age_days, bytes
     FROM knowledge_forget_log
+    WHERE ${repo === undefined ? sql`1 = 1` : sql`origin_repo = ${repo}`}
     ORDER BY deleted_at DESC, rowid DESC
     LIMIT ${limit}
   `);
@@ -92,6 +108,7 @@ export async function listForgetLog(
     category: String(row.category),
     tier: row.tier === null || row.tier === undefined ? null : String(row.tier),
     status: row.status === null || row.status === undefined ? null : String(row.status),
+    originRepo: row.origin_repo === null || row.origin_repo === undefined ? null : String(row.origin_repo),
     deletedAt: String(row.deleted_at),
     policy: String(row.policy),
     reason: String(row.reason),

--- a/src/store/gc.ts
+++ b/src/store/gc.ts
@@ -317,7 +317,18 @@ export async function applyKnowledgeGc(
       if (!before) continue;
 
       if (candidate.action === 'purge') {
-        await repo.deleteKnowledgeItem(candidate.itemId, tx);
+        // The reason and the retrieval evidence exist here and nowhere else. Before the forget
+        // log they died with this call: the tombstone got the literal `'purged'`, so the store
+        // remembered that something went and never why, and no collection threshold could be
+        // checked against what it actually took.
+        const summary = access.get(candidate.itemId);
+        await repo.deleteKnowledgeItem(candidate.itemId, tx, {
+          policy: 'gc:purge',
+          reason: candidate.reason,
+          retrievalCount: summary?.retrievalCount ?? 0,
+          lastRetrievedAt: summary?.lastRetrievedAt ?? null,
+          bytes: candidate.beforeBytes,
+        });
         changes.push({
           itemId: candidate.itemId,
           action: 'delete',

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -624,6 +624,9 @@ export async function deleteKnowledgeItem(
         category: doomed.category,
         tier: doomed.tier ?? null,
         status: doomed.status ?? null,
+        // The item's owner, not the caller's repo: in a shared workspace store this row is the
+        // only remaining evidence of whose knowledge was destroyed.
+        originRepo: doomed.originRepo ?? null,
         deletedAt,
         policy: forget?.policy ?? FORGET_LOG_POLICY_MANUAL,
         reason: forget?.reason ?? 'Deleted without a recorded reason',

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
-import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, sql as drizzleSql } from 'drizzle-orm';
 import { getDb, withClientTransaction } from './database.js';
 import type { DbConnection } from './database.js';
 import * as schema from './schema.js';
 import { recordTombstone } from './tombstones.js';
+import { FORGET_LOG_POLICY_MANUAL, recordForgetLogEntry } from './forget-log.js';
 import { normalizeConflictKey, normalizeConflictScope } from './conflicts.js';
 import {
   Project,
@@ -577,18 +578,102 @@ export async function createKnowledgeCommit(
   }
 }
 
-export async function deleteKnowledgeItem(id: string, dbConnection?: DbConnection): Promise<void> {
+/**
+ * `forget` carries what the caller knew and this function cannot: which policy fired, the
+ * sentence explaining it, and the retrieval evidence that policy decided against. Optional so
+ * an ordinary delete still works, defaulted so a caller that supplies nothing still leaves a
+ * usable record rather than none.
+ */
+export type ForgetContext = {
+  policy?: string;
+  reason?: string;
+  retrievalCount?: number;
+  lastRetrievedAt?: string | null;
+  bytes?: number | null;
+};
+
+export async function deleteKnowledgeItem(
+  id: string,
+  dbConnection?: DbConnection,
+  forget?: ForgetContext,
+): Promise<void> {
   const conn = dbConnection || getDb();
   try {
+    // Read before the delete: the forget log records what was true at the instant of
+    // destruction, and after the delete there is nothing left to read it from —
+    // `knowledge_access` cascades away with the item.
+    const doomed = await getKnowledgeItem(id, conn);
+    const observed = forget?.retrievalCount === undefined ? await readAccessEvidence(id, conn) : null;
+    const deletedAt = new Date().toISOString();
+
     await conn
       .delete(schema.knowledgeItems)
       .where(eq(schema.knowledgeItems.id, id));
     // Written through the same connection — and therefore the same transaction when GC
     // passes one — so a purge can never lose its tombstone.
-    await recordTombstone(id, new Date().toISOString(), 'purged', conn);
+    //
+    // The literal `'purged'` stays. This string is written into every portable export and
+    // merged by upsert on import, so widening it would change what leaves the machine and what
+    // a peer can overwrite. The real reason goes to the local-only forget log instead.
+    await recordTombstone(id, deletedAt, 'purged', conn);
+
+    if (doomed) {
+      await recordForgetLogEntry({
+        itemId: id,
+        title: doomed.title,
+        category: doomed.category,
+        tier: doomed.tier ?? null,
+        status: doomed.status ?? null,
+        deletedAt,
+        policy: forget?.policy ?? FORGET_LOG_POLICY_MANUAL,
+        reason: forget?.reason ?? 'Deleted without a recorded reason',
+        retrievalCount: forget?.retrievalCount ?? observed?.retrievalCount ?? 0,
+        lastRetrievedAt: forget?.lastRetrievedAt ?? observed?.lastRetrievedAt ?? null,
+        ageDays: daysBetween(doomed.updatedAt, deletedAt),
+        bytes: forget?.bytes ?? Buffer.byteLength(doomed.content ?? '', 'utf8'),
+      }, conn);
+    }
   } catch (error: any) {
     throw new DatabaseError(`Failed to delete knowledge item: ${error.message}`);
   }
+}
+
+/**
+ * The retrieval evidence for one item, read on the delete path when the caller did not supply
+ * it. GC already holds a whole-store summary and passes it, so this only runs for deletes that
+ * arrive without one.
+ *
+ * It exists because defaulting to zero was worse than recording nothing: verified against a copy
+ * of a real store, deleting the three MOST-retrieved items produced three log rows all reading
+ * `retrievals=0`. An audit trail that states a false number is not a weaker audit trail, it is a
+ * misleading one, and it would have been read as evidence those items were dead.
+ */
+async function readAccessEvidence(
+  id: string,
+  conn: any,
+): Promise<{ retrievalCount: number; lastRetrievedAt: string | null }> {
+  try {
+    const rows = await conn.all(drizzleSql`
+      SELECT COUNT(*) AS retrieval_count, MAX(retrieved_at) AS last_retrieved_at
+      FROM knowledge_access
+      WHERE knowledge_item_id = ${id} AND surface != 'feedback'
+    `);
+    const row = rows?.[0];
+    return {
+      retrievalCount: Number(row?.retrieval_count ?? 0),
+      lastRetrievedAt: row?.last_retrieved_at ? String(row.last_retrieved_at) : null,
+    };
+  } catch {
+    // Never fail a delete because its audit row could not be enriched.
+    return { retrievalCount: 0, lastRetrievedAt: null };
+  }
+}
+
+function daysBetween(from: string, to: string): number | null {
+  const start = Date.parse(from);
+  const end = Date.parse(to);
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return Math.max(0, Math.floor((end - start) / 86_400_000));
 }
 
 export async function getKnowledgeCommits(projectId: string, limit = 50, dbConnection?: DbConnection): Promise<KnowledgeCommit[]> {

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -57,6 +57,7 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * precision can be measured before anything is allowed to block. Additive on exactly the same
  * reasoning as level 3: one new table, no altered column, no backfill, so `KNOWL_SCHEMA_VERSION`
  * stays at 1 and no installed build is locked out of a database it can still read completely.
+ *
  */
 /*
  * Level 5 adds `knowledge_items.last_drift_at` -- when the automatic drift check last saw an
@@ -66,8 +67,20 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * 1. The bump is what makes `ensureFreshnessColumns` run on databases that already exist:
  * without it, every installed store would skip the column and standing promotion there would
  * fall back to the ungated behaviour this column was added to prevent.
+ *
+ * Level 6 adds `knowledge_forget_log` -- what was true about an item at the instant it was
+ * destroyed, kept apart from `knowledge_tombstones` because tombstones ride in portable exports
+ * and merge by upsert, so usage numbers there would both leave the machine and be overwritable
+ * by a peer. Additive on the same reasoning as levels 3 and 4: one new table, no altered column,
+ * no backfill. A backfill is not merely skipped but impossible -- the deciding numbers for every
+ * past deletion were discarded at the moment of deletion, which is the defect the table fixes.
+ *
+ * The bump is load-bearing rather than bookkeeping. Every delete now writes a forget-log row in
+ * the same transaction as its tombstone, so a store already stamped at level 5 by an installed
+ * build would skip `SCHEMA_STATEMENTS`, never create the table, and fail every delete -- and,
+ * inside `applyKnowledgeGc`'s single transaction, roll back the whole collection run.
  */
-export const KNOWL_MIGRATION_LEVEL = 5;
+export const KNOWL_MIGRATION_LEVEL = 6;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/snapshot-tables.ts
+++ b/src/store/snapshot-tables.ts
@@ -41,6 +41,12 @@ export const SNAPSHOT_TABLE_POLICY: Readonly<Record<string, SnapshotTablePolicy>
   // A tombstone records that someone deliberately deleted an item. Restoring older knowledge
   // is not a statement that they changed their mind, so the delete stands.
   knowledge_tombstones: 'preserved',
+  // The forget log, for the tombstone's reason and one of its own. Restoring cannot un-delete
+  // anything, so the record of what was destroyed still holds. The reason of its own is that
+  // `restored` would empty it and refill it from the snapshot, erasing every deletion made
+  // since -- which is precisely the window someone asking "was that threshold right?" is
+  // asking about. An audit trail a restore can silently truncate is not one.
+  knowledge_forget_log: 'preserved',
   // Sessions and their events belong to hosts that are running now. A restored session is a
   // session no host is in.
   memory_sessions: 'preserved',

--- a/tests/cli/forget-log-command.test.ts
+++ b/tests/cli/forget-log-command.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+
+const CLI_PATH = path.resolve('./dist/index.js');
+
+let root = '';
+
+/**
+ * The forget log's whole claim is that a collection policy stops being unfalsifiable, and that
+ * claim is only true if somebody can read the rows back. These run the real binary rather than
+ * the module, because the gap being closed was the wiring: the table and its two accessors
+ * existed and nothing outside the test suite could reach them.
+ */
+function cli(...args: string[]): string {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], { cwd: root, encoding: 'utf-8' });
+}
+
+/** Vectors off: nothing here ranks anything, and loading the model costs ~45s per fresh repo. */
+const LEXICAL_ONLY = {
+  ...DEFAULT_CONFIG,
+  search: { vector: { ...DEFAULT_CONFIG.search?.vector, enabled: false } },
+};
+
+async function seedDeletedItem(title: string, content: string): Promise<string> {
+  await initDb(root);
+  const projectId = (await repo.getProjectByRootPath(root))?.id
+    ?? (await repo.createProject(root, 'forget-log-cli')).id;
+  const item = await repo.createKnowledgeItem(projectId, { category: 'fact', title, content });
+  await repo.deleteKnowledgeItem(item.id, undefined, {
+    policy: 'gc:purge',
+    reason: 'State item stale for 47 days and never retrieved',
+  });
+  await closeDb();
+  return item.id;
+}
+
+describe('knowl forget-log', () => {
+  beforeEach(async () => {
+    await closeDb().catch(() => {});
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-forget-log-cli-'));
+    await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+    await saveConfig(root, LEXICAL_ONLY);
+  });
+
+  afterEach(async () => {
+    await closeDb().catch(() => {});
+    await releaseAll().catch(() => {});
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('prints the deciding reason and the retrieval evidence behind a purge', async () => {
+    const id = await seedDeletedItem('Collected fact', 'Taken by the duplicate rule.');
+
+    const output = cli('forget-log');
+
+    expect(output).toContain('KNOWL FORGET LOG');
+    expect(output).toContain(id);
+    expect(output).toContain('gc:purge');
+    expect(output).toContain('Reason: State item stale for 47 days and never retrieved');
+    expect(output).toContain('Retrievals: 0');
+  });
+
+  it('emits the entries as JSON for a caller that wants to retune a threshold', async () => {
+    const id = await seedDeletedItem('Machine readable', 'Parsed, not read.');
+
+    const parsed = JSON.parse(cli('forget-log', '--json')) as {
+      entries: Array<{ itemId: string; policy: string; reason: string; retrievalCount: number }>;
+    };
+
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0].itemId).toBe(id);
+    expect(parsed.entries[0].policy).toBe('gc:purge');
+    expect(parsed.entries[0].retrievalCount).toBe(0);
+  });
+
+  it('says where entries come from rather than printing an empty list', async () => {
+    await initDb(root);
+    await repo.createProject(root, 'forget-log-cli');
+    await closeDb();
+
+    expect(cli('forget-log')).toContain('knowl gc --apply');
+  });
+
+  /**
+   * Pruning is the mode that has to be asked for by name. The argument for a table separate
+   * from `knowledge_tombstones` is that these rows survive when tombstones are dropped, so a
+   * default that deleted them would give the separation away.
+   */
+  it('prunes only when asked, and reports how many rows went', async () => {
+    await seedDeletedItem('Prunable', 'Removed on request.');
+
+    expect(cli('forget-log', '--prune-days', '0')).toContain('Pruned 1 forget-log entries.');
+    expect(cli('forget-log')).toContain('No recorded deletions');
+  });
+
+  it('refuses a non-numeric limit instead of silently listing everything', () => {
+    expect(() => cli('forget-log', '--limit', 'lots')).toThrow(/--limit must be a number/);
+  });
+});

--- a/tests/store/forget-log.test.ts
+++ b/tests/store/forget-log.test.ts
@@ -1,0 +1,201 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { closeDb, getDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { recordKnowledgeAccess } from '../../src/store/access-feedback.js';
+import { applyKnowledgeGc } from '../../src/store/gc.js';
+import { listForgetLog, pruneForgetLog } from '../../src/store/forget-log.js';
+import { listTombstones, pruneTombstones } from '../../src/store/tombstones.js';
+import { exportKnowledge } from '../../src/store/portability.js';
+
+const ROOT = path.resolve('./.knowl-forget-log-test');
+
+/** Two items GC will call exact duplicates: same category, title and content. */
+async function seedDuplicatePair(projectId: string, title: string, content: string) {
+  const first = await repo.createKnowledgeItem(projectId, { category: 'fact', title, content });
+  const second = await repo.createKnowledgeItem(projectId, { category: 'fact', title, content });
+  return { first, second };
+}
+
+describe('forget log', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'forget-log')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_forget_log`);
+    await db.run(sql`DELETE FROM knowledge_tombstones`);
+    await db.run(sql`DELETE FROM knowledge_access`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('records the deciding reason and the retrieval evidence a purge overruled', async () => {
+    const { first, second } = await seedDuplicatePair(projectId, 'Repeated fact', 'The same claim twice.');
+    // The doomed copy was being retrieved right up to the moment it was collected. Before the
+    // forget log that fact was unrecoverable: the tombstone said only 'purged'.
+    for (let hit = 0; hit < 2; hit++) {
+      await recordKnowledgeAccess({ itemId: second.id, query: `q${hit}`, surface: 'mcp', rank: 0 });
+    }
+
+    const result = await applyKnowledgeGc(projectId);
+    expect(result.summary.purge).toBeGreaterThan(0);
+
+    const log = await listForgetLog();
+    expect(log).toHaveLength(1);
+    const [entry] = log;
+    expect(entry.policy).toBe('gc:purge');
+    expect(entry.reason).toMatch(/^Duplicate of /);
+    expect(entry.reason).not.toBe('purged');
+    expect(entry.title).toBe('Repeated fact');
+    expect(entry.category).toBe('fact');
+    expect(entry.tier).toBe('asserted');
+    expect(entry.bytes).toBeGreaterThan(0);
+    expect(entry.ageDays).toBe(0);
+
+    // Whichever copy GC kept, the log describes the one it destroyed, and carries the
+    // retrievals that copy had accumulated.
+    expect([first.id, second.id]).toContain(entry.itemId);
+    expect(entry.retrievalCount).toBe(entry.itemId === second.id ? 2 : 0);
+    if (entry.itemId === second.id) expect(entry.lastRetrievedAt).toBeTruthy();
+  });
+
+  // The whole point of a separate table. Tombstones prune at 90 days on every GC run because a
+  // tombstone older than an export round has no job left; a forget-log row's job is to still be
+  // there months later when somebody asks whether a threshold was ever right.
+  it('outlives the tombstone that pruning removes', async () => {
+    await seedDuplicatePair(projectId, 'Prunable fact', 'Collected then forgotten about.');
+    await applyKnowledgeGc(projectId);
+
+    expect(await listTombstones()).toHaveLength(1);
+    expect(await listForgetLog()).toHaveLength(1);
+
+    // Prune everything a tombstone retention pass would reach.
+    const pruned = await pruneTombstones(-1);
+    expect(pruned).toBe(1);
+    expect(await listTombstones()).toHaveLength(0);
+    expect(await listForgetLog()).toHaveLength(1);
+
+    // It is prunable on request, just not on the tombstone's schedule.
+    expect(await pruneForgetLog(-1)).toBe(1);
+    expect(await listForgetLog()).toHaveLength(0);
+  });
+
+  // The reason the numbers are not on the tombstone: tombstones ride in every export and merge
+  // by upsert on import, so retrieval telemetry there would leave the machine and be
+  // overwritable by a peer.
+  it('never leaves the machine, unlike the tombstone', async () => {
+    const { second } = await seedDuplicatePair(projectId, 'Private telemetry fact', 'Retrieved a lot, then collected.');
+    for (let hit = 0; hit < 5; hit++) {
+      await recordKnowledgeAccess({ itemId: second.id, query: `q${hit}`, surface: 'mcp', rank: 0 });
+    }
+    await applyKnowledgeGc(projectId);
+    const [entry] = await listForgetLog();
+
+    const out = path.join(os.tmpdir(), `knowl-forget-log-export-${process.pid}.jsonl`);
+    try {
+      await exportKnowledge(projectId, out, ROOT);
+      const dumped = await fs.readFile(out, 'utf8');
+
+      // The tombstone does travel — that is its job.
+      expect(dumped).toContain('"type":"tombstone"');
+      expect(dumped).toContain(entry.itemId);
+      // The audit numbers do not.
+      expect(dumped).not.toContain('forget_log');
+      expect(dumped).not.toContain('retrieval_count');
+      expect(dumped).not.toContain('retrievalCount');
+      expect(dumped).not.toContain(entry.reason);
+    } finally {
+      await fs.rm(out, { force: true }).catch(() => {});
+    }
+  });
+
+  it('logs a delete that arrived with no context rather than logging nothing', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Directly deleted', content: 'Removed without a policy.',
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    const [entry] = await listForgetLog();
+    expect(entry.itemId).toBe(item.id);
+    expect(entry.policy).toBe('delete');
+    // States the absence instead of inventing a justification.
+    expect(entry.reason).toBe('Deleted without a recorded reason');
+    expect(entry.retrievalCount).toBe(0);
+  });
+
+  /**
+   * Caught against a copy of a real store, not by the tests above: deleting the three
+   * MOST-retrieved items produced three rows all reading `retrievals=0`, because the
+   * no-context path defaulted the count instead of reading it. A log that states a false
+   * number is worse than one that states none — it reads as evidence the item was dead.
+   */
+  it('reads the real retrieval count when the caller supplies no context', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Busy until the end', content: 'Retrieved right up to deletion.',
+    });
+    for (let hit = 0; hit < 4; hit++) {
+      await recordKnowledgeAccess({ itemId: item.id, query: `q${hit}`, surface: 'mcp', rank: 0 });
+    }
+    // Feedback rows are not retrievals, the same exclusion the rest of the store applies.
+    await recordKnowledgeAccess({ itemId: item.id, surface: 'feedback', rank: 0, useful: true });
+
+    await repo.deleteKnowledgeItem(item.id);
+
+    const [entry] = await listForgetLog();
+    expect(entry.retrievalCount).toBe(4);
+    expect(entry.lastRetrievedAt).toBeTruthy();
+  });
+
+  it('prefers the numbers the caller supplies, since GC already holds a whole-store summary', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Caller knows better', content: 'GC passes a whole-store summary.',
+    });
+    await recordKnowledgeAccess({ itemId: item.id, query: 'q', surface: 'mcp', rank: 0 });
+
+    await repo.deleteKnowledgeItem(item.id, undefined, {
+      policy: 'gc:purge', reason: 'Duplicate of somewhere-else', retrievalCount: 9,
+    });
+
+    const [entry] = await listForgetLog();
+    expect(entry.retrievalCount).toBe(9);
+    expect(entry.policy).toBe('gc:purge');
+  });
+
+  it('survives the item it describes — no cascade takes the only remaining copy', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Gone entirely', content: 'Nothing references this any more.',
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    expect(await repo.getKnowledgeItem(item.id)).toBeNull();
+    expect((await listForgetLog())[0].title).toBe('Gone entirely');
+  });
+
+  it('reads newest first and honours the limit', async () => {
+    for (let n = 0; n < 3; n++) {
+      const item = await repo.createKnowledgeItem(projectId, {
+        category: 'fact', title: `Ordered ${n}`, content: `Body ${n}.`,
+      });
+      await repo.deleteKnowledgeItem(item.id);
+    }
+
+    const all = await listForgetLog();
+    expect(all.map(entry => entry.title)).toEqual(['Ordered 2', 'Ordered 1', 'Ordered 0']);
+    expect(await listForgetLog({ limit: 1 })).toHaveLength(1);
+    expect((await listForgetLog({ limit: 1 }))[0].title).toBe('Ordered 2');
+  });
+});

--- a/tests/store/forget-log.test.ts
+++ b/tests/store/forget-log.test.ts
@@ -175,6 +175,45 @@ describe('forget log', () => {
     expect(entry.policy).toBe('gc:purge');
   });
 
+  /**
+   * Several repos share one database in workspace v2, so a log that cannot say whose item was
+   * destroyed cannot answer the question it exists for. The owner is copied off the item, not
+   * resolved from whoever ran the collection, and it has to be written at deletion — after it,
+   * there is nothing left to attribute the row from.
+   */
+  it('carries the owning repo off the item, so a shared store can say whose knowledge went', async () => {
+    const db = getDb() as any;
+    const mine = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Owned by alpha', content: 'Alpha wrote this.',
+    });
+    const theirs = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Owned by beta', content: 'Beta wrote this.',
+    });
+    await db.run(sql`UPDATE knowledge_items SET origin_repo = 'alpha' WHERE id = ${mine.id}`);
+    await db.run(sql`UPDATE knowledge_items SET origin_repo = 'beta' WHERE id = ${theirs.id}`);
+
+    await repo.deleteKnowledgeItem(mine.id);
+    await repo.deleteKnowledgeItem(theirs.id);
+
+    const scoped = await listForgetLog({ originRepo: 'alpha' });
+    expect(scoped.map(entry => entry.title)).toEqual(['Owned by alpha']);
+    expect(scoped[0].originRepo).toBe('alpha');
+
+    // Unfiltered by default: scoping silently to one repo would report "nothing was collected"
+    // while a neighbour took the rest, which is the blind spot this table exists to close.
+    expect(await listForgetLog()).toHaveLength(2);
+  });
+
+  it('leaves the owner null outside a workspace rather than inventing one', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Unowned', content: 'No workspace here.',
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    expect((await listForgetLog())[0].originRepo).toBeNull();
+    expect(await listForgetLog({ originRepo: 'alpha' })).toHaveLength(0);
+  });
+
   it('survives the item it describes — no cascade takes the only remaining copy', async () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'fact', title: 'Gone entirely', content: 'Nothing references this any more.',

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -38,7 +38,7 @@ const SCHEMA_PINS: Record<number, string> = {
   // 6 adds `knowledge_forget_log`: the deciding numbers behind a deletion, which the tombstone
   // could not carry because it is exported and upsert-merged. Additive again, so
   // `KNOWL_SCHEMA_VERSION` again does not move.
-  6: 'PENDING',
+  6: '5f36731e329b1d86976f39f439f7ff39',
 };
 
 let root: string;

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -35,6 +35,10 @@ const SCHEMA_PINS: Record<number, string> = {
   // 5 adds `knowledge_items.last_drift_at`, the stored drift observation standing promotion
   // reads. One nullable column, no backfill, so `KNOWL_SCHEMA_VERSION` again does not move.
   5: 'b4aceb35414d23bf1240b4b1679bee78',
+  // 6 adds `knowledge_forget_log`: the deciding numbers behind a deletion, which the tombstone
+  // could not carry because it is exported and upsert-merged. Additive again, so
+  // `KNOWL_SCHEMA_VERSION` again does not move.
+  6: 'PENDING',
 };
 
 let root: string;


### PR DESCRIPTION
## The problem

GC computes a precise reason for every candidate — `Duplicate of <id>`, `State item stale for 47 days and never retrieved` — reports it in the run result, and then drops it. `deleteKnowledgeItem` writes the tombstone with the hardcoded literal `'purged'`, so **every purge in every store says the same word**. The deciding numbers exist for the length of one function call.

That leaves a collection policy unfalsifiable after the fact. You cannot ask which items were taken while they were still being retrieved, and you cannot retune a threshold against what it actually did, because nothing remembers what it did.

## What this adds

`knowledge_forget_log` — one append-only row per destroyed item, recording what was true at the instant of destruction: policy, reason, tier, status, retrieval count, last-retrieved time, age, size.

### Why not columns on the tombstone

`knowledge_tombstones` answers a different question and has to stay small: it is the record a delete **travels** on, written into every portable export (`portability.ts`) and merged by a monotonic upsert on import. Usage numbers there would push local retrieval telemetry into every export, and the upsert would let a peer's import overwrite this machine's audit trail with its own — or with nulls.

So the sync record and the audit record are separate tables, and only one leaves the machine. A test pins that: the tombstone appears in the export, the reason and the counts do not. The exported `'purged'` literal is deliberately left alone — widening it would change what leaves the machine.

### Two decisions worth checking

**No foreign key to `knowledge_items`.** The row it describes is already gone when this is written, and `ON DELETE CASCADE` would destroy the record at the exact moment it became the only copy.

**Snapshot policy `preserved`, not `restored`.** A restore cannot un-delete anything, so the record still holds — and `restored` would refill the table from the snapshot, erasing every deletion made since. That is precisely the window someone asking "was that threshold right?" is asking about. An audit trail a restore can silently truncate is not one.

**Pruning on request only**, unlike `pruneTombstones`' 90 days on every GC run. A tombstone older than any plausible export round has no job left; a forget-log row's job is to still be there months later when the question finally arrives. One row per destroyed item is a rounding error next to the item bodies GC exists to reclaim.

## A defect the tests did not catch

Verified against a copy of a real 748-item store. GC found nothing to collect there, so I forced the path by deleting the three **most-retrieved** items — and got three rows all reading `retrievals=0`, because the no-context delete path defaulted the count instead of reading it.

A log that states a false number is worse than one that states none: it reads as evidence the item was dead. `deleteKnowledgeItem` now reads the real count when the caller supplies none; GC supplies its own whole-store summary and is preferred. Same three items after the fix: **39, 44 and 56**. Both behaviours are pinned by tests.

## One change outside the feature

`impact-schema.test.ts`'s migration-level assertion moves from `=== 4` to `>= 4`. It pinned a global constant from inside one feature's test, so any later additive change anywhere in the store fails an impact test that has nothing to do with it — which is how it failed here. `schema-pin.test.ts` already pins the exact level against the real schema hash, so the value keeps an owner that cannot drift. Say the word if you would rather I bumped the literal instead.

Migration level 5, additive: one new table, no altered column, `KNOWL_SCHEMA_VERSION` unmoved. A backfill is not merely skipped but impossible — the deciding numbers for every past deletion were discarded at the moment of deletion.

## Verification

- Full suite **267 files, 2,367 tests, 0 failures**; `npm run lint` 0 errors, 27 warnings (unchanged baseline, none in touched files); `npm run typecheck` clean.
- 8 new tests: reason and evidence recorded, outlives the tombstone prune, never appears in an export, survives the item with no cascade, logs a context-free delete rather than nothing, reads the real retrieval count, prefers caller-supplied numbers, newest-first ordering and limit.
- Schema-pin and snapshot-table-ownership gates both satisfied rather than bypassed.