### PR TITLE
Index Codex sessions beside Claude Code's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,47 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 ## Unreleased
 
 Two halves of the same gap: memory that is present but never surfaced, and memory that is never
-written at all.
+written at all. Plus a second harness's transcripts, which were sitting on disk unread.
+
+### Codex sessions are indexed alongside Claude Code's
+
+`knowl reindex --transcripts` read one archive. Measured on the machine that wrote this: **125
+Claude sessions and 137 Codex sessions** for this repository — so more than half of its own history
+was invisible to transcript search, and a developer who had switched tools would have found the
+backfill quietly covering a fraction of their work while reporting success.
+
+Codex needs its own discovery rather than a wider glob, and this is the part worth knowing:
+
+- **Claude Code encodes the project in the directory name** (`d:\coding\knowl` → `d--coding-knowl`),
+  so finding this repo's sessions is a directory match.
+- **Codex partitions by date** (`~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`) and
+  records its project *inside* the file, as `session_meta.payload.cwd` on the first line.
+
+So every candidate file is opened. The read is bounded to 8 KB, because `cwd` is written before
+`base_instructions` — the system prompt, tens of kilobytes — and reading whole headers for a
+477-file archive would be tens of megabytes of I/O to answer a question the first few hundred bytes
+settle. A header that does not yield its `cwd` there falls back to reading on to the end of the
+line, capped at 2 MB.
+
+`response_item` records are read and `event_msg` is ignored. That is deduplication, not preference:
+Codex writes each assistant turn twice, once for its UI stream and once as the item that went to the
+model, and indexing both would put every assistant message in the index twice. `reasoning` items are
+dropped for the same reason Claude's `thinking` blocks are — they are not what was said — and here
+they arrive encrypted anyway. Parser dispatch is on the record's own shape, so no caller needs to
+know which archive a line came from.
+
+Two smaller things that follow:
+
+- `<environment_context>` joins the injected-opener list. It opens *every* Codex session, so without
+  it the session directory would title all of them with the same boilerplate.
+- **Redirecting one archive redirects both.** A caller that passes `projectsDir` no longer gets the
+  real `~/.codex` read underneath it. That is not hypothetical: the first version of this change
+  made eight existing discovery tests start returning 137 of this machine's real sessions beside
+  their three fixtures.
+
+`transcript_files` gains a `harness` column, defaulted to `claude` — not a guess standing in for
+unknown data, since every row that predates it was discovered through the only archive discovery
+could then reach. No watermark reset, so an existing index keeps working.
 
 ### A linked repo's skills now reach the session-start card
 

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -143,7 +143,7 @@ export const CONFIG_FIELDS: ConfigField[] = [
     key: 'search.transcripts.enabled', category: 'Search', type: 'boolean',
     parse: booleanValue, defaultValue: false,
     label: 'Transcript search',
-    description: 'Search this repo\'s past Claude Code sessions. Builds a separate index the first time you run `knowl reindex --transcripts`.',
+    description: 'Search this repo\'s past Claude Code and Codex sessions. Builds a separate index the first time you run `knowl reindex --transcripts`.',
   },
   {
     key: 'search.transcripts.share', category: 'Search', type: 'boolean',

--- a/src/transcripts/database.ts
+++ b/src/transcripts/database.ts
@@ -21,7 +21,8 @@ export const TRANSCRIPT_SCHEMA_STATEMENTS = [
     display_name TEXT,
     name_kind INTEGER NOT NULL DEFAULT 0,
     opening TEXT,
-    anchor TEXT
+    anchor TEXT,
+    harness TEXT NOT NULL DEFAULT 'claude'
   );`,
 
   // No `body` column anywhere: a row is a pointer. The text stays in the .jsonl.
@@ -111,6 +112,16 @@ async function addNamingColumns(client: Client): Promise<void> {
   // rewrite detection without re-reading anything.
   if (!columns.includes('anchor')) {
     await client.execute('ALTER TABLE transcript_files ADD COLUMN anchor TEXT;');
+  }
+  // Which harness wrote the session. Defaulted rather than nullable, and defaulted to `claude`
+  // specifically: every row that predates this column was discovered through the Claude archive,
+  // because that was the only archive discovery could reach. So the default is not a guess
+  // standing in for unknown data -- it is the correct value for every existing row.
+  //
+  // No watermark reset, for the reason spelled out above `opening`: rows and watermark are one
+  // fact, and a migration that moves one without the other strands the index.
+  if (!columns.includes('harness')) {
+    await client.execute(`ALTER TABLE transcript_files ADD COLUMN harness TEXT NOT NULL DEFAULT 'claude';`);
   }
 
   const messageColumns = (await client.execute('PRAGMA table_info(transcript_messages)')).rows

--- a/src/transcripts/index-pass.ts
+++ b/src/transcripts/index-pass.ts
@@ -346,8 +346,8 @@ async function commitBatchOn(
     }
 
     await client.execute({
-      sql: `INSERT INTO transcript_files (path, session_id, parent_session_id, bytes_indexed, lines_indexed, size_at_index, updated_at, display_name, name_kind, opening, anchor)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      sql: `INSERT INTO transcript_files (path, session_id, parent_session_id, bytes_indexed, lines_indexed, size_at_index, updated_at, display_name, name_kind, opening, anchor, harness)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(path) DO UPDATE SET
               bytes_indexed = excluded.bytes_indexed,
               lines_indexed = excluded.lines_indexed,
@@ -357,7 +357,7 @@ async function commitBatchOn(
       args: [
         file.path, file.sessionId, file.parentSessionId,
         watermark.bytesConsumed, watermark.linesConsumed, size, new Date().toISOString(),
-        naming.displayName, naming.nameKind, naming.opening, anchor,
+        naming.displayName, naming.nameKind, naming.opening, anchor, file.harness,
       ],
     });
 
@@ -455,8 +455,8 @@ async function indexOneFile(
       // make the pair describe a file state that never existed.
       const finalAnchor = await anchorAt(file.path, next.value.bytesConsumed);
       await withWriteRetry(dbPath, client => client.execute({
-        sql: `INSERT INTO transcript_files (path, session_id, parent_session_id, bytes_indexed, lines_indexed, size_at_index, updated_at, display_name, name_kind, opening, anchor)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        sql: `INSERT INTO transcript_files (path, session_id, parent_session_id, bytes_indexed, lines_indexed, size_at_index, updated_at, display_name, name_kind, opening, anchor, harness)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
               ON CONFLICT(path) DO UPDATE SET
                 bytes_indexed = MAX(transcript_files.bytes_indexed, excluded.bytes_indexed),
                 lines_indexed = MAX(transcript_files.lines_indexed, excluded.lines_indexed),
@@ -467,7 +467,7 @@ async function indexOneFile(
         args: [
           file.path, file.sessionId, file.parentSessionId,
           next.value.bytesConsumed, next.value.linesConsumed, size, new Date().toISOString(),
-          naming.displayName, naming.nameKind, naming.opening, finalAnchor,
+          naming.displayName, naming.nameKind, naming.opening, finalAnchor, file.harness,
         ],
       }));
       return { indexed, rebuilt: rewritten, complete: true };

--- a/src/transcripts/parse.ts
+++ b/src/transcripts/parse.ts
@@ -24,6 +24,13 @@ type Extracted = Omit<ProseMessage, 'line'>;
 export function extractProse(entry: unknown): Extracted | null {
   if (!entry || typeof entry !== 'object') return null;
   const record = entry as Record<string, unknown>;
+
+  // Dispatched on the record's own shape rather than on a harness passed down from discovery.
+  // The two are disjoint by construction -- Claude Code puts the role in `type`, Codex puts
+  // `response_item` there and the role inside `payload` -- so a record matches one reader or
+  // neither, and no caller has to know which archive a line came from.
+  if (record.type === 'response_item') return extractCodexProse(record);
+
   const role = record.type;
   if (role !== 'user' && role !== 'assistant') return null;
 
@@ -39,6 +46,53 @@ export function extractProse(entry: unknown): Extracted | null {
       if (!block || typeof block !== 'object') continue;
       const typed = block as Record<string, unknown>;
       if (typed.type === 'text' && typeof typed.text === 'string') text += typed.text;
+    }
+  }
+
+  text = text.trim();
+  if (!text) return null;
+
+  const timestamp = typeof record.timestamp === 'string' ? record.timestamp : null;
+  return { role, text, timestamp };
+}
+
+/**
+ * The prose in one Codex `response_item`, or null.
+ *
+ * **`response_item` is read and `event_msg` is ignored, and that is a deduplication rather than a
+ * preference.** Codex writes each assistant turn twice: once as `event_msg`/`agent_message` for
+ * its UI stream and once as the `response_item` that went to the model. Indexing both would put
+ * every assistant message in the index twice, and `response_item` is the one that matches the
+ * invariant the Claude reader already holds -- one record per conversational message.
+ *
+ * `reasoning` items are dropped for exactly the reason Claude's `thinking` blocks are: they are
+ * not what was said. Here they are also unreadable, arriving as `encrypted_content`.
+ *
+ * The `developer` role is dropped too. It carries the sandbox and permissions preamble the
+ * harness injects, which is identical across every session and is not a participant speaking.
+ */
+function extractCodexProse(record: Record<string, unknown>): Extracted | null {
+  const payload = record.payload;
+  if (!payload || typeof payload !== 'object') return null;
+  const typed = payload as Record<string, unknown>;
+  if (typed.type !== 'message') return null;
+
+  const role = typed.role;
+  if (role !== 'user' && role !== 'assistant') return null;
+
+  const content = typed.content;
+  let text = '';
+  if (typeof content === 'string') {
+    text = content;
+  } else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const part = block as Record<string, unknown>;
+      // `input_text` on the way in, `output_text` on the way out. Both are the message; the
+      // distinction is direction, not kind.
+      if ((part.type === 'input_text' || part.type === 'output_text') && typeof part.text === 'string') {
+        text += part.text;
+      }
     }
   }
 
@@ -100,6 +154,11 @@ const INJECTED_OPENERS = new Set([
   'task-notification',
   'ide_opened_file',
   'ide_selection',
+  // Codex's equivalent, and it opens *every* session in that archive rather than 39% of them:
+  // the first user-role item is always `<environment_context>` naming the cwd, shell and date.
+  // Left in, every Codex session in the directory would be titled with the same boilerplate.
+  'environment_context',
+  'user_instructions',
 ]);
 
 /**

--- a/src/transcripts/paths.ts
+++ b/src/transcripts/paths.ts
@@ -6,6 +6,16 @@ import { promisify } from 'node:util';
 
 const run = promisify(execFile);
 
+/**
+ * Which agent harness wrote a transcript.
+ *
+ * Carried per file rather than inferred from the path at the point of use. The two archives are
+ * discovered by genuinely different mechanisms -- Claude Code's directory *is* the project, while
+ * Codex records its project inside the file -- so by the time a file reaches the indexer the
+ * knowledge of where it came from is not recoverable from its path without redoing that work.
+ */
+export type TranscriptHarness = 'claude' | 'codex';
+
 export type TranscriptFile = {
   /** Absolute path to the `.jsonl`. */
   path: string;
@@ -13,6 +23,7 @@ export type TranscriptFile = {
   sessionId: string;
   /** For a subagent transcript, the session that spawned it. Null for a main session. */
   parentSessionId: string | null;
+  harness: TranscriptHarness;
 };
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -30,6 +41,168 @@ export function encodeProjectDir(projectRoot: string): string {
 
 export function defaultProjectsDir(): string {
   return path.join(os.homedir(), '.claude', 'projects');
+}
+
+/**
+ * Codex CLI's session archive: `~/.codex/sessions/YYYY/MM/DD/rollout-<iso>-<uuid>.jsonl`.
+ *
+ * Partitioned by DATE, which is the whole reason Codex needs its own discovery path. Claude Code
+ * names a directory after the project, so finding this repo's sessions is a directory match;
+ * here every project's sessions are interleaved by the day they happened on, and the only record
+ * of which project a session belongs to is `session_meta.payload.cwd` inside the file.
+ */
+export function defaultCodexSessionsDir(): string {
+  return path.join(os.homedir(), '.codex', 'sessions');
+}
+
+/**
+ * How deep below the sessions root the date partitioning goes: `YYYY/MM/DD`.
+ *
+ * A bound rather than a shape assertion, following `MAX_SUBAGENT_DEPTH`. If Codex adds or drops a
+ * level the walk still finds the files; the bound only exists to stop an unbounded descent.
+ */
+const MAX_CODEX_DEPTH = 4;
+
+/**
+ * Bytes of a Codex transcript read to find its project.
+ *
+ * The first line is `session_meta`, and it is large -- it carries `base_instructions`, the whole
+ * system prompt, which runs to tens of kilobytes. Reading it whole for every file on every scan
+ * would be tens of megabytes of I/O to answer a question the first few hundred bytes settle:
+ * `cwd` is written before `base_instructions` in that payload. So the common path reads a bounded
+ * prefix, and only a file that does not yield its `cwd` there pays for a full line.
+ */
+const CODEX_META_PREFIX_BYTES = 8192;
+
+/**
+ * Ceiling on the fallback read, for a header that does not yield its `cwd` in the prefix.
+ *
+ * A bound is required rather than tidy: the fallback reads until it meets a newline, and a
+ * corrupt or truncated file may not contain one before its end. Two megabytes is far past any
+ * real `session_meta` -- the largest in a 477-file archive is tens of kilobytes -- so reaching it
+ * means the file is not what it claims to be, and the right answer is to give up on it.
+ */
+const MAX_CODEX_META_BYTES = 2 * 1024 * 1024;
+
+/** `"cwd":"<json string>"`, matched inside a prefix that may end mid-record. */
+const CWD_IN_PREFIX = /"cwd"\s*:\s*("(?:[^"\\]|\\.)*")/;
+
+/**
+ * The project root a Codex session was recorded against, or null.
+ *
+ * Two reads at most. The prefix regex handles every well-formed session file; the fallback parses
+ * a complete first line, for a file whose meta record is ordered differently than this archive's.
+ */
+async function codexSessionCwd(filePath: string): Promise<string | null> {
+  let handle: import('node:fs/promises').FileHandle | undefined;
+  try {
+    handle = await fs.open(filePath, 'r');
+    const buffer = Buffer.alloc(CODEX_META_PREFIX_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, CODEX_META_PREFIX_BYTES, 0);
+    const prefix = buffer.subarray(0, bytesRead).toString('utf8');
+
+    const matched = CWD_IN_PREFIX.exec(prefix);
+    if (matched) {
+      try {
+        const cwd = JSON.parse(matched[1]) as unknown;
+        if (typeof cwd === 'string' && cwd) return cwd;
+      } catch {
+        // Fall through to the whole-line parse below.
+      }
+    }
+
+    // No `cwd` in the prefix. Either the record is ordered with `base_instructions` first, or the
+    // line is simply longer than the prefix before reaching `cwd`. Both are answered by reading
+    // on to the end of the first line -- which must genuinely continue reading, not re-inspect
+    // the prefix: a header larger than the prefix contains no newline inside it at all.
+    let line = prefix;
+    let offset = bytesRead;
+    while (!line.includes('\n') && offset < MAX_CODEX_META_BYTES && bytesRead > 0) {
+      const next = await handle.read(buffer, 0, CODEX_META_PREFIX_BYTES, offset);
+      if (next.bytesRead === 0) break;
+      line += buffer.subarray(0, next.bytesRead).toString('utf8');
+      offset += next.bytesRead;
+    }
+
+    const newline = line.indexOf('\n');
+    try {
+      const record = JSON.parse(newline === -1 ? line : line.slice(0, newline)) as Record<string, unknown>;
+      const payload = record.payload as Record<string, unknown> | undefined;
+      const cwd = payload?.cwd;
+      return typeof cwd === 'string' && cwd ? cwd : null;
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+/** Every `.jsonl` under the date-partitioned sessions tree. */
+async function collectCodexFiles(dir: string, found: string[], depth: number): Promise<boolean> {
+  const entries = await readDir(dir);
+  // Null is "could not look", which is a degraded scan rather than an empty one -- the same
+  // distinction `readDir` exists to preserve for the Claude archive.
+  if (entries === null) return true;
+
+  let degraded = false;
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      found.push(full);
+      continue;
+    }
+    if (entry.isDirectory() && depth < MAX_CODEX_DEPTH) {
+      degraded = await collectCodexFiles(full, found, depth + 1) || degraded;
+    }
+  }
+  return degraded;
+}
+
+/**
+ * This repo's Codex sessions, matched on the project each file records for itself.
+ *
+ * **Every file is opened, because there is no cheaper filter.** The path carries a date and a
+ * UUID and says nothing about the project, so the alternative to reading each header is not a
+ * faster match -- it is no match at all. The read is bounded (`CODEX_META_PREFIX_BYTES`) and the
+ * archive is small in file count; measured on a real 477-file archive this completes in about a
+ * second.
+ *
+ * Roots are compared with `foldPath`, which the Claude path already needs for the same reason and
+ * which matters more here: this archive records both `D:\coding\knowl` and `d:\coding\knowl` for
+ * one repository, because the drive letter's case follows however the agent was launched.
+ */
+async function scanCodexArchive(sessionsDir: string, roots: string[]): Promise<TranscriptScan> {
+  const paths: string[] = [];
+  const degraded = await collectCodexFiles(sessionsDir, paths, 0);
+
+  const wanted = new Set<string>();
+  for (const root of roots) {
+    const resolved = path.resolve(root);
+    wanted.add(foldPath(resolved));
+    const real = await fs.realpath(resolved).catch(() => null);
+    if (real) wanted.add(foldPath(real));
+  }
+
+  const files: TranscriptFile[] = [];
+  for (const filePath of paths) {
+    const cwd = await codexSessionCwd(filePath);
+    if (!cwd || !wanted.has(foldPath(cwd))) continue;
+    files.push({
+      path: filePath,
+      // `rollout-2026-03-22T21-16-47-019d15e7-....jsonl`. The UUID is the session id Codex uses
+      // in its own meta record; taking it from the name keeps this consistent with the Claude
+      // path, where the basename *is* the session id, and costs no second read.
+      sessionId: path.basename(filePath, '.jsonl').replace(/^rollout-\d{4}-\d{2}-\d{2}T[\d-]+?-(?=[0-9a-f]{8}-)/i, ''),
+      // Codex records no subagent transcripts in this archive: every file is a top-level session.
+      parentSessionId: null,
+      harness: 'codex',
+    });
+  }
+
+  return { files, degraded };
 }
 
 /** Every `worktree <path>` line from `git worktree list --porcelain`, in order. */
@@ -178,6 +351,7 @@ async function collectSubagentFiles(
         path: path.join(dir, entry.name),
         sessionId: entry.name.slice(0, -'.jsonl'.length),
         parentSessionId,
+        harness: 'claude',
       });
       continue;
     }
@@ -217,7 +391,7 @@ export type TranscriptScan = {
  */
 export async function scanTranscriptArchive(
   projectRoot: string,
-  options: { projectsDir?: string; roots?: string[] } = {},
+  options: { projectsDir?: string; codexSessionsDir?: string; roots?: string[] } = {},
 ): Promise<TranscriptScan> {
   const projectsDir = options.projectsDir ?? defaultProjectsDir();
   const rootSet = options.roots
@@ -294,6 +468,7 @@ export async function scanTranscriptArchive(
           path: path.join(repoPath, entry.name),
           sessionId: entry.name.slice(0, -'.jsonl'.length),
           parentSessionId: null,
+          harness: 'claude',
         });
         continue;
       }
@@ -310,6 +485,7 @@ export async function scanTranscriptArchive(
             path: path.join(nestedPath, nested.name),
             sessionId: nested.name.slice(0, -'.jsonl'.length),
             parentSessionId: entry.name,
+            harness: 'claude',
           });
           continue;
         }
@@ -319,13 +495,31 @@ export async function scanTranscriptArchive(
     }
   }
 
+  // Codex, discovered by its own mechanism and merged into one list. A harness that is simply
+  // not installed contributes nothing and is not a degradation: `collectCodexFiles` reports
+  // degraded only when a directory that exists could not be listed.
+  //
+  // **Redirecting one archive redirects both.** A caller that passes `projectsDir` is pointing
+  // discovery at a synthetic archive; letting the Codex half keep reading `~/.codex` would make
+  // that caller's results depend on whatever the developer running it happens to have on disk.
+  // That is not hypothetical -- it is what happened the first time this landed, and eight
+  // discovery tests started returning 137 of this repository's real sessions alongside their
+  // three fixtures. Production passes neither option and gets both real archives.
+  const codexSessionsDir = options.codexSessionsDir
+    ?? (options.projectsDir ? null : defaultCodexSessionsDir());
+  if (codexSessionsDir) {
+    const codex = await scanCodexArchive(codexSessionsDir, rootSet.roots);
+    found.push(...codex.files);
+    degraded = degraded || codex.degraded;
+  }
+
   return { files: found, degraded };
 }
 
 /** The file list alone, for callers with nothing to decide about a degraded scan. */
 export async function discoverTranscriptFiles(
   projectRoot: string,
-  options: { projectsDir?: string; roots?: string[] } = {},
+  options: { projectsDir?: string; codexSessionsDir?: string; roots?: string[] } = {},
 ): Promise<TranscriptFile[]> {
   return (await scanTranscriptArchive(projectRoot, options)).files;
 }

--- a/tests/transcripts/codex-discovery.test.ts
+++ b/tests/transcripts/codex-discovery.test.ts
@@ -1,0 +1,202 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { discoverTranscriptFiles, scanTranscriptArchive } from '../../src/transcripts/paths.js';
+import { extractProse, readOpeningAsk } from '../../src/transcripts/parse.js';
+
+let codexSessionsDir: string;
+let projectsDir: string;
+
+const ROOT = path.resolve(process.platform === 'win32' ? 'd:\\coding\\knowl' : '/coding/knowl');
+const OTHER = path.resolve(process.platform === 'win32' ? 'd:\\coding\\auction' : '/coding/auction');
+
+beforeEach(async () => {
+  codexSessionsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-codex-'));
+  projectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-claude-'));
+});
+
+afterEach(async () => {
+  await fs.rm(codexSessionsDir, { recursive: true, force: true });
+  await fs.rm(projectsDir, { recursive: true, force: true });
+});
+
+/**
+ * A session file in the real shape: date-partitioned path, `session_meta` first with the project
+ * in `payload.cwd`, and `base_instructions` after it — the large field whose position is the
+ * reason the header read is bounded rather than whole-line.
+ */
+async function writeSession(
+  relative: string,
+  cwd: string,
+  lines: unknown[] = [],
+  options: { padding?: number } = {},
+) {
+  const target = path.join(codexSessionsDir, relative);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  const meta = {
+    timestamp: '2026-03-22T14:17:26.166Z',
+    type: 'session_meta',
+    payload: {
+      id: '019d15e7-d37e-7e93-886c-2429599f27cd',
+      timestamp: '2026-03-22T14:16:47.763Z',
+      cwd,
+      originator: 'codex_vscode',
+      base_instructions: { text: 'x'.repeat(options.padding ?? 20_000) },
+    },
+  };
+  const body = [meta, ...lines].map(line => JSON.stringify(line)).join('\n') + '\n';
+  await fs.writeFile(target, body);
+  return target;
+}
+
+const codexMessage = (role: string, text: string, kind = role === 'user' ? 'input_text' : 'output_text') => ({
+  timestamp: '2026-03-22T14:18:00.000Z',
+  type: 'response_item',
+  payload: { type: 'message', role, content: [{ type: kind, text }] },
+});
+
+describe('Codex transcript discovery', () => {
+  it('finds a session by the project recorded inside the file', async () => {
+    // The whole reason Codex needs its own discovery: the path carries a date and a UUID and
+    // says nothing about which project the session belongs to.
+    await writeSession('2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-d37e-7e93-886c-2429599f27cd.jsonl', ROOT);
+
+    const found = await discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir });
+
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ harness: 'codex', parentSessionId: null });
+  });
+
+  it('takes the session id from the rollout name, dropping the date prefix', async () => {
+    await writeSession('2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-d37e-7e93-886c-2429599f27cd.jsonl', ROOT);
+
+    const [file] = await discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir });
+
+    expect(file.sessionId).toBe('019d15e7-d37e-7e93-886c-2429599f27cd');
+  });
+
+  it('leaves another project\'s sessions alone', async () => {
+    await writeSession('2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-aaaa-7e93-886c-2429599f27cd.jsonl', ROOT);
+    await writeSession('2026/03/22/rollout-2026-03-22T21-16-48-019d15e7-bbbb-7e93-886c-2429599f27cd.jsonl', OTHER);
+
+    const found = await discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir });
+
+    expect(found.map(file => file.sessionId)).toEqual(['019d15e7-aaaa-7e93-886c-2429599f27cd']);
+  });
+
+  it('matches a cwd whose drive letter is cased differently', async () => {
+    // Not hypothetical: one real archive held 128 sessions under `D:\coding\knowl` and 9 under
+    // `d:\coding\knowl`, for one repository. The case follows however the agent was launched.
+    const swapped = ROOT[0] === ROOT[0].toLowerCase()
+      ? ROOT[0].toUpperCase() + ROOT.slice(1)
+      : ROOT[0].toLowerCase() + ROOT.slice(1);
+    await writeSession('2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-cccc-7e93-886c-2429599f27cd.jsonl', swapped);
+
+    const found = await discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir });
+
+    expect(found).toHaveLength(1);
+  });
+
+  it('finds the cwd even when the header is far larger than the bounded read', async () => {
+    // The fallback path. `cwd` precedes `base_instructions` in every real record, but a header
+    // ordered the other way must degrade to a full-line parse rather than to silence.
+    const target = path.join(codexSessionsDir, '2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-dddd-7e93-886c-2429599f27cd.jsonl');
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, `${JSON.stringify({
+      type: 'session_meta',
+      payload: { base_instructions: { text: 'x'.repeat(40_000) }, cwd: ROOT },
+    })}\n`);
+
+    const found = await discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir });
+
+    expect(found).toHaveLength(1);
+  });
+
+  it('skips a file with no readable header rather than claiming it', async () => {
+    const target = path.join(codexSessionsDir, '2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-eeee-7e93-886c-2429599f27cd.jsonl');
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, 'not json at all\n');
+
+    await expect(discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir })).resolves.toEqual([]);
+  });
+
+  it('reports an absent Codex archive as empty, not degraded', async () => {
+    const scan = await scanTranscriptArchive(ROOT, {
+      projectsDir,
+      codexSessionsDir: path.join(codexSessionsDir, 'nope'),
+    });
+
+    expect(scan.files).toEqual([]);
+    expect(scan.degraded).toBe(false);
+  });
+
+  it('does not read the real ~/.codex when the caller redirected the Claude archive', async () => {
+    // The isolation rule. Without it, every discovery test in this repo silently returned this
+    // machine's own sessions alongside its fixtures -- which is exactly what happened.
+    const found = await discoverTranscriptFiles(ROOT, { projectsDir });
+
+    expect(found).toEqual([]);
+  });
+
+  it('merges both harnesses into one list, each labelled', async () => {
+    const { encodeProjectDir } = await import('../../src/transcripts/paths.js');
+    const claudeDir = path.join(projectsDir, encodeProjectDir(ROOT));
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.writeFile(path.join(claudeDir, 'aaa.jsonl'), '{}\n');
+    await writeSession('2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-ffff-7e93-886c-2429599f27cd.jsonl', ROOT);
+
+    const found = await discoverTranscriptFiles(ROOT, { projectsDir, codexSessionsDir });
+
+    expect(found.map(file => file.harness).sort()).toEqual(['claude', 'codex']);
+  });
+});
+
+describe('Codex prose extraction', () => {
+  it('reads a user message from input_text', () => {
+    expect(extractProse(codexMessage('user', 'how do I add a harness?'))).toMatchObject({
+      role: 'user', text: 'how do I add a harness?',
+    });
+  });
+
+  it('reads an assistant message from output_text', () => {
+    expect(extractProse(codexMessage('assistant', 'start with discovery.'))).toMatchObject({
+      role: 'assistant', text: 'start with discovery.',
+    });
+  });
+
+  it('ignores event_msg, which duplicates every assistant turn', () => {
+    // Codex writes each assistant turn twice -- once for its UI stream, once as the item that
+    // went to the model. Reading both would put every assistant message in the index twice.
+    expect(extractProse({
+      type: 'event_msg',
+      payload: { type: 'agent_message', message: 'start with discovery.' },
+    })).toBeNull();
+  });
+
+  it('ignores reasoning, which is not what was said', () => {
+    expect(extractProse({
+      type: 'response_item',
+      payload: { type: 'reasoning', summary: [], content: null, encrypted_content: 'gAAAA...' },
+    })).toBeNull();
+  });
+
+  it('ignores the developer role, which is the injected preamble', () => {
+    expect(extractProse(codexMessage('developer', '<permissions instructions>...', 'input_text'))).toBeNull();
+  });
+
+  it('still reads a Claude record, because the two shapes are disjoint', () => {
+    expect(extractProse({
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'claude side still works' }] },
+      timestamp: '2026-03-22T00:00:00.000Z',
+    })).toMatchObject({ role: 'user', text: 'claude side still works' });
+  });
+
+  it('does not title a session by the environment preamble Codex opens with', () => {
+    // Every Codex session's first user item is this block. Left in, every session in the
+    // directory would carry the same opening.
+    expect(readOpeningAsk('<environment_context>\n  <cwd>d:\\coding\\knowl</cwd>\n</environment_context>')).toBeNull();
+    expect(readOpeningAsk('i need to make a realtime database')).toBe('i need to make a realtime database');
+  });
+});


### PR DESCRIPTION
Closes #72.

`knowl reindex --transcripts` reads one archive. Measured on the machine that wrote this: **125 Claude sessions and 137 Codex sessions** for this repository — so more than half of its own history was invisible to transcript search. Worse than the raw miss: a developer who had switched tools would have watched the backfill cover a fraction of their work and report success.

## Why Codex needs its own discovery, not a wider glob

This is the part the issue originally got wrong, and it changes the shape of the work:

| | Claude Code | Codex |
|---|---|---|
| Layout | `~/.claude/projects/<encoded-root>/` | `~/.codex/sessions/YYYY/MM/DD/` |
| Partitioned by | **project** | **date** |
| Project recorded in | the directory name | `session_meta.payload.cwd`, inside the file |

So finding this repo's Claude sessions is a directory match, and finding its Codex sessions means opening every candidate. There is no cheaper filter — the path carries a date and a UUID and says nothing about the project.

**The read is bounded to 8 KB.** `cwd` is written before `base_instructions`, which is the whole system prompt at tens of kilobytes; reading complete headers across a 477-file archive would be tens of megabytes of I/O to settle a question the first few hundred bytes answer. A header that does not yield `cwd` there reads on to the end of the line, capped at 2 MB.

That fallback was wrong in the first draft — it re-inspected the prefix, which by definition contains no newline when the header is larger than it. A test with a 40 KB header caught it.

## Parsing

`response_item` is read and `event_msg` ignored. **That is deduplication, not preference:** Codex writes each assistant turn twice, once as the UI event and once as the item that went to the model. Reading both would put every assistant message in the index twice.

`reasoning` items are dropped for exactly the reason Claude's `thinking` blocks are — they are not what was said — and here they arrive as `encrypted_content` regardless. The `developer` role is dropped as injected preamble.

Dispatch is on the **record's own shape**, not on a harness threaded down from discovery. Claude puts the role in `type`; Codex puts `response_item` there and the role inside `payload`. The two are disjoint, so a record matches one reader or neither and no caller needs to know where a line came from.

`<environment_context>` joins the injected-opener list. It opens *every* Codex session, so without it the session directory would title all of them with the same boilerplate.

## A test-isolation bug this introduced, and fixed

The first version let `codexSessionsDir` default to the real `~/.codex` even when the caller had redirected `projectsDir` at a fixture. Eight existing discovery tests immediately started returning **137 of this machine's real sessions** beside their three fixtures.

Redirecting one archive now redirects both. Production passes neither option and gets both real archives.

## Schema

`transcript_files` gains a `harness` column, defaulted to `'claude'`. That default is not a guess standing in for unknown data — every row predating this column was discovered through the only archive discovery could then reach, so it is the correct value. Added through the existing additive `ALTER TABLE` path with **no watermark reset**, per the warning already in that migration: rows and watermark are one fact, and moving one without the other strands the index.

## Verification

- `npm run build` — success
- `npm test` — **302 files, 2713 passed**, 5 skipped, 0 failed
- `npm run typecheck` — clean
- `git diff --check` — clean
- `npm run lint` — 0 errors (29 pre-existing warnings, none in changed files)

16 new tests cover discovery, the oversized-header fallback, drive-letter casing, the isolation rule, and the parser split.

**Verified against the real archive**, which this subsystem's own history says earns its place — a previous transcript change shipped a bug that only a real-archive check caught. Discovery found 137 Codex sessions for this repo, session ids extracted as clean UUIDs (`019f2872-858c-7771-a5e3-9bd4454f9015` from `rollout-2026-07-03T21-47-01-019f2872-….jsonl`), and 5 sampled files parsed to 598 messages, every one a valid role. That probe was not committed — it depends on the developer's home directory.

## Scope

Codex only. Cursor and aider are absent on this machine, so neither could be built against a real archive — and this subsystem has already been bitten once by assuming an archive's shape from docs rather than from the files. `~/.gemini` exists but was not inspected.
