### PR TITLE
Release 4.0.0: retraction, an agent-visible cloud surface, and a tool surface that explains itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,118 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## 4.0.0 — 2026-08-09
+
+Knowl learns to work with a team. Forty-five commits, almost all of them one feature: a cloud
+client that lets several checkouts share one body of project memory, and lets an agent on any of
+them answer from what a colleague wrote.
+
+**Why a major.** Nothing here breaks: `KNOWL_SCHEMA_VERSION` is held at `1`, the migration to
+level 7 is additive, and every existing command behaves as it did. The number marks the change in
+what Knowl *is* — memory that had never left the machine now has a way to leave it — rather than a
+compatibility break you need to plan around.
+
+### Knowl Cloud
+
+A workspace is a shared store several repositories publish into. The commands:
+
+```
+knowl login                                 # device-code flow, per-host credentials
+knowl cloud connect                         # point this repo at a workspace; publishes nothing
+knowl publish --category decision --apply   # stage: any time, any branch
+knowl cloud push                            # send: only from an up-to-date default branch
+knowl cloud pull                            # fetch team knowledge into the local replica
+knowl cloud status                          # what is connected, staged, and holding it up
+```
+
+Team knowledge lands in a **per-workspace replica** under `knowlHome()/cloud/`, with its sync
+watermark stored inside the replica rather than beside it — so deleting the replica is a complete
+reset, and a watermark can never outlive the data it describes. Queries read the replica directly
+and attribute every row to the repository that wrote it, so a fact from someone else's codebase
+never reads as a fact about yours.
+
+**Retrieval never waits on the network.** A query answers from the local replica immediately and a
+refresh runs in the background; when something new has landed, the next query carries a
+`TEAM UPDATE:` notice telling the agent it may want to look again. There is no path where a remote
+call sits on the retrieval hot path.
+
+### Publishing is two-phase, and the gate is the interesting half
+
+`knowl publish` *stages* an intent and sends nothing. The network push happens only once the code
+an atom describes is on the default branch, and only from a checkout that is not behind its remote.
+
+Both halves are deliberate. An atom describing code only you have would be false for everyone else,
+and being behind the remote is indistinguishable from the code having been deleted — so the client
+stays silent rather than reporting a local truth as a shared one. Only code-coupled atoms are
+gated: "we chose Postgres" is true when decided and pushes immediately. The gate keys on evidence,
+never on category, and it lives entirely in the client because only the client can see the graph.
+
+### `knowl cloud retract` takes something back
+
+```
+knowl cloud retract <id> --reason "leaked a customer name"
+```
+
+The workspace copy is deleted and a tombstone written in one transaction; the id can never be
+published again, and teammates lose the atom on their next sync. This is for knowledge that must
+not remain readable. Knowledge that merely stopped being true should be superseded, which keeps
+the lineage.
+
+**It is the one upward path with no branch gate.** Publishing and drift reports are gated because
+they assert something about code only you have; a removal is true from every vantage, and the case
+that brings you here is a secret sitting in a shared workspace right now. Answering that with
+"switch to the default branch and pull first" would hold the leak open for the length of a rebase.
+
+`expectedVersion` comes from the local ledger, so if a colleague edited the atom after you
+published it the retraction stops with a conflict rather than destroying an edit you never read.
+
+### An agent can see what is shared
+
+New MCP tool `knowl_cloud`, offered only to a repository that is connected. `status` reports the
+connection, your role, what is staged and what a push is waiting for, with no network call.
+`stage` records an intent and is a dry run unless asked otherwise.
+
+It stops there deliberately: sending, retracting, pulling, connecting and signing in stay yours to
+run, and the agent relays the command instead. Both directions across the network are irreversible,
+and neither is a decision to make on an agent's initiative.
+
+### Every MCP tool now says when to use it
+
+The guidance card was shrunk on the assumption that `tools/list` already teaches routing. Auditing
+all 31 tools showed several that never did — `knowl_context` described what it composed but not
+when to reach for it, and left two arguments undocumented; `knowl_conflicts` said to use it "when a
+conflict must be resolved" without saying how you would learn one exists. Nine tools gained a
+trigger, and the batch writer now says its fields mean what `knowl_store`'s mean rather than
+repeating ten descriptions.
+
+### Also in this release
+
+- **`knowl gc` records why an item was destroyed**, not just that it was, in a forget log with a
+  level of its own, an owner, and a way to read it.
+- **Standing knowledge promotes on observed use**, because the feedback channel it previously
+  depended on never fired.
+- **Three live prompt injections closed** in the untrusted-content gate — cases the gate drove but
+  could not itself see — with the containment guarantee now pinned by a test so a new formatter
+  cannot outgrow it.
+- **`knowl doctor` reports cloud connection and replica lag.**
+
+### The hosted service is not reachable yet
+
+The cloud client ships to every user whether they connect or not, which is deliberate and matches
+`gh` and `vercel`. **But there is no deployed server behind the default host.** `knowl login` and
+`knowl cloud connect` will fail with a connection error until there is; everything above was
+verified against a local server, including a two-checkout run proving an atom written on one
+machine reaching another. Point `KNOWL_API_HOST` at your own instance if you are running one.
+
+Related, and worth knowing before you rely on it: the production browser approval path has never
+been exercised, and retrieval counts do not yet flow upward, so team-scale decay has no input.
+
+### Upgrading
+
+Nothing to do. The migration to level 7 adds one table (`cloud_published`) and runs on first use;
+`KNOWL_SCHEMA_VERSION` stays at `1`, so a store written by this version is still readable by the
+last. If you do not connect to a workspace, nothing in this release changes how Knowl behaves.
+
 ## 3.4.1 — 2026-08-08
 
 ### The guidance check is line-ending agnostic

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ loopback binding is the privacy boundary: do not put it behind a public proxy or
 ### Everything else
 
 <!-- generated:tool-count -->
-**27 MCP tools** (plus 3 more when transcript search is on)
+**27 MCP tools** (plus 3 when transcript search is on, and 1 when connected to a cloud workspace)
 <!-- /generated:tool-count -->
 and two resource URIs · the
 **complete CLI**, from `knowl status` to `knowl audit` · a **read-only integrity audit** ·

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -650,6 +650,7 @@ The replica is a replica: deleting it is always safe, and the next pull rebuilds
 | `knowl cloud pull` | Fetch team knowledge into the local replica |
 | `knowl publish [--id <ids...>] [--category <list>] [--apply]` | Stage knowledge for publication. Dry run without `--apply` |
 | `knowl cloud push` | Send staged knowledge, once its code is on the default branch |
+| `knowl cloud retract <id> --reason <text>` | Remove a published atom for good. Works from any branch |
 | `knowl cloud status` | What is connected, how stale the replica is, and what is staged |
 
 ### Pointing at a different server
@@ -694,6 +695,42 @@ indistinguishable from the code having been deleted.
 Only atoms this repository wrote can be published. A reader is refused before anything is sent.
 A version conflict names the atom and stops rather than overwriting; a detected secret fails the
 whole batch and is never retried in altered form.
