### PR TITLE
fix(guidance): stated intent is storable — every storage cue said "verified" and taught agents to drop it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 2. Skip a new query only when directly relevant active lifecycle context, a same-request query, or manual `knowl_task_start` relevant memory already answers it.
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area.
-5. Store or update verified durable findings during work and before the final answer; never store raw transcripts, secrets, or debugging noise.
+5. Store or update durable knowledge during work and before the final answer — verified findings, and stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled. The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or debugging noise.
 6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.
 
 ### Lifecycle modes

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -7,7 +7,7 @@
 2. Skip a new query only when directly relevant active lifecycle context, a same-request query, or manual `knowl_task_start` relevant memory already answers it.
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area.
-5. Store or update verified durable findings during work and before the final answer; never store raw transcripts, secrets, or debugging noise.
+5. Store or update durable knowledge during work and before the final answer — verified findings, and stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled. The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or debugging noise.
 6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.
 
 ### Lifecycle modes

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ installed guidance asks agents to follow is short:
 
 1. Query memory with the words that name the subject **before** reading repository files.
 2. Use an active hit directly; inspect files only on a miss, conflict, or stale result.
-3. Store verified durable findings as you go, and correct contradicted memory rather than
+3. Store durable findings and stated goals as you go, and correct contradicted memory rather than
    duplicating it.
 
 In practice that looks like this — a new session, no context, nothing pasted in:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1382,7 +1382,7 @@ Run `knowl serve` to expose Knowl over stdio MCP. The recommended agent flow is:
    Another on-subject term retrieves better and an off-subject one retrieves worse, so do not pad
    a query to reach a length and do not trim a real term to shorten it.
 3. Verify misses, conflicts, or stale results against the repository.
