### PR TITLE
fix(codeql): scope analysis to shipped code, and drop a dead import

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,34 @@
+name: knowl
+
+# `security-and-quality` rather than the default `security` suite, kept from the inline
+# `queries:` this file replaced. The wider suite adds every maintainability query, which is
+# how dead imports and trivial conditionals get caught -- worth having, provided the tab it
+# writes into stays readable. That proviso is what `paths-ignore` below is for.
+queries:
+  - uses: security-and-quality
+
+# What ships is `dist/`, built from `src/`. Nothing under `tests/` or `scripts/` is published
+# -- `package.json`'s `files` array is `dist`, `README.md`, `CHANGELOG.md` -- so a finding
+# there describes code no user can reach.
+#
+# This is not a way of being quieter about real problems. It is that the findings these paths
+# produce are, by construction, the behaviour the files exist to have:
+#
+#   - `tests/cli/windows-spawn.test.ts` raises `js/indirect-command-line-injection` twice
+#     because it spawns `cmd` on purpose -- that is the thing under test.
+#   - Sixteen `js/insecure-temporary-file` alerts come from fixtures building predictable
+#     paths under a temp root. A test that could not predict its own fixture path could not
+#     assert against it.
+#   - `scripts/e2e-*.ts` are developer end-to-end drivers that read a file and make a request,
+#     which is `js/file-access-to-http` by definition.
+#
+# Nineteen of the twenty-eight alerts open on 2026-08-10 were in these two directories. Alerts
+# that can only ever be dismissed teach people to stop opening the tab, and then the nine that
+# matter are unread too. Scope is the honest fix; dismissing nineteen findings one at a time,
+# again every time a fixture moves, is not.
+#
+# `src/` and `benchmarks/` stay in scope. If a helper moves out of `tests/` into either, it is
+# scanned again the moment it lands.
+paths-ignore:
+  - tests
+  - scripts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,10 @@ jobs:
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: javascript-typescript
-          queries: security-and-quality
+          # The query suite moved into the config file, because `paths-ignore` has nowhere else
+          # to live -- `init` takes no such input. Both settings describe one decision (what is
+          # analysed, and with what), so they belong in one place.
+          config-file: ./.github/codeql/codeql-config.yml
 
       # No build step: this project is TypeScript compiled by tsup, and CodeQL analyses the
       # sources directly for javascript-typescript. Building first would analyse the bundle

--- a/src/cli/query-command.ts
+++ b/src/cli/query-command.ts
@@ -3,7 +3,7 @@ import { loadConfig } from '../core/config.js';
 import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../ai/embeddings.js';
 import { rankKnowledge, type RankOptions } from '../store/agent-query.js';
 import { queryKnowledgeBase } from '../store/queries.js';
-import { flattenGroups, queryFederated, type FederatedResult } from '../workspace/federated-query.js';
+import { queryFederated, type FederatedResult } from '../workspace/federated-query.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
 
 /**


### PR DESCRIPTION
28 open code-scanning alerts. **Nineteen are in `tests/` and `scripts/`**, and every one describes the behaviour those files exist to have.

## The one real finding

`flattenGroups` was imported into `src/cli/query-command.ts` and never used — `js/unused-local-variable`. Removed; lint warnings drop 30 → 29.

## Nineteen that were out of scope, not wrong

`package.json`'s `files` array ships `dist`, `README.md` and `CHANGELOG.md`. Nothing under `tests/` or `scripts/` reaches a user, so a finding there describes code no one can call.

| alerts | rule | why it fires |
|---|---|---|
| 2 | `js/indirect-command-line-injection` | `tests/cli/windows-spawn.test.ts` spawns `cmd` on purpose — that *is* the thing under test |
| 16 | `js/insecure-temporary-file` | fixtures build predictable paths under a temp root; a test that could not predict its own fixture path could not assert on it |
| 1 | `js/file-access-to-http` | `scripts/e2e-*.ts` read a file and make a request, which is the rule's definition |

`paths-ignore` now covers those two directories. **`src/` and `benchmarks/` stay in scope**, so a helper that moves out of `tests/` is analysed the moment it lands.

This is scope, not silence. Alerts that can only ever be dismissed — again every time a fixture moves — teach people to stop opening the tab, and then the findings that matter go unread beside them. This repo already hit that once at 29 alerts, 20 of which were lint.

The query suite moves into the config file alongside it: `init` has no `paths-ignore` input, and *what is analysed* and *what it is analysed with* are one decision.

## The eight remaining `src/` alerts

Not touched here — they need dispositions rather than code, and I'll record them on the alerts themselves:

| # | rule | `src/` location | verdict |
|---|---|---|---|
| 52 | `js/missing-await` | `workspace/demand-ledger.ts:178` | false positive — `opening` is compared by **identity** against the cache entry (`clients.get(resolved) === opening`); it is already awaited two lines up |
| 55 | `js/file-system-race` | `cloud/file-lock.ts:47` | real and accepted, with the reasoning already in the file: a second breaker winning is fine because the guarded operation re-reads state under the lock and is idempotent |
| 47, 48 | `js/insecure-temporary-file` | `session/hook-debounce.ts` | false positive — the path is `<projectRoot>/.knowl/cache/hook-debounce`, not `os.tmpdir()`, and the open is `wx`, which is the mitigation this rule asks for |
| 54 | `js/insecure-temporary-file` | `store/portability.ts:90` | false positive — `outputPath` is the destination the user passed to `knowl export` |
| 56 | `js/file-access-to-http` | `cloud/api-client.ts:115` | by design — sending locally-stored atoms to the API is what `knowl cloud push` *is* |
| 30 | `js/indirect-command-line-injection` | `cli/windows-spawn.ts:138` | not closable — `knowl task run -- <command>` exists to run a command the caller typed. The caret escaping added in #32 made it genuinely safer, but CodeQL does not model caret escaping as a sanitizer |

## Verification

| command | result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors, 29 warnings (was 30) |
| `npm run build` | clean |
| `npm test` | 297 files, 2660 passed, 5 skipped, **0 failures** |
| both YAML files | parse |

**CodeQL does not run on pull requests here** — the triggers are push to `main`, weekly, and dispatch. So this PR will show no CodeQL check, and the alert list only re-evaluates after the merge lands.