+
+#### Taking something back
+
+```
+knowl cloud retract <id> --reason "leaked a customer name"
+```
+
+`knowl cloud retract` removes a published atom from the workspace. The server deletes the row and
+writes a tombstone in one transaction, then refuses every later publish of that id; teammates lose
+it on their next sync. It cannot be undone, and the id can never be used again — this is for
+knowledge that must not remain readable, not for knowledge that stopped being true. Supersede that
+instead, which keeps the lineage.
+
+**It is the one upward path with no branch gate, deliberately.** Publishing and drift reports are
+gated because they assert something about code only you have. A removal is true from every vantage,
+and the case that brings you here is a secret sitting in a shared workspace right now — answering
+that with "switch to the default branch and pull first" would hold the leak open for the length of
+a rebase.
+
+`--reason` is required and stored on the tombstone. `expectedVersion` comes from the local ledger,
+so if a colleague edited the atom after you published it the retraction stops with a conflict
+rather than destroying an edit you never read.
+
+#### From an agent
+
+Once a repository is connected, the MCP server offers one more tool:
+
+- **`knowl_cloud`** — `action: "status"` reports the connection, your role, how many atoms are
+  staged, when the replica last synced, and what a push is currently waiting for. It touches no
+  network, so it answers instantly and offline. `action: "stage"` is `knowl publish`: it records
+  an intent and is a dry run unless you pass `apply: true`.
+
+It stops there deliberately. Sending, pulling, connecting and signing in stay yours to run —
+sending because it is irreversible and gated on a branch state the agent cannot see the whole of,
+the other three because two need a browser and pulling already happens on its own. Asked to send,
+the agent relays the command instead.
 
 ### Staying current
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "3.4.1",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -20,7 +20,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
 import { DEFAULT_PRESET_ID, VECTOR_PRESETS } from '../src/core/vector-profile.js';
 import { stripManagedKnowlGuidance } from '../src/core/agents-guidance.js';
 import { renderManagedKnowlGuidanceSection } from '../src/core/knowl-guidance.js';
