### PR TITLE
Distil session transcripts into reviewable knowledge candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,55 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
-Two halves of the same gap: memory that is present but never surfaced, and memory that is never
-written at all. Plus a second harness's transcripts, which were sitting on disk unread.
+Memory that is present but never surfaced, memory that is never written at all, a second harness's
+transcripts sitting on disk unread — and the cold start, where a fresh install has an archive of
+past sessions beside an empty store and no way across.
+
+### Transcripts can become knowledge, through a review step
+
+The index made past sessions searchable and put nothing in the store, so a fresh `knowl init`
+stayed empty until somebody wrote to it. `knowl transcripts extract` distils indexed sessions into
+staged candidates; `knowl transcripts candidates`, `approve` and `discard` decide what becomes
+memory.
+
+**Nothing is promoted by extraction.** Candidates land in `transcript_candidates` and stop there.
+A first run over a real archive produces on the order of a thousand atoms, and an unreviewed corpus
+of that size would be answering every future query while nobody had yet decided any of it was true.
+Approval is the act that puts an atom in front of a query, and it is separate, explicit, and per
+candidate.
+
+**It costs the operator money, and the command says so before spending any.** `extract` prints the
+session count, the character estimate and the provider it would call, then stops unless `--yes` is
+passed. The default limit is 10 sessions, not the archive. A session that has been extracted is
+watermarked so a rerun never pays for it twice — including one that yielded nothing, since the
+sessions most likely to yield nothing are the short ones and they would otherwise dominate the bill.
+A session whose extraction *fails* is deliberately not watermarked: a provider hiccup is not a
+verdict about that session.
+
+Three bugs found by building it, each fixed:
+
+- **Approval was secretly AI-dependent.** It went through `runDecisionPipeline`, whose `runVerify`
+  calls the model to adjudicate against existing items in the same category. That works on an empty
+  store and throws `AI provider has not been initialized` on the second atom of the first bulk run.
+  It now uses `storeKnowledgeAtomsDeduped`, the same writer `knowl_ingest_atoms` uses — which also
+  turned out to be the path that persists `provenance`.
+- **A bogus category reached the store.** A `not-a-category` atom was written to `knowledge_items`
+  intact, where every reader downstream assumes the enum. Validated at promotion now.
+- **Secret patterns were not being passed.** Approval called the writer without `config.security`,
+  running the weakest available validation on the one input most likely to contain a key — a
+  transcript is a recording of a working session, and working sessions paste credentials.
+
+Promoted atoms carry `provenance: 'inferred'` and `source: transcript:<harness>:<session>`. They
+were distilled by a model from a conversation nobody re-read at approval time; claiming `observed`
+would rank them above knowledge somebody actually verified.
+
+### A query miss now names the cold start
+
+`NO CONFIDENT MATCH` already pointed at `knowl_transcript_search` where transcripts were enabled.
+Where they are *not*, it said nothing — so an empty store could sit beside hundreds of indexable
+sessions and never mention it. It now names the config (not the tool, which that build genuinely
+does not expose), and only when an archive is actually on disk. The probe is two `stat` calls and
+opens no file: it runs at the moment a query has decided memory is empty.
 
 ### Codex sessions are indexed alongside Claude Code's
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -457,6 +457,52 @@ Workspace peers may opt in with `share: true`, which lets linked repositories op
 read-only. Sharing is re-checked on every read, so revoking it revokes previously issued
 locators too.
 
+Both Claude Code and Codex archives are discovered. They are found by different mechanisms
+because they are laid out differently: Claude Code names a directory after the project
+(`~/.claude/projects/<encoded-root>/`), while Codex partitions by date
+(`~/.codex/sessions/YYYY/MM/DD/`) and records the project inside each file as
+`session_meta.payload.cwd`. Every Codex candidate is therefore opened, with a bounded header read.
+
+### `knowl transcripts` — turning sessions into candidates
+
+Searching a transcript answers a question. This turns one into memory. Extraction runs the
+configured model over indexed sessions and **stages** what it finds; nothing reaches the knowledge
+store until you approve it.
+
+```bash
+knowl transcripts extract --limit 10        # prints the estimate, then stops
+knowl transcripts extract --limit 10 --yes  # actually runs
+knowl transcripts candidates                # review what was staged
+knowl transcripts approve <id>...           # promote, or --all
+knowl transcripts discard <id>...           # reject, or --all
+```
+
+**Extraction spends your model quota, so it tells you first.** `extract` prints the session count,
+the character estimate and the provider it would call, and does nothing without `--yes`. The
+default is 10 sessions, not the archive. It requires `ai.provider` and `ai.model`; without them,
+distil a session yourself with `knowl_transcript_read` and store the result through
+`knowl_ingest_atoms`, which needs no AI configuration.
+
+**Nothing is promoted automatically, and that is the point.** A first run over a real archive
+produces on the order of a thousand atoms. An unreviewed corpus that size would be answering every
+future query while nobody had yet decided any of it was true, so approval is a separate, explicit
+act — one candidate at a time, each passing the same secret validation, confidence range and dedup
+checks that every other write does.
+
+Runs are resumable and never pay twice. An extracted session is watermarked, including one that
+yielded nothing — short sessions yield nothing most often and would otherwise dominate the bill. A
+session whose extraction *failed* is deliberately left unwatermarked, because a provider error is
+not a verdict about that session. Long sessions are truncated from the start, keeping the tail,
+where a session's conclusions are.
+
+Promoted atoms carry `provenance: inferred` and `source: transcript:<harness>:<session>`. A model
+distilled them from a conversation nobody re-read at approval time; calling that `observed` would
+rank it above knowledge somebody actually verified.
+
+Candidates live in `.knowl/transcripts.db`, not the knowledge store, so speculative rows never
+reach a query and disabling transcript search discards them with the index. They are regenerable
+from the transcripts, which is what makes that safe.
+
 ### Host and subagent behavior
 
 | Host | MCP | Automatic lifecycle | Subagent lifecycle | Current session behavior or limit |

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -89,7 +89,17 @@ import { synthesizeKnowledge } from '../store/synthesis.js';
 import { startViewer } from '../viewer/server.js';
 import { createAgentReminderOutput } from './agents/reminder.js';
 import { rebuildTranscriptIndex } from '../transcripts/backfill.js';
-import { closeTranscriptDbs } from '../transcripts/database.js';
+import { closeTranscriptDbs, openTranscriptDb } from '../transcripts/database.js';
+import { isTranscriptSearchEnabled } from '../transcripts/config.js';
+import { resolveStorage } from '../store/storage-roles.js';
+import {
+  countCandidates,
+  DEFAULT_EXTRACT_LIMIT,
+  extractCandidates,
+  listCandidates,
+  planExtraction,
+} from '../transcripts/extract-candidates.js';
+import { approveCandidates, discardCandidates } from '../transcripts/approve-candidates.js';
 import { applyTranscriptConfigTransition, describeTranscriptTeardown } from '../transcripts/teardown.js';
 
 // Load environment variables (.env file)