-4. Store verified durable findings and update contradicted memory promptly.
+4. Store durable findings and stated goals, and update contradicted memory promptly.
 5. Use manual task tools only when verified lifecycle hooks are unavailable.
 
 ### Tools

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -63,7 +63,7 @@ const REQUIRED_WORKFLOW = `### Required workflow
 2. Skip a new query only when directly relevant active lifecycle context, a same-request query, or manual \`knowl_task_start\` relevant memory already answers it.
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area.
-5. Store or update verified durable findings during work and before the final answer; never store raw transcripts, secrets, or debugging noise.
+5. Store or update durable knowledge during work and before the final answer — verified findings, and stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled. The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or debugging noise.
 6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.`;
 
 const LIFECYCLE_MODES = `### Lifecycle modes
@@ -147,7 +147,7 @@ function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: b
     'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
     'Route by what you need; the tool list names them:',
     '- retrieval: knowl_query first. Recent context only without bootstrap or for a refresh, broad state for status, a packed context only when a token budget is given.',
-    '- durable memory: store one verified atom, batch several, record a confirmed decision, or correct a stale one. Correct rather than duplicate.',
+    '- durable memory: store one verified atom, batch several, record a confirmed decision or a stated goal, or correct a stale one. Correct rather than duplicate.',
     '- audit: inspect history, evidence or conflicts when needed; record feedback only after actual use or correction.',
     '- skills: read a matching skill before running a trusted entrypoint; create one only on explicit request.',
     '- special: raw-source ingest only on an explicit request, never silent chat; synthesis only for an explicit scope; preview garbage collection first and apply only after approval.',
@@ -155,7 +155,12 @@ function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: b
     // am stopping go?" -- and the distinction between them is the part worth the characters.
     '- leaving work: one baton the next session here consumes once, or a key the user keeps and hands back any time later, from anywhere.',
     ...(options.transcripts ? [TRANSCRIPT_ROUTE_LINE] : []),
-    'During work, store or update verified durable findings; never raw transcripts, secrets, or routine command noise.',
+    // "Stated intent" is here because its absence was a measured failure, not a style choice:
+    // an agent following this card faithfully skipped storing two strategy conversations,
+    // because every storage cue said "verified" and a conversation verifies nothing. Intent is
+    // durable before it is settled — that is what the goal category and user_stated provenance
+    // exist for — and the omission taught agents the opposite.
+    'During work, store durable findings and stated intent — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
   ].join('\n');
 }
 
@@ -172,7 +177,7 @@ export function mcpServerInstructions(config: ProjectConfig | null): string {
   if (!config || !isTranscriptSearchEnabled(config)) return KNOWL_MCP_SERVER_INSTRUCTIONS;
   return renderCompactKnowlGuidance(KNOWL_HOST_NEUTRAL_MODE_LINE, { transcripts: true });
 }
-export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the project-memory workflow active. Use relevant active memory. Before entering a new project area, call knowl_query with the words that name the subject before repository files or commands. Store or update verified durable findings. Claude hooks own lifecycle; do not start the manual task loop.';
+export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the project-memory workflow active. Use relevant active memory. Before entering a new project area, call knowl_query with the words that name the subject before repository files or commands. Store durable findings and stated goals. Claude hooks own lifecycle; do not start the manual task loop.';
 
 // Short per-prompt reminder (UserPromptSubmit). The full tool routing lives in
 // KNOWL.md and the MCP initialize instructions, so the per-prompt card only needs
@@ -180,7 +185,7 @@ export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the 
 export const KNOWL_CLAUDE_PROMPT_REMINDER = [
   'KNOWL — project memory is active.',
   'For any project question or new subtask, call knowl_query BEFORE reading files, using the words that name the subject and no padding; use a relevant active hit directly and inspect files only on a miss, conflict, or stale/low-confidence result.',
-  'Store or update verified durable decisions, facts, state, and constraints as you go with knowl_store / knowl_decide / knowl_update; never store secrets or routine noise.',
+  'Store durable decisions, facts, state, constraints, and stated goals as you go with knowl_store / knowl_decide / knowl_update — intent counts before it settles; never store secrets or routine noise.',
   'Claude hooks own the lifecycle — do not call knowl_task_start/checkpoint/finish. Full tool routing is in KNOWL.md.',
 ].join(' ');
 

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -34,12 +34,12 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
   'Route by what you need; the tool list names them:',
   '- retrieval: knowl_query first. Recent context only without bootstrap or for a refresh, broad state for status, a packed context only when a token budget is given.',
-  '- durable memory: store one verified atom, batch several, record a confirmed decision, or correct a stale one. Correct rather than duplicate.',
+  '- durable memory: store one verified atom, batch several, record a confirmed decision or a stated goal, or correct a stale one. Correct rather than duplicate.',
   '- audit: inspect history, evidence or conflicts when needed; record feedback only after actual use or correction.',
   '- skills: read a matching skill before running a trusted entrypoint; create one only on explicit request.',
   '- special: raw-source ingest only on an explicit request, never silent chat; synthesis only for an explicit scope; preview garbage collection first and apply only after approval.',
   '- leaving work: one baton the next session here consumes once, or a key the user keeps and hands back any time later, from anywhere.',
-  'During work, store or update verified durable findings; never raw transcripts, secrets, or routine command noise.',
+  'During work, store durable findings and stated intent — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
 ].join('\n');
 
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
@@ -127,8 +127,8 @@ describe('canonical Knowl agent guidance', () => {
     // (see 'does not grow when a tool is added'), so a new tool inside an existing group should
     // leave both numbers untouched. If adding a tool changes them, something re-introduced the
     // inventory the card stopped carrying.
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_737);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_788);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_787);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_838);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -165,6 +165,35 @@ describe('canonical Knowl agent guidance', () => {
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_SUBAGENT_BOOTSTRAP_CARD]) {
       expect(card).toMatch(/words that name the subject/);
     }
+  });
+
+  /**
+   * Storage guidance must name stated intent, not only verified findings.
+   *
+   * Grounded in a live failure, not taste: an agent following these cards faithfully skipped
+   * storing two strategy conversations (2026-08-10) — the user's declared plan for a whole
+   * venture — because every storage cue said "verified" and a conversation verifies nothing.
+   * The user had to notice the gap and request the save manually. The goal category and
+   * user_stated provenance exist for exactly this content; guidance that never mentions them
+   * teaches agents to leave intent unstored until it is too late to recover.
+   *
+   * Pinned for the same reason the keyword-cap test above is: "verified durable findings" is
+   * precisely the kind of tight phrase someone re-introduces while shortening a line to buy
+   * room, and the omission it causes is invisible until a user is annoyed.
+   */
+  it('names stated intent as storable in every storage cue that reaches an agent', () => {
+    for (const surface of [
+      KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS,
+      KNOWL_CLAUDE_PROMPT_REMINDER, KNOWL_CLAUDE_CONTINUATION_REMINDER,
+    ]) {
+      expect(surface).toMatch(/stated (intent|goal)/);
+    }
+    // The full guidance names the mechanism, not just the class: which category, which
+    // provenance, and the recovery test that decides.
+    expect(renderFullKnowlGuidance()).toContain('user_stated');
+    expect(renderFullKnowlGuidance()).toContain('could a fresh session recover this from memory alone?');
+    // The subagent card is deliberately absent from this list: a subagent receives a bounded
+    // task, not a user conversation, so findings-only is its correct storable class.
   });
 
   it('changes only the lifecycle mode line between compact renderings', () => {


### PR DESCRIPTION
Grounded in a live failure, not taste.

## The incident

On 2026-08-10, an agent following these cards faithfully skipped storing **two consecutive strategy conversations** — the user's declared plan for an entire venture (a benchmark project: dimensions, distribution mechanics, staged launch). The user noticed the gap and had to request the save manually.

The agent wasn't misbehaving. It was **complying**: every storage cue on every surface says *"verified durable findings"*, a conversation verifies nothing, so the filter said skip — twice, consistently.

## The bug

The `goal` category and `user_stated` provenance exist for exactly this content. The guidance never mentions either. So the storable class the product *supports* and the storable class the guidance *teaches* are different sets — and the difference is precisely the knowledge with no verification moment to anchor a save: intent, plans, direction the user voiced.

This is the same class of defect as the "2–6 keywords" cap this repo already removed: a tight, plausible phrase in the guidance that measurably steered agent behaviour the wrong way. Same treatment here — fix the surfaces, pin a regression test.

## What changed

| surface | change |
|---|---|
| KNOWL.md rule 5 (full guidance) | names the mechanism: goals + `user_stated` provenance, storable while unsettled, plus a decision rule an agent can run — *"could a fresh session recover this from memory alone?"* |
| compact card | durable-memory bullet gains "or a stated goal"; closing line becomes *"store durable findings and stated intent — a goal counts before it settles"* |
| prompt + continuation reminders | same widening, fewer words |
| README quickstart, docs/reference.md, AGENTS.md/KNOWL.md managed sections | aligned |

**Budgets:** cards grew 1,737 → 1,787 and 1,788 → 1,838; the binding transcript-enabled variant stays under the 2,000 ceiling (`mcp-gating` green). Length pins updated — the test's own comment says they're pinned so changes are deliberate, and this one is.

**Deliberately unchanged:** the subagent bootstrap card stays findings-only. A subagent receives a bounded task, not a user conversation — intent isn't content it encounters, and its card's characters are scarcer than anyone's.

**Untouched everywhere:** the exclusions (transcripts, secrets, routine noise). This widens the storable class surgically; it does not say "save more."

## The pin

A new test asserts every storage cue that reaches an agent names stated intent, and that the full guidance carries `user_stated` and the recovery test — because "verified durable findings" is exactly the kind of phrase someone re-introduces while shortening a line to buy room, and the omission it causes is invisible until a user is annoyed.

## The other half

Wording fixes the bias; nothing yet *detects* a missed save — the only detector today is a user complaining, which is how this was found. Filed separately as #54 (write-side negative signal in the session-finish hook), since that's a design call rather than a wording fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
