### PR TITLE
fix(bench): typecheck and run the benchmarks in CI, and fix the two errors that hid there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,21 @@ jobs:
 
       - run: npm run typecheck
       - run: npm run lint
+
+      # `benchmarks/` has its own tsconfig and its own vitest config, so neither `npm run
+      # typecheck` nor `npm test` reaches it -- and nothing else did either. The directory went
+      # unchecked long enough that `typecheck:bench` was failing on main with two errors nobody
+      # could see, and the invariant suite that exists to stop an untrustworthy number shipping
+      # was a gate that never ran.
+      #
+      # Both live in this job rather than a new one for the reason stated at the top: they are
+      # ubuntu, cheap (the bench suite is under a second) and share the `npm ci` already paid
+      # for. A failing step still names itself.
+      - name: Benchmark types
+        run: npm run typecheck:bench
+      - name: Benchmark invariants
+        run: npm run test:bench
+
       - run: npm run build
       - name: Generated documentation is current
         run: npm run docs:check

--- a/benchmarks/accuracy/src/report.ts
+++ b/benchmarks/accuracy/src/report.ts
@@ -4,9 +4,9 @@ import os from 'node:os';
 import path from 'node:path';
 import type { CollectionResult } from './collect.js';
 import type { NativeCollectionResult } from './native-collect.js';
-import type { NativeCaptureScore } from './native-score.js';
+import type { NativeCaptureScore, NativeHistoryScore } from './native-score.js';
 import type { AdapterMetadata } from './protocol.js';
-import type { MetricValue, RetrievalScore } from './score.js';
+import type { MetricValue, RetrievalQueryScore, RetrievalScore } from './score.js';
 import type { BenchmarkBundle } from './schema.js';
 
 export type ScoredSystemRun = {
@@ -23,6 +23,32 @@ type MetricSummary = {
   numerators: number[];
   denominators: number[];
 };
+
+/** The columns every emitted result row carries, whatever produced it. */
+type ResultIdentity = {
+  datasetId: string;
+  system: string;
+  version: string;
+  mode: string;
+  run: number;
+};
+
+/**
+ * A result row is either a scored one or the N/A placeholder standing in for a system that
+ * produced nothing, and the two shapes share only `ResultIdentity`.
+ *
+ * Naming the union is what makes the branch legal rather than merely tidy. `flatMap` infers its
+ * element type `U` from the callback's return, so a callback returning `Scored[] | NotApplicable[]`
+ * fixes `U` from the first branch and then rejects the second for missing every metric field --
+ * which is what `typecheck:bench` was failing on. Annotating `U` up front admits both.
+ */
+type NormalizedResultRow =
+  | (ResultIdentity & RetrievalQueryScore)
+  | (ResultIdentity & { questionId: string; notApplicableReason: string });
+
+type NativeResultRow =
+  | (ResultIdentity & NativeHistoryScore)
+  | (ResultIdentity & { historyId: string; notApplicableReason: string });
 
 function median(values: number[]): number | null {
   if (!values.length) return null;
@@ -127,7 +153,7 @@ export async function writeBenchmarkReport(input: {
     seed: run.seed,
     ...prediction,
   }))));
-  const normalizedResults = input.systems.flatMap(system => {
+  const normalizedResults = input.systems.flatMap<NormalizedResultRow>(system => {
     if (system.scores.length) {
       return system.scores.flatMap((score, runIndex) => score.perQuery.map(result => ({
         datasetId: manifest.datasetId,
@@ -148,7 +174,7 @@ export async function writeBenchmarkReport(input: {
       notApplicableReason: system.collection.reason ?? 'no normalized result was collected',
     }))).flat();
   });
-  const nativeResults = input.systems.flatMap(system => {
+  const nativeResults = input.systems.flatMap<NativeResultRow>(system => {
     if (system.nativeScores.length) {
       return system.nativeScores.flatMap((score, runIndex) => score.perHistory.map(result => ({
         datasetId: manifest.datasetId,


### PR DESCRIPTION
`benchmarks/` has its own tsconfig and its own vitest config, so neither `npm run typecheck` nor `npm test` reaches it — and no CI job ran `typecheck:bench` or `test:bench` either. The directory was unchecked, and both halves of that showed.

## `typecheck:bench` was failing on main

Two `TS2345`s in `benchmarks/accuracy/src/report.ts`, at the `normalizedResults` and `nativeResults` builders. Same shape both times: a `flatMap` whose callback returns a scored-row array in one branch and an N/A placeholder array in the other. `flatMap` infers its element type `U` from the first branch, then rejects the second for missing `category`, `strictCorrect`, `relevantRetrieved` and 14 more.

Fixed by **naming the union** rather than widening to `any` or making two passes over the same systems: `ResultIdentity` for the five columns both shapes carry, then `NormalizedResultRow` and `NativeResultRow` supplied as `flatMap`'s type argument. Annotating `U` up front admits both branches.

The emitted NDJSON is byte-identical — this is an annotation, not a behaviour change.

## The invariant suite was a gate that never ran

#49 landed the checks that must pass before a CR number is trusted, including the contaminated-baseline check that asserts each `supersede-off` run leaks strictly more than its `supersede-on` counterpart. Nothing in CI ran them. A gate that fires only when someone remembers to run it is not a gate.

## Why these steps go in the existing `checks` job

For the reason that job already documents in its own header comment: lint, types, docs, audit and the tarball smoke test are all ubuntu, all cheap, and all share one `npm ci`. The bench suite runs in under a second. A failing step still names itself.

## Verification

| command | result |
|---|---|
| `npm run typecheck:bench` | clean (was 2 errors on main) |
| `npm run test:bench` | 110 tests, 0 failures |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors, no new warnings from the changed files |
| `npm run docs:check` | current |