### PR TITLE
fix(cloud): stage ownership by the local workspace name, not the git identity

### DIFF
--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -70,11 +70,26 @@ export async function stagePublishInRequest(input: {
 }
 
 async function stageInContext(
-  input: { projectRoot: string; ids?: string[]; categories?: KnowledgeCategory[]; apply?: boolean },
+  input: {
+    projectRoot: string;
+    config: ProjectConfig;
+    ids?: string[];
+    categories?: KnowledgeCategory[];
+    apply?: boolean;
+  },
   pointer: NonNullable<ProjectConfig['cloud']>,
 ): Promise<StageResult> {
   const { items, skippedForeign } = await selectOwnedItems({
-    repoName: pointer.repo,
+    // The local name, not `pointer.repo`. A repo has two of them and both are right: local
+    // workspace membership stamps `origin_repo` with the member name from the manifest
+    // ("web"), while `cloud connect` records the git identity ("github.com/acme/web")
+    // because that is the bucket the server keys publications on -- which is why the push
+    // below still sends `pointer.repo`. Asking the ownership question with the cloud name
+    // compared the two namespaces against each other, so every item in a locally-linked repo
+    // came back foreign and such a repo could never publish anything at all. Outside a
+    // workspace `origin_repo` is NULL, which `selectOwnedItems` claims regardless, so the
+    // fallback only has to be a name nothing is stamped with.
+    repoName: input.config.workspace?.repo ?? pointer.repo,
     categories: input.categories,
     ids: input.ids,
   });

--- a/tests/cloud/publish-stage.test.ts
+++ b/tests/cloud/publish-stage.test.ts
@@ -105,6 +105,42 @@ describe('stagePublish', () => {
     expect(await staged()).toEqual([ids.decision]);
   });
 
+  it('owns items stamped with the local workspace repo name, not the cloud identity', async () => {
+    // Two names for the same repo, and they are both correct: a repo linked into a local
+    // workspace stamps `origin_repo` with its member name ("web"), while `cloud connect`
+    // records the git identity ("github.com/acme/web") because that is what the server keys
+    // publications on. Comparing the second against the first made every item foreign, so a
+    // repo that was both linked locally and connected to cloud could never publish anything.
+    await execute("UPDATE knowledge_items SET origin_repo = 'web'");
+
+    const result = await stagePublish({
+      projectRoot: ROOT,
+      config: { ...connected, workspace: { workspace: 'acme', repo: 'web' } },
+      categories: ['decision'],
+      apply: true,
+    });
+
+    expect(result).toMatchObject({ status: 'staged', applied: true, skippedForeign: 0 });
+    expect(await staged()).toEqual([ids.decision]);
+  });
+
+  it('still counts a peer repo foreign when the local workspace name is in play', async () => {
+    // The fix must not turn the ownership check off. `api` is another member of the same
+    // local workspace, and its items stay unpublishable from here.
+    await execute(`UPDATE knowledge_items SET origin_repo = 'web'`);
+    await execute(`UPDATE knowledge_items SET origin_repo = 'api' WHERE id = '${ids.fact}'`);
+
+    const result = await stagePublish({
+      projectRoot: ROOT,
+      config: { ...connected, workspace: { workspace: 'acme', repo: 'web' } },
+      categories: ['decision', 'fact'],
+      apply: true,
+    });
+
+    expect(result).toMatchObject({ skippedForeign: 1 });
+    expect(await staged()).toEqual([ids.decision]);
+  });
+
   it('stages from a feature branch, because the gate belongs to the push', async () => {
     // Staging is an intent and can be formed at any time. Only sending is gated -- refusing to
     // stage would mean the work has to be remembered by a human until the merge lands.


### PR DESCRIPTION
Found on the first real `knowl cloud connect` against api.knowl.cloud.

## Symptom

`knowl cloud stage` over four categories returned **0 items** and `skippedForeign: 566`. Every atom in the repo read as belonging to some other repo, so nothing could ever be staged and nothing could ever be pushed. A locally-linked repo could not publish at all.

## Cause

A repo has two names and **both are correct**:

- Local workspace membership stamps `origin_repo` with the manifest member name — `knowl`.
- `cloud connect` records the git remote identity — `github.com/dat999zx/knowl` — because that is the bucket the server keys publications on.

`stageInContext` asked the ownership question with `pointer.repo`, the cloud name, and compared it against `origin_repo`, the local name. Two namespaces measured against each other: every row foreign, every time.

## Fix

Ownership is now asked with `input.config.workspace?.repo ?? pointer.repo`. The **push** still sends `pointer.repo` — that half was always right, and the two are genuinely different questions: *whose atom is this* is a local question, *which bucket does it publish into* is a server one.

Outside a workspace `origin_repo` is NULL, which `selectOwnedItems` claims regardless, so the fallback only has to be a name nothing is stamped with.

## Tests

`tests/cloud/publish-stage.test.ts` gains coverage for the workspace case — the one that was broken and had no test, which is why a 566-item false negative shipped.

## Verification

| command | result |
|---|---|
| `npm run typecheck` | clean |
| `npx vitest run tests/cloud/` | 27 files, 198 passed, 1 skipped |