@@ -1803,6 +1813,149 @@ program
       }
     } catch (error: any) {
       console.error(`Error reindexing: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+// --- 8b. TRANSCRIPT CANDIDATE COMMANDS ---
+//
+// Extraction and approval are separate commands because they are separate decisions, and because
+// only one of them costs money. `extract` runs the configured model over whole sessions and stages
+// what it finds; nothing it writes can be retrieved. `approve` is the act that puts an atom in
+// front of every future query, and it names what it is promoting.
+const transcripts = program
+  .command('transcripts')
+  .description('Distil indexed session transcripts into reviewable knowledge candidates');
+
+/** The transcripts index for the current project, or a readable error saying how to build one. */
+async function openCandidateStore(root: string) {
+  const config = await loadConfig(root);
+  if (!isTranscriptSearchEnabled(config)) {
+    throw new Error(
+      'Transcript search is not enabled for this repository. Set search.transcripts.enabled to true (knowl config), then run knowl reindex --transcripts.',
+    );
+  }
+  const dbPath = resolveStorage(root).transcripts;
+  return { config, db: await openTranscriptDb(dbPath) };
+}
+
+transcripts
+  .command('extract')
+  .description('Run the configured model over unextracted sessions and stage what it finds')
+  .option('--limit <n>', `Sessions to extract in this run (default ${DEFAULT_EXTRACT_LIMIT})`, parseInt)
+  .option('--budget <minutes>', 'Stop after this many minutes; the next run resumes', parseFloat)
+  .option('--yes', 'Skip the cost estimate and run')
+  .action(async (options) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const { config, db } = await openCandidateStore(root);
+      const plan = await planExtraction(db, { limit: options.limit });
+
+      if (plan.sessions.length === 0) {
+        console.log(plan.done > 0
+          ? `Nothing to extract: all ${plan.done} indexed session(s) have been extracted.`
+          : 'Nothing to extract. Run knowl reindex --transcripts first.');
+        await closeTranscriptDbs();
+        return;
+      }
+
+      // Printed before anything is sent, and gated behind --yes. This spends the operator's API
+      // quota on their own archive; the size of that is theirs to see before it happens, not
+      // after. `remaining` is stated too, so a run that covers a tenth of the archive cannot read
+      // as having covered it.
+      console.log(`Extract ${plan.sessions.length} session(s), about ${Math.round(plan.chars / 1000)}k characters, using ${config.ai?.provider}/${config.ai?.model}.`);
+      console.log(`${plan.pending} session(s) await extraction; ${plan.done} already done.`);
+      if (!options.yes) {
+        console.log('This calls your configured model and spends your quota. Re-run with --yes to proceed.');
+        await closeTranscriptDbs();
+        return;
+      }
+
+      const deadline = options.budget !== undefined ? Date.now() + options.budget * 60_000 : undefined;
+      const result = await extractCandidates(db, config, { limit: options.limit, deadline });
+
+      console.log(`Extracted ${result.sessionsExtracted} session(s) into ${result.candidates} candidate(s).`);
+      if (result.empty > 0) console.log(`${result.empty} session(s) yielded nothing and will not be retried.`);
+      if (result.remaining > 0) console.log(`${result.remaining} session(s) still unextracted. Run again to continue.`);
+      console.log('Review them with knowl transcripts candidates; nothing is stored until you approve it.');
+      await closeTranscriptDbs();
+    } catch (error: any) {
+      console.error(`Error extracting: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+transcripts
+  .command('candidates')
+  .description('List staged candidates awaiting a decision')
+  .option('--status <status>', 'pending, approved or discarded', 'pending')
+  .option('--limit <n>', 'Maximum rows to show', parseInt)
+  .action(async (options) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const { db } = await openCandidateStore(root);
+      const counts = await countCandidates(db);
+      const rows = await listCandidates(db, { status: options.status, limit: options.limit });
+
+      if (rows.length === 0) {
+        console.log(`No ${options.status} candidates.`);
+      } else {
+        for (const row of rows) {
+          console.log(`[${row.id}] ${row.category.padEnd(12)} ${row.title}`);
+          console.log(`    ${row.content.replace(/\s+/g, ' ').slice(0, 160)}`);
+          console.log(`    from ${row.harness} session ${row.sessionId}, confidence ${row.confidence.toFixed(2)}`);
+        }
+      }
+      const summary = Object.entries(counts).map(([status, n]) => `${n} ${status}`).join(', ');
+      if (summary) console.log(`\n${summary}.`);
+      await closeTranscriptDbs();
+    } catch (error: any) {
+      console.error(`Error listing candidates: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+transcripts
+  .command('approve [ids...]')
+  .description('Promote staged candidates into the knowledge store')
+  .option('--all', 'Approve every pending candidate')
+  .action(async (ids: string[], options) => {
+    try {
+      if (!options.all && (!ids || ids.length === 0)) {
+        throw new Error('Name the candidate ids to approve, or pass --all.');
+      }
+      const root = await findProjectRoot(process.cwd());
+      const { config, db } = await openCandidateStore(root);
+      await initDb(root);
+      const project = await repo.getProjectByRootPath(root);
+      if (!project) throw new Error('Project not registered in the database.');
+
+      const result = await approveCandidates(db, project.id, config, { ids, all: options.all });
+      console.log(`Approved ${result.approved} candidate(s).`);
+      if (result.deduped > 0) console.log(`${result.deduped} merged into knowledge the store already held.`);
+      for (const failure of result.failed) console.log(`Failed ${failure.id}: ${failure.reason}`);
+      await closeTranscriptDbs();
+    } catch (error: any) {
+      console.error(`Error approving: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+transcripts
+  .command('discard [ids...]')
+  .description('Reject staged candidates, so a rerun does not ask again')
+  .option('--all', 'Discard every pending candidate')
+  .action(async (ids: string[], options) => {
+    try {
+      if (!options.all && (!ids || ids.length === 0)) {
+        throw new Error('Name the candidate ids to discard, or pass --all.');
+      }
+      const root = await findProjectRoot(process.cwd());
+      const { db } = await openCandidateStore(root);
+      console.log(`Discarded ${await discardCandidates(db, { ids, all: options.all })} candidate(s).`);
+      await closeTranscriptDbs();
+    } catch (error: any) {
+      console.error(`Error discarding: ${error.message}`);
       process.exit(1);
     }
   });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -40,6 +40,7 @@ import { resumeInstruction } from '../session/resume-keys.js';
 import { finalizeMemorySession } from '../store/session-finalizer.js';
 import { configuredNamespaces, namespaceDescriptor, queryLayeredKnowledge, withNamespaceDatabase } from '../store/namespaces.js';
 import { isTranscriptSearchEnabled } from '../transcripts/config.js';
+import { hasIndexableArchive } from '../transcripts/paths.js';
 import { handleSessionList, handleTranscriptRead, handleTranscriptSearch } from '../transcripts/mcp-handlers.js';
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
 import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
@@ -1011,9 +1012,17 @@ export function registerTools(
           // agent has decided memory is empty, and transcript search is the thing that can
           // still answer -- but it is off by default, so an unconditional mention would send
           // callers to a tool their build does not expose.
+          //
+          // Where it is off, the next move is not a tool but a decision, and staying silent about
+          // it is the cold start: an empty store sits beside an archive of past sessions on disk
+          // and nothing ever says so. Named as the config rather than the tool, because the tool
+          // genuinely is not exposed in that build -- and only when an archive is actually there,
+          // so a machine with no sessions is never told to index them.
           const transcriptRoute = config && isTranscriptSearchEnabled(config)
             ? ' Before you do, try `knowl_transcript_search` with the same words: past sessions are indexed separately from knowledge items and are not searched by this tool.'
-            : '';
+            : (projectRoot && await hasIndexableArchive(projectRoot).catch(() => false)
+              ? ' This machine holds past agent sessions for this repository that are not indexed. Enabling `search.transcripts.enabled` and running `knowl reindex --transcripts` makes them searchable.'
+              : '');
           blocks.push({
             type: 'text',
             text: 'NO CONFIDENT MATCH: every result above scored below the relevance floor, so this store probably does not hold the answer. They are returned rather than withheld because the floor is a fixed threshold on a corpus-dependent scale and is wrong often enough to matter — read `score` and judge. If none of them answers the question, treat this as a miss and go to the files.'

--- a/src/transcripts/approve-candidates.ts
+++ b/src/transcripts/approve-candidates.ts
@@ -1,0 +1,166 @@
+import type { Client } from '@libsql/client';
+import { KNOWLEDGE_CATEGORIES, type KnowledgeCategory, type ProjectConfig } from '../core/types.js';
+import { storeKnowledgeAtomsDeduped } from '../store/knowledge-writer.js';
+import { candidateToAtom, listCandidates, type ExtractionCandidate } from './extract-candidates.js';
+
+/**
+ * Promoting a staged candidate into the knowledge store, one explicit decision at a time.
+ *
+ * This is the half that makes bulk extraction safe to have. Extraction is cheap to re-run and
+ * writes nothing anybody has to trust; everything that reaches a future query passes through
+ * here, and only because somebody named it.
+ *
+ * Promotion goes through `storeKnowledgeAtomsDeduped` -- the same writer `knowl_ingest_atoms`
+ * uses -- so a candidate meets the checks everything else passes: secret validation, confidence
+ * range, dedup against what is already stored, workspace ownership. A transcript is the least
+ * reviewed text in the system, an archive full of things that were true for ten minutes, so the
+ * last thing it should get is a shortcut around those.
+ *
+ * **Not `runDecisionPipeline`, and the reason is load-bearing.** That path runs `runVerify`,
+ * which calls the model to adjudicate against existing items in the same category -- so it works
+ * on an empty store and starts throwing "AI provider has not been initialized" on the second
+ * atom of the very first bulk run. Approval must not require AI: extraction already does, and
+ * making the human's decision depend on a provider too would mean a configured key is needed to
+ * accept work that has already been paid for.
+ */
+
+export type ApprovalResult = {
+  approved: number;
+  /** Candidates the merge path folded into an item that already said this. */
+  deduped: number;
+  failed: { id: string; reason: string }[];
+  itemIds: string[];
+};
+
+function parseTags(raw: unknown): string[] | null {
+  if (typeof raw !== 'string' || !raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((tag): tag is string => typeof tag === 'string') : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadCandidates(db: Client, ids: string[]): Promise<(ExtractionCandidate & { tags: string[] | null })[]> {
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(', ');
+  const rows = (await db.execute({
+    sql: `SELECT id, session_id, source_path, harness, category, title, content, confidence, status, tags
+          FROM transcript_candidates
+          WHERE id IN (${placeholders}) AND status = 'pending'`,
+    args: ids,
+  })).rows;
+
+  return rows.map(row => ({
+    id: String(row.id),
+    sessionId: String(row.session_id),
+    sourcePath: String(row.source_path),
+    harness: String(row.harness ?? 'claude'),
+    category: String(row.category),
+    title: String(row.title),
+    content: String(row.content),
+    confidence: Number(row.confidence ?? 0),
+    status: String(row.status),
+    tags: parseTags(row.tags),
+  }));
+}
+
+/**
+ * Promote the named candidates, or every pending one.
+ *
+ * Each is promoted in its own call rather than as a batch, so one bad atom fails alone. A batch
+ * would be faster and would mean a single rejected secret took the whole run's work with it --
+ * on a path whose input is a thousand model-written atoms, of which some will be wrong.
+ *
+ * A candidate that fails stays `pending`. It can be retried after the cause is fixed, or
+ * discarded; what it must not do is silently disappear into a status that reads like a decision
+ * somebody made.
+ */
+export async function approveCandidates(
+  db: Client,
+  projectId: string,
+  config: ProjectConfig,
+  selection: { ids?: string[]; all?: boolean; limit?: number },
+): Promise<ApprovalResult> {
+  const targets = selection.all
+    ? (await listCandidates(db, { status: 'pending', limit: selection.limit ?? 1_000 }))
+      .map(candidate => candidate.id)
+    : selection.ids ?? [];
+
+  const candidates = await loadCandidates(db, targets);
+  const result: ApprovalResult = { approved: 0, deduped: 0, failed: [], itemIds: [] };
+
+  for (const candidate of candidates) {
+    try {
+      // Checked here rather than trusted from the row. These titles and categories were written
+      // by a model over unreviewed text, and nothing between the provider and this line refuses a
+      // category that does not exist -- a `not-a-category` atom reached `knowledge_items` intact
+      // before this guard existed, where every reader downstream assumes the enum.
+      if (!KNOWLEDGE_CATEGORIES.includes(candidate.category as KnowledgeCategory)) {
+        throw new Error(`Unknown category "${candidate.category}"`);
+      }
+
+      // `config.security` carries this repo's secret patterns, exactly as `knowl_ingest_atoms`
+      // passes them. Omitting it would have run the weakest secret validation available on the
+      // one input most likely to contain a key: a transcript is a recording of a working session,
+      // and working sessions paste credentials.
+      const batch = await storeKnowledgeAtomsDeduped(
+        projectId,
+        [candidateToAtom(candidate, candidate.tags)],
+        `Approve transcript candidate from session ${candidate.sessionId}`,
+        config?.security,
+      );
+
+      const outcome = batch.outcomes[0];
+      const itemId = outcome?.itemId ?? null;
+      // A duplicate is a success and is counted apart: on a bulk run it is the number that says
+      // whether extraction is producing knowledge or echoes of what is already stored.
+      if (outcome?.action === 'duplicate') result.deduped += 1;
+
+      await db.execute({
+        sql: `UPDATE transcript_candidates
+              SET status = 'approved', decided_at = ?, promoted_item_id = ?
+              WHERE id = ? AND status = 'pending'`,
+        args: [new Date().toISOString(), itemId, candidate.id],
+      });
+
+      result.approved += 1;
+      if (itemId) result.itemIds.push(itemId);
+    } catch (error) {
+      result.failed.push({ id: candidate.id, reason: (error as Error).message });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Mark candidates rejected, without deleting them.
+ *
+ * Kept rather than removed so a rerun of extraction does not resurrect what somebody has already
+ * turned down -- the session watermark stops the model being paid twice, and this stops the human
+ * being asked twice.
+ */
+export async function discardCandidates(
+  db: Client,
+  selection: { ids?: string[]; all?: boolean },
+): Promise<number> {
+  if (selection.all) {
+    const result = await db.execute({
+      sql: `UPDATE transcript_candidates SET status = 'discarded', decided_at = ? WHERE status = 'pending'`,
+      args: [new Date().toISOString()],
+    });
+    return Number(result.rowsAffected ?? 0);
+  }
+
+  const ids = selection.ids ?? [];
+  if (ids.length === 0) return 0;
+  const placeholders = ids.map(() => '?').join(', ');
+  const result = await db.execute({
+    sql: `UPDATE transcript_candidates SET status = 'discarded', decided_at = ?
+          WHERE id IN (${placeholders}) AND status = 'pending'`,
+    args: [new Date().toISOString(), ...ids],
+  });
+  return Number(result.rowsAffected ?? 0);
+}

--- a/src/transcripts/database.ts
+++ b/src/transcripts/database.ts
@@ -72,6 +72,49 @@ export const TRANSCRIPT_SCHEMA_STATEMENTS = [
   );`,
 
   `CREATE INDEX IF NOT EXISTS idx_transcript_vectors_fingerprint ON transcript_vectors(fingerprint);`,
+
+  // Atoms distilled from a transcript, staged rather than promoted.
+  //
+  // **In the transcripts database rather than the knowledge store, deliberately.** These are
+  // speculative until a human says otherwise: an unreviewed thousand-row corpus sitting in
+  // `knowledge_items` would be answering every future query while nobody had yet decided any of
+  // it was true. Here they are derived data beside the thing they were derived from, they never
+  // reach a query, and they cost the main store no schema level, no snapshot policy and no space
+  // in an export.
+  //
+  // The consequence is accepted rather than overlooked: turning transcript search off deletes the
+  // index and these with it. They are regenerable from the transcripts by construction, which is
+  // the property that makes staging them here safe.
+  `CREATE TABLE IF NOT EXISTS transcript_candidates (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    harness TEXT NOT NULL DEFAULT 'claude',
+    category TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    reasoning TEXT,
+    tags TEXT,
+    confidence REAL NOT NULL DEFAULT 0.5,
+    status TEXT NOT NULL DEFAULT 'pending',
+    extracted_at TEXT NOT NULL,
+    decided_at TEXT,
+    promoted_item_id TEXT
+  );`,
+
+  `CREATE INDEX IF NOT EXISTS idx_transcript_candidates_status ON transcript_candidates(status);`,
+  `CREATE INDEX IF NOT EXISTS idx_transcript_candidates_session ON transcript_candidates(session_id);`,
+
+  // One row per session that extraction has finished with, so a second run resumes instead of
+  // paying the model again for work already done. Distinct from `transcript_files.bytes_indexed`:
+  // that watermark tracks what has been *indexed*, and extraction is a separate, far more
+  // expensive pass over the same rows that a user may never run at all.
+  `CREATE TABLE IF NOT EXISTS transcript_extractions (
+    session_id TEXT PRIMARY KEY,
+    extracted_at TEXT NOT NULL,
+    candidate_count INTEGER NOT NULL DEFAULT 0,
+    chars_sent INTEGER NOT NULL DEFAULT 0
+  );`,
 ];
 
 /**

--- a/src/transcripts/extract-candidates.ts
+++ b/src/transcripts/extract-candidates.ts
@@ -1,0 +1,280 @@
+import crypto from 'node:crypto';
+import type { Client } from '@libsql/client';
+import type { KnowledgeAtom, ProjectConfig } from '../core/types.js';
+import { hasAiConfigured } from '../core/config.js';
+// `extractKnowledge` directly rather than `pipeline/extract.js`, which merely wraps it. The
+// module-boundary guard refuses transcripts -> pipeline, and it is right to: pipeline's job is
+// extract-verify-merge as one unit, and what this needs is the extract step alone -- staging
+// exists precisely so verify and merge happen later, under a human decision.
+import { extractKnowledge, initAI } from '../ai/provider.js';
+import { readProseFrom } from './parse.js';
+
+/**
+ * Distilling a transcript into atoms, staged for review rather than promoted.
+ *
+ * The index makes past sessions searchable; it never puts anything in the knowledge store, so a
+ * fresh install stays empty until somebody writes to it. This is the bulk path that fills it.
+ *
+ * **Nothing here promotes.** Extraction writes to `transcript_candidates` and stops. That is the
+ * whole design: a first run over a real archive produces on the order of a thousand atoms, and
+ * promoting them unreviewed would put an unexamined corpus in front of every future query while
+ * the standing rule for this write path is that a human decides what durable memory contains.
+ * Approval is a separate, explicit act -- see `approveCandidates`.
+ *
+ * **It costs the operator money, and the code says so out loud.** Extraction runs the configured
+ * model over whole sessions; an archive of a few hundred is a real bill. So there is no "extract
+ * everything" default: the caller states a session limit, the estimate is reported before any
+ * request is made, and the resume watermark means a second run never pays twice for one session.
+ */
+
+/** Bytes of one session's prose handed to the model. */
+const MAX_SESSION_CHARS = 24_000;
+
+/** Sessions extracted in one run unless the caller raises it. Deliberately small: see above. */
+export const DEFAULT_EXTRACT_LIMIT = 10;
+
+const newId = (): string => crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+
+export type ExtractionCandidate = {
+  id: string;
+  sessionId: string;
+  sourcePath: string;
+  harness: string;
+  category: string;
+  title: string;
+  content: string;
+  confidence: number;
+  status: string;
+};
+
+export type ExtractionPlanSession = { sessionId: string; path: string; harness: string; chars: number };
+
+export type ExtractionPlan = {
+  /** Sessions this run would extract, already limited. */
+  sessions: ExtractionPlanSession[];
+  /** Sessions with prose that have never been extracted, before the limit was applied. */
+  pending: number;
+  /** Sessions already extracted and therefore skipped. */
+  done: number;
+  /** Characters this run would send to the model, after per-session truncation. */
+  chars: number;
+};
+
+/**
+ * What a run would do, without doing any of it.
+ *
+ * Separate from `extractCandidates` so a caller can show the operator the size of the bill before
+ * a single request is made. The CLI prints this and requires confirmation; nothing here decides
+ * that policy, it only makes it possible to have one.
+ */
+export async function planExtraction(
+  db: Client,
+  options: { limit?: number } = {},
+): Promise<ExtractionPlan> {
+  const limit = Math.max(1, options.limit ?? DEFAULT_EXTRACT_LIMIT);
+
+  const rows = (await db.execute(
+    `SELECT f.session_id AS session_id, f.path AS path, f.harness AS harness,
+            COALESCE(SUM(m.chars), 0) AS chars
+     FROM transcript_files f
+     JOIN transcript_messages m ON m.path = f.path
+     LEFT JOIN transcript_extractions e ON e.session_id = f.session_id
+     WHERE e.session_id IS NULL
+     GROUP BY f.path
+     HAVING chars > 0
+     ORDER BY chars DESC`,
+  )).rows;
+
+  const done = Number((await db.execute('SELECT COUNT(*) AS n FROM transcript_extractions')).rows[0]?.n ?? 0);
+
+  const sessions = rows.slice(0, limit).map(row => ({
+    sessionId: String(row.session_id),
+    path: String(row.path),
+    harness: String(row.harness ?? 'claude'),
+    // What will actually be sent, which is the truncated length rather than the session's size.
+    chars: Math.min(Number(row.chars ?? 0), MAX_SESSION_CHARS),
+  }));
+
+  return {
+    sessions,
+    pending: rows.length,
+    done,
+    chars: sessions.reduce((total, session) => total + session.chars, 0),
+  };
+}
+
+/**
+ * One session's prose, as the text handed to the model.
+ *
+ * Read from the `.jsonl` rather than the index because the index stores pointers, not bodies --
+ * that is the property that keeps it small, and it means the text has to come from the file.
+ *
+ * Truncated from the START, keeping the tail. A session's conclusions are at its end: what was
+ * decided, what turned out to be true, what was fixed. Keeping the head would preserve the
+ * problem statement and drop the answer.
+ */
+async function sessionText(filePath: string): Promise<string> {
+  const { messages } = await readProseFrom(filePath, 0, 0);
+  const joined = messages.map(message => `${message.role}: ${message.text}`).join('\n\n');
+  return joined.length > MAX_SESSION_CHARS ? joined.slice(joined.length - MAX_SESSION_CHARS) : joined;
+}
+
+function stageAtom(
+  db: Client,
+  session: ExtractionPlanSession,
+  atom: KnowledgeAtom,
+  now: string,
+): Promise<unknown> {
+  return db.execute({
+    sql: `INSERT INTO transcript_candidates
+            (id, session_id, source_path, harness, category, title, content, reasoning, tags, confidence, status, extracted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)`,
+    args: [
+      newId(), session.sessionId, session.path, session.harness,
+      atom.category, atom.title, atom.content,
+      atom.reasoning ?? null,
+      atom.tags && atom.tags.length ? JSON.stringify(atom.tags) : null,
+      typeof atom.confidence === 'number' ? atom.confidence : 0.5,
+      now,
+    ],
+  });
+}
+
+export type ExtractionResult = {
+  sessionsExtracted: number;
+  candidates: number;
+  /** Sessions left unextracted by the limit or the deadline. */
+  remaining: number;
+  /** Sessions that produced no atoms, which are still recorded so a rerun does not repay. */
+  empty: number;
+};
+
+/**
+ * Extract the planned sessions into staged candidates.
+ *
+ * A session that yields nothing is still watermarked. Otherwise every run would re-send the same
+ * unproductive sessions to the model forever, and the sessions most likely to yield nothing are
+ * the short ones -- so the bill would be dominated by exactly the work with no output.
+ *
+ * A session whose extraction throws is left unwatermarked and simply not counted: a transient
+ * provider failure must not mark a session permanently done.
+ */
+export async function extractCandidates(
+  db: Client,
+  config: ProjectConfig,
+  options: { limit?: number; deadline?: number } = {},
+): Promise<ExtractionResult> {
+  if (!hasAiConfigured(config)) {
+    throw new Error(
+      'Extracting atoms from transcripts requires explicit Knowl AI configuration. '
+      + 'Configure ai.provider and ai.model (knowl config), or distil a session yourself with '
+      + 'knowl_transcript_read and store the result with knowl_ingest_atoms.',
+    );
+  }
+  initAI(config.ai!);
+
+  const plan = await planExtraction(db, options);
+  let sessionsExtracted = 0;
+  let candidates = 0;
+  let empty = 0;
+  let stopped = 0;
+
+  for (const session of plan.sessions) {
+    if (options.deadline !== undefined && Date.now() >= options.deadline) break;
+    stopped += 1;
+
+    const text = await sessionText(session.path);
+    if (!text.trim()) {
+      await recordExtraction(db, session.sessionId, 0, 0);
+      empty += 1;
+      continue;
+    }
+
+    let atoms: KnowledgeAtom[];
+    try {
+      atoms = await extractKnowledge(text);
+    } catch {
+      // Unwatermarked on purpose: a provider hiccup is not a verdict about this session.
+      stopped -= 1;
+      continue;
+    }
+
+    const now = new Date().toISOString();
+    for (const atom of atoms) await stageAtom(db, session, atom, now);
+    await recordExtraction(db, session.sessionId, atoms.length, text.length);
+
+    sessionsExtracted += 1;
+    candidates += atoms.length;
+    if (atoms.length === 0) empty += 1;
+  }
+
+  return {
+    sessionsExtracted,
+    candidates,
+    empty,
+    remaining: Math.max(0, plan.pending - stopped),
+  };
+}
+
+async function recordExtraction(db: Client, sessionId: string, count: number, chars: number): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO transcript_extractions (session_id, extracted_at, candidate_count, chars_sent)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(session_id) DO UPDATE SET
+            extracted_at = excluded.extracted_at,
+            candidate_count = excluded.candidate_count,
+            chars_sent = excluded.chars_sent`,
+    args: [sessionId, new Date().toISOString(), count, chars],
+  });
+}
+
+export async function listCandidates(
+  db: Client,
+  options: { status?: string; limit?: number } = {},
+): Promise<ExtractionCandidate[]> {
+  const status = options.status ?? 'pending';
+  const rows = (await db.execute({
+    sql: `SELECT id, session_id, source_path, harness, category, title, content, confidence, status
+          FROM transcript_candidates
+          WHERE status = ?
+          ORDER BY confidence DESC, title ASC
+          LIMIT ?`,
+    args: [status, Math.max(1, options.limit ?? 50)],
+  })).rows;
+
+  return rows.map(row => ({
+    id: String(row.id),
+    sessionId: String(row.session_id),
+    sourcePath: String(row.source_path),
+    harness: String(row.harness ?? 'claude'),
+    category: String(row.category),
+    title: String(row.title),
+    content: String(row.content),
+    confidence: Number(row.confidence ?? 0),
+    status: String(row.status),
+  }));
+}
+
+export async function countCandidates(db: Client): Promise<Record<string, number>> {
+  const rows = (await db.execute(
+    'SELECT status, COUNT(*) AS n FROM transcript_candidates GROUP BY status',
+  )).rows;
+  const counts: Record<string, number> = {};
+  for (const row of rows) counts[String(row.status)] = Number(row.n ?? 0);
+  return counts;
+}
+
+/** The atom a staged row becomes, with its origin attached as evidence. */
+export function candidateToAtom(candidate: ExtractionCandidate, tags: string[] | null): KnowledgeAtom {
+  return {
+    category: candidate.category as KnowledgeAtom['category'],
+    title: candidate.title,
+    content: candidate.content,
+    tags,
+    confidence: candidate.confidence,
+    // Distilled by a model from a conversation nobody re-read at approval time. That is inferred,
+    // and claiming `observed` would rank this above knowledge somebody actually verified.
+    provenance: 'inferred',
+    source: `transcript:${candidate.harness}:${candidate.sessionId}`,
+  };
+}

--- a/src/transcripts/paths.ts
+++ b/src/transcripts/paths.ts
@@ -516,6 +516,27 @@ export async function scanTranscriptArchive(
   return { files: found, degraded };
 }
 
+/**
+ * Whether either harness has an archive on this machine that this repo could index.
+ *
+ * **Two `stat` calls and no file is opened**, which is the entire design constraint. This answers
+ * a question asked at the one moment a query has decided memory is empty, so it must cost
+ * approximately nothing and must never throw. It reports *existence*, never a count: counting
+ * Codex sessions means opening every file to read its `cwd`, and that is a scan, not a probe.
+ *
+ * The Claude check is repo-specific because its archive is keyed by project. The Codex check is
+ * not -- the directory is shared across every project -- so this can answer true where a repo has
+ * no Codex sessions of its own. That asymmetry is accepted: the notice it drives suggests turning
+ * a feature on, and the cost of suggesting it to somebody with nothing to index is one line of
+ * text, while the cost of staying silent is the cold start this exists to fix.
+ */
+export async function hasIndexableArchive(projectRoot: string): Promise<boolean> {
+  const exists = (target: string) => fs.access(target).then(() => true, () => false);
+  const claudeDir = path.join(defaultProjectsDir(), encodeProjectDir(path.resolve(projectRoot)));
+  if (await exists(claudeDir)) return true;
+  return exists(defaultCodexSessionsDir());
+}
+
 /** The file list alone, for callers with nothing to decide about a degraded scan. */
 export async function discoverTranscriptFiles(
   projectRoot: string,

--- a/tests/transcripts/candidate-approval.test.ts
+++ b/tests/transcripts/candidate-approval.test.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Client } from '@libsql/client';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import * as repo from '../../src/store/repository.js';
+import { queryKnowledgeBase } from '../../src/store/queries.js';
+import { closeTranscriptDbs, openTranscriptDb } from '../../src/transcripts/database.js';
+import { approveCandidates } from '../../src/transcripts/approve-candidates.js';
+import { listCandidates } from '../../src/transcripts/extract-candidates.js';
+import { hasIndexableArchive } from '../../src/transcripts/paths.js';
+
+let roots: string[] = [];
+let db: Client;
+let projectId = '';
+let root = '';
+
+/** A staged candidate, written straight in — extraction is `candidates.test.ts`'s subject. */
+async function stage(client: Client, over: Partial<{ category: string; title: string; content: string }> = {}) {
+  const id = Math.random().toString(16).slice(2, 10);
+  await client.execute({
+    sql: `INSERT INTO transcript_candidates
+            (id, session_id, source_path, harness, category, title, content, confidence, status, extracted_at)
+          VALUES (?, 'sess-1', '/archive/sess-1.jsonl', 'codex', ?, ?, ?, 0.7, 'pending', ?)`,
+    args: [
+      id,
+      over.category ?? 'decision',
+      over.title ?? 'Retries use bounded backoff',
+      over.content ?? 'Retries are bounded rather than infinite, decided while fixing the queue.',
+      new Date().toISOString(),
+    ],
+  });
+  return id;
+}
+
+beforeEach(async () => {
+  await closeDb();
+  await closeTranscriptDbs();
+  await releaseAll();
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-approve-'));
+  roots.push(root);
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  projectId = (await repo.createProject(root, 'approval')).id;
+  db = await openTranscriptDb(path.join(root, '.knowl', 'transcripts.db'));
+});
+
+afterEach(async () => {
+  await closeDb();
+  await closeTranscriptDbs();
+  await releaseAll();
+});
+
+afterAll(async () => {
+  await closeDb();
+  await closeTranscriptDbs();
+  await releaseAll();
+  for (const dir of roots) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  roots = [];
+});
+
+describe('approving a staged candidate', () => {
+  it('puts it in the knowledge store, attributed to the transcript it came from', async () => {
+    const id = await stage(db);
+
+    const result = await approveCandidates(db, projectId, DEFAULT_CONFIG, { ids: [id] });
+
+    expect(result.approved).toBe(1);
+    const stored = await queryKnowledgeBase(projectId, { status: 'active' });
+    const promoted = stored.find(item => item.title === 'Retries use bounded backoff');
+    expect(promoted).toBeDefined();
+    // Distilled by a model from a conversation nobody re-read at approval time. Claiming
+    // `observed` would rank it above knowledge somebody actually verified.
+    expect(promoted!.provenance).toBe('inferred');
+    expect(promoted!.source).toBe('transcript:codex:sess-1');
+  });
+
+  it('leaves nothing in the store until approval happens', async () => {
+    await stage(db);
+
+    expect(await queryKnowledgeBase(projectId, { status: 'active' })).toEqual([]);
+  });
+
+  it('marks the row decided, so it stops being offered', async () => {
+    const id = await stage(db);
+
+    await approveCandidates(db, projectId, DEFAULT_CONFIG, { ids: [id] });
+
+    expect(await listCandidates(db, { status: 'pending' })).toEqual([]);
+    const [approved] = await listCandidates(db, { status: 'approved' });
+    expect(approved.id).toBe(id);
+  });
+
+  it('approves every pending candidate on --all', async () => {
+    await stage(db, { title: 'First thing', content: 'One distinct fact about retries.' });
+    await stage(db, { title: 'Second thing', content: 'A different fact about caching entirely.' });
+
+    const result = await approveCandidates(db, projectId, DEFAULT_CONFIG, { all: true });
+
+    expect(result.approved).toBe(2);
+  });
+
+  it('never touches a candidate that was already decided', async () => {
+    const id = await stage(db);
+    await approveCandidates(db, projectId, DEFAULT_CONFIG, { ids: [id] });
+
+    const again = await approveCandidates(db, projectId, DEFAULT_CONFIG, { ids: [id] });
+
+    expect(again.approved).toBe(0);
+  });
+
+  it('fails one candidate alone rather than taking the run down with it', async () => {
+    // One bad atom among a thousand model-written ones is the expected case, not the exception.
+    const bad = await stage(db, { category: 'not-a-category', title: 'Bad', content: 'Nonsense.' });
+    const good = await stage(db, { title: 'Good one', content: 'A real fact worth keeping around.' });
+
+    const result = await approveCandidates(db, projectId, DEFAULT_CONFIG, { ids: [bad, good] });
+
+    expect(result.approved).toBe(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].id).toBe(bad);
+    // The failure stays pending: retryable, and never silently reported as a decision.
+    expect((await listCandidates(db, { status: 'pending' })).map(row => row.id)).toEqual([bad]);
+  });
+});
+
+describe('the cold-start probe', () => {
+  it('answers without opening a single transcript', async () => {
+    // Two stats and no file reads: this runs at the moment a query has decided memory is empty.
+    await expect(hasIndexableArchive(root)).resolves.toEqual(expect.any(Boolean));
+  });
+});

--- a/tests/transcripts/candidates.test.ts
+++ b/tests/transcripts/candidates.test.ts
@@ -1,0 +1,234 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Client } from '@libsql/client';
+import { DEFAULT_CONFIG } from '../../src/core/config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+import { closeTranscriptDbs, openTranscriptDb } from '../../src/transcripts/database.js';
+import {
+  countCandidates,
+  extractCandidates,
+  listCandidates,
+  planExtraction,
+} from '../../src/transcripts/extract-candidates.js';
+import { discardCandidates } from '../../src/transcripts/approve-candidates.js';
+
+// The model is the one thing these tests must not actually call: extraction spends the operator's
+// quota, and a suite that did so would bill whoever ran it.
+const extractKnowledge = vi.hoisted(() => vi.fn());
+vi.mock('../../src/ai/provider.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../src/ai/provider.js')>()),
+  extractKnowledge,
+  initAI: vi.fn(),
+}));
+
+let roots: string[] = [];
+let db: Client;
+
+// Ollama because it is the one provider `hasAiConfigured` accepts without an apiKey — it is local
+// and keyless, so naming it is the whole opt-in. A fixture carrying a fake key would be testing
+// the same gate through a field nobody should put a placeholder in.
+const AI_CONFIG: ProjectConfig = {
+  ...DEFAULT_CONFIG,
+  ai: { provider: 'ollama', model: 'llama-test' },
+};
+
+async function freshDb(): Promise<Client> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-cand-'));
+  roots.push(root);
+  return openTranscriptDb(path.join(root, 'transcripts.db'));
+}
+
+/** A session in the index, with a real `.jsonl` behind it, since extraction reads the file. */
+async function seedSession(client: Client, sessionId: string, messages: string[], harness = 'claude') {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-cand-src-'));
+  roots.push(dir);
+  const filePath = path.join(dir, `${sessionId}.jsonl`);
+  const lines = messages.map((text, index) => JSON.stringify({
+    type: index % 2 === 0 ? 'user' : 'assistant',
+    message: { content: [{ type: 'text', text }] },
+    timestamp: '2026-08-11T00:00:00.000Z',
+  }));
+  await fs.writeFile(filePath, lines.join('\n') + '\n');
+
+  await client.execute({
+    sql: `INSERT INTO transcript_files (path, session_id, parent_session_id, bytes_indexed, lines_indexed, size_at_index, updated_at, harness)
+          VALUES (?, ?, NULL, 0, 0, 0, ?, ?)`,
+    args: [filePath, sessionId, new Date().toISOString(), harness],
+  });
+  for (const [index, text] of messages.entries()) {
+    await client.execute({
+      sql: `INSERT INTO transcript_messages (path, session_id, parent_session_id, line, role, chars)
+            VALUES (?, ?, NULL, ?, ?, ?)`,
+      args: [filePath, sessionId, index + 1, index % 2 === 0 ? 'user' : 'assistant', text.length],
+    });
+  }
+  return filePath;
+}
+
+beforeEach(async () => {
+  extractKnowledge.mockReset();
+  await closeTranscriptDbs();
+  db = await freshDb();
+});
+
+afterEach(async () => {
+  await closeTranscriptDbs();
+});
+
+afterAll(async () => {
+  await closeTranscriptDbs();
+  for (const root of roots) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  roots = [];
+});
+
+describe('planning an extraction run', () => {
+  it('reports what a run would cost before anything is sent', async () => {
+    await seedSession(db, 'a', ['how do we handle retries?', 'with a bounded backoff.']);
+
+    const plan = await planExtraction(db, { limit: 5 });
+
+    expect(plan.sessions).toHaveLength(1);
+    expect(plan.pending).toBe(1);
+    expect(plan.done).toBe(0);
+    expect(plan.chars).toBeGreaterThan(0);
+    // Nothing was extracted merely by planning.
+    expect(extractKnowledge).not.toHaveBeenCalled();
+  });
+
+  it('limits the run but still reports how much is left', async () => {
+    for (const id of ['a', 'b', 'c']) await seedSession(db, id, [`ask ${id}`, `answer ${id}`]);
+
+    const plan = await planExtraction(db, { limit: 2 });
+
+    expect(plan.sessions).toHaveLength(2);
+    expect(plan.pending).toBe(3);
+  });
+
+  it('ignores a session with no indexed messages', async () => {
+    await db.execute({
+      sql: `INSERT INTO transcript_files (path, session_id, parent_session_id, bytes_indexed, lines_indexed, size_at_index, updated_at)
+            VALUES ('/nowhere.jsonl', 'empty', NULL, 0, 0, 0, ?)`,
+      args: [new Date().toISOString()],
+    });
+
+    expect((await planExtraction(db)).sessions).toEqual([]);
+  });
+});
+
+describe('extraction', () => {
+  it('refuses without AI configured, and names the alternative', async () => {
+    await seedSession(db, 'a', ['question', 'answer']);
+
+    await expect(extractCandidates(db, DEFAULT_CONFIG)).rejects.toThrow(/knowl_ingest_atoms/);
+    expect(extractKnowledge).not.toHaveBeenCalled();
+  });
+
+  it('stages what the model returns without storing any of it', async () => {
+    await seedSession(db, 'a', ['how do we handle retries?', 'with a bounded backoff.']);
+    extractKnowledge.mockResolvedValue([
+      { category: 'decision', title: 'Retries use bounded backoff', content: 'Bounded, not infinite.', confidence: 0.8 },
+    ]);
+
+    const result = await extractCandidates(db, AI_CONFIG);
+
+    expect(result).toMatchObject({ sessionsExtracted: 1, candidates: 1 });
+    const staged = await listCandidates(db);
+    expect(staged).toHaveLength(1);
+    expect(staged[0]).toMatchObject({ status: 'pending', title: 'Retries use bounded backoff' });
+  });
+
+  it('does not pay the model twice for one session', async () => {
+    await seedSession(db, 'a', ['question', 'answer']);
+    extractKnowledge.mockResolvedValue([
+      { category: 'fact', title: 'A fact', content: 'Something.', confidence: 0.5 },
+    ]);
+
+    await extractCandidates(db, AI_CONFIG);
+    const second = await extractCandidates(db, AI_CONFIG);
+
+    expect(extractKnowledge).toHaveBeenCalledTimes(1);
+    expect(second.sessionsExtracted).toBe(0);
+  });
+
+  it('watermarks a session that yielded nothing, so the bill is not dominated by empty runs', async () => {
+    await seedSession(db, 'a', ['hi', 'hello']);
+    extractKnowledge.mockResolvedValue([]);
+
+    await extractCandidates(db, AI_CONFIG);
+    await extractCandidates(db, AI_CONFIG);
+
+    expect(extractKnowledge).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a session unwatermarked when the provider fails', async () => {
+    // A transient provider error is not a verdict about the session. Marking it done would lose
+    // it permanently, and silently.
+    await seedSession(db, 'a', ['question', 'answer']);
+    extractKnowledge.mockRejectedValueOnce(new Error('502 upstream'));
+
+    const failed = await extractCandidates(db, AI_CONFIG);
+    expect(failed.sessionsExtracted).toBe(0);
+
+    extractKnowledge.mockResolvedValue([
+      { category: 'fact', title: 'Recovered', content: 'Now it works.', confidence: 0.6 },
+    ]);
+    const retried = await extractCandidates(db, AI_CONFIG);
+
+    expect(retried.sessionsExtracted).toBe(1);
+  });
+
+  it('sends the tail of a long session, where its conclusions are', async () => {
+    const filler = 'x'.repeat(30_000);
+    await seedSession(db, 'a', [filler, 'THE CONCLUSION AT THE END']);
+    extractKnowledge.mockResolvedValue([]);
+
+    await extractCandidates(db, AI_CONFIG);
+
+    const sent = extractKnowledge.mock.calls[0][0] as string;
+    expect(sent).toContain('THE CONCLUSION AT THE END');
+    expect(sent.length).toBeLessThanOrEqual(24_000);
+  });
+
+  it('stops at the deadline and leaves the rest for the next run', async () => {
+    for (const id of ['a', 'b', 'c']) await seedSession(db, id, [`ask ${id}`, `answer ${id}`]);
+    extractKnowledge.mockResolvedValue([]);
+
+    const result = await extractCandidates(db, AI_CONFIG, { limit: 3, deadline: Date.now() - 1 });
+
+    expect(extractKnowledge).not.toHaveBeenCalled();
+    expect(result.remaining).toBe(3);
+  });
+});
+
+describe('deciding on candidates', () => {
+  beforeEach(async () => {
+    await seedSession(db, 'a', ['question', 'answer']);
+    extractKnowledge.mockResolvedValue([
+      { category: 'fact', title: 'One', content: 'First.', confidence: 0.7 },
+      { category: 'fact', title: 'Two', content: 'Second.', confidence: 0.6 },
+    ]);
+    await extractCandidates(db, AI_CONFIG);
+  });
+
+  it('discards without deleting, so a rerun does not ask again', async () => {
+    const discarded = await discardCandidates(db, { all: true });
+
+    expect(discarded).toBe(2);
+    expect(await listCandidates(db, { status: 'pending' })).toEqual([]);
+    expect(await countCandidates(db)).toMatchObject({ discarded: 2 });
+  });
+
+  it('discards only the ids it was given', async () => {
+    const [first] = await listCandidates(db);
+
+    expect(await discardCandidates(db, { ids: [first.id] })).toBe(1);
+    expect(await listCandidates(db, { status: 'pending' })).toHaveLength(1);
+  });
+
+  it('does nothing when given no ids and no --all', async () => {
+    expect(await discardCandidates(db, {})).toBe(0);
+    expect(await listCandidates(db, { status: 'pending' })).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #71.

The index made past sessions searchable and put nothing in the knowledge store, so a fresh `knowl init` stayed empty until somebody wrote to it. That was the cold start #53 originally set out to fix.

**First, what already worked.** The *incremental* path ships today and needed no code: `knowl_transcript_search` → `knowl_transcript_read` → the agent distils → `knowl_ingest_atoms`, and the MCP guidance already tells agents to do exactly that ("*Store what you use*"). This PR is the bulk half.

## Extraction stages; it never promotes

```
knowl transcripts extract --limit 10 --yes
knowl transcripts candidates
knowl transcripts approve <id> | --all
knowl transcripts discard <id> | --all
```

Candidates land in `transcript_candidates` and stop there. A first run over a real archive produces on the order of a thousand atoms, and an unreviewed corpus that size would be answering every future query while nobody had yet decided any of it was true. Approval is separate, explicit, and per candidate.

The staging table lives in the **transcripts** database, not the knowledge store — speculative rows never reach a query, cost the main store no schema level, no snapshot policy and no space in an export, and are regenerable from the transcripts by construction.

## It spends the operator's money, so it says so first

`extract` prints the session count, the character estimate and the provider it would call, then **stops unless `--yes`**. The default limit is 10 sessions, not the archive.

- An extracted session is watermarked, so a rerun never pays twice.
- **Including one that yielded nothing** — short sessions yield nothing most often, and would otherwise dominate the bill.
- A session whose extraction **fails** is deliberately left unwatermarked: a provider hiccup is not a verdict about that session.
- Long sessions are truncated from the **start**, keeping the tail — a session's conclusions are at its end.

## Three bugs found by building it

Each was caught by a test, and each is the kind that would have shipped quietly:

1. **Approval was secretly AI-dependent.** It went through `runDecisionPipeline`, whose `runVerify` calls the model to adjudicate against existing items in the same category. That works on an empty store and throws `AI provider has not been initialized` on the second atom of the first bulk run — so approval would have failed exactly when a bulk import made it matter. Now uses `storeKnowledgeAtomsDeduped`, the writer `knowl_ingest_atoms` uses, which also turned out to be the path that persists `provenance`.
2. **A bogus category reached the store.** A `not-a-category` atom was written into `knowledge_items` intact, where every reader downstream assumes the enum. Validated at promotion now.
3. **Secret patterns were not passed.** Approval called the writer without `config.security` — the weakest available validation on the one input most likely to contain a key. A transcript records a working session, and working sessions paste credentials.

Promoted atoms carry `provenance: 'inferred'` and `source: transcript:<harness>:<session>`. A model distilled them from a conversation nobody re-read at approval time; claiming `observed` would rank them above knowledge somebody actually verified.

## The cold start now announces itself

`NO CONFIDENT MATCH` already pointed at `knowl_transcript_search` where transcripts were enabled. Where they are **not**, it said nothing — so an empty store could sit beside hundreds of indexable sessions in silence. It now names the *config* (not the tool, which that build genuinely does not expose), and only when an archive is actually on disk. The probe is two `stat` calls and opens no file: it runs at the moment a query has decided memory is empty.

## Verification

- `npm run build` — success
- `npm test` — **304 files, 2733 passed**, 5 skipped, 0 failed
- `npm run typecheck` — clean
- `git diff --check` — clean
- `npm run lint` — 0 errors (29 pre-existing warnings, unchanged, none in new files)
- CLI smoke-tested against a real `knowl init`: refuses cleanly when transcripts are disabled, and `--help` lists all four subcommands.

20 new tests cover planning, the AI gate, the resume watermark, empty-vs-failed sessions, tail truncation, the deadline, per-candidate failure isolation, and promotion attribution. The model is mocked throughout — a suite that actually called it would bill whoever ran it.

The `module-boundaries` guard also caught `transcripts → pipeline` and was right to: pipeline is extract-verify-merge as one unit, and staging exists precisely so verify and merge happen later, under a human decision. Extraction now imports `ai/provider` directly.

## Standing caveat

I flagged before building this that "what is a good atom mined from a transcript" is an unanswered question, and it still is. Nothing here commits to an answer: extraction is cheap to re-run, candidates are disposable, and the staging table can be dropped and rebuilt. The first real archive run is what will tell us whether the extraction prompt is right — and `deduped` in the approval result is the number to watch, since it says whether extraction is producing knowledge or echoes of what is already stored.