@@ -38,7 +38,7 @@ function contextLabel(tokens: number): string {
 /** Region id -> [file, body]. */
 const regions: Record<string, [string, string]> = {
   'tool-count': [README, [
-    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} more when transcript search is on)`,
+    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, and ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace)`,
   ].join('\n')],
 
   'embedding-presets': [REFERENCE, [
@@ -75,7 +75,7 @@ for (const [id, [file, body]] of Object.entries(regions)) {
  * happened three times before the counts were reconciled by hand.
  */
 const referenceText = fs.readFileSync(REFERENCE, 'utf8');
-for (const tool of [...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS]) {
+for (const tool of [...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ...CLOUD_TOOL_DEFINITIONS]) {
   if (!referenceText.includes(`\`${tool.name}\``)) {
     failures.push(`docs/reference.md documents no tool named ${tool.name}`);
   }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -46,6 +46,7 @@ import { defaultApiHost, runLogin, runLogout } from '../cloud/login.js';
 import { runConnect } from '../cloud/connect.js';
 import { runPull } from '../cloud/pull.js';
 import { pushStaged, stagePublish } from '../cloud/publish.js';
+import { retractItem } from '../cloud/retract.js';
 import { cloudStatus, formatCloudStatus } from '../cloud/status.js';
 import { verifyCustomModel } from '../ai/model-probe.js';
 import { announceProfileChange, shadowedByPresetNotice } from './config/profile-change.js';
@@ -672,7 +673,7 @@ program
       console.log(result.applied
         ? `Staged ${result.items.length} item(s). Run knowl cloud push to send them.`
         : `${result.items.length} item(s) would be staged. Re-run with --apply.`);
-      if (result.applied) console.log('Publishing cannot be undone from here yet.');
+      if (result.applied) console.log('Once pushed, removing it again takes knowl cloud retract, which is irreversible.');
     } catch (error: any) {
       console.error(`Publish failed: ${error.message}`);
       process.exit(1);
@@ -794,6 +795,48 @@ cloudCommand
       }
     } catch (error: any) {
       console.error(`Push failed: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+cloudCommand
+  .command('retract <id>')
+  .description('Remove a published atom from the workspace. Irreversible, and works from any branch')
+  .requiredOption('--reason <text>', 'Why it is being removed; stored on the tombstone')
+  .action(async (id, options) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const config = await loadConfig(root);
+      const result = await retractItem({ projectRoot: root, config, itemId: id, reason: options.reason });
+
+      if (result.status === 'not-connected') {
+        console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
+        process.exit(1);
+      }
+      if (result.status === 'not-logged-in') {
+        console.error('Not signed in. Run knowl login first.');
+        process.exit(1);
+      }
+      if (result.status === 'forbidden') {
+        console.error(`You are a ${result.role} in this workspace, which cannot remove knowledge.`);
+        process.exit(1);
+      }
+      if (result.status === 'not-published') {
+        console.error(`${id} was never pushed from this machine, so there is nothing in the workspace to remove.`);
+        process.exit(1);
+      }
+      if (result.status === 'conflict') {
+        console.error(
+          `${id} changed in the workspace after this machine published it (now version ${result.currentVersion}).`,
+        );
+        console.error('Run knowl cloud pull, read what it says now, and retract again if it should still go.');
+        process.exit(1);
+      }
+
+      console.log(`Removed ${id} from the workspace. Teammates lose it on their next sync.`);
+      console.log('This cannot be undone, and the id can never be published again.');
+    } catch (error: any) {
+      console.error(`Retract failed: ${error.message}`);
       process.exit(1);
     }
   });

--- a/src/cloud/ledger.ts
+++ b/src/cloud/ledger.ts
@@ -137,6 +137,27 @@ export async function recordPushed(
 }
 
 /**
+ * Record that the server accepted a retraction.
+ *
+ * `remote_version` is cleared with it, and that is the load-bearing half. The row is kept rather
+ * than deleted so `knowl cloud status` can say this machine retracted the atom instead of
+ * silently forgetting it ever published one -- but a version left behind would be a claim about
+ * a server-side row that no longer exists, and the next `knowl publish --id` naming this atom
+ * would send it as `expectedVersion` and be refused by a tombstone it could not see.
+ *
+ * Re-staging deliberately clears `retracted_at` (see `restageForPublish`): retracting is not a
+ * ban on the id, it is the removal of what was there. The server disagrees and refuses the
+ * republish, which is the safer of the two and the one that wins.
+ */
+export async function recordRetracted(itemId: string, workspace: string): Promise<void> {
+  await getClient().execute({
+    sql: `UPDATE cloud_published SET retracted_at = ?, remote_version = NULL
+          WHERE item_id = ? AND remote_workspace = ?`,
+    args: [new Date().toISOString(), itemId, workspace],
+  });
+}
+
+/**
  * The version to send as `expectedVersion`, or null on a first publish.
  *
  * Scoped to the workspace because one atom may be published to more than one, and a version

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -44,33 +44,59 @@ export async function stagePublish(input: {
 
   await initDb(input.projectRoot);
   try {
-    const { items, skippedForeign } = await selectOwnedItems({
-      repoName: pointer.repo,
-      categories: input.categories,
-      ids: input.ids,
-    });
-
-    if (input.apply && items.length > 0) {
-      // Swallowed on purpose, and only here. The branch is what the push's refusal quotes back,
-      // not what it decides on -- `checkPublishGate` re-reads git itself and reports being
-      // unable to run it as its own verdict. Failing to record an intent because git is missing
-      // would refuse the one half of publishing that is safe from every vantage.
-      let branch: string | null = null;
-      try { branch = currentBranchOf(input.projectRoot); } catch { branch = null; }
-
-      // Naming ids is a deliberate act about items the caller has in hand, and it is the only
-      // way to send a correction, so it re-stages what was already pushed. A category sweep
-      // means "publish what is not published yet" and leaves those alone -- otherwise every
-      // `knowl publish --category decision --apply` would re-send the whole category, spending a
-      // version bump and a server-side embedding job per atom on identical content.
-      const stage = input.ids?.length ? restageForPublish : stageForPublish;
-      await stage(items.map(item => item.id), pointer.workspaceId, branch);
-    }
-
-    return { status: 'staged', items, applied: Boolean(input.apply) && items.length > 0, skippedForeign };
+    return await stageInContext(input, pointer);
   } finally {
     await closeDb();
   }
+}
+
+/**
+ * The same staging, for a caller that already holds a database context -- an MCP request.
+ *
+ * `stagePublish` owns the process-wide context and must never be reached from one: its
+ * `closeDb` would leave every LATER tool call in that server with no database. See constraint
+ * `defde27f6f234535`.
+ */
+export async function stagePublishInRequest(input: {
+  projectRoot: string;
+  config: ProjectConfig;
+  ids?: string[];
+  categories?: KnowledgeCategory[];
+  apply?: boolean;
+}): Promise<StageResult> {
+  const pointer = input.config.cloud;
+  if (!pointer) return { status: 'not-connected' };
+  return stageInContext(input, pointer);
+}
+
+async function stageInContext(
+  input: { projectRoot: string; ids?: string[]; categories?: KnowledgeCategory[]; apply?: boolean },
+  pointer: NonNullable<ProjectConfig['cloud']>,
+): Promise<StageResult> {
+  const { items, skippedForeign } = await selectOwnedItems({
+    repoName: pointer.repo,
+    categories: input.categories,
+    ids: input.ids,
+  });
+
+  if (input.apply && items.length > 0) {
+    // Swallowed on purpose, and only here. The branch is what the push's refusal quotes back,
+    // not what it decides on -- `checkPublishGate` re-reads git itself and reports being
+    // unable to run it as its own verdict. Failing to record an intent because git is missing
+    // would refuse the one half of publishing that is safe from every vantage.
+    let branch: string | null = null;
+    try { branch = currentBranchOf(input.projectRoot); } catch { branch = null; }
+
+    // Naming ids is a deliberate act about items the caller has in hand, and it is the only
+    // way to send a correction, so it re-stages what was already pushed. A category sweep
+    // means "publish what is not published yet" and leaves those alone -- otherwise every
+    // `knowl publish --category decision --apply` would re-send the whole category, spending a
+    // version bump and a server-side embedding job per atom on identical content.
+    const stage = input.ids?.length ? restageForPublish : stageForPublish;
+    await stage(items.map(item => item.id), pointer.workspaceId, branch);
+  }
+
+  return { status: 'staged', items, applied: Boolean(input.apply) && items.length > 0, skippedForeign };
 }
 
 export type PushResult =

--- a/src/cloud/retract.ts
+++ b/src/cloud/retract.ts
@@ -1,0 +1,96 @@
+import type { ProjectConfig } from '../core/types.js';
+import { closeDb, initDb } from '../store/database.js';
+import { createCloudApi, type CloudApi } from './api-client.js';
+import { publishedVersion, recordRetracted } from './ledger.js';
+import { readSyncState } from './sync-state.js';
+import { withTeamStore } from './team-store.js';
+import { ensureAccessToken } from './token.js';
+
+export type RetractResult =
+  | { status: 'retracted' }
+  | { status: 'not-connected' }
+  | { status: 'not-published' }
+  | { status: 'not-logged-in' }
+  | { status: 'forbidden'; role: string }
+  | { status: 'conflict'; currentVersion: number };
+
+/**
+ * Take a published atom back out of the workspace.
+ *
+ * The server hard-deletes the row and writes a tombstone in one transaction, then refuses every
+ * later publish of that id. Teammates lose it on their next sync, because the feed carries the
+ * deletion as a row of its own. This is the only path that removes something from the team, and
+ * it cannot be undone from either side.
+ *
+ * **Deliberately NOT behind the publish gate, and that is the whole point of the command.**
+ * `checkPublishGate` exists because publishing from a feature branch asserts something about code
+ * only you have, which is false for everyone else. Removal is the opposite act: it is true from
+ * every vantage, and the case that brings someone here is a leaked name or a secret sitting in a
+ * shared workspace right now. Answering that with "switch to the default branch and pull first"
+ * would hold the leak open for the length of a rebase. Staging is ungated for the mirror-image
+ * reason -- an intent is safe to record from anywhere -- and this is safe to *send* from anywhere.
+ *
+ * The ledger check still comes first: an atom this machine never pushed has no server-side row,
+ * so there is nothing to retract and sending the user to log in could not help.
+ *
+ * `expectedVersion` comes from the ledger rather than from a fetch. It is what this machine last
+ * put there, so a mismatch means someone edited the atom after this machine published it -- and
+ * deleting an edit you never read is exactly what the version is for. That surfaces as `conflict`
+ * and is never retried: re-reading is the caller's job, and a retry loop here would delete the
+ * correction on the second pass.
+ */
+export async function retractItem(input: {
+  projectRoot: string;
+  config: ProjectConfig;
+  itemId: string;
+  reason: string;
+  api?: CloudApi;
+}): Promise<RetractResult> {
+  const pointer = input.config.cloud;
+  if (!pointer) return { status: 'not-connected' };
+
+  await initDb(input.projectRoot);
+  try {
+    const remoteVersion = await publishedVersion(input.itemId, pointer.workspaceId);
+    // Null covers both "never staged" and "staged but never pushed". Neither has a server-side
+    // row, and a retraction for one would be a request about nothing.
+    if (remoteVersion === null) return { status: 'not-published' };
+
+    // The same cheap local refusal `pushStaged` makes: the role rides on every sync response, so
+    // a reader is refused without a round trip that could only end in 403. A replica with no role
+    // recorded is unknown rather than denied, and the server decides.
+    const role = await withTeamStore(pointer.workspaceId, input.projectRoot, () => readSyncState())
+      .then(state => state?.role ?? null)
+      .catch(() => null);
+    if (role === 'reader') return { status: 'forbidden', role };
+
+    const api = input.api ?? createCloudApi({ apiHost: pointer.apiHost });
+    const credential = await ensureAccessToken({
+      apiHost: pointer.apiHost,
+      refresh: refreshToken => api.refresh(refreshToken),
+    });
+    if (!credential) return { status: 'not-logged-in' };
+
+    const { outcome } = await api.updateItem({
+      workspaceId: pointer.workspaceId,
+      accessToken: credential.accessToken,
+      itemId: input.itemId,
+      body: { op: 'delete', expectedVersion: remoteVersion, reason: input.reason },
+    });
+
+    // A missing atom and a moved one both come back as `conflict` (the server sends
+    // `currentVersion: 0` for the first), and both mean the same thing here: re-read before
+    // writing. The ledger is left alone, so `knowl cloud status` keeps saying this machine
+    // published it -- which is still true.
+    if (outcome?.status === 'conflict') {
+      return { status: 'conflict', currentVersion: outcome.currentVersion };
+    }
+
+    // Only a confirmed removal updates the ledger. Anything else leaves the local record matching
+    // what is actually on the server.
+    await recordRetracted(input.itemId, pointer.workspaceId);
+    return { status: 'retracted' };
+  } finally {
+    await closeDb();
+  }
+}

--- a/src/cloud/status.ts
+++ b/src/cloud/status.ts
@@ -38,6 +38,29 @@ export async function cloudStatus(projectRoot: string, config: ProjectConfig): P
     await closeDb();
   }
 
+  return composeStatus(pointer, projectRoot, staged);
+}
+
+/**
+ * The same report, for a caller that already holds a database context -- an MCP request.
+ *
+ * `cloudStatus` above owns the process-wide context and must never be reached from one: its
+ * `closeDb` would leave every LATER tool call in that server with no database, surfacing in a
+ * different request from the one that caused it. See constraint `defde27f6f234535`.
+ */
+export async function cloudStatusInRequest(projectRoot: string, config: ProjectConfig): Promise<CloudStatus> {
+  const pointer = config.cloud;
+  if (!pointer) return { connected: false };
+
+  // The caller's context answers this; nothing is opened and nothing is closed.
+  return composeStatus(pointer, projectRoot, await listStaged(pointer.workspaceId));
+}
+
+async function composeStatus(
+  pointer: NonNullable<ProjectConfig['cloud']>,
+  projectRoot: string,
+  staged: Awaited<ReturnType<typeof listStaged>>,
+): Promise<CloudStatus> {
   // A replica that cannot be opened at all reads as "never synced" rather than failing the
   // whole report -- the same choice `cloudDoctorChecks` makes, for the same reason.
   const state = await withTeamStore(pointer.workspaceId, projectRoot, () => readSyncState())
@@ -86,10 +109,11 @@ export function formatCloudStatus(status: CloudStatus): string {
   lines.push(status.gate.ok
     ? '           Ready to send. Run knowl cloud push.'
     : `           ${status.gate.detail}`);
-  // Only while something is staged, so the warning still means something when it appears. The
-  // server has a retire verb and no client path wires it, so a confirmation that omits this is
-  // a confirmation that misleads.
-  lines.push('           Publishing cannot be undone from here yet.');
+  // Only while something is staged, so the warning still means something when it appears. It no
+  // longer says publishing cannot be undone -- `knowl cloud retract` wires the server's delete
+  // verb -- but undoing is a hard delete plus a tombstone that bars the id forever, which is a
+  // different thing from a mistake being cheap.
+  lines.push('           Sending is irreversible: knowl cloud retract removes an atom for good.');
 
   return lines.join('\n');
 }

--- a/src/cloud/sync-contract.ts
+++ b/src/cloud/sync-contract.ts
@@ -168,16 +168,26 @@ export type PublishOutcome =
   | { id: string; status: 'tombstoned'; deletedAt: string };
 
 /**
- * The two verbs this client sends on the update endpoint, and their asymmetry is deliberate.
+ * The three verbs this client sends on the update endpoint, and their asymmetry is deliberate.
  *
  * `needsReview` takes no version and bumps none: a drift report is an observation about an atom,
  * not a revision of it, so a report is never dropped for arriving mid-edit. `reviewed` is a
  * positive claim about specific content, so it takes `expectedVersion` and refuses to vouch for
  * text the caller did not read.
+ *
+ * `delete` is the destructive one and takes `expectedVersion` for the sharper version of the same
+ * reason: deleting an atom a colleague edited since you read it destroys a correction you never
+ * saw. The server hard-deletes the row and writes a tombstone in one transaction, then refuses
+ * every later publish of that id, so this cannot be undone from either side. `reason` is required
+ * and stored on the tombstone -- a deletion nobody can explain later is its own problem.
+ *
+ * This is a strict subset of the server's patch union, which also carries `transfer`. A verb
+ * absent here is one this client has no path for, not one the server lacks.
  */
 export type UpdateItemBody =
   | { op: 'needsReview'; reason: string; observedAtCommit?: string }
-  | { op: 'reviewed'; expectedVersion: number; sourceCommit: string; note?: string };
+  | { op: 'reviewed'; expectedVersion: number; sourceCommit: string; note?: string }
+  | { op: 'delete'; expectedVersion: number; reason: string };
 
 export type SyncRow =
   | { op: 'upsert'; seq: string; item: SyncAtom }

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -80,6 +80,47 @@ export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
 ];
 
+/**
+ * Registered only when this repo is connected to a cloud workspace.
+ *
+ * One tool rather than four, for the reason `knowl_impact` is one: every registered tool costs
+ * guidance-card space in every session of every user, so a capability earns a name, not a verb.
+ *
+ * It deliberately stops at the local half of publishing. `push` sends to the team and is gated on
+ * default-branch state the agent cannot see the whole of. `retract` exists now and is worse to
+ * call by mistake, not better: it hard-deletes the row and writes a tombstone that bars the id
+ * forever. `connect`, `login` and `pull` are likewise operator actions: two need a browser, and
+ * pulling already happens on its own. Staging is the half that is safe from every vantage, so it
+ * is the half exposed.
+ */
+export const CLOUD_TOOL_DEFINITIONS: ToolDefinition[] = [
+        {
+          name: 'knowl_cloud',
+          description: 'Check this repo\'s cloud workspace connection, or stage knowledge for publication to the team. `status` is local-only and instant -- use it before telling a user anything about what is or is not shared, because sync also runs on its own and the answer changes without you. `stage` records the intent to publish and sends nothing; it is a dry run unless you pass apply. It cannot send, retract, pull, connect or sign in: those are the user\'s to run (`knowl cloud push`, `knowl cloud retract`, `knowl cloud pull`, `knowl cloud connect`, `knowl login`). Relay the command rather than trying to work around it. Both directions are irreversible: a push cannot be recalled except by a retract, and a retract is a hard delete that bars the id forever.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              action: {
+                type: 'string', enum: ['status', 'stage'],
+                description: 'status (default): connection, role, staged count, last sync, and what a push is currently waiting for. stage: record the intent to publish.',
+              },
+              ids: {
+                type: 'array', items: { type: 'string' }, maxItems: 50,
+                description: 'stage only. Item ids to stage, as returned by knowl_query. Naming ids re-stages an atom that was already pushed, which is how a correction is sent; a category sweep deliberately leaves those alone.',
+              },
+              categories: {
+                type: 'array', items: { type: 'string', enum: KNOWLEDGE_CATEGORIES }, maxItems: 20,
+                description: 'stage only. Stage every not-yet-published item in these categories. Ignored when ids is given.',
+              },
+              apply: {
+                type: 'boolean',
+                description: 'stage only. False (the default) reports what would be staged and writes nothing. Only pass true when the user asked for this specific publication -- staging is what a later push sends, and undoing that push means destroying the atom outright.',
+              },
+            },
+          },
+        },
+];
+
 /** Every tool the server always offers, in listing order. */
 export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
@@ -257,7 +298,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
                   required: ['category', 'title', 'content'],
                 },
                 minItems: 1,
-                description: 'Structured knowledge atoms extracted by the MCP client model.',
+                description: 'Structured knowledge atoms extracted by the MCP client model. Every field means exactly what the same field means on knowl_store.',
               },
               commitMessage: {
                 type: 'string',
@@ -269,7 +310,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_decide',
-          description: 'Record a specific project decision directly into the knowledge base without requiring Knowl AI configuration. When this decision reverses or replaces an earlier one, pass that item id as `supersedes` so the superseded decision is retired in the same write; never leave two active decisions contradicting each other. The result reports any decision left active beside this one and the exact call to retire it.',
+          description: 'Record a confirmed project decision -- what was chosen, why, and what was rejected. Use this rather than knowl_store when the reasoning and the alternatives are the point; reasoning is required here and optional there. Record only settled decisions, not options still under discussion. Needs no Knowl AI configuration. When this decision reverses or replaces an earlier one, pass that item id as `supersedes` so the superseded decision is retired in the same write; never leave two active decisions contradicting each other. The result reports any decision left active beside this one and the exact call to retire it.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -374,22 +415,22 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_timeline',
-          description: 'Inspect immutable assertions for one knowledge item when its history is needed.',
-          inputSchema: { type: 'object', properties: { itemId: { type: 'string', minLength: 1 } }, required: ['itemId'] },
+          description: 'Read one item\'s immutable assertion history: what it claimed, when, and what superseded it. Use when memory looks contradictory or you need to know whether a fact changed -- knowl_query answers what it says now, this answers how it got there.',
+          inputSchema: { type: 'object', properties: { itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID, as returned by knowl_query.' } }, required: ['itemId'] },
         },
         {
           name: 'knowl_conflicts',
-          description: 'Inspect active exclusive conflict identities when a conflict must be resolved.',
+          description: 'List active exclusive conflict identities -- keys where two items claim the same thing and only one may be true. Use when a write reports an overlapping item left active, or when memory gives contradictory answers. Resolve with knowl_update, never by storing a third item.',
           inputSchema: { type: 'object', properties: {} },
         },
         {
           name: 'knowl_context',
-          description: 'Compose a diversified token-budgeted context pack.',
+          description: 'Fill an explicit token budget with diversified project context. Use only when you have a budget to fill -- briefing a subagent, or packing a fixed-size prompt. For a specific question use knowl_query instead: this spreads across categories to fill the budget rather than ranking for one subject, so it is deliberately broader and less precise.',
           inputSchema: {
             type: 'object',
             properties: {
-              query: { type: 'string', maxLength: 500 },
-              task: { type: 'string', maxLength: 500 },
+              query: { type: 'string', maxLength: 500, description: 'Words naming the subject to centre the pack on. Omit to pack the project\'s standing context.' },
+              task: { type: 'string', maxLength: 500, description: 'What the context is for, in a phrase. Steers selection when query is broad or absent.' },
               tokenBudget: { type: 'integer', minimum: 100, maximum: MAX_CONTEXT_TOKEN_BUDGET, description: `Token ceiling for the pack, 100-${MAX_CONTEXT_TOKEN_BUDGET}.` },
               explain: { type: 'boolean', description: 'Include excluded-item diagnostics.' },
             },
@@ -398,12 +439,12 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_synthesize',
-          description: 'Create or refresh one deterministic evidence-backed project understanding. This never runs automatically on normal writes.',
-          inputSchema: { type: 'object', properties: { scope: { type: 'string', minLength: 1 } }, required: ['scope'] },
+          description: 'Create or refresh one deterministic evidence-backed project understanding. Use only for a scope the user explicitly asked to have synthesised -- never as background tidy-up, and never to summarise a session. This never runs automatically on normal writes.',
+          inputSchema: { type: 'object', properties: { scope: { type: 'string', minLength: 1, description: 'The subject to synthesise, named explicitly, e.g. "retrieval ranking". One scope per call.' } }, required: ['scope'] },
         },
         {
           name: 'knowl_evidence_list',
-          description: 'Inspect evidence linked to one knowledge item when source support must be checked.',
+          description: 'List the evidence linked to one knowledge item. Use before relying on an item that is low-confidence, contested, or old enough that its support matters more than its claim.',
           inputSchema: {
             type: 'object',
             properties: { itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID.' } },
@@ -426,10 +467,13 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_session_finish',
-          description: 'Finish and optionally promote an explicitly owned manual memory session; never a hook-owned session.',
+          description: 'Finish and optionally promote a manual memory session you explicitly own. Never call this for a hook-owned session: when verified lifecycle hooks are active they finalize it themselves, and finishing it here closes a session out from under them.',
           inputSchema: {
             type: 'object', properties: {
-              sessionId: { type: 'string', minLength: 1, description: 'Memory session ID.' }, status: { type: 'string', enum: ['finished', 'failed'] }, summary: { type: 'string' }, promote: { type: 'boolean' },
+              sessionId: { type: 'string', minLength: 1, description: 'Memory session ID you started and own.' },
+              status: { type: 'string', enum: ['finished', 'failed'], description: 'How the session ended. failed still records what was learned.' },
+              summary: { type: 'string', description: 'Durable summary of what the session established.' },
+              promote: { type: 'boolean', description: 'Whether to promote the session\'s captures into project memory. Defaults to false.' },
             }, required: ['sessionId', 'status'],
           },
         },
@@ -598,7 +642,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_skill_read',
-          description: 'Read one learned skill package from `.knowl/skills/<name>/`, including `skill.json` and `SKILL.md`.',
+          description: 'Read one learned skill package from `.knowl/skills/<name>/`, including `skill.json` and `SKILL.md`. Read a skill before running it, so knowl_skill_run executes an entrypoint you have seen rather than one you guessed at.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -642,8 +686,8 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
                 items: {
                   type: 'object',
                   properties: {
-                    path: { type: 'string', minLength: 1 },
-                    content: { type: 'string' },
+                    path: { type: 'string', minLength: 1, description: 'Package-relative path, e.g. `run.ps1`.' },
+                    content: { type: 'string', description: 'Full file contents.' },
                   },
                   required: ['path', 'content'],
                 },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -42,9 +42,15 @@ import { configuredNamespaces, namespaceDescriptor, queryLayeredKnowledge, withN
 import { isTranscriptSearchEnabled } from '../transcripts/config.js';
 import { handleSessionList, handleTranscriptRead, handleTranscriptSearch } from '../transcripts/mcp-handlers.js';
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
-import { CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
 import { teamUpdateNotice } from '../cloud/team-update.js';
 import { maybeAutoSync } from '../cloud/auto-sync.js';
+import { cloudStatusInRequest } from '../cloud/status.js';
+import { stagePublishInRequest } from '../cloud/publish.js';
+import { loadConfig } from '../core/config.js';
+
+export const CLOUD_DISCONNECTED_MESSAGE =
+  'This repository is not connected to a cloud workspace. Ask the user to run `knowl cloud connect` (and `knowl login` first if they are not signed in).';
 
 /**
  * Ceilings for the handlers. The ones the SCHEMAS quote live beside the schemas, in
@@ -220,6 +226,10 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
     tools.push(...IMPACT_TOOLS);
   }
 
+  if (config?.cloud) {
+    tools.push(...CLOUD_TOOL_DEFINITIONS);
+  }
+
   return orderForSelection(tools);
 }
 
@@ -231,7 +241,8 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
  * to know their shape even when listing does not offer them.
  */
 const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
-  [...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOLS].map(tool => [tool.name, tool.inputSchema]),
+  [...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOLS, ...CLOUD_TOOL_DEFINITIONS]
+    .map(tool => [tool.name, tool.inputSchema]),
 );
 
 /** What a shortened result keeps of its body: enough to judge relevance, not to answer from. */
@@ -1561,6 +1572,55 @@ export function registerTools(
             }),
           }],
         };
+      }
+
+      // Re-checks its own gate rather than trusting the listing, for the reason above.
+      else if (name === 'knowl_cloud') {
+        // Fail closed if EITHER the captured config or the file on disk says disconnected:
+        // the captured one is the server's own view, and disk must be able to disconnect
+        // without waiting for a restart. See constraint 9a234a5626d5449f.
+        const live = projectRoot ? await loadConfig(projectRoot).catch(() => null) : null;
+        if (!config?.cloud || !live?.cloud || !projectRoot) {
+          return { content: [{ type: 'text', text: CLOUD_DISCONNECTED_MESSAGE }] };
+        }
+
+        const { action, ids, categories, apply } = args as any;
+
+        if (action === 'stage') {
+          // The request-safe variant. `stagePublish` owns the process-wide database context and
+          // would close it here, breaking every LATER tool call. See constraint defde27f6f234535.
+          const result = await stagePublishInRequest({
+            projectRoot,
+            config: live,
+            ids: Array.isArray(ids) && ids.length ? ids.map(String) : undefined,
+            categories: Array.isArray(categories) && categories.length
+              ? categories.map(String) as KnowledgeCategory[]
+              : undefined,
+            apply: apply === true,
+          });
+
+          if (result.status === 'not-connected') {
+            return { content: [{ type: 'text', text: CLOUD_DISCONNECTED_MESSAGE }] };
+          }
+
+          return {
+            content: [{
+              type: 'text',
+              text: compactMcpJson({
+                action: 'stage',
+                applied: result.applied,
+                items: result.items.map(item => ({ id: item.id, category: item.category, title: item.title })),
+                ...(result.skippedForeign > 0 ? { skippedForeign: result.skippedForeign } : {}),
+                next: result.applied
+                  ? 'Staged, and nothing has been sent. Ask the user to run `knowl cloud push` -- it is irreversible and cannot be undone from here.'
+                  : 'Dry run: nothing was written. Re-call with apply: true only if the user asked for this publication.',
+              }),
+            }],
+          };
+        }
+
+        const status = await cloudStatusInRequest(projectRoot, live);
+        return { content: [{ type: 'text', text: compactMcpJson({ action: 'status', ...status }) }] };
       }
 
       // A name the server does not serve is a malformed request, which the spec groups with

--- a/tests/cloud/ambient-context.test.ts
+++ b/tests/cloud/ambient-context.test.ts
@@ -5,10 +5,18 @@ import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { withTeamStore } from '../../src/cloud/team-store.js';
 import { writeSyncState } from '../../src/cloud/sync-state.js';
 import { teamUpdateNotice } from '../../src/cloud/team-update.js';
+import { cloudStatusInRequest } from '../../src/cloud/status.js';
+import { stagePublishInRequest } from '../../src/cloud/publish.js';
+import type { ProjectConfig } from '../../src/core/types.js';
 
 const HOME = path.resolve('./.knowl-ambient-home');
 const ROOT = path.resolve('./.knowl-ambient-root');
 const WS = 'ws-ambient';
+
+const CONNECTED: ProjectConfig = {
+  version: 1,
+  cloud: { apiHost: 'https://api.knowl.test', workspaceId: WS, workspaceName: 'Team', repo: 'github.com/acme/app' },
+};
 
 /** The project's own database, read through whatever context is currently active. */
 const localItemCount = async (): Promise<number> =>
@@ -63,6 +71,54 @@ describe('the replica never disturbs the caller\'s database context', () => {
       const update = await teamUpdateNotice({ workspaceId: WS, configRoot: ROOT, seenSeq: null });
 
       expect(update?.seq).toBe('7');
+      expect(await localItemCount()).toBe(0);
+    } finally {
+      await closeDb();
+    }
+  });
+
+  // The `knowl_cloud` tool reaches these two. Their `cloudStatus`/`stagePublish` siblings own
+  // the process-wide context and call `closeDb`, which from inside a request would leave every
+  // LATER tool call in that server with no database at all -- in a different request, with
+  // nothing in the error pointing back. These variants must open and close nothing.
+  it('reports cloud status from inside a live context without stealing it', async () => {
+    await initDb(ROOT);
+    try {
+      const status = await cloudStatusInRequest(ROOT, CONNECTED);
+
+      expect(status.connected).toBe(true);
+      if (status.connected) {
+        expect(status.workspace).toBe('Team');
+        expect(status.staged).toBe(0);
+      }
+      expect(await localItemCount()).toBe(0);
+    } finally {
+      await closeDb();
+    }
+  });
+
+  it('stages from inside a live context without stealing it', async () => {
+    await initDb(ROOT);
+    try {
+      const result = await stagePublishInRequest({
+        projectRoot: ROOT,
+        config: CONNECTED,
+        categories: ['decision'],
+      });
+
+      expect(result.status).toBe('staged');
+      expect(await localItemCount()).toBe(0);
+    } finally {
+      await closeDb();
+    }
+  });
+
+  it('says not-connected without touching the database when there is no cloud pointer', async () => {
+    await initDb(ROOT);
+    try {
+      expect(await cloudStatusInRequest(ROOT, { version: 1 })).toEqual({ connected: false });
+      expect(await stagePublishInRequest({ projectRoot: ROOT, config: { version: 1 } }))
+        .toEqual({ status: 'not-connected' });
       expect(await localItemCount()).toBe(0);
     } finally {
       await closeDb();

--- a/tests/cloud/login.test.ts
+++ b/tests/cloud/login.test.ts
@@ -9,8 +9,11 @@ import { CloudApiError } from '../../src/cloud/api-client.js';
 const HOME = path.resolve('./.knowl-login-home');
 const HOST = 'https://api.knowl.test';
 
-/** The instant the expiry test advances its clock towards. Fifteen minutes, like the server's. */
-const CODE_EXPIRES_AT = new Date(Date.parse('2026-08-09T12:00:00.000Z') + 900_000).toISOString();
+/** Fifteen minutes, like the server's. */
+const CODE_LIFETIME_MS = 900_000;
+
+/** The instant the expiry test's injected clock starts from, and the only pinned date here. */
+const EXPIRY_TEST_EPOCH = Date.parse('2026-08-09T12:00:00.000Z');
 
 /**
  * The server's real shape: an absolute `expiresAt`, and no `verificationUri`.
@@ -18,12 +21,24 @@ const CODE_EXPIRES_AT = new Date(Date.parse('2026-08-09T12:00:00.000Z') + 900_00
  * This fixture used to carry `expiresInSeconds: 900` and a URL, neither of which the server
  * sends. That is what made the deadline `now() + NaN` in production while every test here passed
  * -- the fake was written from what the client wanted rather than from what the server returns.
+ *
+ * The deadline is computed per run rather than pinned to a date. It was pinned to
+ * 2026-08-09T12:15:00Z, which every test compared against the real `Date.now()`: the suite
+ * passed until the wall clock reached that instant and then failed for everyone, permanently,
+ * with no code change. Only the expiry test below pins an instant, and only because it supplies
+ * the clock that reads it.
  */
 const authorization: DeviceAuthorization = {
   deviceCode: 'dev-1',
   userCode: 'ABCD-EFGH',
   intervalSeconds: 5,
-  expiresAt: CODE_EXPIRES_AT,
+  expiresAt: new Date(Date.now() + CODE_LIFETIME_MS).toISOString(),
+};
+
+/** Reached in 180 polls of 5s from `EXPIRY_TEST_EPOCH`, on the clock that test injects. */
+const expiringAuthorization: DeviceAuthorization = {
+  ...authorization,
+  expiresAt: new Date(EXPIRY_TEST_EPOCH + CODE_LIFETIME_MS).toISOString(),
 };
 
 const credential = {
@@ -33,10 +48,13 @@ const credential = {
   sessionId: 'sess-1',
 };
 
-function fakeApi(polls: Array<'pending' | typeof credential | CloudApiError>): CloudApi {
+function fakeApi(
+  polls: Array<'pending' | typeof credential | CloudApiError>,
+  auth: DeviceAuthorization = authorization,
+): CloudApi {
   const queue = [...polls];
   return {
-    startDeviceAuthorization: async () => authorization,
+    startDeviceAuthorization: async () => auth,
     pollForToken: async () => {
       const next = queue.shift();
       if (next instanceof CloudApiError) throw next;
@@ -106,10 +124,10 @@ describe('runLogin', () => {
     let elapsed = 0;
     const result = await runLogin({
       apiHost: HOST,
-      api: fakeApi(Array.from({ length: 500 }, () => 'pending' as const)),
+      api: fakeApi(Array.from({ length: 500 }, () => 'pending' as const), expiringAuthorization),
       onPrompt: () => {},
       sleep: async ms => { elapsed += ms; },
-      now: () => Date.parse('2026-08-09T12:00:00.000Z') + elapsed,
+      now: () => EXPIRY_TEST_EPOCH + elapsed,
     });
 
     expect(result).toEqual({ status: 'expired' });

--- a/tests/cloud/retract.test.ts
+++ b/tests/cloud/retract.test.ts
@@ -1,0 +1,205 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CloudApi } from '../../src/cloud/api-client.js';
+import type { UpdateItemBody } from '../../src/cloud/sync-contract.js';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { listPushed, publishedVersion, recordPushed, stageForPublish } from '../../src/cloud/ledger.js';
+import { retractItem } from '../../src/cloud/retract.js';
+import { writeSyncState } from '../../src/cloud/sync-state.js';
+import { withTeamStore } from '../../src/cloud/team-store.js';
+import { writeCredential, clearCredential } from '../../src/cloud/credentials.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+const API_HOST = 'https://api.retract.test';
+const HOME = path.resolve('./.knowl-retract-home');
+
+const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+
+// Fresh directories per test, for the Windows reason `publish-push.test.ts` documents: libSQL can
+// hold the database inside the clone, the `rm` is refused, and the next clone fails into a
+// directory still holding the previous test's branch.
+let run = 0;
+let ORIGIN: string;
+let CLONE: string;
+let WS: string;
+let connected: ProjectConfig;
+
+const published = 'atom-published';
+
+function capture(
+  onSend?: (body: UpdateItemBody) => void,
+  outcome: unknown = { status: 'deleted', id: published },
+): CloudApi {
+  return {
+    startDeviceAuthorization: async () => { throw new Error('unused'); },
+    pollForToken: async () => 'pending' as const,
+    refresh: async () => { throw new Error('unused'); },
+    listWorkspaces: async () => [],
+    fetchSyncPage: async () => { throw new Error('unused'); },
+    publishItems: async () => { throw new Error('unused'); },
+    updateItem: async (input: any) => { onSend?.(input.body); return { outcome }; },
+  } as unknown as CloudApi;
+}
+
+describe('retracting a published atom', () => {
+  let base: { projectRoot: string; config: ProjectConfig };
+
+  beforeEach(async () => {
+    await closeDb().catch(() => {});
+    await releaseAll();
+    process.env.KNOWL_HOME = HOME;
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+
+    run += 1;
+    ORIGIN = path.resolve(`./.knowl-retract-origin-${run}`);
+    CLONE = path.resolve(`./.knowl-retract-clone-${run}`);
+    WS = `ws-retract-${run}`;
+    connected = {
+      version: 1,
+      cloud: {
+        apiHost: API_HOST, workspaceId: WS, workspaceName: 'Acme',
+        repo: 'github.com/acme/web', remote: 'origin',
+      },
+    };
+    base = { projectRoot: CLONE, config: connected };
+
+    await fs.mkdir(ORIGIN, { recursive: true });
+    git(ORIGIN, ['init', '-q', '-b', 'main']);
+    git(ORIGIN, ['config', 'user.email', 'test@example.com']);
+    git(ORIGIN, ['config', 'user.name', 'Test']);
+    await fs.writeFile(path.join(ORIGIN, 'a.txt'), 'a', 'utf8');
+    git(ORIGIN, ['add', '.']);
+    git(ORIGIN, ['commit', '-qm', 'a']);
+    git(process.cwd(), ['clone', '-q', ORIGIN, CLONE]);
+
+    await fs.mkdir(path.join(CLONE, '.knowl'), { recursive: true });
+    await fs.writeFile(path.join(CLONE, '.knowl', 'config.json'), JSON.stringify({ version: 1 }), 'utf8');
+    await initDb(CLONE);
+    await getClient().execute('DELETE FROM cloud_published');
+    await stageForPublish([published], WS, 'main');
+    await recordPushed(published, WS, 3);
+    await closeDb();
+
+    await writeCredential(API_HOST, {
+      accessToken: 'at', refreshToken: 'rt', sessionId: 'sess-1',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    await closeDb().catch(() => {});
+    await releaseAll();
+    await clearCredential(API_HOST).catch(() => {});
+    delete process.env.KNOWL_HOME;
+    for (const dir of [ORIGIN, CLONE, HOME]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('refuses an atom this machine never pushed', async () => {
+    // No server-side row exists, so the request would be about nothing. Checked before the token,
+    // so the user is never sent to log in for a remedy that could not help.
+    expect(await retractItem({ ...base, itemId: 'never-published', reason: 'leak', api: capture() }))
+      .toEqual({ status: 'not-published' });
+  });
+
+  it('refuses an atom that was staged but never pushed', async () => {
+    await initDb(CLONE);
+    await stageForPublish(['staged-only'], WS, 'main');
+    await closeDb();
+
+    expect(await retractItem({ ...base, itemId: 'staged-only', reason: 'leak', api: capture() }))
+      .toEqual({ status: 'not-published' });
+  });
+
+  // The reason this command exists, and the one behaviour that must differ from `reportDrift`.
+  it('works from a feature branch, unlike every other upward path', async () => {
+    // A leaked name sits in the shared workspace right now. Telling the user to switch branches
+    // and pull would hold the leak open for the length of a rebase.
+    git(CLONE, ['checkout', '-qb', 'feature/whatever']);
+
+    expect(await retractItem({ ...base, itemId: published, reason: 'leaked a customer name', api: capture() }))
+      .toEqual({ status: 'retracted' });
+  });
+
+  it('works from a checkout behind its remote', async () => {
+    // Same reasoning: being behind makes a *claim* about code untrustworthy, and makes a removal
+    // no less correct.
+    await fs.writeFile(path.join(ORIGIN, 'b.txt'), 'b', 'utf8');
+    git(ORIGIN, ['add', '.']);
+    git(ORIGIN, ['commit', '-qm', 'b']);
+    git(CLONE, ['fetch', '-q']);
+
+    expect(await retractItem({ ...base, itemId: published, reason: 'leak', api: capture() }))
+      .toEqual({ status: 'retracted' });
+  });
+
+  it('sends the delete op with the ledger version and the reason', async () => {
+    let sent: UpdateItemBody | undefined;
+    await retractItem({ ...base, itemId: published, reason: 'leaked a token', api: capture(body => { sent = body; }) });
+
+    // `expectedVersion` is what THIS machine last put there, not a fetched value: a mismatch is
+    // precisely the signal that someone edited the atom after this machine published it.
+    expect(sent).toEqual({ op: 'delete', expectedVersion: 3, reason: 'leaked a token' });
+  });
+
+  it('clears the local version on success, so a later republish cannot send a stale one', async () => {
+    expect(await retractItem({ ...base, itemId: published, reason: 'leak', api: capture() }))
+      .toEqual({ status: 'retracted' });
+
+    await initDb(CLONE);
+    try {
+      // Null, not 3. The server row is gone; holding its old version would make the next
+      // `knowl publish --id` send an expectedVersion for something that no longer exists.
+      expect(await publishedVersion(published, WS)).toBeNull();
+      // The row survives so status can still say this machine published it once.
+      expect((await listPushed(WS)).map(record => record.itemId)).toContain(published);
+    } finally {
+      await closeDb();
+    }
+  });
+
+  it('surfaces a conflict and leaves the ledger untouched', async () => {
+    // The atom moved after this machine published it. Deleting it now would destroy an edit
+    // nobody here has read, which is the whole reason the server demands a version.
+    const conflicting = capture(undefined, { status: 'conflict', id: published, currentVersion: 9 });
+
+    expect(await retractItem({ ...base, itemId: published, reason: 'leak', api: conflicting }))
+      .toEqual({ status: 'conflict', currentVersion: 9 });
+
+    await initDb(CLONE);
+    try {
+      // Still 3: the local record continues to match what is actually on the server.
+      expect(await publishedVersion(published, WS)).toBe(3);
+    } finally {
+      await closeDb();
+    }
+  });
+
+  it('treats a vanished atom as a conflict rather than a success', async () => {
+    // The server reports a missing atom as `conflict` with `currentVersion: 0`. Reporting that as
+    // "retracted" would tell the user their leak was removed by a call that removed nothing.
+    const gone = capture(undefined, { status: 'conflict', id: published, currentVersion: 0 });
+
+    expect(await retractItem({ ...base, itemId: published, reason: 'leak', api: gone }))
+      .toEqual({ status: 'conflict', currentVersion: 0 });
+  });
+
+  it('refuses a reader before spending a request that could only 403', async () => {
+    await withTeamStore(WS, CLONE, () => writeSyncState({
+      apiHost: API_HOST, since: '1', cursor: null,
+      lastSyncedAt: new Date().toISOString(), lastError: null, role: 'reader',
+    }));
+
+    expect(await retractItem({ ...base, itemId: published, reason: 'leak', api: capture() }))
+      .toEqual({ status: 'forbidden', role: 'reader' });
+  });
+
+  it('lets an editor through, and a replica with no recorded role', async () => {
+    // Unknown is not denied: a replica synced by a build older than the `role` column must not
+    // block a legitimate editor over a column that had not been invented yet.
+    expect(await retractItem({ ...base, itemId: published, reason: 'leak', api: capture() }))
+      .toEqual({ status: 'retracted' });
+  });
+});

--- a/tests/cloud/status.test.ts
+++ b/tests/cloud/status.test.ts
@@ -105,17 +105,20 @@ describe('cloudStatus', () => {
     expect(text).toContain('feature/rollback');
   });
 
-  it('says publishing cannot be undone whenever anything is staged', async () => {
-    // A product requirement, not a nicety. The server has a retire verb; no client path wires
-    // it, so a confirmation that omits this is a confirmation that misleads.
+  it('warns that sending is irreversible whenever anything is staged', async () => {
+    // A product requirement, not a nicety. `knowl cloud retract` now wires the server's delete
+    // verb, so this no longer says publishing cannot be undone -- but undoing means a hard delete
+    // and a tombstone barring the id forever, which is not the same as a mistake being cheap.
     await stagePublish({ projectRoot: CLONE, config: connected, ids: [id], apply: true });
-    expect(formatCloudStatus(await cloudStatus(CLONE, connected))).toMatch(/cannot be undone/i);
+    const text = formatCloudStatus(await cloudStatus(CLONE, connected));
+    expect(text).toMatch(/irreversible/i);
+    expect(text).toContain('knowl cloud retract');
   });
 
   it('says nothing about irreversibility when nothing is staged', async () => {
     // The warning has to mean something. Printed on every run it becomes furniture, and the one
     // time it matters nobody reads it.
-    expect(formatCloudStatus(await cloudStatus(CLONE, connected))).not.toMatch(/cannot be undone/i);
+    expect(formatCloudStatus(await cloudStatus(CLONE, connected))).not.toMatch(/irreversible/i);
   });
 
   it('makes no network call', async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -6,6 +6,8 @@ import * as repo from '../../src/store/repository.js';
 import { startMemorySession, appendMemorySessionEvent } from '../../src/store/session-repository.js';
 import { createEvidence, linkKnowledgeEvidence } from '../../src/store/evidence-repository.js';
 import { createMcpServer } from '../../src/mcp/server.js';
+import { knowlToolDefinitions } from '../../src/mcp/tools.js';
+import { CLOUD_TOOL_DEFINITIONS } from '../../src/mcp/tool-definitions.js';
 import { ProjectConfig } from '../../src/core/types.js';
 import { DEFAULT_CONTEXT_MAX_CHARS, MAX_ITEM_CONTENT_CHARS, MAX_PREVIEW_CHARS } from '../../src/core/token-budget.js';
 import { approveSkill } from '../../src/skills/trust.js';
@@ -274,10 +276,40 @@ describe('MCP Server Layer', () => {
     expect(byName.get('knowl_recent')).toContain('only when lifecycle bootstrap is unavailable');
     expect(byName.get('knowl_task_start')).toContain('manual work loop');
     expect(byName.get('knowl_task_start')).toContain('Never use for a hook-owned session');
-    expect(byName.get('knowl_session_finish')).toContain('never a hook-owned session');
+    expect(byName.get('knowl_session_finish')).toContain('Never call this for a hook-owned session');
     expect(byName.get('knowl_ingest')).toContain('never silently ingest the current conversation');
     expect(byName.get('knowl_skill_create')).toContain('explicitly requested');
     expect(byName.get('knowl_gc_apply')).toContain('explicit user approval');
+  });
+
+  it('offers knowl_cloud only to a repository that is connected to a workspace', () => {
+    const disconnected = knowlToolDefinitions(MOCK_CONFIG).map(tool => tool.name);
+    expect(disconnected).not.toContain('knowl_cloud');
+
+    const connected = knowlToolDefinitions({
+      ...MOCK_CONFIG,
+      cloud: { apiHost: 'https://api.knowl.test', workspaceId: 'ws-1', repo: 'github.com/acme/app' },
+    }).map(tool => tool.name);
+    expect(connected).toContain('knowl_cloud');
+  });
+
+  it('refuses knowl_cloud when the repository is not connected, rather than answering "unknown tool"', async () => {
+    // A client holding a cached tool list can still call it after a disconnect, so dispatch
+    // re-checks the gate instead of trusting the listing.
+    const res = await runRpcRequest('tools/call', { name: 'knowl_cloud', arguments: { action: 'status' } });
+    expect(res.error).toBeUndefined();
+    expect(res.result.content[0].text).toContain('not connected to a cloud workspace');
+  });
+
+  it('tells the agent that sending is the user\'s to run, not its own', async () => {
+    const res = await runRpcRequest('tools/list');
+    const byName = new Map(res.result.tools.map((tool: any) => [tool.name, tool.description]));
+    // Not listed here (MOCK_CONFIG has no cloud), so assert against the definition itself:
+    // publishing is irreversible and the agent must relay the command rather than route around it.
+    const cloud = CLOUD_TOOL_DEFINITIONS[0];
+    expect(byName.has('knowl_cloud')).toBe(false);
+    expect(cloud.description).toContain('knowl cloud push');
+    expect(cloud.description).toContain('irreversible');
   });
 
   it('should list tools', async () => {


### PR DESCRIPTION
Cuts **4.0.0**. Four commits on top of `main`, plus the 42 cloud-client commits already merged and unreleased since `v3.4.1`.

## What is in it

**`knowl cloud retract <id> --reason <text>`** — the last thing standing between the cloud client and a release. The server already had every piece (tombstone table, transactional delete, publish refusing tombstoned ids, delete rows on the feed); the client had no verb to ask with. It is the only upward path with **no branch gate**, deliberately: publishing and drift reports are gated because they assert something about code only you have, and a removal is true from every vantage. The case that brings you here is a leaked name in a shared workspace right now, and "switch to main and pull first" would hold it open for the length of a rebase.

**`knowl_cloud`** — cloud was CLI-only, yet `maybeAutoSync` and `teamUpdateNotice` already ran *inside* MCP tool handling. Sync happened underneath the agent while it had no way to see connection state or publish deliberately. Now it can see and stage; sending stays the user's to run.

**Every MCP tool says when to use it.** The guidance card was shrunk on the assumption `tools/list` teaches routing. Auditing all 31 found several that never did. +2150 chars on a 26803-char payload, kept tight because it is paid in every session.

**A test that would have gone red for everyone.** `tests/cloud/login.test.ts` pinned a device-code expiry of `2026-08-09T12:15:00Z` and compared it against the real clock. It passed before that instant and failed after, permanently — confirmed on a clean tree by stashing every local edit. Anyone bisecting would have blamed unrelated work.

## Two constraints that would have broken things silently

`cloudStatus` and `stagePublish` call `initDb`/`closeDb` — correct for a CLI that owns its process, fatal in an MCP request, where that `closeDb` leaves every **later** tool call in the server with no database, surfacing in a different request with nothing pointing back. Hence `cloudStatusInRequest` / `stagePublishInRequest`, pinned by three cases in `tests/cloud/ambient-context.test.ts`.

The handler also re-reads config per call and fails closed unless both the captured and on-disk config carry a cloud pointer, so a disconnect does not wait for a server restart.

## Why major

Nothing breaks. `KNOWL_SCHEMA_VERSION` stays at `1`, the migration to level 7 is additive, and a user who never connects sees no behavioural change. The number marks the change in what Knowl is.

## Known, and stated in the release notes

The hosted service is **not deployed**, so `knowl login` and `knowl cloud connect` fail with a connection error until it is. Production browser auth has never been exercised. Retrieval counts do not flow upward yet.

## Verification

- `npm run build && npm test` — **297 files, 2652 passed**, 5 skipped, 0 failures
- typecheck, `docs:check`, `check:lockfile` clean; lint 0 errors
- `knowl cloud retract --help` exercised from `dist`; missing `--reason` correctly refused

Do not tag until CI is green — the tag is what publishes to npm.
