### PR TITLE
Surface a peer repo's skills, and measure the sessions that store nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,85 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+Two halves of the same gap: memory that is present but never surfaced, and memory that is never
+written at all.
+
+### A linked repo's skills now reach the session-start card
+
+Workspace visibility governed *query* reach but not *ambient* reach. `bootstrapAgentSession` filled
+its "Available skills" section from `listActiveSkillItems`, which reads the local store only — so a
+sibling repo's workspace-visible skill could be found by an agent that already knew to ask for it,
+which is precisely the agent that does not know the tooling exists. The knowledge most worth sharing
+across a workspace is reusable tooling, and that is the kind nobody queries for by name.
+
+Peer skills now ride the same card as pointers, labelled with the repo that owns them
+(`- **mascot-art** (in duckprep, not runnable here) — …`), local rows first, inside the existing
+750-character budget. A repo with enough of its own skills degrades to exactly the previous card.
+
+Two things that had to be right, and were not free:
+
+- **A peer skill is forced non-runnable rather than derived as one.** `toSurfacedSkills` reads
+  runnability off `source.startsWith('.knowl/skills/')`, and a peer's package carries exactly that
+  source — it is a real package, just not under this root. Left to the derivation, peer rows came
+  back `runnable: true`, and two things believe that field: `knowl_skill_run` resolves against the
+  local root, and `matchSkillForCommand` filters on it, so a peer row could have won the mid-turn
+  slot and told the agent to run something unreachable. Trust is the deeper reason —
+  `assertSkillApproved` is per-repo, so running a peer's bytes from here spends an approval nobody
+  gave.
+- **The repo label is priced by the function that renders it.** `selectSurfacedSkills` charges
+  `renderSkillRow(skill).length`; a label appended at the render site would have priced one string
+  and emitted another.
+
+`listActiveSkillItems` is untouched: it runs on every command tool event and is index-scoped for
+that reason, so bootstrap got its own peer lookup rather than a widened hot path.
+
+### The write path can now see what it failed to store
+
+Knowl's write path is all admission control — secret validation, categories, conflict keys, dedup —
+and every one of those gates decides what gets *in*. Nothing noticed what should have got in and did
+not. The read side had been growing exactly that telemetry (`knowledge_access` records
+retrieved-but-never-used); the write side had no twin, and its only detector was a person noticing
+afterwards and asking for the save by hand.
+
+`capture_outcomes` now records, per conversation, how many turns it produced and how many durable
+writes it made. `knowl status` reports it:
+
+```
+🔍 CAPTURE HEALTH
+  Sessions recorded:     88
+  Stored nothing:        79
+  ...and ran long enough to count: 31 (35%)
+```
+
+Measurement runs unconditionally; `capture.nudge` decides only what is done with the answer, and
+defaults to `off`. `shadow` records the nudge it would have sent. `enforce` withholds one stop and
+asks the agent to store what it learned. That is the same `off → shadow → enforce` ladder
+`impact.gate` climbs, for the same reason: the number a decision to intervene rests on cannot be
+measured by something already intervening.
+
+Four design points worth stating, because each is a place the obvious version is wrong:
+
+- **Turns, not tool events.** The sessions this exists to catch are strategy conversations — long on
+  turns, short on tool calls — so any threshold counted in tool events would have excluded exactly
+  them.
+- **Keyed on the conversation, not a memory session.** A Claude turn binds its own memory session and
+  `Stop` closes it, so the next turn gets a fresh one; a counter keyed that way reports one turn
+  forever however long the conversation runs.
+- **`finalizeMemorySession` reporting `skipped` is not "stored nothing".** It means automatic
+  promotion found no candidate, which is true of nearly every conversation and says nothing about
+  what the agent stored by hand. Reading it as silence would have fired on the sessions that did
+  everything right.
+- **There is no non-blocking channel at stop.** A stop hook either withholds the stop and hands back
+  a reason, or is not heard; `SessionEnd` fires once the model is gone. So `enforce` costs a turn,
+  which is why it is claimed once per conversation before delivery — a block keyed on "stored
+  nothing" is a condition the agent may rightly decline to clear, and without the one-shot it would
+  fire on every subsequent stop forever.
+
+Reads do not count as writes: a session that queried diligently and stored nothing is the case this
+measures.
+
 ## 4.1.0 — 2026-08-10
 
 The first release after 4.0.0 met a real cloud workspace, and the first thing it found was that

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -23,9 +23,10 @@ export type ConfigKey =
   | 'memory.global.enabled'
   | 'memory.global.path'
   | 'impact.enabled'
-  | 'impact.gate';
+  | 'impact.gate'
+  | 'capture.nudge';
 
-export type ConfigCategory = 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact';
+export type ConfigCategory = 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact' | 'Capture';
 
 /**
  * How a value should be asked for. Without this the UI had only `parse`, so every field
@@ -85,6 +86,10 @@ const AI_PROVIDERS = ['openai', 'anthropic', 'ollama', 'custom'] as const;
 // Ordered by how much they can cost the person running them, which is also the order they are
 // meant to be adopted in: nothing, then measurement, then refusal.
 const IMPACT_GATE_MODES = ['off', 'shadow', 'enforce'] as const;
+// The same three, in the same order and for the same reason. Kept as its own constant rather
+// than shared: they mean different things (one refuses a write, one withholds a stop), and a
+// shared list is how a fourth mode added for one of them silently becomes settable on the other.
+const CAPTURE_NUDGE_MODES = ['off', 'shadow', 'enforce'] as const;
 
 export const CONFIG_FIELDS: ConfigField[] = [
   // The preset leads the Search list: it is the one setting most people should touch,
@@ -225,6 +230,19 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(IMPACT_GATE_MODES), defaultValue: 'off',
     label: 'Write gate',
     description: 'Before an edit lands on code this session read and has not seen since: shadow records what it would have refused and lets the write through, enforce refuses it and hands back what changed. Needs change impact detection on.',
+  },
+  {
+    // `defaultValue: 'off'` lives here and nowhere else, for the same reason as `impact.gate`
+    // above: the literal in DEFAULT_CONFIG would be merged into every config on the machine by
+    // `upgradeConfigDefaults`, which for this key means every repository the user has ever
+    // initialized starts withholding stops.
+    //
+    // Note what this key does *not* control: the counting. `knowl status` reports capture health
+    // whatever this says, because the number is what a decision to arm has to be made against.
+    key: 'capture.nudge', category: 'Capture', type: 'enum', values: CAPTURE_NUDGE_MODES,
+    parse: enumValue(CAPTURE_NUDGE_MODES), defaultValue: 'off',
+    label: 'Empty-session nudge',
+    description: 'When a conversation has run for several turns and stored nothing durable: shadow records the nudge it would have sent, enforce withholds the stop once and asks the agent to store what it learned. Measurement runs either way.',
   },
 ];
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -18,6 +18,8 @@ import { recordDecisionDirect } from '../store/knowledge-actions.js';
 import { getHierarchicalKnowledge, queryKnowledgeBase } from '../store/queries.js';
 import { formatHierarchyToMarkdown } from '../core/format.js';
 import { formatStatusReport } from './status-report.js';
+import { captureHealth } from '../store/capture-outcome.js';
+import { captureNudgeMode } from '../store/capture-config.js';
 import { KNOWLEDGE_CATEGORIES, type KnowledgeCategory } from '../core/types.js';
 import { createManifest, isValidRepoName, readManifest, writeManifest } from '../workspace/manifest.js';
 import { knowlHome, listKnownWorkspaces, workspaceManifestPath } from '../workspace/paths.js';
@@ -396,6 +398,8 @@ program
         supersededItems,
         deprecatedItems,
         commits,
+        capture: await captureHealth(),
+        captureNudgeMode: captureNudgeMode(config),
       }));
 
       if (isUpdateCheckEnabled(config)) {

--- a/src/cli/status-report.ts
+++ b/src/cli/status-report.ts
@@ -1,5 +1,6 @@
 import { KNOWLEDGE_CATEGORIES, KnowledgeCommit, KnowledgeItem, Project, ProjectConfig } from '../core/types.js';
 import type { ActiveWorkspace } from '../workspace/resolve.js';
+import type { CaptureHealth } from '../store/capture-outcome.js';
 import { formatWorkspaceBlock } from './workspace-report.js';
 
 const STATUS_LINE = '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━';
@@ -13,6 +14,9 @@ export function formatStatusReport(input: {
   commits: KnowledgeCommit[];
   /** Absent for an unlinked project, which keeps its output byte-identical. */
   workspace?: ActiveWorkspace | null;
