### PR TITLE
chore(deps): take the four updates from the production-patches group that can actually resolve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,13 +46,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.12.tgz",
-      "integrity": "sha512-IquWNkGRSF2ulYJ6YIIUqMsNAIDeZFB3/4W92aSOtCxH1TfuVoq3qw4M4TxTxIw4As9cnkeRLe7b9LDMzPDsnA==",
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.36.tgz",
+      "integrity": "sha512-Wg5jfray0X4+qkrr73GZ7U7K2JNGx+S+rNY9LorVlXhkhTqnvtNLYWRA1WxSxlCDCw3yjRCJdL9kyc+b7naAog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.7"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.25"
       },
       "engines": {
         "node": ">=22"
@@ -62,13 +62,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.16.tgz",
-      "integrity": "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==",
+      "version": "4.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.46.tgz",
+      "integrity": "sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.7",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.25",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
@@ -79,13 +79,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.11.tgz",
-      "integrity": "sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==",
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.36.tgz",
+      "integrity": "sha512-wHJNArBdjJPXb8GXcA+FslbRt+7qIE1KoHSAVi+CeBFidinVrTVBZKFMJz3mNZMj8YILBMl/VIvTD/oGFjX6/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.7"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.25"
       },
       "engines": {
         "node": ">=22"
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
-      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -107,15 +107,16 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
-      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
+      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider": "4.0.7",
         "@standard-schema/spec": "^1.1.0",
         "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=22"
@@ -2953,14 +2954,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "7.0.22",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.22.tgz",
-      "integrity": "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==",
+      "version": "7.0.58",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.58.tgz",
+      "integrity": "sha512-GfgO90CQQ0yYuoxJAUOeQ6tviyYw1BUIDygSZ1q3Ce6kSc93tYmB5eltKY/NxC0YOouAax7JvDqVnYxvIAr04Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "4.0.16",
-        "@ai-sdk/provider": "4.0.3",
-        "@ai-sdk/provider-utils": "5.0.7"
+        "@ai-sdk/gateway": "4.0.46",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.25"
       },
       "engines": {
         "node": ">=22"
@@ -5662,9 +5663,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -7085,6 +7086,15 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",


### PR DESCRIPTION
Replaces #57, which could not install on any platform.

## Why #57 cannot be rebased into working order

Two of its six updates are impossible, not merely awkward:

- `tree-sitter-typescript` latest is **0.23.2**, peer `tree-sitter@^0.21.0` — nothing newer is published.
- `tree-sitter-javascript@0.25.0` requires `tree-sitter@^0.25.0`.

So `tree-sitter` and `tree-sitter-javascript` are **jointly frozen** at 0.21/0.23 until upstream publishes. Any bump of either produces `ERESOLVE ... Conflicting peer dependency: tree-sitter@0.21.1`, which is what took down `npm ci` on 4 of 5 legs. `.github/dependabot.yml` predicted this verbatim when npm version updates were dropped: *"tree-sitter cannot leave 0.21 while tree-sitter-typescript's latest release still pins it there."*

## What this takes instead

The other four had nothing to do with tree-sitter and were only held hostage by sharing a group:

| package | from | to |
|---|---|---|
| `@ai-sdk/anthropic` | 4.0.12 | 4.0.36 |
| `@ai-sdk/openai` | 4.0.11 | 4.0.36 |
| `ai` | 7.0.22 | 7.0.58 |
| `smol-toml` | 1.7.0 | 1.7.1 |

**Lockfile only.** Every existing caret range already covered these — which is why #57 changed `package.json` for the two tree-sitter entries and nothing else. A few days ahead of the exact versions #57 proposed, since time passed.

## Verification

| command | result |
|---|---|
| `npm run check:lockfile` | matches package.json (4.0.0) |
| `npm run build` | clean |
| `npm test` | 297 files, 2653 passed, 5 skipped, **0 failures** |
| `npm run audit:prod` | passes |