### PR TITLE
fix(guidance): recurring diagnoses are storable, and method questions belong to the workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 1. For every project-specific request, call `knowl_query` before repository files or commands, using the words that name the subject: another on-subject term retrieves better, an off-subject one retrieves worse, so do not pad the query and do not trim a real term to shorten it.
 2. Skip a new query only when directly relevant active lifecycle context, a same-request query, or manual `knowl_task_start` relevant memory already answers it.
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
-4. Query again before switching to a distinct subtask or project area.
-5. Store or update durable knowledge during work and before the final answer — verified findings, and stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled. The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or debugging noise.
+4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
+5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
 6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.
 
 ### Lifecycle modes
@@ -102,6 +102,7 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 - When this repo is in a workspace, read the **shape** of a `knowl_query` result first. A bare JSON array means every row belongs to this repo. An object keyed by repo name means at least one row does **not** — and a fact from another repo describes **that** repo unless it says otherwise, so verify before applying it here.
 - An empty array under this repo's own key means this repo holds nothing on the subject. Read the other keys as background, not as an answer, and treat it as a miss if what they say does not transfer.
 - Narrow with `scope: "local"` (this repo alone, always a bare array) or `scope: "workspace"` (every sharing repo, always keyed). `repos: ["<name>"]` restricts to named repos and matches the repo that owns an item; it wins if both are given.
+- Method questions — "how do we generate X", "is there a script for Y" — belong to the whole workspace: query them unscoped before building new tooling; a sibling repo's pipeline answers them more often than this repo's files do.
 - A `WORKSPACE:` notice names linked repos that matched but were not shown, with counts. Re-query with `repos` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -6,8 +6,8 @@
 1. For every project-specific request, call `knowl_query` before repository files or commands, using the words that name the subject: another on-subject term retrieves better, an off-subject one retrieves worse, so do not pad the query and do not trim a real term to shorten it.
 2. Skip a new query only when directly relevant active lifecycle context, a same-request query, or manual `knowl_task_start` relevant memory already answers it.
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
-4. Query again before switching to a distinct subtask or project area.
-5. Store or update durable knowledge during work and before the final answer — verified findings, and stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled. The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or debugging noise.
+4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
+5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
 6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.
 
 ### Lifecycle modes
@@ -36,6 +36,7 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 - When this repo is in a workspace, read the **shape** of a `knowl_query` result first. A bare JSON array means every row belongs to this repo. An object keyed by repo name means at least one row does **not** — and a fact from another repo describes **that** repo unless it says otherwise, so verify before applying it here.
 - An empty array under this repo's own key means this repo holds nothing on the subject. Read the other keys as background, not as an answer, and treat it as a miss if what they say does not transfer.
 - Narrow with `scope: "local"` (this repo alone, always a bare array) or `scope: "workspace"` (every sharing repo, always keyed). `repos: ["<name>"]` restricts to named repos and matches the repo that owns an item; it wins if both are given.
+- Method questions — "how do we generate X", "is there a script for Y" — belong to the whole workspace: query them unscoped before building new tooling; a sibling repo's pipeline answers them more often than this repo's files do.
 - A `WORKSPACE:` notice names linked repos that matched but were not shown, with counts. Re-query with `repos` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ installed guidance asks agents to follow is short:
 
 1. Query memory with the words that name the subject **before** reading repository files.
 2. Use an active hit directly; inspect files only on a miss, conflict, or stale result.
-3. Store durable findings and stated goals as you go, and correct contradicted memory rather than
-   duplicating it.
+3. Store durable findings, stated goals, and resolved diagnoses as you go, and correct
+   contradicted memory rather than duplicating it.
 
 In practice that looks like this — a new session, no context, nothing pasted in:
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ installed guidance asks agents to follow is short:
 
 1. Query memory with the words that name the subject **before** reading repository files.
 2. Use an active hit directly; inspect files only on a miss, conflict, or stale result.