+  /** Absent on a store with no recorded sessions, which renders no section at all. */
+  capture?: CaptureHealth;
+  captureNudgeMode?: string;
 }): string {
   const countsByCategory = input.activeItems.reduce((acc, item) => {
     acc[item.category] = (acc[item.category] || 0) + 1;
@@ -46,8 +50,41 @@ export function formatStatusReport(input: {
       lines.push(`  [${commit.id}] ${new Date(commit.createdAt).toLocaleString()} - ${commit.message}`);
     }
   }
+  lines.push(...formatCaptureHealthBlock(input.capture, input.captureNudgeMode));
   lines.push(...formatWorkspaceBlock(input.workspace ?? null));
   lines.push(STATUS_LINE);
 
   return lines.join('\n');
+}
+
+/**
+ * What this repo failed to store, beside what it stored.
+ *
+ * The knowledge counts above answer "what got in". This is the other half of that sentence: how
+ * often a session talked for a while and put nothing durable in the store. It is reported whether
+ * or not `capture.nudge` is armed, because the number has to exist before anyone can sensibly
+ * decide whether they want something done about it.
+ *
+ * Absent until a session has been recorded, rather than printed as a row of zeros: a repo whose
+ * hooks have never run has not measured 0%, it has measured nothing, and a confident zero is the
+ * wrong thing to tell someone whose capture is simply not wired up.
+ */
+function formatCaptureHealthBlock(capture?: CaptureHealth, mode?: string): string[] {
+  if (!capture || capture.sessions === 0) return [];
+
+  const share = Math.round((capture.substantiveSilent / capture.sessions) * 100);
+  const lines = [
+    STATUS_LINE,
+    '🔍 CAPTURE HEALTH',
+    `  Sessions recorded:     ${capture.sessions}`,
+    `  Stored nothing:        ${capture.silent}`,
+    `  ...and ran long enough to count: ${capture.substantiveSilent} (${share}%)`,
+  ];
+  // Only once something has fired, and named by mode: "12 recorded" and "12 delivered" are very
+  // different facts about a repository, and a single count that means either is worth nothing.
+  if (capture.nudged > 0) {
+    lines.push(`  Nudges ${mode === 'enforce' ? 'delivered' : 'recorded (shadow)'}:  ${capture.nudged}`);
+  }
+  if (mode === 'off') lines.push('  Nudge: off — measuring only. Arm with capture.nudge=shadow.');
+  return lines;
 }

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -1,6 +1,6 @@
 import { KnowledgeCommit, KnowledgeItem } from './types.js';
 import { DEFAULT_CONTEXT_MAX_CHARS, MAX_SUMMARY_ITEM_CHARS, truncateText } from './token-budget.js';
-import { renderSkillsSection, selectSurfacedSkills } from './skill-surface.js';
+import { renderSkillsSection, selectSurfacedSkills, toPeerSurfacedSkills } from './skill-surface.js';
 import { fenceUntrusted, inlineUntrusted, UNTRUSTED_NOTICE_BRIEF } from './untrusted.js';
 
 /**
@@ -157,6 +157,11 @@ export function formatRecentContextToMarkdown(context: {
   items: KnowledgeItem[];
   commits: KnowledgeCommit[];
   skills?: KnowledgeItem[];
+  /**
+   * Linked repos' workspace-visible skills, structurally typed so `core` stays at the bottom of
+   * the dependency graph -- `workspace/peer-skills.ts` produces this shape and imports downward.
+   */
+  peerSkills?: Array<{ repo: string; item: KnowledgeItem }>;
 }, options: { maxChars?: number; maxItemChars?: number; includeTags?: boolean; includeCommitDetails?: boolean; workspace?: WorkspaceContext } = {}): string {
   const maxChars = options.maxChars ?? DEFAULT_CONTEXT_MAX_CHARS;
   const maxItemChars = options.maxItemChars ?? MAX_SUMMARY_ITEM_CHARS;
@@ -179,7 +184,15 @@ export function formatRecentContextToMarkdown(context: {
   const skillBudget = Math.floor(Math.min(maxChars, DEFAULT_CONTEXT_MAX_CHARS) * 0.25);
   // Rendered by the same module that priced it, so the section can never exceed the budget
   // selection thought it was spending.
-  md += renderSkillsSection(selectSurfacedSkills(context.skills ?? [], skillBudget));
+  //
+  // Peers are passed in beside the local rows rather than concatenated into them, because the
+  // two are mapped differently: a peer row is a pointer whose `runnable` is forced false, and
+  // deriving it from `source` the way a local row does would mark it runnable.
+  md += renderSkillsSection(selectSurfacedSkills(
+    context.skills ?? [],
+    skillBudget,
+    toPeerSurfacedSkills(context.peerSkills ?? []),
+  ));
 
   md += '## Recent Active Knowledge\n\n';
   if (context.items.length === 0) {

--- a/src/core/skill-surface.ts
+++ b/src/core/skill-surface.ts
@@ -6,6 +6,14 @@ export interface SurfacedSkill {
   purpose: string;
   /** True when `knowl_skill_run` can actually execute it -- a file-backed package. */
   runnable: boolean;
+  /**
+   * The linked repo that owns this skill, for a row that is not this repo's own.
+   *
+   * Absent for a local skill, and its absence is what the whole rest of the pipeline reads as
+   * "local": `renderSkillRow` labels on it and `matchSkillForCommand` will not fire on a row
+   * that has it. Set it and the row is a pointer, never a thing to run.
+   */
+  repo?: string;
 }
 
 /** How much of a purpose line is worth showing. */
@@ -39,7 +47,23 @@ export const SKILLS_SECTION_HEADER = '## Available skills\n\n';
 export function renderSkillRow(skill: SurfacedSkill): string {
   const name = inlineUntrusted(skill.name);
   const purpose = inlineUntrusted(skill.purpose);
-  return `- **${name}**${skill.runnable ? '' : ' (not runnable)'} — ${purpose}\n`;
+  return `- **${name}**${renderSkillTag(skill)} — ${purpose}\n`;
+}
+
+/**
+ * The parenthetical after a skill's name.
+ *
+ * A peer row states both facts at once because they are one fact to the reader: it belongs to
+ * another repo, and that is *why* it cannot be run from here. "not runnable here" rather than
+ * "not runnable" is deliberate -- the skill runs perfectly well in the repo that owns it, and
+ * an agent told otherwise would stop looking for the tooling instead of going to find it.
+ *
+ * Repo names come from the workspace manifest, which is a file on disk like any other stored
+ * text, so the name is contained on the same terms as the rest of the row.
+ */
+function renderSkillTag(skill: SurfacedSkill): string {
+  if (skill.repo) return ` (in ${inlineUntrusted(skill.repo)}, not runnable here)`;
+  return skill.runnable ? '' : ' (not runnable)';
 }
 
 /** The whole section, header and trailing blank line included, or '' for no skills. */
@@ -71,17 +95,59 @@ export function toSurfacedSkills(items: KnowledgeItem[]): SurfacedSkill[] {
 }
 
 /**
+ * A linked repo's shared skills as rows, always as pointers and never as runnables.
+ *
+ * **`runnable` is forced here rather than derived, and that is the entire point of this
+ * function.** `toSurfacedSkills` reads runnability off `source.startsWith('.knowl/skills/')`,
+ * and a peer's skill package carries exactly that source -- it is a real package, in a real
+ * `.knowl/skills/` directory, just not one under this root. Left to the derivation a peer row
+ * would come back `runnable: true`, and two things downstream believe that field: `knowl_skill_run`
+ * resolves `readSkillPackage(projectRoot, name)` against the LOCAL root, so the call fails or,
+ * worse, runs a same-named local skill instead; and `matchSkillForCommand` filters on it, so a
+ * peer row could win the mid-turn slot and tell the agent to run something unreachable.
+ *
+ * Trust is the deeper reason. `assertSkillApproved` is per-repo: a human approved those exact
+ * bytes for that entrypoint *in the repo that owns them*. Running them from here on the strength
+ * of a shared row would spend an approval nobody gave.
+ *
+ * So a peer skill is a pointer, which is all the surfacing needs to be. Knowing the pipeline
+ * exists is the whole gap -- an agent that knows can go and read it.
+ */
+export function toPeerSurfacedSkills(entries: Array<{ repo: string; item: KnowledgeItem }>): SurfacedSkill[] {
+  return entries
+    .filter(({ item }) => item.category === 'skill' && item.status === 'active')
+    .map(({ repo, item }) => ({
+      name: item.title,
+      purpose: purposeOf(item.content ?? ''),
+      runnable: false,
+      repo,
+    }));
+}
+
+/**
  * The skills that fit `maxChars` once rendered, header included.
  *
  * The budget is the whole section's, not the rows' alone: `renderSkillsSection` of the
  * result is guaranteed to be at most `maxChars` characters.
+ *
+ * **Local first, and peers only with what is left.** A repo's own runnable tooling is the more
+ * actionable row and it keeps its place unconditionally, so a store with enough local skills
+ * degrades to exactly today's card rather than trading a runnable skill for a pointer.
  */
-export function selectSurfacedSkills(items: KnowledgeItem[], maxChars: number): SurfacedSkill[] {
+export function selectSurfacedSkills(
+  items: KnowledgeItem[],
+  maxChars: number,
+  peers: SurfacedSkill[] = [],
+): SurfacedSkill[] {
   const kept: SurfacedSkill[] = [];
   // The header and the blank line that closes the section are only paid once, and only
   // if at least one row survives -- an empty section renders as nothing at all.
   let used = SKILLS_SECTION_HEADER.length + 1;
-  for (const skill of toSurfacedSkills(items)) {
+  // A peer sharing a name with a local skill is dropped rather than shown twice: the local one
+  // is already rendered, is the one that runs, and is the one `knowl_skill_run` would resolve.
+  const localNames = new Set(toSurfacedSkills(items).map((skill) => skill.name.toLowerCase()));
+  const ordered = [...toSurfacedSkills(items), ...peers.filter((peer) => !localNames.has(peer.name.toLowerCase()))];
+  for (const skill of ordered) {
     const cost = renderSkillRow(skill).length;
     if (used + cost > maxChars) break;
     kept.push(skill);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -330,6 +330,32 @@ export interface ProjectConfig {
     gate?: 'off' | 'shadow' | 'enforce';
   };
   /**
+   * The write side's negative signal: sessions that talked and stored nothing.
+   *
+   * The write path has admission control -- secret validation, categories, conflict keys --
+   * deciding what gets *in*. Nothing detected what should have got in and did not, and the
+   * knowledge with no verification moment to trigger a save is exactly the most durable kind:
+   * declared intent. The only detector before this was a user noticing and asking.
+   *
+   * Measurement is unconditional and costs one counter per session; `nudge` decides only what
+   * is done with the answer. Deliberately absent from DEFAULT_CONFIG, for the reason `impact`
+   * and `search.transcripts` are: `upgradeConfigDefaults` merges defaults into every config on
+   * the machine, so a value written there would arm this in every repository at once.
+   */
+  capture?: {
+    /**
+     * `shadow` records the nudge it would have delivered and delivers nothing. `enforce` blocks
+     * the stop once, with the nudge as the reason, and never blocks that session again.
+     *
+     * A separate switch from measurement, and off by default, because the two carry different
+     * risk. Counting is invisible; blocking a stop takes a turn the person did not ask for, and
+     * a heuristic that fires on a session which stored plenty is the fatigue that teaches
+     * everyone to ignore the channel. Shadow is where this is expected to sit until the numbers
+     * say otherwise -- the same ladder `impact.gate` climbs.
+     */
+    nudge?: 'off' | 'shadow' | 'enforce';
+  };
+  /**
    * This repo's half of workspace membership. The other half is the workspace manifest
    * listing this repo; either alone is not membership, which is what makes linkage
    * un-forgeable by a cloned repository.

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -7,6 +7,17 @@ import { hostProfile } from './hosts/index.js';
 import { indexFile, listCodeSymbols } from '../code/symbol-index.js';
 import { loadConfig } from '../core/config.js';
 import { isImpactEnabled } from '../store/impact-config.js';
+import { captureNudgeMode } from '../store/capture-config.js';
+import {
+  claimSilenceNudge,
+  conversationKey,
+  isDurableWriteTool,
+  readCaptureOutcome,
+  recordDurableWrite,
+  recordSessionTurn,
+  renderSilenceNudge,
+  shouldNudgeForSilence,
+} from '../store/capture-outcome.js';
 import { detectCertainImpactBestEffort, markFindingsDelivered, openFindingsForSession } from './impact.js';
 import {
   recordReadsBestEffort, releaseReadSetBestEffort, repoRelativePath, sweepReadSetsBestEffort,
@@ -639,6 +650,63 @@ async function releaseSessionReadSet(sessionId: string): Promise<void> {
   await releaseReadSetBestEffort(sessionId);
 }
 
+/**
+ * Whether to tell this session it has stored nothing, and the envelope to say it in.
+ *
+ * **Fired at a turn boundary, not at session end, and that is forced rather than chosen.** The
+ * natural home would be session finish -- it knows the session is over and owns capture. But
+ * `SessionEnd` fires after the model is gone, so nothing said there can reach an agent, and the
+ * only channel that reaches one at stop time withholds the stop. So this fires at the first turn
+ * boundary where the silence has become meaningful (`MIN_SUBSTANTIVE_TURNS`), which is also the
+ * last moment the agent can still act on it. Once.
+ *
+ * **Three modes, one verdict**, following `shouldRefuseWrite`: `off` does not compute it,
+ * `shadow` computes it and records what it would have said, `enforce` delivers it. Shadow is
+ * where this is expected to sit -- the measurement it produces is what a decision to enforce
+ * would have to be made on, and that measurement cannot be taken by something already blocking.
+ *
+ * **The claim is spent before the message is delivered.** See `claimSilenceNudge`: a block keyed
+ * on "this session stored nothing" is a condition the agent may reasonably decline to clear, so
+ * without a one-shot it would fire on every subsequent stop forever.
+ *
+ * **Fail open, without exception.** No config, an unknown host, a host with no stop channel, a
+ * broken store -- every one of them returns undefined and the stop proceeds. This runs in front
+ * of every stop in every session of every repo that turns it on, and the failure mode of a nudge
+ * that does not fire is a missed note, while the failure mode of a stop that will not complete is
+ * somebody's session.
+ *
+ * Hosts that bind one memory session per turn never reach the floor, because their `turns` count
+ * resets with each session. In practice that makes this a Claude-only signal today, which is also
+ * the only host whose stop channel is verified.
+ */
+async function evaluateSilenceNudge(input: NormalizedHostHook): Promise<Record<string, unknown> | undefined> {
+  try {
+    const config = await loadConfig(input.projectRoot).catch(() => null);
+    const mode = captureNudgeMode(config ?? undefined);
+    if (mode === 'off') return undefined;
+
+    const conversation = conversationKey(input);
+    const outcome = await readCaptureOutcome(conversation);
+    if (!shouldNudgeForSilence(outcome)) return undefined;
+
+    if (mode === 'shadow') {
+      await claimSilenceNudge(conversation, 'shadow');
+      return undefined;
+    }
+
+    // Checked before the claim is spent: a host that cannot deliver would otherwise consume the
+    // session's one nudge and deliver nothing, so turning the feature on for an unsupported host
+    // would look identical to it firing.
+    const profile = hostProfile(input.host);
+    if (!profile.stopContext) return undefined;
+    if (!await claimSilenceNudge(conversation, 'enforce')) return undefined;
+
+    return profile.stopContext(renderSilenceNudge());
+  } catch {
+    return undefined;
+  }
+}
+
 async function finalizeFailedStop(projectId: string, input: NormalizedHostHook, sessionId: string) {
   await finishMemorySession(
     sessionId,
@@ -824,6 +892,12 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       const type = input.event === 'checkpoint' ? 'checkpoint' : input.type;
       if (!type) throw new Error('Normalized host session event requires a type.');
       await captureMemorySessionEvent(started.session.id, type, input.payload);
+      // Write-side attribution, recorded on the event that causes it rather than recovered at
+      // finalization: session event rows expire about two days out, so a count derived from them
+      // later reads zero when it means "I no longer know". Keyed on the conversation and not on
+      // `started.session.id`, which is turn-scoped and would scatter one conversation's writes
+      // across a row per turn.
+      if (isDurableWriteTool(input.knowlToolName)) await recordDurableWrite(conversationKey(input));
       // Runs for `checkpoint` events too -- a host that reports a tool under that event still
       // read or wrote the file it named -- but never for a failed one: a tool that failed
       // returned no contents, so a read-set row from it would record a belief the agent was
@@ -918,6 +992,11 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     }
     if (!session) return { accepted: false, reason: 'event-loss' };
 
+    // One assistant turn ended. Counted here rather than at session end because this is the only
+    // event that fires per turn, and turns -- not tool events -- are what tell a working
+    // conversation apart from a single question answered.
+    await recordSessionTurn(conversationKey(input));
+
     // gpt-5.5 often share one session binding across turns. Normal Stop only closes the turn
     // binding. Hard failures finish the session and record a host-scoped handoff.
     if (hostProfile(input.host).sharesSessionBinding && sessionBinding?.id === session.id) {
@@ -927,8 +1006,9 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         await closeHostSessionBinding(bindingKey(input, 'session'));
         return { accepted: true, sessionId: session.id, promotion: result.promotion, handoff: result.handoff };
       }
+      const silence = await evaluateSilenceNudge(input);
       await closeHostSessionBinding(key);
-      return { accepted: true, sessionId: session.id };
+      return { accepted: true, sessionId: session.id, ...(silence ? { hostOutput: silence } : {}) };
     }
 
     if (input.status === 'failed') {
@@ -944,8 +1024,15 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // left live for other sessions' detectors to keep finding.
     await releaseSessionReadSet(session.id);
     const promotion = await finalizeMemorySession(projectId, session.id);
+    // Also evaluated here, and this is the path that actually carries it for Claude. The branch
+    // above needs the turn's memory session to *be* the session binding's, which only holds when
+    // a turn started before anything bound the session; the ordinary `SessionStart` then
+    // `UserPromptSubmit` sequence gives the turn its own, so a normal Claude stop lands here.
+    // Keying the counters on the conversation rather than on either memory session is what lets
+    // one verdict serve both paths.
+    const silence = await evaluateSilenceNudge(input);
     await closeHostSessionBinding(key);
-    return { accepted: true, sessionId: session.id, promotion };
+    return { accepted: true, sessionId: session.id, promotion, ...(silence ? { hostOutput: silence } : {}) };
   }
 
   const key = bindingKey(input, 'session');

--- a/src/session/hosts/claude.ts
+++ b/src/session/hosts/claude.ts
@@ -90,4 +90,16 @@ export const claudeProfile: HostProfile = {
       },
     };
   },
+  // Claude Code's documented Stop shape: a top-level `decision`/`reason` pair, not the
+  // `hookSpecificOutput` envelope the other two use. `block` withholds the stop and shows the
+  // model the reason, which is the only way anything reaches an agent at stop time -- `SessionEnd`
+  // fires once the model is already gone.
+  //
+  // So this necessarily costs a turn, and the caller treats it as expensive: it is claimed
+  // once per session against `capture_outcomes.nudged` before it is ever returned, because a
+  // block keyed on a condition the agent may rightly decline to clear would otherwise repeat
+  // forever.
+  stopContext(reason) {
+    return { decision: 'block', reason };
+  },
 };

--- a/src/session/hosts/profile.ts
+++ b/src/session/hosts/profile.ts
@@ -56,6 +56,21 @@ export interface HostProfile {
    * channel: whatever the agent needs in order to recover has to be inside this string.
    */
   denyToolCall?: (reason: string) => HostOutput | undefined;
+  /**
+   * The host's envelope for speaking to the agent as it stops, if it has one.
+   *
+   * Capability by return value again, and absent for every host whose stop channel is not
+   * confirmed. Note what this necessarily is on the hosts that do have it: **there is no
+   * non-blocking way to reach a model at stop time.** A stop hook either withholds the stop and
+   * hands back a reason, which costs a turn, or it says nothing at all -- and a session-end hook
+   * fires after the model is gone, so it can reach a log and never the agent.
+   *
+   * That is why this is a separate member from `midTurnContext` rather than a reuse of it. A
+   * mid-turn card is free: it rides an event the agent was already getting. This is not free, so
+   * a caller has to choose it deliberately, and the only caller does so behind a config that
+   * defaults to off.
+   */
+  stopContext?: (reason: string) => HostOutput | undefined;
 }
 
 export const hostString = (value: unknown): string | undefined =>

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -476,6 +476,32 @@ const SCHEMA_STATEMENTS = [
   // so the measurement survives -- but only if the session is recorded where GC cannot reach it.
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_impact_gate_shadow_finding ON impact_gate_shadow(finding_id);`,
 
+  // The write side's negative signal: one row per session, counting what it did rather than what
+  // it stored. `memory_sessions` cannot hold this -- those rows carry an `expires_at` about two
+  // days out, and the question this answers ("how often does this repo talk and store nothing")
+  // is asked over months. Not swept by GC for the same reason.
+  //
+  // `turns` rather than an event count, and the distinction is the whole design: the sessions
+  // worth catching are conversations, which are long on turns and short on tool events, so any
+  // threshold counted in tool events would exclude precisely them.
+  //
+  // `nudged` is a claim, not a log. It is written before the nudge is delivered so a session can
+  // be spoken to at most once -- in `enforce` the delivery is a blocked stop, and a block keyed
+  // on "stored nothing" would otherwise fire on every subsequent stop, with no action available
+  // to the agent that clears it.
+  // Keyed on the *conversation* -- host, project root and the host's own session id -- and not on
+  // a memory session, which is the one identity that cannot work here. A Claude turn binds its own
+  // memory session and `Stop` closes it, so the next turn gets a fresh one; a counter keyed that
+  // way reads `turns: 1` forever no matter how long the conversation runs. The host's session id
+  // is stable across turns by construction and needs no extra lookup on the tool path.
+  `CREATE TABLE IF NOT EXISTS capture_outcomes (
+    conversation TEXT PRIMARY KEY,
+    observed_at TEXT NOT NULL,
+    turns INTEGER NOT NULL DEFAULT 0,
+    durable_writes INTEGER NOT NULL DEFAULT 0,
+    nudged TEXT
+  );`,
+
   `CREATE TRIGGER IF NOT EXISTS knowledge_items_fts_ai AFTER INSERT ON knowledge_items BEGIN
     INSERT INTO knowledge_items_fts(item_id, category, status, title, content, reasoning, tags)
     VALUES (new.id, new.category, new.status, new.title, new.content, coalesce(new.reasoning, ''), coalesce(new.tags, ''));

--- a/src/store/capture-config.ts
+++ b/src/store/capture-config.ts
@@ -1,0 +1,26 @@
+import type { ProjectConfig } from '../core/types.js';
+
+export type CaptureNudgeMode = 'off' | 'shadow' | 'enforce';
+
+const NUDGE_MODES: readonly CaptureNudgeMode[] = ['off', 'shadow', 'enforce'];
+
+/**
+ * How a session that stored nothing should be handled, resolved in one place.
+ *
+ * Anything unrecognised is `off`, following `impactGateMode`'s rule and for the same reason
+ * stated in its own terms: `enforce` blocks a stop, which spends a turn the person did not ask
+ * for, and `config.json` is a file people edit by hand. A typo must fail towards silence.
+ *
+ * The argument is optional because the callers sit on the lifecycle path, where the config is
+ * only present once a project root has resolved -- making each of them write
+ * `config ? captureNudgeMode(config) : 'off'` is how one of them eventually writes the negation
+ * by mistake.
+ *
+ * Note what this does *not* gate: the counting. `capture_outcomes` is written whatever this
+ * returns, because measurement before mechanism is the whole point -- a repo that never turns
+ * the nudge on should still be able to answer "how often does this happen here?".
+ */
+export function captureNudgeMode(config?: ProjectConfig): CaptureNudgeMode {
+  const mode = config?.capture?.nudge;
+  return NUDGE_MODES.includes(mode as CaptureNudgeMode) ? mode as CaptureNudgeMode : 'off';
+}

--- a/src/store/capture-outcome.ts
+++ b/src/store/capture-outcome.ts
@@ -1,0 +1,220 @@
+import { getClient } from './database.js';
+
+/**
+ * The write side's negative signal: what a session was given the chance to store, and did not.
+ *
+ * Knowl's write path is all admission control -- secret validation, categories, conflict keys,
+ * dedup. Every one of those gates decides what gets *in*. None of them notices what should have
+ * got in and did not, and the read side has been growing exactly that kind of telemetry
+ * (`knowledge_access` records retrieved-but-never-used) while the write side had no twin. The
+ * only writer-side detector that existed was a person noticing afterwards and asking for the
+ * save by hand.
+ *
+ * **Counted as it happens, not reconstructed at the end.** `memory_session_events` rows carry an
+ * `expires_at` roughly two days out, so a count derived from them at finalization is a count that
+ * silently becomes zero for any session finalized late -- and a measurement that reads zero when
+ * it means "I no longer know" is worse than no measurement. Both counters are incremented on the
+ * event that causes them.
+ *
+ * **Not swept.** These rows outlive the sessions they describe, which is the point: the sessions
+ * expire and the question "how often does this repo talk and store nothing" is asked over months.
+ * One row per session, a handful of integers wide.
+ */
+
+/**
+ * The tools that put durable knowledge in the store.
+ *
+ * `knowl_query` is not here, and neither is any other read: an agent that queried diligently and
+ * stored nothing is precisely the session this measures, so counting reads as writes would hide
+ * the thing being looked for. Bare names, as `bareKnowlToolName` produces them.
+ */
+const DURABLE_WRITE_TOOLS = new Set([
+  'knowl_store',
+  'knowl_decide',
+  'knowl_update',
+  'knowl_ingest_atoms',
+  'knowl_ingest',
+]);
+
+export function isDurableWriteTool(toolName?: string): boolean {
+  return typeof toolName === 'string' && DURABLE_WRITE_TOOLS.has(toolName);
+}
+
+/**
+ * Assistant turns a session must have produced before its silence means anything.
+ *
+ * A floor rather than a ratio, and a low one. The sessions this exists to catch are strategy
+ * conversations -- long on turns, short on tool calls -- so any threshold counted in *tool
+ * events* would exclude exactly them. Three turns is enough to distinguish "the person asked one
+ * question and got one answer", where storing nothing is correct, from a working conversation.
+ */
+export const MIN_SUBSTANTIVE_TURNS = 3;
+
+export type CaptureOutcome = {
+  conversation: string;
+  turns: number;
+  durableWrites: number;
+  /** Which mode acted on this session's silence, or null if none has. */
+  nudged: string | null;
+};
+
+/**
+ * The stable identity of one conversation, across every turn it contains.
+ *
+ * Deliberately not a memory session id. A Claude turn binds its own memory session and `Stop`
+ * closes it, so the following turn gets a new one -- a counter keyed that way reports one turn
+ * forever, however long the conversation runs. The host's own session id does not move, and it is
+ * already on every hook event, so reading it costs nothing on the tool path.
+ *
+ * NUL-joined because a separator that can appear inside a project path lets two different
+ * conversations collide on one row.
+ */
+export function conversationKey(input: {
+  host: string;
+  projectRoot: string;
+  externalSessionId?: string;
+}): string {
+  return [input.host, input.projectRoot, input.externalSessionId ?? ''].join('\u0000');
+}
+
+/** Every counter starts its row, so neither caller has to know which of them ran first. */
+async function bump(conversation: string, column: 'turns' | 'durable_writes'): Promise<void> {
+  const id = (conversation ?? '').trim();
+  if (!id) return;
+  try {
+    await getClient().execute({
+      sql: `INSERT INTO capture_outcomes (conversation, observed_at, turns, durable_writes)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(conversation) DO UPDATE SET ${column} = ${column} + 1, observed_at = excluded.observed_at`,
+      args: [id, new Date().toISOString(), column === 'turns' ? 1 : 0, column === 'durable_writes' ? 1 : 0],
+    });
+  } catch {
+    // Advisory throughout. This runs inside a hook with the host blocked on the answer, and a
+    // store mid-snapshot or a schema older than this table costs one measurement -- never a
+    // session. A diagnostic must not change the process it observes.
+  }
+}
+
+/** One assistant turn ended in this conversation. */
+export async function recordSessionTurn(conversation: string): Promise<void> {
+  await bump(conversation, 'turns');
+}
+
+/** One durable-write tool call was made in this conversation. */
+export async function recordDurableWrite(conversation: string): Promise<void> {
+  await bump(conversation, 'durable_writes');
+}
+
+export async function readCaptureOutcome(conversation: string): Promise<CaptureOutcome | null> {
+  const id = (conversation ?? '').trim();
+  if (!id) return null;
+  try {
+    const rows = await getClient().execute({
+      sql: 'SELECT conversation, turns, durable_writes, nudged FROM capture_outcomes WHERE conversation = ?',
+      args: [id],
+    });
+    const row = rows.rows[0];
+    if (!row) return null;
+    return {
+      conversation: String(row.conversation),
+      turns: Number(row.turns ?? 0),
+      durableWrites: Number(row.durable_writes ?? 0),
+      nudged: row.nudged === null || row.nudged === undefined ? null : String(row.nudged),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether this session's silence is worth acting on.
+ *
+ * Both halves are required and neither is a proxy for the other. Zero durable writes alone
+ * catches the one-question session where storing nothing was the right call; enough turns alone
+ * says nothing about whether anything was stored.
+ *
+ * Note this deliberately does not consult whether the *extractor* promoted anything.
+ * `finalizeMemorySession` reporting `skipped` means automatic promotion found no candidate,
+ * which is true of nearly every conversation and says nothing about what the agent stored by
+ * hand -- a session with five `knowl_store` calls still finalizes `skipped`. Reading that as
+ * "stored nothing" is how this fires on the sessions that did everything right.
+ */
+export function shouldNudgeForSilence(outcome: CaptureOutcome | null): boolean {
+  if (!outcome) return false;
+  if (outcome.nudged) return false;
+  return outcome.durableWrites === 0 && outcome.turns >= MIN_SUBSTANTIVE_TURNS;
+}
+
+/**
+ * Claim the one nudge this session gets. True only for the caller that won it.
+ *
+ * **This is the no-loop guarantee, and it is the reason the flag is written before the message
+ * is delivered rather than after.** In `enforce` the nudge is delivered by blocking a stop, and a
+ * block that fires on the condition "this session stored nothing" would fire again on the next
+ * stop, and the one after -- the agent cannot clear the condition by any action except a write it
+ * may reasonably decline to make. A gate that can trap an agent is strictly worse than no gate.
+ *
+ * The conditional UPDATE is what makes it a claim rather than a check: two concurrent stop hooks
+ * race here, and exactly one sees a row change.
+ */
+export async function claimSilenceNudge(conversation: string, mode: string): Promise<boolean> {
+  const id = (conversation ?? '').trim();
+  if (!id) return false;
+  try {
+    const result = await getClient().execute({
+      sql: 'UPDATE capture_outcomes SET nudged = ? WHERE conversation = ? AND nudged IS NULL',
+      args: [mode, id],
+    });
+    return Number(result.rowsAffected ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+export type CaptureHealth = {
+  sessions: number;
+  /** Conversations that finished having stored nothing durable, of any length. */
+  silent: number;
+  /** Of those, the ones long enough for the silence to be worth a look. */
+  substantiveSilent: number;
+  /** Sessions where a nudge fired or would have. */
+  nudged: number;
+};
+
+/**
+ * The repo's capture health, for `knowl status`.
+ *
+ * Reported whatever `capture.nudge` says, because the number is the deliverable: a repo can see
+ * how often this happens before deciding whether it wants anything done about it. That ordering
+ * is the same one the access-count work followed, and the one `impact.gate` is still following.
+ */
+export async function captureHealth(): Promise<CaptureHealth> {
+  try {
+    const rows = await getClient().execute({
+      sql: `SELECT COUNT(*) AS sessions,
+                   SUM(CASE WHEN durable_writes = 0 THEN 1 ELSE 0 END) AS silent,
+                   SUM(CASE WHEN durable_writes = 0 AND turns >= ? THEN 1 ELSE 0 END) AS substantive_silent,
+                   SUM(CASE WHEN nudged IS NOT NULL THEN 1 ELSE 0 END) AS nudged
+            FROM capture_outcomes`,
+      args: [MIN_SUBSTANTIVE_TURNS],
+    });
+    const row = rows.rows[0];
+    return {
+      sessions: Number(row?.sessions ?? 0),
+      silent: Number(row?.silent ?? 0),
+      substantiveSilent: Number(row?.substantive_silent ?? 0),
+      nudged: Number(row?.nudged ?? 0),
+    };
+  } catch {
+    return { sessions: 0, silent: 0, substantiveSilent: 0, nudged: 0 };
+  }
+}
+
+/** The nudge text, and the only place it is written. */
+export function renderSilenceNudge(): string {
+  return [
+    'KNOWL: this session is ending and nothing durable was stored.',
+    'If any of it was a decision, a plan, or a direction you were given — store it now with knowl_store or knowl_decide. Stated intent counts before it settles.',
+    'If there was genuinely nothing worth keeping, say so and stop; this will not ask again.',
+  ].join('\n');
+}

--- a/src/store/context-bootstrap.ts
+++ b/src/store/context-bootstrap.ts
@@ -3,6 +3,7 @@ import { DEFAULT_CONTEXT_MAX_CHARS } from '../core/token-budget.js';
 import { heartbeatMemorySession, startMemorySession } from './session-repository.js';
 import { getRecentContext } from './recent-context.js';
 import { listActiveSkillItems } from './repository.js';
+import type { PeerSkillItem } from '../workspace/peer-skills.js';
 
 export type AgentBootstrapInput = {
   projectId: string;
@@ -13,32 +14,39 @@ export type AgentBootstrapInput = {
 };
 
 /**
- * The active workspace, shaped for the context block, or undefined.
+ * The active workspace, shaped for the context block, plus the skills its peers share.
  *
  * Resolved from the open store's root rather than a passed-in path, because bootstrap is
  * given a project id and the root is what `resolveWorkspace` needs. Never fatal: a workspace
  * that cannot be read degrades to no section, exactly as an unlinked repo does.
+ *
+ * Both answers come from one resolve because they come from one workspace, and resolving twice
+ * would open every peer's manifest twice on a path that runs at the start of every session.
  */
-async function workspaceContext(): Promise<WorkspaceContext | undefined> {
+async function workspaceContext(): Promise<{ workspace?: WorkspaceContext; peerSkills: PeerSkillItem[] }> {
   try {
     const { getConfigRoot } = await import('./database.js');
     const { resolveWorkspace } = await import('../workspace/resolve.js');
     const { repoEntry } = await import('../workspace/repo-settings.js');
+    const { listPeerSkillItems } = await import('../workspace/peer-skills.js');
     const active = await resolveWorkspace(getConfigRoot());
-    if (!active) return undefined;
+    if (!active) return { peerSkills: [] };
 
     const self = repoEntry(active.manifest, active.repo);
     return {
-      name: active.name,
-      repo: active.repo,
-      selfRole: self?.role,
-      selfDefaultVisibility: self?.defaultVisibility,
-      peers: active.peers.map(peer => ({
-        name: peer.name, role: peer.role, kin: peer.kin, defaultVisibility: peer.defaultVisibility,
-      })),
+      workspace: {
+        name: active.name,
+        repo: active.repo,
+        selfRole: self?.role,
+        selfDefaultVisibility: self?.defaultVisibility,
+        peers: active.peers.map(peer => ({
+          name: peer.name, role: peer.role, kin: peer.kin, defaultVisibility: peer.defaultVisibility,
+        })),
+      },
+      peerSkills: await listPeerSkillItems(active),
     };
   } catch {
-    return undefined;
+    return { peerSkills: [] };
   }
 }
 
@@ -59,9 +67,13 @@ export async function bootstrapAgentSession(input: AgentBootstrapInput, options:
   // Skills are surfaced regardless of recency: getRecentContext returns only the three
   // most recent items of any category, so a skill created last month would never appear.
   const skills = await listActiveSkillItems();
-  const fallback = formatRecentContextToMarkdown({ ...recent, skills }, {
+  // Workspace visibility governed query reach but not ambient reach: a sibling repo's shared
+  // skill could be found only by an agent who already knew to ask for it, which is exactly the
+  // agent who does not know the tooling exists. Peers ride the same card, as pointers.
+  const { workspace, peerSkills } = await workspaceContext();
+  const fallback = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
     maxChars: Number.MAX_SAFE_INTEGER,
-    workspace: await workspaceContext(),
+    workspace,
   });
   const truncated = fallback.length > DEFAULT_CONTEXT_MAX_CHARS;
   return {

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -539,6 +539,33 @@ export async function listActiveSkillItems(dbConnection?: DbConnection): Promise
   }
 }
 
+/**
+ * The active skill items a linked repo shares with its workspace.
+ *
+ * Deliberately a sibling of `listActiveSkillItems` rather than an option on it. That function
+ * runs on every command tool event and is index-scoped for that reason; a peer lookup belongs
+ * only to session-start bootstrap, and folding the two would put a peer database open on the
+ * mid-turn path. The visibility predicate is in the SQL, matching `queryFederated`: a peer's
+ * repo-private row is never read into this process at all.
+ */
+export async function listWorkspaceVisibleSkillItems(dbConnection?: DbConnection): Promise<KnowledgeItem[]> {
+  const conn = dbConnection || getDb();
+  try {
+    const result = await conn
+      .select()
+      .from(schema.knowledgeItems)
+      .where(and(
+        eq(schema.knowledgeItems.category, 'skill'),
+        eq(schema.knowledgeItems.status, 'active'),
+        eq(schema.knowledgeItems.visibility, 'workspace'),
+      ));
+
+    return result.map(mapRowToKnowledgeItem);
+  } catch (error: any) {
+    throw new DatabaseError(`Failed to list workspace-visible skill items: ${error.message}`);
+  }
+}
+
 export async function createKnowledgeCommit(
   projectId: string,
   message: string,

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -107,7 +107,24 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * `application_id`, and whichever migrates first tells the other's gate there is nothing to do --
  * so the second table is silently never created on any store the first one touched.
  */
-export const KNOWL_MIGRATION_LEVEL = 8;
+/*
+ * Level 9 adds `capture_outcomes` -- one row per conversation, counting the turns it produced and
+ * the durable writes it made, so a repo can see how often a session talks and stores nothing.
+ * Additive on the same reasoning as levels 3, 4 and 7: one new table, no altered column, no
+ * backfill.
+ *
+ * A backfill is impossible rather than merely skipped, and for the same shape of reason level 6
+ * gives. The counters are incremented on the events that cause them, and `memory_session_events`
+ * expires roughly two days out -- so history far enough back to be worth backfilling is already
+ * gone, and inventing zeros for it would report every past conversation as having stored nothing.
+ *
+ * The bump is what makes an existing store get the table at all. Without it a database stamped at
+ * level 8 skips `SCHEMA_STATEMENTS`, never creates `capture_outcomes`, and every counter write
+ * silently no-ops -- which this subsystem is built to survive (it swallows its own errors, by
+ * design, because it runs inside a hook), so the failure would present as a repository that
+ * simply always reports zero sessions rather than as anything breaking.
+ */
+export const KNOWL_MIGRATION_LEVEL = 9;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/skill-surface.ts
+++ b/src/store/skill-surface.ts
@@ -40,7 +40,12 @@ export function matchSkillForCommand(command: string, skills: SurfacedSkill[]): 
   const haystack = command.toLowerCase();
   const matches = skills.filter((skill) => {
     const name = skill.name.toLowerCase();
-    return skill.runnable
+    // Belt to `toPeerSurfacedSkills`'s braces. A peer row is already `runnable: false` and would
+    // fail the next test anyway, but this nudge ends in "Run it with knowl_skill_run" and that
+    // call resolves against the local root -- so the one row that must never reach it is checked
+    // for by name here rather than left to hold somewhere else.
+    return !skill.repo
+      && skill.runnable
       && name.length >= MIN_MATCHABLE_NAME_CHARS
       && appearsAsWord(haystack, name)
       && isSpecificEnough(haystack, name);

--- a/src/store/snapshot-tables.ts
+++ b/src/store/snapshot-tables.ts
@@ -77,6 +77,18 @@ export const SNAPSHOT_TABLE_POLICY: Readonly<Record<string, SnapshotTablePolicy>
   // silently reset the precision denominator to zero while leaving the findings they point at in
   // place, so the next reading would be taken over a sample that no longer matches the history.
   impact_gate_shadow: 'preserved',
+  // Capture health: turns produced and durable writes made, per conversation. Preserved on both
+  // of the reasons above at once.
+  //
+  // It is a measurement, like `impact_gate_shadow`, and rolling it back would restate a number
+  // somebody is deciding against -- a repo watching its silent-session rate to judge whether to
+  // arm the nudge would see that rate jump on a restore that had nothing to do with capture.
+  //
+  // And it describes conversations that happened, like `memory_sessions`. A restore does not
+  // un-hold them. `nudged` is the sharper case: it is a spent one-shot, and refilling this table
+  // from a week-old snapshot would clear the flag on conversations that were already nudged --
+  // re-arming a stop-blocking interrupt against sessions that had answered it.
+  capture_outcomes: 'preserved',
   // What THIS machine has staged for, and pushed to, a cloud workspace. The server's copy is the
   // truer one and a snapshot cannot roll it back, so restoring an older ledger would only make
   // this machine forget the `remote_version` every republish needs -- turning the next publish

--- a/src/workspace/peer-skills.ts
+++ b/src/workspace/peer-skills.ts
@@ -1,0 +1,51 @@
+import type { KnowledgeItem } from '../core/types.js';
+import { listWorkspaceVisibleSkillItems } from '../store/repository.js';
+import { openPeerStore } from '../store/store-handle.js';
+import type { ActiveWorkspace } from './resolve.js';
+
+/** A linked repo's shared skill, carrying the repo that owns it. */
+export type PeerSkillItem = { repo: string; item: KnowledgeItem };
+
+/**
+ * Per peer, not overall.
+ *
+ * The card's character budget already decides how many rows survive; this cap decides whose.
+ * Without it a single repo sharing forty skills would fill every peer slot before the second
+ * repo was read, and "what else is in this workspace" is exactly the question the section
+ * exists to answer.
+ */
+const MAX_PER_PEER = 3;
+
+/**
+ * Every linked repo's workspace-visible skills, most recently updated first.
+ *
+ * This is the ambient half of workspace reach. `queryFederated` already lets an agent *find* a
+ * sibling repo's skill, but only if it knows to ask -- and an agent that does not know a
+ * pipeline exists is precisely the one that will not ask. The knowledge most worth sharing
+ * across a workspace is reusable tooling, which is the kind nobody queries for by name.
+ *
+ * **Never fatal.** A peer that is absent, unreadable, or holds a schema this build does not
+ * understand contributes nothing and is skipped in silence. This runs inside session-start
+ * bootstrap, where the cost of throwing is the whole context card -- and the section is an
+ * enrichment, so degrading to today's local-only behaviour is always the right failure.
+ */
+export async function listPeerSkillItems(workspace: ActiveWorkspace): Promise<PeerSkillItem[]> {
+  const found: PeerSkillItem[] = [];
+
+  for (const peer of workspace.peers) {
+    if (!peer.present) continue;
+    try {
+      const store = await openPeerStore(peer.databasePath);
+      const items = await listWorkspaceVisibleSkillItems(store.db);
+      // The query has no ORDER BY, so the cap needs one of its own or which three survive is
+      // whatever order the index happened to return. Recency is the same tie-break the rest of
+      // the card uses.
+      const ordered = [...items].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+      for (const item of ordered.slice(0, MAX_PER_PEER)) found.push({ repo: peer.name, item });
+    } catch {
+      continue;
+    }
+  }
+
+  return found;
+}

--- a/tests/store/capture-nudge-lifecycle.test.ts
+++ b/tests/store/capture-nudge-lifecycle.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { handleHostLifecycleEvent } from '../../src/session/host-lifecycle.js';
+import * as repo from '../../src/store/repository.js';
+import { conversationKey, MIN_SUBSTANTIVE_TURNS, readCaptureOutcome } from '../../src/store/capture-outcome.js';
+import type { CaptureNudgeMode } from '../../src/store/capture-config.js';
+
+// One root per test, for the reason `capture-outcome.test.ts` states at length: a libsql file
+// this process opened cannot be unlinked, so a shared root carries the previous test's counters.
+let nextRoot = 0;
+const ROOTS: string[] = [];
+
+const hook = (root: string, input: Partial<NormalizedHostHook>): NormalizedHostHook => ({
+  host: 'claude',
+  event: 'turn-start',
+  externalSessionId: 'session-under-test',
+  externalTurnId: undefined,
+  projectRoot: root,
+  payload: {},
+  ...input,
+});
+
+async function withRepo(mode: CaptureNudgeMode | undefined) {
+  const root = path.resolve(`./.knowl-capture-nudge-${nextRoot += 1}`);
+  ROOTS.push(root);
+  await closeDb();
+  await releaseAll();
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG, ...(mode ? { capture: { nudge: mode } } : {}) });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, 'capture nudge')).id;
+  return { root, projectId };
+}
+
+/**
+ * A session that has produced `turns` assistant turns and stored nothing.
+ *
+ * `turn-start` before every `turn-stop`, because that is the real sequence: `SessionStart` binds
+ * the session, `UserPromptSubmit` binds the turn, and `Stop` closes it. A stop with no turn
+ * binding is `event-loss` and never reaches the code under test -- which is how the first draft
+ * of this file passed a `null` outcome to every assertion.
+ */
+async function talkFor(root: string, projectId: string, turns: number) {
+  let last;
+  await handleHostLifecycleEvent(projectId, hook(root, { event: 'session-start' }));
+  for (let turn = 0; turn < turns; turn += 1) {
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+    last = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+  }
+  return last;
+}
+
+describe('the write-side negative signal, through the hook path', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('counts turns even when no nudge is configured', async () => {
+    // Measurement before mechanism: the number exists whether or not anyone armed anything,
+    // because the decision to arm has to be made against it.
+    const { root, projectId } = await withRepo(undefined);
+
+    const result = await talkFor(root, projectId, MIN_SUBSTANTIVE_TURNS);
+
+    expect(result?.hostOutput).toBeUndefined();
+    const outcome = await readCaptureOutcome(conversationKey(hook(root, {})));
+    expect(outcome).toMatchObject({ turns: MIN_SUBSTANTIVE_TURNS, durableWrites: 0, nudged: null });
+  });
+
+  it('records the withheld nudge in shadow, and delivers nothing', async () => {
+    const { root, projectId } = await withRepo('shadow');
+
+    const result = await talkFor(root, projectId, MIN_SUBSTANTIVE_TURNS);
+
+    expect(result?.hostOutput).toBeUndefined();
+    expect(await readCaptureOutcome(conversationKey(hook(root, {})))).toMatchObject({ nudged: 'shadow' });
+  });
+
+  it('blocks the stop once in enforce, and names what to do about it', async () => {
+    const { root, projectId } = await withRepo('enforce');
+
+    const result = await talkFor(root, projectId, MIN_SUBSTANTIVE_TURNS);
+
+    expect(result?.hostOutput).toMatchObject({ decision: 'block' });
+    expect(String((result!.hostOutput as { reason: string }).reason)).toContain('knowl_store');
+  });
+
+  it('never blocks the same session twice', async () => {
+    // The no-loop guarantee, end to end. "Stored nothing" is a condition the agent may rightly
+    // decline to clear, so a second block is a session that can never finish.
+    const { root, projectId } = await withRepo('enforce');
+
+    await talkFor(root, projectId, MIN_SUBSTANTIVE_TURNS);
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+    const again = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+
+    expect(again.hostOutput).toBeUndefined();
+  });
+
+  it('stays quiet for a session too short for silence to mean anything', async () => {
+    const { root, projectId } = await withRepo('enforce');
+
+    const result = await talkFor(root, projectId, MIN_SUBSTANTIVE_TURNS - 1);
+
+    expect(result?.hostOutput).toBeUndefined();
+  });
+
+  it('stays quiet for a session that stored something', async () => {
+    const { root, projectId } = await withRepo('enforce');
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'session-start' }));
+    await handleHostLifecycleEvent(projectId, hook(root, {
+      event: 'session-event',
+      type: 'checkpoint',
+      toolName: 'mcp__knowl__knowl_store',
+      knowlTool: true,
+      knowlToolName: 'knowl_store',
+      payload: { summary: 'stored a decision' },
+    }));
+
+    let result;
+    for (let turn = 0; turn < MIN_SUBSTANTIVE_TURNS; turn += 1) {
+      await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+      result = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    }
+
+    expect(result?.hostOutput).toBeUndefined();
+    expect(await readCaptureOutcome(conversationKey(hook(root, {})))).toMatchObject({ durableWrites: 1, nudged: null });
+  });
+
+  it('does not count a query as a write', async () => {
+    const { root, projectId } = await withRepo('enforce');
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'session-start' }));
+    await handleHostLifecycleEvent(projectId, hook(root, {
+      event: 'session-event',
+      type: 'checkpoint',
+      toolName: 'mcp__knowl__knowl_query',
+      knowlTool: true,
+      knowlToolName: 'knowl_query',
+      payload: { summary: 'queried memory' },
+    }));
+
+    let result;
+    for (let turn = 0; turn < MIN_SUBSTANTIVE_TURNS; turn += 1) {
+      await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+      result = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    }
+
+    // A session that retrieved diligently and stored nothing is exactly the case this exists
+    // for, so a read must not buy its way out of the nudge.
+    expect(result?.hostOutput).toMatchObject({ decision: 'block' });
+  });
+
+  it('never blocks a host with no verified stop channel', async () => {
+    const { root, projectId } = await withRepo('enforce');
+
+    let result;
+    await handleHostLifecycleEvent(projectId, hook(root, { host: 'generic', event: 'session-start' }));
+    for (let turn = 0; turn < MIN_SUBSTANTIVE_TURNS; turn += 1) {
+      await handleHostLifecycleEvent(projectId, hook(root, { host: 'generic', event: 'turn-start' }));
+      result = await handleHostLifecycleEvent(projectId, hook(root, {
+        host: 'generic', event: 'turn-stop', status: 'finished',
+      }));
+    }
+
+    expect(result?.hostOutput).toBeUndefined();
+    // And the claim was not spent on a delivery that could not happen: turning this on for an
+    // unsupported host must not look identical to it having fired.
+    expect(await readCaptureOutcome(conversationKey(hook(root, { host: 'generic' })))).toMatchObject({ nudged: null });
+  });
+});

--- a/tests/store/capture-outcome.test.ts
+++ b/tests/store/capture-outcome.test.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { captureNudgeMode } from '../../src/store/capture-config.js';
+import {
+  captureHealth,
+  claimSilenceNudge,
+  isDurableWriteTool,
+  MIN_SUBSTANTIVE_TURNS,
+  readCaptureOutcome,
+  recordDurableWrite,
+  recordSessionTurn,
+  shouldNudgeForSilence,
+} from '../../src/store/capture-outcome.js';
+
+/*
+ * A fresh root per test, rather than one root cleaned between them.
+ *
+ * The obvious shape -- one directory, `fs.rm` in `beforeEach` -- silently does nothing here: a
+ * process cannot unlink a libsql file it has opened, so on Windows the remove fails, the same
+ * database survives, and every count in this file reads the previous test's rows plus its own.
+ * It fails as wrong numbers rather than as an error, which is the kind of test bug that gets
+ * "fixed" by loosening the assertion.
+ */
+let nextRoot = 0;
+const ROOTS: string[] = [];
+const freshRoot = (): string => {
+  const root = path.resolve(`./.knowl-capture-outcome-${nextRoot += 1}`);
+  ROOTS.push(root);
+  return root;
+};
+
+describe('capture nudge mode', () => {
+  it('reads only the three known modes, and anything else as off', () => {
+    expect(captureNudgeMode({ ...DEFAULT_CONFIG, capture: { nudge: 'shadow' } })).toBe('shadow');
+    expect(captureNudgeMode({ ...DEFAULT_CONFIG, capture: { nudge: 'enforce' } })).toBe('enforce');
+    expect(captureNudgeMode({ ...DEFAULT_CONFIG, capture: { nudge: 'off' } })).toBe('off');
+  });
+
+  it('fails towards silence on a hand-edited value', () => {
+    // `enforce` blocks a stop, and config.json is a file people edit by hand. A typo must not
+    // be the thing that starts interrupting them.
+    expect(captureNudgeMode({ ...DEFAULT_CONFIG, capture: { nudge: 'yes' } as never })).toBe('off');
+    expect(captureNudgeMode({ ...DEFAULT_CONFIG })).toBe('off');
+    expect(captureNudgeMode(undefined)).toBe('off');
+  });
+});
+
+describe('durable write tools', () => {
+  it('counts the four tools that put knowledge in the store', () => {
+    for (const tool of ['knowl_store', 'knowl_decide', 'knowl_update', 'knowl_ingest_atoms']) {
+      expect(isDurableWriteTool(tool), tool).toBe(true);
+    }
+  });
+
+  it('does not count a read as a write', () => {
+    // The whole point is catching a session that queried diligently and stored nothing, so
+    // counting retrieval here would hide exactly what is being looked for.
+    for (const tool of ['knowl_query', 'knowl_recent', 'knowl_state', 'knowl_context', undefined]) {
+      expect(isDurableWriteTool(tool), String(tool)).toBe(false);
+    }
+  });
+});
+
+describe('the silence verdict', () => {
+  const outcome = (over: Partial<{ turns: number; durableWrites: number; nudged: string | null }>) => ({
+    conversation: 's1', turns: MIN_SUBSTANTIVE_TURNS, durableWrites: 0, nudged: null, ...over,
+  });
+
+  it('fires for a session that ran long enough and stored nothing', () => {
+    expect(shouldNudgeForSilence(outcome({}))).toBe(true);
+  });
+
+  it('stays quiet when the session stored something', () => {
+    expect(shouldNudgeForSilence(outcome({ durableWrites: 1 }))).toBe(false);
+  });
+
+  it('stays quiet for a session too short for silence to mean anything', () => {
+    expect(shouldNudgeForSilence(outcome({ turns: MIN_SUBSTANTIVE_TURNS - 1 }))).toBe(false);
+  });
+
+  it('stays quiet once the session has already been nudged', () => {
+    expect(shouldNudgeForSilence(outcome({ nudged: 'enforce' }))).toBe(false);
+  });
+
+  it('stays quiet for a session it has no record of', () => {
+    expect(shouldNudgeForSilence(null)).toBe(false);
+  });
+});
+
+describe('capture outcomes on disk', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    const root = freshRoot();
+    await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+    await saveConfig(root, { ...DEFAULT_CONFIG });
+    await initDb(root);
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('counts turns and writes independently, whichever arrives first', async () => {
+    await recordDurableWrite('s1');
+    await recordSessionTurn('s1');
+    await recordSessionTurn('s1');
+
+    expect(await readCaptureOutcome('s1')).toMatchObject({ turns: 2, durableWrites: 1 });
+  });
+
+  it('starts a row from either counter', async () => {
+    await recordSessionTurn('turn-first');
+    await recordDurableWrite('write-first');
+
+    expect(await readCaptureOutcome('turn-first')).toMatchObject({ turns: 1, durableWrites: 0 });
+    expect(await readCaptureOutcome('write-first')).toMatchObject({ turns: 0, durableWrites: 1 });
+  });
+
+  it('gives a session exactly one nudge, however many stops it takes', async () => {
+    // The no-loop guarantee. In enforce mode the nudge is delivered by blocking a stop, and the
+    // agent cannot clear "stored nothing" by any action it may reasonably want to take -- so a
+    // second claim succeeding is an agent that can never finish.
+    await recordSessionTurn('s1');
+
+    expect(await claimSilenceNudge('s1', 'enforce')).toBe(true);
+    expect(await claimSilenceNudge('s1', 'enforce')).toBe(false);
+    expect(await readCaptureOutcome('s1')).toMatchObject({ nudged: 'enforce' });
+  });
+
+  it('does not claim a session it has never seen', async () => {
+    expect(await claimSilenceNudge('never-seen', 'enforce')).toBe(false);
+  });
+
+  it('survives a blank session id rather than writing a row that joins to nothing', async () => {
+    await recordSessionTurn('');
+    await recordDurableWrite('   ');
+
+    expect(await captureHealth()).toMatchObject({ sessions: 0 });
+    expect(await readCaptureOutcome('')).toBeNull();
+  });
+
+  it('reports the health of the repo, counting only long-enough silences as substantive', async () => {
+    // Talked and stored nothing.
+    for (let turn = 0; turn < MIN_SUBSTANTIVE_TURNS; turn += 1) await recordSessionTurn('silent');
+    // One question, one answer, nothing to store -- silent, but correctly so.
+    await recordSessionTurn('brief');
+    // Did the right thing.
+    for (let turn = 0; turn < MIN_SUBSTANTIVE_TURNS; turn += 1) await recordSessionTurn('wrote');
+    await recordDurableWrite('wrote');
+
+    expect(await captureHealth()).toEqual({ sessions: 3, silent: 2, substantiveSilent: 1, nudged: 0 });
+  });
+
+  it('reports no sessions rather than throwing when the table has never been written', async () => {
+    expect(await captureHealth()).toEqual({ sessions: 0, silent: 0, substantiveSilent: 0, nudged: 0 });
+  });
+});

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -50,6 +50,12 @@ const SCHEMA_PINS: Record<number, string> = {
   // the same failure mode that made the forget log claim 6 instead of 5 in the first place.
   // 8 rather than 7 because `cloud_published` took 7 while this branch was open.
   8: 'e96218e9fbe0594d73078033d718af4f',
+  // 9 adds `capture_outcomes` -- turns produced and durable writes made, per conversation, so a
+  // repo can measure how often a session talks and stores nothing. Additive again, so
+  // `KNOWL_SCHEMA_VERSION` again does not move. No backfill, and none is possible: the counters
+  // ride the events that cause them and `memory_session_events` expires in about two days, so
+  // any history worth backfilling is already gone.
+  9: 'e35a04dead1990c2af454fc44545e39a',
 };
 
 let root: string;

--- a/tests/store/skill-surface.test.ts
+++ b/tests/store/skill-surface.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { matchSkillForCommand, renderSkillUseNudge } from '../../src/store/skill-surface.js';
-import { renderSkillsSection, selectSurfacedSkills } from '../../src/core/skill-surface.js';
+import { renderSkillsSection, selectSurfacedSkills, toPeerSurfacedSkills } from '../../src/core/skill-surface.js';
 import type { KnowledgeItem } from '../../src/core/types.js';
 
 // `skillSourcePath` writes `.knowl/skills/<name>/SKILL.md`, so fixtures say so too: a
@@ -77,6 +77,88 @@ describe('selectSurfacedSkills', () => {
 
   it('returns an empty array for no input rather than throwing', () => {
     expect(selectSurfacedSkills([], 1_000)).toEqual([]);
+  });
+});
+
+describe('peer skills on the session-start card', () => {
+  // The regression this whole path exists to prevent: a peer's package carries the same
+  // `.knowl/skills/...` source a local one does, so deriving runnability from `source` marks
+  // another repo's skill runnable here -- and `knowl_skill_run` resolves against the local root.
+  it('never marks a peer skill runnable, however its source reads', () => {
+    const [peer] = toPeerSurfacedSkills([{ repo: 'duckprep', item: item({ title: 'mascot-art' }) }]);
+
+    expect(peer).toMatchObject({ name: 'mascot-art', runnable: false, repo: 'duckprep' });
+  });
+
+  it('keeps a peer row out of the mid-turn nudge even if something marks it runnable', () => {
+    const forced = { name: 'verify-bench', purpose: 'run the suite', runnable: true, repo: 'duckprep' };
+
+    expect(matchSkillForCommand('npm run verify-bench', [forced])).toBeNull();
+  });
+
+  it('names the owning repo in the row, and says the skill is not runnable from here', () => {
+    const rendered = renderSkillsSection(toPeerSurfacedSkills([
+      { repo: 'duckprep', item: item({ title: 'mascot-art', content: 'Purpose: style-anchored generation.' }) },
+    ]));
+
+    expect(rendered).toContain('- **mascot-art** (in duckprep, not runnable here) — style-anchored generation.');
+  });
+
+  it('prices the peer label, so the section still fits the budget it was given', () => {
+    const peers = toPeerSurfacedSkills(Array.from({ length: 40 }, (_, index) => ({
+      repo: 'a-very-long-linked-repository-name',
+      item: item({ id: `p${index}`, title: `peer-skill-${index}` }),
+    })));
+
+    const skills = selectSurfacedSkills([], 300, peers);
+
+    expect(renderSkillsSection(skills).length).toBeLessThanOrEqual(300);
+    expect(skills.length).toBeGreaterThan(0);
+  });
+
+  it('orders every local skill ahead of every peer skill', () => {
+    const locals = Array.from({ length: 3 }, (_, index) => item({ id: `l${index}`, title: `local-${index}` }));
+    const peers = toPeerSurfacedSkills([{ repo: 'duckprep', item: item({ title: 'peer-only' }) }]);
+
+    const skills = selectSurfacedSkills(locals, 1_000, peers);
+
+    expect(skills.findIndex(skill => skill.repo)).toBe(skills.length - 1);
+  });
+
+  it("degrades to today's card when local skills already spend the budget", () => {
+    // Nine local rows at 30 characters each overrun a 300-character section on their own, so
+    // the peer row never reaches the card. A repo rich in its own tooling loses nothing.
+    const locals = Array.from({ length: 9 }, (_, index) => item({ id: `l${index}`, title: `local-${index}` }));
+    const peers = toPeerSurfacedSkills([{ repo: 'duckprep', item: item({ title: 'peer-only' }) }]);
+
+    const skills = selectSurfacedSkills(locals, 300, peers);
+
+    expect(skills.every(skill => !skill.repo)).toBe(true);
+    expect(renderSkillsSection(skills).length).toBeLessThanOrEqual(300);
+  });
+
+  it('shows a peer skill when the local store has room for it', () => {
+    const peers = toPeerSurfacedSkills([{ repo: 'duckprep', item: item({ title: 'peer-only' }) }]);
+
+    const skills = selectSurfacedSkills([item({ title: 'local-one' })], 1_000, peers);
+
+    expect(skills.map(skill => skill.name)).toEqual(['local-one', 'peer-only']);
+  });
+
+  it('drops a peer skill whose name a local skill already occupies', () => {
+    const peers = toPeerSurfacedSkills([{ repo: 'duckprep', item: item({ title: 'Shared-Name' }) }]);
+
+    const skills = selectSurfacedSkills([item({ title: 'shared-name' })], 1_000, peers);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].repo).toBeUndefined();
+  });
+
+  it('ignores a peer row that is not an active skill', () => {
+    expect(toPeerSurfacedSkills([
+      { repo: 'duckprep', item: item({ category: 'fact' }) },
+      { repo: 'duckprep', item: item({ status: 'superseded' }) },
+    ])).toEqual([]);
   });
 });
 

--- a/tests/workspace/peer-skills-card.test.ts
+++ b/tests/workspace/peer-skills-card.test.ts
@@ -1,0 +1,129 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { bootstrapAgentSession } from '../../src/store/context-bootstrap.js';
+import { listPeerSkillItems } from '../../src/workspace/peer-skills.js';
+import { resolveWorkspace } from '../../src/workspace/resolve.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+
+const HOME = path.resolve('./.knowl-peerskill-home');
+const A = path.resolve('./.knowl-peerskill-a');
+const B = path.resolve('./.knowl-peerskill-b');
+
+type Seed = { title: string; content: string; visibility: string; source?: string };
+
+/**
+ * A skill row exactly as `indexSkillPackage` writes one -- `.knowl/skills/<name>/SKILL.md` as
+ * the source, and a `Purpose:` second line. The source matters more than it looks: it is what
+ * makes a peer row *look* runnable, which is the bug this file exists to hold shut.
+ */
+const skill = (title: string, purpose: string, visibility: string): Seed => ({
+  title,
+  content: `File-backed learned skill package at \`.knowl/skills/${title}/SKILL.md\`.\nPurpose: ${purpose}`,
+  visibility,
+  source: `.knowl/skills/${title}/SKILL.md`,
+});
+
+async function seed(root: string, name: string, items: Seed[]) {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, name)).id;
+  for (const item of items) {
+    const stored = await storeKnowledgeItemDeduped(projectId, {
+      category: 'skill', title: item.title, content: item.content,
+    });
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ?, source = ? WHERE id = ?',
+      args: [item.visibility, name, item.source ?? null, stored.item.id],
+    });
+  }
+  await closeDb();
+}
+
+describe('a linked repo\'s shared skills on the session-start card', () => {
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
+    await seed(A, 'a', []);
+    await seed(B, 'duckprep', [
+      skill('mascot-art', 'style-anchored generation with a judge loop.', 'workspace'),
+      skill('private-chore', 'not for sharing.', 'repo'),
+    ]);
+    await joinWorkspace({ projectRoot: A, workspaceName: 'ws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'ws', repoName: 'duckprep' });
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('reads a peer\'s workspace-visible skill and leaves its private one behind', async () => {
+    await initDb(A);
+    try {
+      const active = (await resolveWorkspace(A))!;
+      const found = await listPeerSkillItems(active);
+
+      expect(found.map(entry => entry.item.title)).toEqual(['mascot-art']);
+      expect(found[0].repo).toBe('duckprep');
+    } finally {
+      await closeDb();
+    }
+  });
+
+  it('puts the peer skill on the card, attributed and marked unrunnable', async () => {
+    await initDb(A);
+    try {
+      const projectId = (await repo.createProject(A, 'a')).id;
+      const { context } = await bootstrapAgentSession({ projectId, title: 'peer skills' });
+
+      // The whole incident in one assertion: an agent in this repo now learns the pipeline
+      // exists without having known to query for it.
+      expect(context).toContain('mascot-art');
+      expect(context).toContain('(in duckprep, not runnable here)');
+      expect(context).not.toContain('private-chore');
+    } finally {
+      await closeDb();
+    }
+  });
+
+  /*
+   * Both skip branches, driven through the workspace shape rather than the filesystem.
+   *
+   * The obvious version of this test deletes the peer's database and asserts the card survives.
+   * It cannot be written that way here: a process cannot unlink a libsql file it has opened, so
+   * on Windows the delete fails rather than the read. Handing `listPeerSkillItems` an absent peer
+   * and an unreadable one exercises the same two branches without asking the platform for
+   * something it does not do.
+   */
+  it('skips a peer that is absent or whose store will not open', async () => {
+    await initDb(A);
+    try {
+      const active = (await resolveWorkspace(A))!;
+      const broken = {
+        ...active,
+        peers: [
+          { ...active.peers[0], name: 'gone', present: false },
+          { ...active.peers[0], name: 'unreadable', present: true, databasePath: path.join(A, 'no', 'such.db') },
+        ],
+      };
+
+      await expect(listPeerSkillItems(broken)).resolves.toEqual([]);
+    } finally {
+      await closeDb();
+    }
+  });
+});


### PR DESCRIPTION
Resolves #70 and #54. (#53 was closed separately with a correction — its premise was already false when filed — and split into #71 and #72.)

Two halves of one gap: memory that is present but never surfaced, and memory that is never written at all.

## #70 — a linked repo's skills now reach the session-start card

`bootstrapAgentSession` filled its "Available skills" section from `listActiveSkillItems`, which reads the local store only. So workspace visibility governed **query** reach but not **ambient** reach: a sibling repo's shared skill could be found by an agent that already knew to ask for it — precisely the agent that does not know the tooling exists.

Peer skills now ride the same card as pointers, local rows first, inside the existing 750-character budget:

```
## Available skills

- **verify-bench** — run the benchmark suite and filter its output
- **mascot-art** (in duckprep, not runnable here) — style-anchored generation with a judge loop.
```

Two traps that would have shipped broken, both now pinned by tests:

- **A peer skill computes as runnable.** `toSurfacedSkills` derives `runnable` from `source.startsWith('.knowl/skills/')`, and a peer's package carries exactly that source — it is a real package, just not under this root. Left derived, peer rows came back `runnable: true`, and two things believe that field: `knowl_skill_run` resolves `readSkillPackage(projectRoot, name)` against the **local** root, and `matchSkillForCommand` filters on it — so a peer row could have won the mid-turn slot and told the agent to run something unreachable, or run a same-named local skill instead. `toPeerSurfacedSkills` forces it false, and the matcher refuses a peer row by name as well. The deeper reason is trust: `assertSkillApproved` is per-repo, so running a peer's bytes here spends an approval nobody gave.
- **The repo label has to be priced by the function that renders it.** `selectSurfacedSkills` charges `renderSkillRow(skill).length`; a label appended at the render site would price one string and emit another.

`listActiveSkillItems` is deliberately untouched — it runs on every command tool event and is index-scoped for that reason, so bootstrap got its own peer lookup rather than a widened hot path. Peer reads are read-only, visibility-filtered in SQL, and a peer that is absent or unreadable is skipped silently.

## #54 — the write path can now see what it failed to store

Every gate Knowl has decides what gets *in*. Nothing noticed what should have got in and did not. The read side already had that telemetry (`knowledge_access` records retrieved-but-never-used); the write side's only detector was a person noticing afterwards.

`capture_outcomes` records turns and durable writes per conversation, and `knowl status` reports it:

```
🔍 CAPTURE HEALTH
  Sessions recorded:     88
  Stored nothing:        79
  ...and ran long enough to count: 31 (35%)
  Nudge: off — measuring only. Arm with capture.nudge=shadow.
```

Measurement is unconditional. `capture.nudge` (`off` | `shadow` | `enforce`, default `off`) decides only what is done with the answer — the same ladder `impact.gate` climbs, for the same reason: the number a decision to intervene rests on cannot be measured by something already intervening.

Four places the obvious implementation is wrong, each one found by building it:

- **Turns, not tool events.** The sessions worth catching are strategy conversations — long on turns, short on tool calls — so any threshold in tool events excludes exactly them.
- **Keyed on the conversation, not a memory session.** A Claude turn binds its own memory session and `Stop` closes it, so the next turn gets a fresh one. A session-keyed counter reads `turns: 1` forever. (This is what the first draft did, and the test caught it.)
- **`finalizeMemorySession` reporting `skipped` is not "stored nothing".** It means automatic promotion found no candidate — true of nearly every conversation, and silent about what the agent stored by hand. Using it would have fired on the sessions that did everything right.
- **There is no non-blocking channel at stop.** A stop hook either withholds the stop and hands back a reason, or is not heard; `SessionEnd` fires once the model is gone. So `enforce` costs a turn, and the nudge is claimed against `capture_outcomes.nudged` *before* delivery — "stored nothing" is a condition the agent may rightly decline to clear, so without the one-shot the block would fire on every subsequent stop forever.

Reads do not count as writes: a session that queried diligently and stored nothing is the case this measures.

### Housekeeping

Schema level 9 (additive, no backfill — and none is possible, since the counters ride events that expire in ~2 days). `capture_outcomes` is `preserved` across snapshot restore: it is a measurement somebody decides against, and refilling it from a snapshot would clear `nudged` on conversations already nudged, re-arming a stop-block against sessions that had answered it.

## Verification

Full set, in order:

- `npm run build` — success
- `npm test` — **301 files, 2697 passed**, 5 skipped, 0 failed
- `npm run typecheck` — clean
- `git diff --check` — clean
- `npm run lint` — 0 errors (29 pre-existing warnings, none in changed files)

Two repo guards did their job during the work and are satisfied: `schema-pin` (level-9 hash recorded) and `snapshot-table-ownership` (policy decided, with the reason).

### Known limitation

`enforce` reaches Claude only. Hosts that bind one memory session per turn never accumulate turns, and Claude is the only host whose stop channel is verified — `stopContext` is absent on the others, so they fail closed and the claim is not spent.
