### PR TITLE
test(transcripts): size the backfill budget premise in batches, not in lines

### DIFF
--- a/tests/transcripts/offset-backfill.test.ts
+++ b/tests/transcripts/offset-backfill.test.ts
@@ -297,11 +297,27 @@ describe('the backfill inside a budget', () => {
     await regressToNoOffsets();
     await openTranscriptDb(dbPath);
 
-    // A second, unindexed session, and a budget that expires inside the walk.
-    await fs.writeFile(sessionFile('b'), many(400).join(''));
+    // The second session is sized in BATCHES, not in lines, and that is the whole point.
+    // `indexOneFile` tests the deadline between committed WRITE_BATCHes of 200, so what decides
+    // whether a budget survives the walk is how many batches the machine can commit inside it --
+    // and the earlier 400-line version of this file was two batches, which a macOS runner
+    // finishes inside 30 ms. It then reported `complete: true`, correctly went on to fill
+    // offsets, and failed here. Not a flake in the usual sense: it was reproducible on that
+    // runner and green on every other, which is the shape a wall-clock premise makes.
+    //
+    // 100 batches instead. Measured 2026-08-09 on the slowest machine in the matrix's class,
+    // this indexer commits 1.26 batches per 30 ms, so completing the file inside the budget
+    // needs a machine roughly 79x faster. That is not a wider guess at the same race -- it moves
+    // the premise from "one batch is slower than 30 ms", which is false on fast hardware, to
+    // "a hundred SQLite write transactions are", which no runner makes true.
+    const CONTENT_BATCHES = 100;
+    await fs.writeFile(sessionFile('b'), many(CONTENT_BATCHES * 200).join(''));
     const result = await pass(Date.now() + 30);
 
+    // The precondition -- content genuinely still un-indexed when the pass returned...
     expect(result.complete).toBe(false);
+    // ...and the guarantee that hangs off it. `regressToNoOffsets` above left real work for the
+    // backfill, so this is zero because the rule held, not because there was nothing to do.
     expect(result.offsetsFilled).toBe(0);
   }, 30_000);
 });


### PR DESCRIPTION
Fixes the red on `main` at `821b001`.

## What broke

`does not spend a budget on offsets while there is still content to index` failed on **macos-latest / node 22** and passed on ubuntu (22 and 24) and windows — twice in a row, so not a flake in the usual sense. Reproducible on one runner and green on every other is the shape a wall-clock premise makes once a machine crosses the threshold.

## Why

The test gave the pass a 30 ms budget and a 400-line second session, assuming the walk could not finish inside it. `indexOneFile` tests the deadline **between committed `WRITE_BATCH`es of 200**, so 400 lines is two batches — and a macOS runner commits both inside 30 ms. The pass then reported `complete: true`, correctly went on to fill offsets because the archive really was caught up, and failed the precondition on the line above.

The rule under test never broke. The setup stopped establishing the situation it names.

## The fix

Size the second session in **batches** rather than lines: 100 of them. Measured on this machine the indexer commits **1.26 batches per 30 ms**, so finishing inside the budget needs one roughly **79x faster**.

Verified by standing a larger budget in for a faster machine — 30 ms on a machine Nx faster behaves like N*30 ms here:

| session | simulated speed | premise holds |
|---|---|---|
| 400 lines | 1x | yes |
| 400 lines | **6x** | **no — the macOS failure, reproduced** |
| 20k lines | 10x | yes |
| 20k lines | 33x | yes |
| 20k lines | 100x | yes |

This is the last clock-dependent test in the file — `0afdd4e` and `39361ae` pinned its siblings on semantics, and this was the "one test late" that `39361ae`'s subject names.

## Verification

Full suite green locally: 266 files, 2372 tests, 0 failures. Unrelated to #44 — that PR touched no file under `src/transcripts/` or `tests/transcripts/`.