-3. Store durable findings, stated goals, and resolved diagnoses as you go, and correct
+3. Store durable findings, stated goals, and recurring diagnoses as you go, and correct
    contradicted memory rather than duplicating it.
 
 In practice that looks like this — a new session, no context, nothing pasted in:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1382,7 +1382,8 @@ Run `knowl serve` to expose Knowl over stdio MCP. The recommended agent flow is:
    Another on-subject term retrieves better and an off-subject one retrieves worse, so do not pad
    a query to reach a length and do not trim a real term to shorten it.
 3. Verify misses, conflicts, or stale results against the repository.
-4. Store durable findings, stated goals, and resolved diagnoses, and update contradicted memory promptly.
+4. Store durable findings, stated goals, and recurring diagnoses, and update contradicted
+   memory promptly.
 5. Use manual task tools only when verified lifecycle hooks are unavailable.
 
 ### Tools

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1382,7 +1382,7 @@ Run `knowl serve` to expose Knowl over stdio MCP. The recommended agent flow is:
    Another on-subject term retrieves better and an off-subject one retrieves worse, so do not pad
    a query to reach a length and do not trim a real term to shorten it.
 3. Verify misses, conflicts, or stale results against the repository.
-4. Store durable findings and stated goals, and update contradicted memory promptly.
+4. Store durable findings, stated goals, and resolved diagnoses, and update contradicted memory promptly.
 5. Use manual task tools only when verified lifecycle hooks are unavailable.
 
 ### Tools

--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -9,12 +9,12 @@ Valuable project knowledge includes:
 - Project goals or product requirements (e.g. "We must support offline usage").
 - Constraints or rules (e.g. "No cloud APIs allowed").
 - Evolving project state updates (e.g. "Starting implementation of JWT auth flow").
-- Successfully resolved debugging procedures or skills (e.g. "To fix Maven db errors, run clean install and rebuild database").
+- Successfully resolved debugging procedures or skills, and diagnoses whose cause will recur such as an environment quirk or a config trap (e.g. "To fix Maven db errors, run clean install and rebuild database").
 
 You MUST reject (pass = false) the following:
 - Conversational filler, greetings, general pleasantries (e.g. "Hi", "Thanks", "How are you?").
-- Typographical mistakes, syntax corrections, or temporary coding errors that are immediately fixed.
-- Failed attempts, dead-end brainstorming, or intermediate debugging noise (e.g. "Wait, it didn't work. Let me try X instead... No, that failed too").
+- Typographical mistakes, syntax corrections, or one-off coding errors whose cause cannot recur.
+- Failed attempts, dead-end brainstorming, or in-progress debugging that never reached a cause (e.g. "Wait, it didn't work. Let me try X instead... No, that failed too").
 - Sensitive data, credentials, secrets, passwords, or API keys (e.g. "My key is sk-12345...").
 
 Analyze the input text carefully and decide whether it should pass the filter.

--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -37,7 +37,7 @@ Rules for Extraction:
 1. Ignore conversational noise (e.g. "Sure, let's do this", "Okay, I modified...").
 2. Extract the CORE information in clean markdown.
 3. If the input contains a skill/procedure, make sure to extract the ordered "steps" to reproduce/execute that skill.
