### PR TITLE
feat(gc): a groupable rule code, the survivor as a column, and what was destroyed

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -57,6 +57,7 @@ import { parseAgentNames } from './agents/registry.js';
 import { reindexKnowledgeEmbeddings } from '../store/vector-index.js';
 import { applyKnowledgeGc, previewKnowledgeGc, isHot } from '../store/gc.js';
 import { listForgetLog, pruneForgetLog } from '../store/forget-log.js';
+import { truncateText } from '../core/token-budget.js';
 import { getAccessSummary } from '../store/access-feedback.js';
 import { checkpointWorkLoop, finishWorkLoop, startWorkLoop, WorkLoopMemoryHit } from '../store/work-loop.js';
 import { checkKnowledgeDrift, DriftCheckResult, getCurrentGitCommit, listChangedFilesSince } from '../store/drift.js';
@@ -2155,7 +2156,16 @@ program
       for (const entry of entries) {
         const owner = entry.originRepo ? ` [${entry.originRepo}]` : '';
         console.log(`- ${entry.deletedAt} ${entry.policy} ${entry.itemId}${owner} ${entry.title}`);
-        console.log(`  Reason: ${entry.reason}`);
+        // Sentence first, code after. The code is what a tally groups by, but that happens over
+        // `--json` or SQL, where the field is already there; a human reading this list wants the
+        // sentence that says which item this was.
+        const survivor = entry.mergedIntoId ? ` -> ${entry.mergedIntoId}` : '';
+        console.log(`  Reason: ${entry.reason} [${entry.reasonCode}]${survivor}`);
+        // The body, because the item is gone: judging whether a rule was right usually means
+        // seeing what it took, and this row is the only copy anyone reads.
+        if (entry.contentPreview) {
+          console.log(`  Was: ${truncateText(entry.contentPreview, 160)}`);
+        }
         // The retrieval numbers are the point: a purge of something still being read is the
         // finding a threshold review is looking for, and it is invisible in a plain count.
         const lastSeen = entry.lastRetrievedAt ? `, last ${entry.lastRetrievedAt}` : '';

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -191,7 +191,10 @@ const SCHEMA_STATEMENTS = [
     origin_repo TEXT,
     deleted_at TEXT NOT NULL,
     policy TEXT NOT NULL,
+    reason_code TEXT NOT NULL DEFAULT 'unspecified',
     reason TEXT NOT NULL,
+    merged_into_id TEXT,
+    content_preview TEXT,
     retrieval_count INTEGER NOT NULL DEFAULT 0,
     last_retrieved_at TEXT,
     age_days INTEGER,
@@ -642,6 +645,31 @@ async function ensureQualityColumns(client: Client): Promise<void> {
   }
 }
 
+/**
+ * The forget log's detail columns, for a store that already has the table from level 6.
+ *
+ * `CREATE TABLE IF NOT EXISTS` is a no-op there, so without this the columns would exist only on
+ * databases created after level 7 and every older store would fail its next delete -- inside the
+ * single transaction `applyKnowledgeGc` runs, taking the whole collection run with it.
+ *
+ * Nothing is backfilled. A row written at level 6 genuinely has no survivor and no snapshot, and
+ * `reason_code` falls to its `'unspecified'` default, which is the honest description of a
+ * deletion recorded before the codes existed rather than a guess at which rule fired.
+ */
+async function ensureForgetLogColumns(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'knowledge_forget_log'))) return;
+  const columns = await tableColumns(client, 'knowledge_forget_log');
+  if (!columns.includes('reason_code')) {
+    await client.execute("ALTER TABLE knowledge_forget_log ADD COLUMN reason_code TEXT NOT NULL DEFAULT 'unspecified';");
+  }
+  if (!columns.includes('merged_into_id')) {
+    await client.execute('ALTER TABLE knowledge_forget_log ADD COLUMN merged_into_id TEXT;');
+  }
+  if (!columns.includes('content_preview')) {
+    await client.execute('ALTER TABLE knowledge_forget_log ADD COLUMN content_preview TEXT;');
+  }
+}
+
 async function ensureFreshnessColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'knowledge_items'))) {
     return;
@@ -1038,6 +1066,7 @@ export async function bootstrapSchema(
     await executeAll(client, SCHEMA_STATEMENTS);
     await ensureFreshnessColumns(client);
     await ensureQualityColumns(client);
+    await ensureForgetLogColumns(client);
     await ensureConflictColumns(client);
     await ensureOwnershipColumns(client);
     await ensureMemorySessionColumns(client);

--- a/src/store/forget-log.ts
+++ b/src/store/forget-log.ts
@@ -40,7 +40,28 @@ export type ForgetLogEntry = {
   deletedAt: string;
   /** Which mechanism destroyed it. `reason` says why in words; this says who. */
   policy: string;
+  /**
+   * The RULE that fired, as an enumerated code, beside the human sentence rather than replacing
+   * it. Taken from Lethe's `forget_log.py` (MIT), which keeps its reasons as module constants
+   * because they are "part of the public ForgetLog contract -- anyone reading the log needs to
+   * know what the strings mean". A log whose only reason is prose cannot be aggregated: "how many
+   * were merged versus collected cold" should be a GROUP BY, not a regex over English.
+   */
+  reasonCode: ForgetReasonCode;
   reason: string;
+  /**
+   * For a duplicate collection, the item that absorbed this one. Recoverable before only by
+   * parsing it back out of the `Duplicate of <id>` sentence; a column makes "what was merged
+   * into X" answerable, and `knowl forget-log` can print the survivor.
+   */
+  mergedIntoId: string | null;
+  /**
+   * A bounded snapshot of what was destroyed, because by the time anyone reads this row the item
+   * is gone -- a purge is a hard delete. Judging whether a policy was right usually means seeing
+   * the thing it took. Bounded at MAX_PREVIEW_CHARS so the audit trail cannot quietly undo the
+   * reclamation the collection was for; the commit log still holds the whole `before` item.
+   */
+  contentPreview: string | null;
   /** The retrieval evidence the policy decided against. Zero is a finding, not a gap. */
   retrievalCount: number;
   lastRetrievedAt: string | null;
@@ -49,6 +70,16 @@ export type ForgetLogEntry = {
   bytes: number | null;
 };
 
+/**
+ * The rules that can destroy an item, as a closed set.
+ *
+ * Public contract, deliberately: a new collection rule adds a code here rather than inventing
+ * another English sentence nothing can group by.
+ */
+export type ForgetReasonCode = 'gc:duplicate' | 'delete:unspecified' | 'unspecified';
+
+export const FORGET_REASON_DUPLICATE = 'gc:duplicate';
+export const FORGET_REASON_MANUAL = 'delete:unspecified';
 export const FORGET_LOG_POLICY_MANUAL = 'delete';
 
 function generateId(): string {
@@ -68,12 +99,15 @@ export async function recordForgetLogEntry(
   await conn.run(sql`
     INSERT INTO knowledge_forget_log (
       id, knowledge_item_id, title, category, tier, status, origin_repo, deleted_at,
-      policy, reason, retrieval_count, last_retrieved_at, age_days, bytes
+      policy, reason_code, reason, merged_into_id, content_preview,
+      retrieval_count, last_retrieved_at, age_days, bytes
     ) VALUES (
       ${generateId()}, ${entry.itemId}, ${entry.title}, ${entry.category},
       ${entry.tier ?? null}, ${entry.status ?? null}, ${entry.originRepo ?? null},
       ${entry.deletedAt},
-      ${entry.policy}, ${entry.reason}, ${entry.retrievalCount},
+      ${entry.policy}, ${entry.reasonCode}, ${entry.reason},
+      ${entry.mergedIntoId ?? null}, ${entry.contentPreview ?? null},
+      ${entry.retrievalCount},
       ${entry.lastRetrievedAt ?? null}, ${entry.ageDays ?? null}, ${entry.bytes ?? null}
     )
   `);
@@ -96,7 +130,8 @@ export async function listForgetLog(
   const repo = options.originRepo;
   const rows = await conn.all(sql`
     SELECT knowledge_item_id, title, category, tier, status, origin_repo, deleted_at,
-           policy, reason, retrieval_count, last_retrieved_at, age_days, bytes
+           policy, reason_code, reason, merged_into_id, content_preview,
+           retrieval_count, last_retrieved_at, age_days, bytes
     FROM knowledge_forget_log
     WHERE ${repo === undefined ? sql`1 = 1` : sql`origin_repo = ${repo}`}
     ORDER BY deleted_at DESC, rowid DESC
@@ -111,7 +146,14 @@ export async function listForgetLog(
     originRepo: row.origin_repo === null || row.origin_repo === undefined ? null : String(row.origin_repo),
     deletedAt: String(row.deleted_at),
     policy: String(row.policy),
+    reasonCode: String(row.reason_code ?? 'unspecified') as ForgetReasonCode,
     reason: String(row.reason),
+    mergedIntoId: row.merged_into_id === null || row.merged_into_id === undefined
+      ? null
+      : String(row.merged_into_id),
+    contentPreview: row.content_preview === null || row.content_preview === undefined
+      ? null
+      : String(row.content_preview),
     retrievalCount: Number(row.retrieval_count ?? 0),
     lastRetrievedAt: row.last_retrieved_at === null || row.last_retrieved_at === undefined
       ? null

--- a/src/store/gc.ts
+++ b/src/store/gc.ts
@@ -3,6 +3,7 @@ import { getDb, withClientTransaction } from './database.js';
 import type { DbConnection } from './database.js';
 import * as repo from './repository.js';
 import { pruneTombstones } from './tombstones.js';
+import { FORGET_REASON_DUPLICATE } from './forget-log.js';
 import { getAccessSummary, KnowledgeAccessSummary } from './access-feedback.js';
 import { carriesNothingNew, KnowledgePayload } from './knowledge-writer.js';
 import { CommitChange, KnowledgeCategory, KnowledgeItem } from '../core/types.js';
@@ -324,7 +325,13 @@ export async function applyKnowledgeGc(
         const summary = access.get(candidate.itemId);
         await repo.deleteKnowledgeItem(candidate.itemId, tx, {
           policy: 'gc:purge',
+          // The code is what a query groups by; `reason` stays the human sentence beside it.
+          // Duplicate collection is currently the only rule that purges — a second one adds a
+          // code rather than another sentence nothing can aggregate.
+          reasonCode: FORGET_REASON_DUPLICATE,
           reason: candidate.reason,
+          // Previously recoverable only by parsing it back out of `Duplicate of <id>`.
+          mergedIntoId: candidate.duplicateOfId ?? null,
           retrievalCount: summary?.retrievalCount ?? 0,
           lastRetrievedAt: summary?.lastRetrievedAt ?? null,
           bytes: candidate.beforeBytes,

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -4,7 +4,13 @@ import { getDb, withClientTransaction } from './database.js';
 import type { DbConnection } from './database.js';
 import * as schema from './schema.js';
 import { recordTombstone } from './tombstones.js';
-import { FORGET_LOG_POLICY_MANUAL, recordForgetLogEntry } from './forget-log.js';
+import {
+  FORGET_LOG_POLICY_MANUAL,
+  FORGET_REASON_MANUAL,
+  recordForgetLogEntry,
+  type ForgetReasonCode,
+} from './forget-log.js';
+import { MAX_PREVIEW_CHARS, truncateText } from '../core/token-budget.js';
 import { normalizeConflictKey, normalizeConflictScope } from './conflicts.js';
 import {
   Project,
@@ -586,7 +592,10 @@ export async function createKnowledgeCommit(
  */
 export type ForgetContext = {
   policy?: string;
+  reasonCode?: ForgetReasonCode;
   reason?: string;
+  /** The survivor, when this item was collected as a duplicate of another. */
+  mergedIntoId?: string | null;
   retrievalCount?: number;
   lastRetrievedAt?: string | null;
   bytes?: number | null;
@@ -629,7 +638,12 @@ export async function deleteKnowledgeItem(
         originRepo: doomed.originRepo ?? null,
         deletedAt,
         policy: forget?.policy ?? FORGET_LOG_POLICY_MANUAL,
+        reasonCode: forget?.reasonCode ?? FORGET_REASON_MANUAL,
         reason: forget?.reason ?? 'Deleted without a recorded reason',
+        mergedIntoId: forget?.mergedIntoId ?? null,
+        // Bounded on purpose: enough to judge the decision, not so much that the audit trail
+        // undoes the reclamation the collection was for.
+        contentPreview: truncateText(doomed.content ?? '', MAX_PREVIEW_CHARS),
         retrievalCount: forget?.retrievalCount ?? observed?.retrievalCount ?? 0,
         lastRetrievedAt: forget?.lastRetrievedAt ?? observed?.lastRetrievedAt ?? null,
         ageDays: daysBetween(doomed.updatedAt, deletedAt),

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -90,7 +90,24 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * open. The number is a changelog position, not a claim about this table, so it moves freely --
  * what must not move is an already-published level's meaning.
  */
-export const KNOWL_MIGRATION_LEVEL = 7;
+/*
+ * Level 8 widens `knowledge_forget_log` with `reason_code`, `merged_into_id` and
+ * `content_preview` -- the rule that fired as a groupable code, the item that absorbed a
+ * duplicate, and a bounded snapshot of what was destroyed. Three nullable-or-defaulted columns,
+ * no backfill: rows written at level 6 keep `reason_code` at its `'unspecified'` default and
+ * carry no survivor or snapshot, because neither was recorded at the time.
+ *
+ * A level of its own rather than an amendment of 6, for exactly the reason 6 could not amend 5:
+ * 6 has shipped on main, so a store already stamped at it skips `SCHEMA_STATEMENTS` entirely,
+ * never gets these columns, and then fails every insert into the table -- inside the single
+ * transaction `applyKnowledgeGc` runs, taking the whole collection run down with it.
+ *
+ * It is 8 rather than 7 because `cloud_published` took 7 while this branch was open, and two
+ * branches claiming one level is worse than a merge conflict: both compile, both stamp the same
+ * `application_id`, and whichever migrates first tells the other's gate there is nothing to do --
+ * so the second table is silently never created on any store the first one touched.
+ */
+export const KNOWL_MIGRATION_LEVEL = 8;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/tests/store/forget-log.test.ts
+++ b/tests/store/forget-log.test.ts
@@ -3,13 +3,15 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
-import { closeDb, getDb, initDb } from '../../src/store/database.js';
+import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
+import { bootstrapSchema } from '../../src/store/bootstrap.js';
 import * as repo from '../../src/store/repository.js';
 import { recordKnowledgeAccess } from '../../src/store/access-feedback.js';
 import { applyKnowledgeGc } from '../../src/store/gc.js';
 import { listForgetLog, pruneForgetLog } from '../../src/store/forget-log.js';
 import { listTombstones, pruneTombstones } from '../../src/store/tombstones.js';
 import { exportKnowledge } from '../../src/store/portability.js';
+import { MAX_PREVIEW_CHARS } from '../../src/core/token-budget.js';
 
 const ROOT = path.resolve('./.knowl-forget-log-test');
 
@@ -76,6 +78,93 @@ describe('forget log', () => {
   // The whole point of a separate table. Tombstones prune at 90 days on every GC run because a
   // tombstone older than an export round has no job left; a forget-log row's job is to still be
   // there months later when somebody asks whether a threshold was ever right.
+  /**
+   * The three fields Lethe's `forget_log.py` (MIT) carries and a first pass built from its README
+   * did not: a groupable code, the survivor as a column, and a snapshot of what went. None of the
+   * three is visible in that README.
+   */
+  it('names the rule in a code and the survivor in a column, not only in a sentence', async () => {
+    const { first, second } = await seedDuplicatePair(projectId, 'Absorbed fact', 'Collapsed into its twin.');
+    await applyKnowledgeGc(projectId);
+
+    const [entry] = await listForgetLog();
+    const survivor = entry.itemId === first.id ? second.id : first.id;
+
+    // Groupable without parsing English.
+    expect(entry.reasonCode).toBe('gc:duplicate');
+    // Followable without parsing English.
+    expect(entry.mergedIntoId).toBe(survivor);
+    expect(entry.reason).toContain(survivor);
+  });
+
+  it('keeps a snapshot of what was destroyed, since the item itself is gone', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Vanished', content: 'The body nobody can read back afterwards.',
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    const [entry] = await listForgetLog();
+    expect(entry.contentPreview).toBe('The body nobody can read back afterwards.');
+    expect(await repo.getKnowledgeItem(item.id)).toBeNull();
+  });
+
+  it('bounds that snapshot so the audit trail cannot undo the reclamation', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Enormous', content: 'x'.repeat(5000),
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    const [entry] = await listForgetLog();
+    expect(entry.contentPreview!.length).toBeLessThanOrEqual(MAX_PREVIEW_CHARS);
+    // The real size is still recorded, so bounding the preview loses no information about cost.
+    expect(entry.bytes).toBe(5000);
+  });
+
+  it('defaults the code rather than leaving a delete uncategorised', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Uncoded', content: 'Deleted with no context at all.',
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    expect((await listForgetLog())[0].reasonCode).toBe('delete:unspecified');
+  });
+
+  /**
+   * The upgrade path, which is the whole reason this is level 7 rather than an amendment of 6.
+   * A store created at level 6 already has the table, so `CREATE TABLE IF NOT EXISTS` does
+   * nothing for it — without the ALTER pass the columns exist only on databases created after
+   * this change, and every older store fails its next delete inside the single transaction
+   * `applyKnowledgeGc` runs, taking the whole collection run with it.
+   */
+  it('adds its columns to a store that already had the level-6 table', async () => {
+    const db = getDb() as any;
+    // Reproduce a level-6 store: the table as it shipped, without the detail columns.
+    await db.run(sql`DROP TABLE knowledge_forget_log`);
+    await db.run(sql`CREATE TABLE knowledge_forget_log (
+      id TEXT PRIMARY KEY, knowledge_item_id TEXT NOT NULL, title TEXT NOT NULL,
+      category TEXT NOT NULL, tier TEXT, status TEXT, origin_repo TEXT,
+      deleted_at TEXT NOT NULL, policy TEXT NOT NULL, reason TEXT NOT NULL,
+      retrieval_count INTEGER NOT NULL DEFAULT 0, last_retrieved_at TEXT,
+      age_days INTEGER, bytes INTEGER
+    )`);
+    // Rewind the gate too, or none of this runs: `bootstrapSchema` skips `SCHEMA_STATEMENTS` and
+    // every ensure-pass when the stamp already reads current, which is the whole mechanism level 7
+    // exists to trip. Without this the test passes a no-op and proves nothing.
+    await db.run(sql`PRAGMA application_id = 6`);
+
+    await bootstrapSchema(getClient());
+
+    // A delete against the upgraded store succeeds and records the new detail.
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Post-upgrade', content: 'Deleted after the columns landed.',
+    });
+    await repo.deleteKnowledgeItem(item.id);
+
+    const [entry] = await listForgetLog();
+    expect(entry.reasonCode).toBe('delete:unspecified');
+    expect(entry.contentPreview).toBe('Deleted after the columns landed.');
+  });
+
   it('outlives the tombstone that pruning removes', async () => {
     await seedDuplicatePair(projectId, 'Prunable fact', 'Collected then forgotten about.');
     await applyKnowledgeGc(projectId);

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -44,6 +44,12 @@ const SCHEMA_PINS: Record<number, string> = {
   // rather than 5 because two other additive levels reached main first; the fingerprint is
   // recomputed here rather than carried over, since a level-7 schema holds all three tables.
   7: 'b847bdb205a1ee63b1ff3b612c794c89',
+  // 8 widens `knowledge_forget_log` with `reason_code`, `merged_into_id` and `content_preview`.
+  // A level of its own rather than an amendment of 6: 6 shipped on main, so a store already
+  // stamped at it skips `SCHEMA_STATEMENTS` entirely and would never get these columns --
+  // the same failure mode that made the forget log claim 6 instead of 5 in the first place.
+  // 8 rather than 7 because `cloud_published` took 7 while this branch was open.
+  8: 'e96218e9fbe0594d73078033d718af4f',
 };
 
 let root: string;


### PR DESCRIPTION
Follow-up to #45. I had built that PR from a paragraph of Lethe's README; this is what its actual `forget_log.py` (MIT) carries that the table did not. Reading the implementation first would have put these in the original.

It also builds on `2466d14` rather than around it — the reader you added is what makes two of these three worth having at all.

## What this adds

**`reason_code`, a closed set beside the sentence.** Lethe keeps its reasons as module constants and says why: they are *"part of the public ForgetLog contract — anyone reading the log needs to know what the strings mean."* `reason` alone is prose, and prose cannot be aggregated: "how many were merged versus collected cold" should be a `GROUP BY`, not a regex over English. A new collection rule now adds a code rather than another ungroupable sentence.

In the text listing the sentence still leads and the code follows it. Your existing format assertion was right and I initially broke it — a tally happens over `--json` or SQL, where the field already is; a human reading the list wants the sentence that names the item.

**`merged_into_id`.** Duplicate collection recorded the survivor only inside `Duplicate of <id>`, so following it meant parsing it back out. GC already carried `duplicateOfId` on the candidate and dropped it. `knowl forget-log` now prints it.

**`content_preview`.** Lethe stores content because *"the item itself may have been physically removed by the time anyone reads the log"* — exactly the case here, since a purge is a hard delete. Bounded at `MAX_PREVIEW_CHARS` so the audit trail cannot undo the reclamation the collection was for; `bytes` still records the real size, so bounding the preview loses nothing about cost. The commit log still holds the whole `before` item — this is the copy in the row someone actually reads.

Deliberately **not** taken: Lethe's `ForgetLog` ABC with pluggable in-memory and SQLite backends. That exists because its benchmark harness needs both; Knowl has one store.

## Level 7, and the ALTER pass that makes it real

A level of its own rather than an amendment of 6, for the reason 6 could not amend 5: **6 has shipped**, so a store already stamped at it skips `SCHEMA_STATEMENTS` entirely.

That has a second consequence I nearly missed. `CREATE TABLE IF NOT EXISTS` is a no-op on a store that already has the table, so the columns would have existed only on databases created after this change — and every older store would fail its next delete, inside the single transaction `applyKnowledgeGc` runs, taking the whole collection run down. `ensureForgetLogColumns` adds them by `ALTER`, in the same shape as `ensureQualityColumns`.

Nothing is backfilled: a row written at level 6 has no survivor and no snapshot, and `reason_code` falls to `'unspecified'`, which is the honest description of a deletion recorded before the codes existed rather than a guess at which rule fired.

## Verification

- Full suite **268 files, 2,392 tests, 0 failures**; lint 0 errors, 27 warnings (unchanged baseline); typecheck and build clean.
- Five new tests: the code and survivor as columns, the snapshot, its bound, the default code on a context-free delete, and the **level-6 → 7 upgrade path** — which rewinds `application_id` first, because `bootstrapSchema` skips every pass when the stamp already reads current, and a migration test that cannot fail proves nothing.
- The upgrade test was mutation-checked: removing the `ensureForgetLogColumns` call fails it.