-4. Extract only validated facts/decisions. Do not extract temporary debugging errors or brainstorming that was rejected.
+4. Extract validated facts and decisions, stated goals, and resolved diagnoses — a failure whose cause was found and whose fix transfers to the next occurrence is a 'skill', with the trigger and fix as steps. Do not extract transient failures that taught nothing, failed attempts along the way, or brainstorming that was rejected.
 5. Create separate atoms if the input contains distinct pieces of knowledge (e.g. a tech choice AND a project state update).
 `;
 

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -148,7 +148,7 @@ function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: b
     'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
     'Route by what you need; the tool list names them:',
     '- retrieval: knowl_query first. Recent context only without bootstrap or for a refresh, broad state for status, a packed context only when a token budget is given.',
-    '- durable memory: store one verified atom, batch several, record a confirmed decision, a stated goal, or a resolved diagnosis, or correct a stale one. Correct rather than duplicate.',
+    '- durable memory: store one verified atom, batch several, record a confirmed decision, a stated goal, or a recurring diagnosis, or correct a stale one. Correct rather than duplicate.',
     '- audit: inspect history, evidence or conflicts when needed; record feedback only after actual use or correction.',
     '- skills: read a matching skill before running a trusted entrypoint; create one only on explicit request.',
     '- special: raw-source ingest only on an explicit request, never silent chat; synthesis only for an explicit scope; preview garbage collection first and apply only after approval.',
@@ -160,11 +160,13 @@ function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: b
     // an agent following this card faithfully skipped storing two strategy conversations,
     // because every storage cue said "verified" and a conversation verifies nothing. Intent is
     // durable before it is settled — that is what the goal category and user_stated provenance
-    // exist for — and the omission taught agents the opposite. "Resolved diagnoses" joined it
+    // exist for — and the omission taught agents the opposite. "Recurring diagnoses" joined it
     // after the same failure in a third shape (2026-08-11): a fixed environment trap — the kind
     // that recurs — went unstored because "findings" read as build results, and the next
-    // session re-diagnosed it from scratch.
-    'During work, store durable findings, stated intent, and resolved diagnoses — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
+    // session re-diagnosed it from scratch. The adjective is the rule, not decoration: rule 5
+    // excludes the typo, and a typo is a resolved diagnosis too, so a cue saying only "resolved"
+    // would summarise the rule as its own counterexample.
+    'During work, store durable findings, stated intent, and recurring diagnoses — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
   ].join('\n');
 }
 
@@ -189,7 +191,7 @@ export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the 
 export const KNOWL_CLAUDE_PROMPT_REMINDER = [
   'KNOWL — project memory is active.',
   'For any project question or new subtask, call knowl_query BEFORE reading files, using the words that name the subject and no padding; use a relevant active hit directly and inspect files only on a miss, conflict, or stale/low-confidence result.',
-  'Store durable decisions, facts, state, constraints, stated goals, and resolved diagnoses as you go with knowl_store / knowl_decide / knowl_update — intent counts before it settles, a recurring cause once fixed; never store secrets or routine noise.',
+  'Store durable decisions, facts, state, constraints, stated goals, and recurring diagnoses as you go with knowl_store / knowl_decide / knowl_update — intent counts before it settles; never store secrets or routine noise.',
   'Claude hooks own the lifecycle — do not call knowl_task_start/checkpoint/finish. Full tool routing is in KNOWL.md.',
 ].join(' ');
 

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -62,8 +62,8 @@ const REQUIRED_WORKFLOW = `### Required workflow
 1. For every project-specific request, call \`knowl_query\` before repository files or commands, using the words that name the subject: another on-subject term retrieves better, an off-subject one retrieves worse, so do not pad the query and do not trim a real term to shorten it.
 2. Skip a new query only when directly relevant active lifecycle context, a same-request query, or manual \`knowl_task_start\` relevant memory already answers it.
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
-4. Query again before switching to a distinct subtask or project area.
-5. Store or update durable knowledge during work and before the final answer — verified findings, and stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled. The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or debugging noise.
+4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
+5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
 6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.`;
 
 const LIFECYCLE_MODES = `### Lifecycle modes
@@ -84,6 +84,7 @@ const WORKSPACE = `### Linked repositories
 - When this repo is in a workspace, read the **shape** of a \`knowl_query\` result first. A bare JSON array means every row belongs to this repo. An object keyed by repo name means at least one row does **not** — and a fact from another repo describes **that** repo unless it says otherwise, so verify before applying it here.
 - An empty array under this repo's own key means this repo holds nothing on the subject. Read the other keys as background, not as an answer, and treat it as a miss if what they say does not transfer.
 - Narrow with \`scope: "local"\` (this repo alone, always a bare array) or \`scope: "workspace"\` (every sharing repo, always keyed). \`repos: ["<name>"]\` restricts to named repos and matches the repo that owns an item; it wins if both are given.
+- Method questions — "how do we generate X", "is there a script for Y" — belong to the whole workspace: query them unscoped before building new tooling; a sibling repo's pipeline answers them more often than this repo's files do.
 - A \`WORKSPACE:\` notice names linked repos that matched but were not shown, with counts. Re-query with \`repos\` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while \`--default-visibility repo\` keeps writes private. \`knowl workspace set\` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs \`knowl workspace promote\`. Only the owning repo can promote, update, or retire its own items.`;
@@ -147,7 +148,7 @@ function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: b
     'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
     'Route by what you need; the tool list names them:',
     '- retrieval: knowl_query first. Recent context only without bootstrap or for a refresh, broad state for status, a packed context only when a token budget is given.',
-    '- durable memory: store one verified atom, batch several, record a confirmed decision or a stated goal, or correct a stale one. Correct rather than duplicate.',
+    '- durable memory: store one verified atom, batch several, record a confirmed decision, a stated goal, or a resolved diagnosis, or correct a stale one. Correct rather than duplicate.',
     '- audit: inspect history, evidence or conflicts when needed; record feedback only after actual use or correction.',
     '- skills: read a matching skill before running a trusted entrypoint; create one only on explicit request.',
     '- special: raw-source ingest only on an explicit request, never silent chat; synthesis only for an explicit scope; preview garbage collection first and apply only after approval.',
@@ -159,8 +160,11 @@ function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: b
     // an agent following this card faithfully skipped storing two strategy conversations,
     // because every storage cue said "verified" and a conversation verifies nothing. Intent is
     // durable before it is settled — that is what the goal category and user_stated provenance
-    // exist for — and the omission taught agents the opposite.
-    'During work, store durable findings and stated intent — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
+    // exist for — and the omission taught agents the opposite. "Resolved diagnoses" joined it
+    // after the same failure in a third shape (2026-08-11): a fixed environment trap — the kind
+    // that recurs — went unstored because "findings" read as build results, and the next
+    // session re-diagnosed it from scratch.
+    'During work, store durable findings, stated intent, and resolved diagnoses — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
   ].join('\n');
 }
 
@@ -177,7 +181,7 @@ export function mcpServerInstructions(config: ProjectConfig | null): string {
   if (!config || !isTranscriptSearchEnabled(config)) return KNOWL_MCP_SERVER_INSTRUCTIONS;
   return renderCompactKnowlGuidance(KNOWL_HOST_NEUTRAL_MODE_LINE, { transcripts: true });
 }
-export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the project-memory workflow active. Use relevant active memory. Before entering a new project area, call knowl_query with the words that name the subject before repository files or commands. Store durable findings and stated goals. Claude hooks own lifecycle; do not start the manual task loop.';
+export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the project-memory workflow active. Use relevant active memory. Before entering a new project area, call knowl_query with the words that name the subject before repository files or commands. Store durable findings, stated goals, and recurring diagnoses. Claude hooks own lifecycle; do not start the manual task loop.';
 
 // Short per-prompt reminder (UserPromptSubmit). The full tool routing lives in
 // KNOWL.md and the MCP initialize instructions, so the per-prompt card only needs
@@ -185,7 +189,7 @@ export const KNOWL_CLAUDE_CONTINUATION_REMINDER = 'KNOWL CONTINUATION: Keep the 
 export const KNOWL_CLAUDE_PROMPT_REMINDER = [
   'KNOWL — project memory is active.',
   'For any project question or new subtask, call knowl_query BEFORE reading files, using the words that name the subject and no padding; use a relevant active hit directly and inspect files only on a miss, conflict, or stale/low-confidence result.',
-  'Store durable decisions, facts, state, constraints, and stated goals as you go with knowl_store / knowl_decide / knowl_update — intent counts before it settles; never store secrets or routine noise.',
+  'Store durable decisions, facts, state, constraints, stated goals, and resolved diagnoses as you go with knowl_store / knowl_decide / knowl_update — intent counts before it settles, a recurring cause once fixed; never store secrets or routine noise.',
   'Claude hooks own the lifecycle — do not call knowl_task_start/checkpoint/finish. Full tool routing is in KNOWL.md.',
 ].join(' ');
 
@@ -202,7 +206,7 @@ export const KNOWL_CLAUDE_PROMPT_REMINDER = [
 export const KNOWL_SUBAGENT_BOOTSTRAP_CARD = [
   'KNOWL — project memory is active for this subagent.',
   'Before reading repository files, call knowl_query with the words that name the subject and use a relevant active hit directly; inspect files only on a miss, conflict, or stale result.',
-  'Store verified durable findings with knowl_store or knowl_update before you return; never store secrets or routine noise.',
+  'Store durable findings — including a diagnosis whose cause will recur — with knowl_store or knowl_update before you return; never store secrets or routine noise.',
   'Do not call knowl_task_start/checkpoint/finish — the host session owns the lifecycle.',
   'If a result carries a repo field, that knowledge belongs to that repo and describes it, not necessarily this one.',
   'If the knowl tools are listed but not callable, load their schemas before calling them.',

--- a/tests/ai/prompts.test.ts
+++ b/tests/ai/prompts.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { FILTER_SYSTEM_PROMPT } from '../../src/ai/prompts.js';
+
+/**
+ * The filter is a gate, not an advisor. `runPipeline` returns early the moment it rejects
+ * (`src/pipeline/pipeline.ts`), so extraction never sees that input and no later stage can
+ * report what was lost. Anything the extract prompt is told to keep has to survive the filter
+ * first, or the extract rule is unreachable prose.
+ *
+ * The pair drifted apart exactly there. Extraction learned to keep a diagnosis whose cause will
+ * recur, while the filter still carried a MUST-reject for "temporary coding errors that are
+ * immediately fixed" — precisely what a diagnosed and fixed config trap looks like from the
+ * gate. The filter's own allow list already named resolved debugging procedures as valuable, so
+ * that bullet was also contradicting the line eight above it. Both stages now split on
+ * recurrence rather than on whether an error occurred.
+ */
+describe('AI pipeline prompts', () => {
+  it('does not reject at the gate the recurring diagnoses extraction is told to keep', () => {
+    expect(FILTER_SYSTEM_PROMPT).toMatch(/recur/);
+    // The two phrases that made a fixed, understood config trap read as a MUST-reject.
+    expect(FILTER_SYSTEM_PROMPT).not.toMatch(/immediately fixed/);
+    expect(FILTER_SYSTEM_PROMPT).not.toMatch(/intermediate debugging noise/);
+  });
+});

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -34,12 +34,12 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
   'Route by what you need; the tool list names them:',
   '- retrieval: knowl_query first. Recent context only without bootstrap or for a refresh, broad state for status, a packed context only when a token budget is given.',
-  '- durable memory: store one verified atom, batch several, record a confirmed decision or a stated goal, or correct a stale one. Correct rather than duplicate.',
+  '- durable memory: store one verified atom, batch several, record a confirmed decision, a stated goal, or a resolved diagnosis, or correct a stale one. Correct rather than duplicate.',
   '- audit: inspect history, evidence or conflicts when needed; record feedback only after actual use or correction.',
   '- skills: read a matching skill before running a trusted entrypoint; create one only on explicit request.',
   '- special: raw-source ingest only on an explicit request, never silent chat; synthesis only for an explicit scope; preview garbage collection first and apply only after approval.',
   '- leaving work: one baton the next session here consumes once, or a key the user keeps and hands back any time later, from anywhere.',
-  'During work, store durable findings and stated intent — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
+  'During work, store durable findings, stated intent, and resolved diagnoses — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
 ].join('\n');
 
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
@@ -127,8 +127,8 @@ describe('canonical Knowl agent guidance', () => {
     // (see 'does not grow when a tool is added'), so a new tool inside an existing group should
     // leave both numbers untouched. If adding a tool changes them, something re-introduced the
     // inventory the card stopped carrying.
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_787);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_838);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_831);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_882);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -181,19 +181,22 @@ describe('canonical Knowl agent guidance', () => {
    * precisely the kind of tight phrase someone re-introduces while shortening a line to buy
    * room, and the omission it causes is invisible until a user is annoyed.
    */
-  it('names stated intent as storable in every storage cue that reaches an agent', () => {
+  it('names stated intent and recurring diagnoses as storable in every storage cue that reaches an agent', () => {
     for (const surface of [
       KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS,
       KNOWL_CLAUDE_PROMPT_REMINDER, KNOWL_CLAUDE_CONTINUATION_REMINDER,
     ]) {
       expect(surface).toMatch(/stated (intent|goal)/);
+      expect(surface).toMatch(/diagnos/);
     }
     // The full guidance names the mechanism, not just the class: which category, which
     // provenance, and the recovery test that decides.
     expect(renderFullKnowlGuidance()).toContain('user_stated');
     expect(renderFullKnowlGuidance()).toContain('could a fresh session recover this from memory alone?');
-    // The subagent card is deliberately absent from this list: a subagent receives a bounded
-    // task, not a user conversation, so findings-only is its correct storable class.
+    expect(renderFullKnowlGuidance()).toContain('resolved diagnoses stored as skills');
+    // The subagent card stays intent-free — a subagent receives a bounded task, not a user
+    // conversation — but it does debug, so diagnoses are in its storable class too.
+    expect(KNOWL_SUBAGENT_BOOTSTRAP_CARD).toMatch(/diagnos/);
   });
 
   it('changes only the lifecycle mode line between compact renderings', () => {

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -34,12 +34,12 @@ const EXPECTED_CLAUDE_CARD = [
   'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
   'Route by what you need; the tool list names them:',
   '- retrieval: knowl_query first. Recent context only without bootstrap or for a refresh, broad state for status, a packed context only when a token budget is given.',
-  '- durable memory: store one verified atom, batch several, record a confirmed decision, a stated goal, or a resolved diagnosis, or correct a stale one. Correct rather than duplicate.',
+  '- durable memory: store one verified atom, batch several, record a confirmed decision, a stated goal, or a recurring diagnosis, or correct a stale one. Correct rather than duplicate.',
   '- audit: inspect history, evidence or conflicts when needed; record feedback only after actual use or correction.',
   '- skills: read a matching skill before running a trusted entrypoint; create one only on explicit request.',
   '- special: raw-source ingest only on an explicit request, never silent chat; synthesis only for an explicit scope; preview garbage collection first and apply only after approval.',
   '- leaving work: one baton the next session here consumes once, or a key the user keeps and hands back any time later, from anywhere.',
-  'During work, store durable findings, stated intent, and resolved diagnoses — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
+  'During work, store durable findings, stated intent, and recurring diagnoses — a goal counts before it settles; never raw transcripts, secrets, or routine command noise.',
 ].join('\n');
 
 const namesIn = (text: string) => [...new Set(text.match(/\bknowl_[a-z_]+\b/g) ?? [])].sort();
@@ -127,8 +127,8 @@ describe('canonical Knowl agent guidance', () => {
     // (see 'does not grow when a tool is added'), so a new tool inside an existing group should
     // leave both numbers untouched. If adding a tool changes them, something re-introduced the
     // inventory the card stopped carrying.
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_831);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_882);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_833);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_884);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -180,14 +180,22 @@ describe('canonical Knowl agent guidance', () => {
    * Pinned for the same reason the keyword-cap test above is: "verified durable findings" is
    * precisely the kind of tight phrase someone re-introduces while shortening a line to buy
    * room, and the omission it causes is invisible until a user is annoyed.
+   *
+   * The diagnosis half is pinned with its qualifier, not just its class name. Recurrence is the
+   * axis that predicts value, and "resolved" is not it: a typo is resolved too, and rule 5
+   * excludes it by name. A cue reading only "resolved diagnoses" would summarise the rule as its
+   * own counterexample, so each surface has to say *which* diagnoses — the recurring ones. The
+   * compact cards get this wrong the moment someone drops an adjective to buy back characters,
+   * which is the same pressure that produced the original omission.
    */
   it('names stated intent and recurring diagnoses as storable in every storage cue that reaches an agent', () => {
+    const recurrence = /recurring diagnos|diagnosis whose cause will recur/;
     for (const surface of [
       KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS,
       KNOWL_CLAUDE_PROMPT_REMINDER, KNOWL_CLAUDE_CONTINUATION_REMINDER,
     ]) {
       expect(surface).toMatch(/stated (intent|goal)/);
-      expect(surface).toMatch(/diagnos/);
+      expect(surface).toMatch(recurrence);
     }
     // The full guidance names the mechanism, not just the class: which category, which
     // provenance, and the recovery test that decides.
@@ -196,7 +204,7 @@ describe('canonical Knowl agent guidance', () => {
     expect(renderFullKnowlGuidance()).toContain('resolved diagnoses stored as skills');
     // The subagent card stays intent-free — a subagent receives a bounded task, not a user
     // conversation — but it does debug, so diagnoses are in its storable class too.
-    expect(KNOWL_SUBAGENT_BOOTSTRAP_CARD).toMatch(/diagnos/);
+    expect(KNOWL_SUBAGENT_BOOTSTRAP_CARD).toMatch(recurrence);
   });
 
   it('changes only the lifecycle mode line between compact renderings', () => {


### PR DESCRIPTION
Follow-up to #55, which fixed the first of these gaps (stated intent). Two more storage-cue gaps, both caught the same way: a live miss the user had to notice by hand. That is now four manual catches total, which is also fresh evidence for #54 — every one of these was detected by a human, because nothing else can detect them.

## The diagnosis miss (2026-08-11)

An agent hit an environment trap — MCP servers vanishing mid-session because the host machine switches between two Claude config dirs and the server was defined in only one — diagnosed it correctly, fixed it, and stored nothing. Caught only when the user asked why the same class of problem kept being re-diagnosed. Two causes, layered:

- Every storage cue reads as build-results language ("findings"), and nothing names a resolved diagnosis as storable — the same shape as #55's gap, in a third class of knowledge.
- The extraction prompt's rule 4 says outright "do not extract temporary debugging errors", three lines below a category list defining `skill` as "successfully resolved debugging steps or procedures". The prompt contradicts its own taxonomy.

The axis that predicts value is not "is it an error" — it is **recurrence and derivability**. A typo fails both and should stay excluded. A config trap recurs on every account switch, in every repo, and is written down nowhere. The new wording splits on that axis instead of on the word "debugging".

## The method miss (2026-08-10)

Asked to generate mascot art in a repo whose linked sibling carries a complete image-generation pipeline (stored, workspace-visible, and retrieved at score 0.91 the moment it was finally queried), an agent started hand-building an alternative instead. It never queried for the method: choosing *how* to build something did not register as a knowledge question, and the one early query was deliberately `scope: "local"`. The workflow taught querying the request's subject and how to interpret cross-repo results — it never said method questions are queries too, nor that they are exactly the queries not to scope local.

## What changed

- **Rule 5**: resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo); the exclusion narrows from "debugging noise" to "transient debugging noise".
- **Rule 4**: query again before choosing how to build something new, with method queries left unscoped.
- **Linked repositories**: a bullet naming method questions as workspace-wide queries.
- **Compact card**: route bullet and closing line gain resolved diagnoses. Cards move 1,787 → 1,831 and 1,838 → 1,882; the binding transcript-enabled variant lands at 1,987, under the 2,000 ceiling.
- **Prompt + continuation reminders**: same widening, fewer words.
- **Subagent card**: #55 left it findings-only because intent never reaches a subagent; a diagnosis does — debugging is half of what subagents are sent to do — so it now names a diagnosis whose cause will recur.
- **Extraction prompt rule 4**: extracts stated goals and resolved diagnoses (as `skill`, with trigger and fix as steps); excludes transient failures that taught nothing. Resolves the self-contradiction.
- **README + docs/reference.md**: aligned.

The pinned cue test from #55 now also asserts every surface names diagnoses, and that the full guidance carries the skills mechanism.

## Verification

- The three guidance suites pass 74/74.
- Full suite: the failure set is byte-identical to clean upstream/main in the same environment (87 = 87, `comm -13` empty) — the pre-existing environmental failures, no regressions.

## Related, not included

The method miss has a structural half the wording cannot fix: the session-start "Available skills" card is built from `listActiveSkillItems`, which reads only the local store — a workspace-visible skill in a sibling repo can never ambient-surface at bootstrap. Filing that separately with the measured evidence, since it needs design decisions (budget, repo labeling, run-ability across repos) rather than wording.