### PR TITLE
fix(transcripts): two silent losses in the archive readers, and the lint backlog to zero

### DIFF
--- a/benchmarks/accuracy/src/dataset.ts
+++ b/benchmarks/accuracy/src/dataset.ts
@@ -33,7 +33,10 @@ function parseNdjson<T>(content: string, parse: (value: unknown) => T, filename:
     try {
       return parse(JSON.parse(line));
     } catch (error) {
-      throw new Error(`${filename}:${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `${filename}:${index + 1}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
     }
   });
 }

--- a/benchmarks/unassisted-capture/src/answer-key.ts
+++ b/benchmarks/unassisted-capture/src/answer-key.ts
@@ -33,7 +33,7 @@ export function parseAnswerKey(ndjson: string): AnswerKey[] {
     try {
       json = JSON.parse(line);
     } catch (error) {
-      throw new Error(`Answer key line ${lineNumber} is not valid JSON: ${(error as Error).message}`);
+      throw new Error(`Answer key line ${lineNumber} is not valid JSON: ${(error as Error).message}`, { cause: error });
     }
 
     const parsed = AnswerKeySchema.safeParse(json);

--- a/benchmarks/unassisted-capture/src/preflight.ts
+++ b/benchmarks/unassisted-capture/src/preflight.ts
@@ -25,7 +25,7 @@ export function parseFrozenThreshold(raw: string, file: string): FrozenThreshold
   try {
     json = JSON.parse(raw);
   } catch (error) {
-    throw new Error(`${file} is not valid JSON: ${(error as Error).message}`);
+    throw new Error(`${file} is not valid JSON: ${(error as Error).message}`, { cause: error });
   }
 
   const parsed = FrozenThresholdSchema.safeParse(json);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,10 @@ export default tseslint.config(
   // empty catch blocks -- against generated third-party code nobody can fix. It is gitignored, so
   // CI's fresh checkout never has it and only local runs went red, which is the worst shape for a
   // signal to fail in: contributors learn the lint output is wrong and stop reading it.
-  { ignores: ['dist/**', 'node_modules/**', '.benchmark-dist/**', '.bridge-dist/**', 'benchmarks/**/dist/**', '.tmp/**', '.claude/**'] },
+  // `.verify-dist/**` is the same case as `.bridge-dist/**` above and was missed for the same
+  // reason: it is gitignored, so CI's fresh checkout never has it and only a developer who had
+  // run the verification bundle saw the extra findings.
+  { ignores: ['dist/**', 'node_modules/**', '.benchmark-dist/**', '.bridge-dist/**', '.verify-dist/**', 'benchmarks/**/dist/**', '.tmp/**', '.claude/**'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
@@ -32,7 +35,13 @@ export default tseslint.config(
       // meant to be used. Bundling that refactor into the commit that adds the linter would
       // make both unreviewable. CI gates on errors, so this stays visible without blocking,
       // and every NEW occurrence shows up in the same output.
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      // `ignoreRestSiblings` covers the omit idiom -- `const { secret, ...rest } = row` -- where
+      // the named binding exists in order NOT to appear in `rest`. It is load-bearing rather than
+      // dead: renaming it to `_secret` changes which key is dropped, so the underscore convention
+      // above is not available here and the alternative to this option is a lint exception at
+      // every use. tseslint's own recommended config turns it on for the same reason; naming the
+      // options object at all is what had switched it back off.
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', ignoreRestSiblings: true }],
       // Same reasoning, same backlog: 7 dead stores and 5 rethrows that drop the original
       // error as `cause`. Both are real and neither is mechanical.
       'no-useless-assignment': 'warn',

--- a/scripts/e2e-cloud.ts
+++ b/scripts/e2e-cloud.ts
@@ -26,7 +26,7 @@ import { resolveWorkspace } from '../src/workspace/resolve.js';
 import { closeDb, getClient, initDb } from '../src/store/database.js';
 import { storeKnowledgeItemDeduped } from '../src/store/knowledge-writer.js';
 import * as repo from '../src/store/repository.js';
-import { loadConfig, saveConfig } from '../src/core/config.js';
+import { loadConfig } from '../src/core/config.js';
 
 const API = 'http://localhost:3000';
 const OWNER_USER_ID = '00000000-0000-0000-0000-0000000000e1';

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1357,7 +1357,29 @@ program.command('import').argument('<path>').description('Load portable JSONL me
 
 program.command('synthesize').description('Summarize knowledge for a path or tag into one item').requiredOption('--scope <path-or-tag>').action(async options => { try { const root = await findProjectRoot(process.cwd()); await initDb(root); const project = await repo.getProjectByRootPath(root); if (!project) throw new Error('Project not found in database.'); console.log(JSON.stringify(await synthesizeKnowledge(project.id, options.scope), null, 2)); await closeDb(); } catch (error: any) { console.error(`Error synthesizing knowledge: ${error.message}`); process.exit(1); } });
 
-program.command('view').description('Serve the local knowledge viewer in a browser').option('--port <port>').action(async options => { try { const root = await findProjectRoot(process.cwd()); const viewer = await startViewer(root, { port: options.port === undefined ? 0 : Number(options.port) }); console.log(`Knowl viewer: ${viewer.browseUrl}`); const stop = async () => { await viewer.close(); process.exit(0); }; process.once('SIGINT', stop); process.once('SIGTERM', stop); } catch (error: any) { console.error(`Error starting viewer: ${error.message}`); process.exit(1); } });
+program
+  .command('view')
+  .description('Serve the local knowledge viewer in a browser')
+  .option('--port <port>')
+  .action(async options => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const viewer = await startViewer(root, { port: options.port === undefined ? 0 : Number(options.port) });
+      console.log(`Knowl viewer: ${viewer.browseUrl}`);
+
+      // The rejection is caught rather than left to the handler's caller, because a signal
+      // handler has no caller: Node invokes it with nothing awaiting the promise, so a `close()`
+      // that failed would surface as ERR_UNHANDLED_REJECTION and abort the process -- on the one
+      // path that exists to shut it down in order. Ctrl-C means stop the server either way, and
+      // an exit code that says "crashed" for a clean interrupt is worse than a lost close error.
+      const stop = () => { void viewer.close().catch(() => {}).then(() => process.exit(0)); };
+      process.once('SIGINT', stop);
+      process.once('SIGTERM', stop);
+    } catch (error: any) {
+      console.error(`Error starting viewer: ${error.message}`);
+      process.exit(1);
+    }
+  });
 
 
 // --- 4. DECIDE COMMAND ---
@@ -2558,8 +2580,8 @@ taskCommand
       process.exit(1);
     }
 
-    let root = '';
-    let taskId = '';
+    let root: string;
+    let taskId: string;
     try {
       root = await findProjectRoot(process.cwd());
       await initDb(root);

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -99,7 +99,7 @@ async function stageInContext(
     // not what it decides on -- `checkPublishGate` re-reads git itself and reports being
     // unable to run it as its own verdict. Failing to record an intent because git is missing
     // would refuse the one half of publishing that is safe from every vantage.
-    let branch: string | null = null;
+    let branch: string | null;
     try { branch = currentBranchOf(input.projectRoot); } catch { branch = null; }
 
     // Naming ids is a deliberate act about items the caller has in hand, and it is the only

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -142,7 +142,12 @@ export function registerResources(
       // caller-supplied field, so the missing-argument route into it does not exist here --
       // but "statement text and bound parameters never leave the process" is the rule, and a
       // rule with one unguarded exit is the shape of the finding, not a fix for it.
-      throw new Error(`Error reading resource "${uri}": ${sanitizeToolErrorMessage(String(error?.message ?? error))}`);
+      // The cause is attached but never rendered: `sanitizeToolErrorMessage` decides what reaches
+      // the client, and this keeps the original for a local stack trace without widening that.
+      throw new Error(
+        `Error reading resource "${uri}": ${sanitizeToolErrorMessage(String(error?.message ?? error))}`,
+        { cause: error },
+      );
     }
   });
 }

--- a/src/store/knowledge-writer.ts
+++ b/src/store/knowledge-writer.ts
@@ -373,7 +373,7 @@ async function activeWorkspaceForWrite(): Promise<ActiveWorkspace | null> {
 
   if (workspaceCache?.root === root) return workspaceCache.workspace;
 
-  let workspace: ActiveWorkspace | null = null;
+  let workspace: ActiveWorkspace | null;
   try {
     const { resolveWorkspace } = await import('../workspace/resolve.js');
     workspace = await resolveWorkspace(root);

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -36,7 +36,9 @@ export async function getActiveKnowledgeByCategory(
 /**
  * Fetch all active knowledge items hierarchically organized by layers.
  */
-export async function getHierarchicalKnowledge(projectId: string) {
+// One store holds one project, so the id narrows nothing here; it stays in the signature because
+// every other read in this module takes it and a lone exception reads as an oversight.
+export async function getHierarchicalKnowledge(_projectId: string) {
   const db = getDb();
   try {
     const results = await db

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -104,11 +104,14 @@ export function mapRowToKnowledgeItem(row: typeof schema.knowledgeItems.$inferSe
   };
 }
 
-export async function createProject(rootPath: string, name: string, description?: string, dbConnection?: DbConnection): Promise<Project> {
+// The trailing parameters are the signature callers still pass, not fields this reads: a project
+// is derived from its root path alone. Underscored rather than deleted so the call sites keep
+// compiling and the shape stays legible to anyone reading a call.
+export async function createProject(rootPath: string, _name: string, _description?: string, _dbConnection?: DbConnection): Promise<Project> {
   return localProject(rootPath);
 }
 
-export async function getProjectByRootPath(rootPath: string, dbConnection?: DbConnection): Promise<Project | null> {
+export async function getProjectByRootPath(rootPath: string, _dbConnection?: DbConnection): Promise<Project | null> {
   return localProject(rootPath);
 }
 

--- a/src/store/retention.ts
+++ b/src/store/retention.ts
@@ -386,14 +386,14 @@ export async function adoptLegacyModelCache(
     const source = path.join(legacyDir, relative);
     const destination = path.join(sharedDir, relative);
 
-    let size = 0;
+    let size: number;
     try {
       size = (await fs.stat(source)).size;
     } catch {
       continue; // vanished under us
     }
 
-    let existing: Awaited<ReturnType<typeof fs.stat>> | null = null;
+    let existing: Awaited<ReturnType<typeof fs.stat>> | null;
     try {
       existing = await fs.stat(destination);
     } catch {

--- a/src/store/snapshots.ts
+++ b/src/store/snapshots.ts
@@ -249,7 +249,8 @@ async function readSnapshotManifest(source: string): Promise<SnapshotManifest> {
   } catch (error: any) {
     throw new Error(error.code === 'ENOENT'
       ? `Snapshot manifest "${manifestPath}" was not found. Restore requires the manifest written beside the snapshot.`
-      : `Snapshot manifest "${manifestPath}" is unreadable: ${error.message}`);
+      : `Snapshot manifest "${manifestPath}" is unreadable: ${error.message}`,
+    { cause: error });
   }
 
   if (!Number.isInteger(manifest.schemaVersion) || manifest.schemaVersion > KNOWL_SCHEMA_VERSION) {

--- a/src/store/write-embedding.ts
+++ b/src/store/write-embedding.ts
@@ -85,7 +85,7 @@ async function resolveEmbedder(): Promise<KnowledgeEmbedder | null> {
 
   if (cache?.key === key) return cache.embedder;
 
-  let embedder: KnowledgeEmbedder | null = null;
+  let embedder: KnowledgeEmbedder | null;
   try {
     embedder = build ? await build() : null;
   } catch {

--- a/src/transcripts/extract-candidates.ts
+++ b/src/transcripts/extract-candidates.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { access } from 'node:fs/promises';
 import type { Client } from '@libsql/client';
 import type { KnowledgeAtom, ProjectConfig } from '../core/types.js';
 import { hasAiConfigured } from '../core/config.js';
@@ -183,18 +184,30 @@ export async function extractCandidates(
     if (options.deadline !== undefined && Date.now() >= options.deadline) break;
     stopped += 1;
 
-    const text = await sessionText(session.path);
-    if (!text.trim()) {
-      await recordExtraction(db, session.sessionId, 0, 0);
-      empty += 1;
-      continue;
-    }
-
+    let text: string;
     let atoms: KnowledgeAtom[];
     try {
+      // Inside the guard with the model call, not before it. The read is the other thing here
+      // that can fail on a session, and for the same kind of reason -- a transcript deleted
+      // between indexing and now, an archive on a volume that went away. Outside, one such file
+      // ended the whole run, after the sessions before it had already been paid for.
+      text = await sessionText(session.path);
+      if (!text.trim()) {
+        // An empty read has two causes and they deserve opposite answers: a session that really
+        // holds no prose is finished with, while a transcript that is no longer on disk has not
+        // been judged at all. `readProseFrom` cannot tell them apart -- it reports an unreadable
+        // file as an empty one, which is right for the index pass and wrong here -- so the
+        // question is asked directly, and only in the ambiguous case. A throw here lands in the
+        // catch below and leaves the session unwatermarked, exactly like a provider failure.
+        await access(session.path);
+        await recordExtraction(db, session.sessionId, 0, 0);
+        empty += 1;
+        continue;
+      }
       atoms = await extractKnowledge(text);
     } catch {
-      // Unwatermarked on purpose: a provider hiccup is not a verdict about this session.
+      // Unwatermarked on purpose: a provider hiccup is not a verdict about this session, and
+      // neither is a file that could not be read this once.
       stopped -= 1;
       continue;
     }

--- a/src/transcripts/parse.ts
+++ b/src/transcripts/parse.ts
@@ -254,56 +254,77 @@ export async function* streamProseFrom(
   let consumed = startByte;
   let line = startLine;
 
-  let stream: import('node:fs').ReadStream;
+  // A file that has been deleted, or that cannot be opened, yields nothing and reports the
+  // watermark it was given -- it must not throw at the caller.
+  //
+  // **The guard has to be around the iteration, not around `createReadStream`.** That call
+  // succeeds on a path that does not exist: `fs.ReadStream` opens lazily and reports ENOENT by
+  // emitting `error`, which rejects the `for await` below. Wrapping only the construction caught
+  // nothing a real archive produces, so a transcript deleted between discovery and this read
+  // aborted `knowl transcripts extract` mid-run -- after the model had been paid for the sessions
+  // before it -- and `backfillOffsets` with it, both under comments promising the opposite.
+  //
+  // Only the open is protected. A failure part-way through iteration is a truncated read of a
+  // file that IS there, and returning the watermark for it would commit the caller to a position
+  // past lines it never saw; that has to keep propagating.
+  const stream = createReadStream(filePath, { start: startByte });
+  let delivered = false;
+
   try {
-    stream = createReadStream(filePath, { start: startByte });
-  } catch {
-    return { bytesConsumed: startByte, linesConsumed: startLine };
-  }
+    for await (const chunk of stream) {
+      delivered = true;
+      carry = carry.length === 0 ? Buffer.from(chunk) : Buffer.concat([carry, Buffer.from(chunk)]);
+      let cursor = 0;
 
-  for await (const chunk of stream) {
-    carry = carry.length === 0 ? Buffer.from(chunk) : Buffer.concat([carry, Buffer.from(chunk)]);
-    let cursor = 0;
+      for (;;) {
+        const newline = carry.indexOf(0x0a, cursor);
+        if (newline === -1) break;
 
-    for (;;) {
-      const newline = carry.indexOf(0x0a, cursor);
-      if (newline === -1) break;
+        const lineStart = consumed + cursor;
+        // Safe to decode here: 0x0a cannot occur inside a multi-byte UTF-8 sequence, so a
+        // complete line is always a complete sequence of characters.
+        const raw = carry.subarray(cursor, newline).toString('utf8');
+        cursor = newline + 1;
+        line++;
 
-      const lineStart = consumed + cursor;
-      // Safe to decode here: 0x0a cannot occur inside a multi-byte UTF-8 sequence, so a
-      // complete line is always a complete sequence of characters.
-      const raw = carry.subarray(cursor, newline).toString('utf8');
-      cursor = newline + 1;
-      line++;
-
-      const trimmed = raw.trim();
-      if (trimmed) {
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(trimmed);
-        } catch {
-          // One unreadable line must not cost the rest of the file.
-          parsed = undefined;
-        }
-        const prose = parsed === undefined ? null : extractProse(parsed);
-        if (prose) {
-          yield {
-            message: { line, ...prose },
-            byteOffset: lineStart,
-            bytesConsumed: consumed + cursor,
-            linesConsumed: line,
-          };
-        } else if (parsed !== undefined && onNaming) {
-          // Naming entries are not prose and must not become messages -- they carry no line the
-          // reader would ever want to open. Surfaced by callback so no existing caller changes.
-          const naming = readSessionNaming(parsed);
-          if (naming) onNaming(naming);
+        const trimmed = raw.trim();
+        if (trimmed) {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch {
+            // One unreadable line must not cost the rest of the file.
+            parsed = undefined;
+          }
+          const prose = parsed === undefined ? null : extractProse(parsed);
+          if (prose) {
+            yield {
+              message: { line, ...prose },
+              byteOffset: lineStart,
+              bytesConsumed: consumed + cursor,
+              linesConsumed: line,
+            };
+          } else if (parsed !== undefined && onNaming) {
+            // Naming entries are not prose and must not become messages -- they carry no line the
+            // reader would ever want to open. Surfaced by callback so no existing caller changes.
+            const naming = readSessionNaming(parsed);
+            if (naming) onNaming(naming);
+          }
         }
       }
-    }
 
-    consumed += cursor;
-    carry = carry.subarray(cursor);
+      consumed += cursor;
+      carry = carry.subarray(cursor);
+    }
+  } catch (error) {
+    // Nothing arrived, so the stream failed to open: the file is gone, or is not ours to read.
+    // Report the watermark unmoved and let the caller carry on with the rest of the archive.
+    //
+    // A failure AFTER a chunk has been delivered is a different thing -- a truncated read of a
+    // file that is really there -- and returning a watermark for it would tell the caller it had
+    // seen lines it never did. That keeps propagating.
+    if (delivered) throw error;
+    return { bytesConsumed: startByte, linesConsumed: startLine };
   }
 
   // Past any trailing non-prose lines, which advanced the watermark without yielding.

--- a/src/transcripts/paths.ts
+++ b/src/transcripts/paths.ts
@@ -99,9 +99,11 @@ async function codexSessionCwd(filePath: string): Promise<string | null> {
     handle = await fs.open(filePath, 'r');
     const buffer = Buffer.alloc(CODEX_META_PREFIX_BYTES);
     const { bytesRead } = await handle.read(buffer, 0, CODEX_META_PREFIX_BYTES, 0);
-    const prefix = buffer.subarray(0, bytesRead).toString('utf8');
+    // Copied, not aliased: `buffer` is reused by the fallback reads below, so a subarray of it
+    // would change under the bytes already collected.
+    const head = Buffer.from(buffer.subarray(0, bytesRead));
 
-    const matched = CWD_IN_PREFIX.exec(prefix);
+    const matched = CWD_IN_PREFIX.exec(head.toString('utf8'));
     if (matched) {
       try {
         const cwd = JSON.parse(matched[1]) as unknown;
@@ -115,18 +117,33 @@ async function codexSessionCwd(filePath: string): Promise<string | null> {
     // line is simply longer than the prefix before reaching `cwd`. Both are answered by reading
     // on to the end of the first line -- which must genuinely continue reading, not re-inspect
     // the prefix: a header larger than the prefix contains no newline inside it at all.
-    let line = prefix;
+    //
+    // **Accumulated as BYTES and decoded once at the end**, never chunk by chunk. A read boundary
+    // falls wherever 8 KB lands, which is routinely mid-character: decoding each chunk on its own
+    // turns the two halves of one multi-byte sequence into two U+FFFD, and when the split lands
+    // inside the `cwd` value itself the path comes back corrupted, matches no root, and every
+    // session under it is silently dropped from discovery. `parse.ts` splits on 0x0a before
+    // decoding for the same reason. Newlines are searched for in the bytes, which is safe: 0x0a
+    // cannot occur inside a multi-byte UTF-8 sequence.
+    const chunks: Buffer[] = [head];
+    // Only the newest chunk is searched each time: every earlier one has already been checked and
+    // held no newline, so rescanning them would make this quadratic in the header's size.
+    let tail = head;
     let offset = bytesRead;
-    while (!line.includes('\n') && offset < MAX_CODEX_META_BYTES && bytesRead > 0) {
+    while (tail.indexOf(0x0a) === -1 && offset < MAX_CODEX_META_BYTES) {
       const next = await handle.read(buffer, 0, CODEX_META_PREFIX_BYTES, offset);
       if (next.bytesRead === 0) break;
-      line += buffer.subarray(0, next.bytesRead).toString('utf8');
+      tail = Buffer.from(buffer.subarray(0, next.bytesRead));
+      chunks.push(tail);
       offset += next.bytesRead;
     }
 
-    const newline = line.indexOf('\n');
+    const whole = chunks.length === 1 ? head : Buffer.concat(chunks);
+    const newline = whole.indexOf(0x0a);
     try {
-      const record = JSON.parse(newline === -1 ? line : line.slice(0, newline)) as Record<string, unknown>;
+      const record = JSON.parse(
+        (newline === -1 ? whole : whole.subarray(0, newline)).toString('utf8'),
+      ) as Record<string, unknown>;
       const payload = record.payload as Record<string, unknown> | undefined;
       const cwd = payload?.cwd;
       return typeof cwd === 'string' && cwd ? cwd : null;
@@ -215,10 +232,23 @@ export function parseWorktreeList(stdout: string): string[] {
 }
 
 /** Windows and macOS paths compare case-insensitively; POSIX ones do not. */
+const CASE_INSENSITIVE_PATHS = process.platform === 'win32' || process.platform === 'darwin';
+
 const foldPath = (target: string) =>
-  process.platform === 'win32' || process.platform === 'darwin'
-    ? path.resolve(target).toLowerCase()
-    : path.resolve(target);
+  CASE_INSENSITIVE_PATHS ? path.resolve(target).toLowerCase() : path.resolve(target);
+
+/**
+ * The same case policy applied to a string that is *not* a whole path -- one character, or the
+ * leading fragment of one.
+ *
+ * Separate from `foldPath` because that one resolves, and resolving a fragment answers a different
+ * question than the caller asked: `path.resolve` of a single character returns it appended to the
+ * working directory, so `/` and `\` both come back as the drive root and compare equal, and a
+ * prefix with a trailing separator loses it. Neither of those changes the answer here today --
+ * both sides of every comparison come from `path.resolve` already, so the separators agree -- but
+ * it is true by luck rather than by construction, and it cost a `resolve` per character compared.
+ */
+const foldText = (text: string) => CASE_INSENSITIVE_PATHS ? text.toLowerCase() : text;
 
 const samePath = (left: string, right: string) => foldPath(left) === foldPath(right);
 
@@ -429,14 +459,17 @@ export async function scanTranscriptArchive(
     let shared = 0;
     while (
       shared < realGivenRoot.length && shared < givenRoot.length
-      && foldPath(realGivenRoot[realGivenRoot.length - 1 - shared]) === foldPath(givenRoot[givenRoot.length - 1 - shared])
+      && foldText(realGivenRoot[realGivenRoot.length - 1 - shared]) === foldText(givenRoot[givenRoot.length - 1 - shared])
     ) shared += 1;
     realHead = realGivenRoot.slice(0, realGivenRoot.length - shared);
     givenHead = givenRoot.slice(0, givenRoot.length - shared);
   }
   const uncanonicalise = (target: string): string | null => {
     if (!realHead) return null;
-    if (!foldPath(target).startsWith(foldPath(realHead))) return null;
+    // `foldText`, because `realHead` is a leading fragment rather than a path and the slice below
+    // indexes into `target` by its raw length -- a comparison that had normalised either side
+    // would be measuring a different string than the one being cut.
+    if (!foldText(target).startsWith(foldText(realHead))) return null;
     return givenHead + target.slice(realHead.length);
   };
 

--- a/src/workspace/federated-query.ts
+++ b/src/workspace/federated-query.ts
@@ -189,7 +189,13 @@ export async function queryFederated(input: {
   // produce. Reported rather than raised: a request naming three repos and one typo should
   // still search the three, and the notice is what makes the fourth's absence visible.
   if (wanted) {
+    // The cloud workspace id belongs in here because it is a name `repos` accepts: the replica
+    // below is searched when it is named. Left out, naming it produced a response that both
+    // returned its rows and reported it unknown -- and `unknown` is the one notice that tells a
+    // caller their name matched nothing, so a response contradicting itself on that point is
+    // worse than either verdict alone.
     const known = new Set([input.workspace.repo, ...input.workspace.peers.map(peer => peer.name)]);
+    if (input.workspace.cloud) known.add(input.workspace.cloud.workspaceId);
     for (const name of wanted) {
       if (!known.has(name)) skipped.push({ repo: name, reason: 'unknown' });
     }

--- a/tests/cloud/federation.test.ts
+++ b/tests/cloud/federation.test.ts
@@ -100,6 +100,24 @@ describe('federation with the cloud replica', () => {
     expect((await run()).shape).toBe('grouped');
   });
 
+  it('accepts the workspace id as a repo name instead of calling it unknown', async () => {
+    // `repos: [WS]` is what narrows a query to the replica, and it works -- the rows come back.
+    // The name check was built from the manifest alone, so the same call also reported the id as
+    // a name that matched nothing: one response asserting both that the repo does not exist and
+    // that here is its knowledge.
+    await seedReplica();
+    const workspace = (await resolveWorkspace(ROOT, config))!;
+    await initDb(ROOT);
+    try {
+      const result = await queryFederated({ workspace, query: 'rollback procedure', limit: 5, repos: [WS] });
+
+      expect(result.groups.flatMap(group => group.items).length).toBeGreaterThan(0);
+      expect(result.skipped).toEqual([]);
+    } finally {
+      await closeDb();
+    }
+  });
+
   it('reports an unreadable replica as skipped rather than failing the query', async () => {
     // The rule every peer already follows: a store this process cannot read costs the caller
     // a notice, never their answer.

--- a/tests/store/extractor-corpus.test.ts
+++ b/tests/store/extractor-corpus.test.ts
@@ -12,7 +12,7 @@ async function corpusEvents(): Promise<Map<string, MemorySessionEvent[]>> {
   const bySession = new Map<string, MemorySessionEvent[]>();
   for (const row of rows) {
     const sessionId = String(row.session_id);
-    let payload: Record<string, unknown> = {};
+    let payload: Record<string, unknown>;
     try { payload = JSON.parse(String(row.payload)); } catch { payload = {}; }
     const event = {
       id: String(row.id),

--- a/tests/transcripts/candidates.test.ts
+++ b/tests/transcripts/candidates.test.ts
@@ -179,6 +179,28 @@ describe('extraction', () => {
     expect(retried.sessionsExtracted).toBe(1);
   });
 
+  it('skips a session whose transcript has vanished and still extracts the rest', async () => {
+    // The archive is not this process's to keep: a transcript indexed last week can be gone by
+    // the time extraction reaches it. Reading it used to happen outside the per-session guard, so
+    // one deleted file ended the run with an ENOENT — after the sessions before it had already
+    // been paid for, and with no report of which one stopped it.
+    const gone = await seedSession(db, 'gone', ['ask', 'answer']);
+    await seedSession(db, 'alive', ['still here', 'and readable']);
+    await fs.rm(gone);
+    extractKnowledge.mockResolvedValue([
+      { category: 'fact', title: 'Survivor', content: 'Extracted after the gap.', confidence: 0.6 },
+    ]);
+
+    const result = await extractCandidates(db, AI_CONFIG);
+
+    expect(result.sessionsExtracted).toBe(1);
+    expect(result.candidates).toBe(1);
+    // Unwatermarked, exactly like a provider failure: the file being unreadable once is not a
+    // verdict about the session.
+    const done = await db.execute('SELECT session_id FROM transcript_extractions');
+    expect(done.rows.map(row => String(row.session_id))).toEqual(['alive']);
+  });
+
   it('sends the tail of a long session, where its conclusions are', async () => {
     const filler = 'x'.repeat(30_000);
     await seedSession(db, 'a', [filler, 'THE CONCLUSION AT THE END']);

--- a/tests/transcripts/codex-discovery.test.ts
+++ b/tests/transcripts/codex-discovery.test.ts
@@ -113,6 +113,37 @@ describe('Codex transcript discovery', () => {
     expect(found).toHaveLength(1);
   });
 
+  it('finds a non-ASCII cwd split across the bounded read', async () => {
+    // The fallback assembles the header from 8 KB reads, and a read boundary falls wherever
+    // 8,192 bytes land — routinely mid-character. Decoded chunk by chunk, the two halves of one
+    // multibyte sequence each become U+FFFD; when the split lands inside `cwd` the path comes
+    // back corrupt, matches no root, and the session is dropped with nothing said.
+    const root = path.resolve(process.platform === 'win32' ? 'd:\\coding\\côding' : '/coding/côding');
+    const target = path.join(codexSessionsDir, '2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-ffff-7e93-886c-2429599f27cd.jsonl');
+    await fs.mkdir(path.dirname(target), { recursive: true });
+
+    // Padded so the accented character in `cwd` straddles byte 8,192 exactly.
+    let body: string | null = null;
+    for (let padding = 7_900; padding < 8_400 && body === null; padding++) {
+      const record = JSON.stringify({
+        type: 'session_meta',
+        payload: { base_instructions: { text: 'x'.repeat(padding) }, cwd: root },
+      });
+      let bytes = 0;
+      for (const character of record) {
+        const width = Buffer.byteLength(character, 'utf8');
+        if (width > 1 && bytes < 8_192 && bytes + width > 8_192) { body = record; break; }
+        bytes += width;
+      }
+    }
+    expect(body).not.toBeNull();
+    await fs.writeFile(target, `${body}\n`);
+
+    const found = await discoverTranscriptFiles(root, { projectsDir, codexSessionsDir });
+
+    expect(found).toHaveLength(1);
+  });
+
   it('skips a file with no readable header rather than claiming it', async () => {
     const target = path.join(codexSessionsDir, '2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-eeee-7e93-886c-2429599f27cd.jsonl');
     await fs.mkdir(path.dirname(target), { recursive: true });

--- a/tests/transcripts/parse.test.ts
+++ b/tests/transcripts/parse.test.ts
@@ -120,6 +120,16 @@ describe('readProseFrom', () => {
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].line).toBe(2);
   });
+
+  it('returns no messages for a file that is not there', async () => {
+    // `knowl transcripts extract` reads through here, one session at a time; a throw at this
+    // level ended the whole run on the first transcript that had been deleted since indexing.
+    await expect(readProseFrom(path.join(dir, 'absent.jsonl'), 0, 0)).resolves.toEqual({
+      messages: [],
+      bytesRead: 0,
+      linesRead: 0,
+    });
+  });
 });
 
 describe('streamProseFrom', () => {
@@ -189,5 +199,28 @@ describe('streamProseFrom', () => {
     for await (const chunk of streamProseFrom(file, 0, 0)) chunks.push(chunk);
 
     expect(chunks[0].message.text).toBe('π'.repeat(100_000));
+  });
+
+  it('reports the watermark it was given for a file that is not there', async () => {
+    // `createReadStream` succeeds on a missing path and reports ENOENT by emitting `error`, which
+    // rejects the iteration rather than the construction — so a guard around the construction
+    // alone caught nothing, and every caller inherited a throw where this promises silence.
+    const iterator = streamProseFrom(path.join(dir, 'never-written.jsonl'), 40, 7);
+
+    const next = await iterator.next();
+
+    expect(next.done).toBe(true);
+    expect(next.value).toEqual({ bytesConsumed: 40, linesConsumed: 7 });
+  });
+
+  it('reports the watermark it was given for a path that is a directory', async () => {
+    // The other shape of unreadable, and the one that is not ENOENT: something is there, and it
+    // is not a file. It must degrade the same way rather than throw EISDIR at the caller.
+    const iterator = streamProseFrom(dir, 0, 0);
+
+    const next = await iterator.next();
+
+    expect(next.done).toBe(true);
+    expect(next.value).toEqual({ bytesConsumed: 0, linesConsumed: 0 });
   });
 });


### PR DESCRIPTION
A repo-wide bug sweep on a clean `main` at `a047e85`. Four defects, each proved
to fail on the pre-fix tree by stashing only the source and re-running its new
test, plus the lint backlog cleared.

## Two silent losses in the transcript readers

Both sat under comments promising the behaviour the code did not have, so
neither is caught by reading intent.

**A non-ASCII project path lost every Codex session.** `codexSessionCwd` reads
the `session_meta` header in 8 KB reads and decoded each one separately. A read
boundary lands wherever 8,192 bytes fall — routinely mid-character — so the two
halves of one multi-byte sequence each became `U+FFFD`. When the split landed
inside the `cwd` value the path came back corrupt, matched no root, and every
session under it was dropped from discovery with nothing said. Reproduced:

```
expected cwd: "D:\côding\knowl"
actual cwd  : "D:\c<?><?>ding\knowl"
MATCHES     : false
```

Bytes are now accumulated and decoded once, and newlines are found with
`indexOf(0x0a)` — safe, because `0x0a` cannot occur inside a multi-byte UTF-8
sequence, and exactly how `parse.ts` had been doing it all along.

**One deleted transcript ended a whole extraction run.** `streamProseFrom`
guarded `createReadStream`, but that call *succeeds* on a path that does not
exist: `fs.ReadStream` opens lazily and reports ENOENT by emitting `error`,
which rejects the `for await`. The unreadable-file path had never been
reachable. `knowl transcripts extract` died on the first transcript deleted
since indexing — mid-run, after the model had been paid for the sessions before
it — and `backfillOffsets` had the same hole, under a comment saying such a file
"yields nothing and is simply left for a later pass".

The guard moves to the iteration. A failure *after* a chunk has arrived is a
truncated read of a file that is really there, and still propagates: returning a
watermark for it would tell the caller it had seen lines it never did.

That fix then makes an unreadable file look like an empty one, which
`extractCandidates` would have watermarked as "extracted, yielded nothing" —
retiring a session permanently on the strength of a read failure. The ambiguous
zero-length case now asks directly, and only there.

## Two smaller ones

**`knowl view` crashed instead of stopping on Ctrl-C.** The signal handler was
an unawaited `async` function, so a failing `viewer.close()` surfaced as
`ERR_UNHANDLED_REJECTION` — on the one path that exists to shut the process down
in order.

**A federated response contradicted itself.** `queryFederated` built its
known-repo set from the manifest alone, so `repos: ['<cloud workspaceId>']` both
returned the replica's rows and reported the id as `unknown` — the notice whose
whole job is to say a name matched nothing.

## Lint warnings 29 → 0

Three groups, none mechanical.

- **Eight** were the rest-sibling omit idiom (`const { secret, ...rest } = row`),
  where the binding is load-bearing: renaming it to `_secret` changes which key
  is dropped, so the `^_` convention is unavailable. `ignoreRestSiblings: true`
  is the purpose-built fix — naming an options object at all is what had switched
  it off, since tseslint's recommended config sets it.
- **Seven** `no-useless-assignment` were `let x = <initial>` with a try/catch
  assigning both arms. The initializer just goes.
- **Five** rethrows took `{ cause: error }`. The rest were genuinely unused
  parameters, underscored.

`.verify-dist/**` joins the eslint ignores: the same case as `.bridge-dist/**`,
gitignored so CI's fresh checkout never has it and only local runs carried the
extra findings — the shape the config already warns about.

## A note on type-aware lint rules

Run once over `src/` as part of the sweep, and worth recording rather than
adopting. `no-floating-promises` / `no-misused-promises` / `await-thenable`
produced **6 findings total** — one real (the `view` handler), one duplicate of
it, and four `await client.close()` on a libsql `void` return, which are
harmless and deliberately defensive. `no-unnecessary-condition` produced **160**,
nearly all false positives: libsql types `Row` values as non-nullable when they
are not, and without `noUncheckedIndexedAccess` every `sections[0]` guard reads
as dead. **Recommend against enabling it.** The narrow promise rules are cheap
to re-run by hand and did find something.

## Found and deliberately left

All real, none produces a wrong answer:

- `transcripts approve --all` silently caps at 1,000 candidates and reports the
  capped number as the total.
- Ids that are no longer `pending` are dropped by `loadCandidates` rather than
  reported in `failed`, so approving an already-decided id prints
  `Approved 0 candidate(s).` with no explanation.
- `scanCodexArchive` does not apply the `uncanonicalise` inverse substitution the
  Claude path needs, so on macOS a sibling worktree known only canonically can
  miss.

## Verification

| Gate | Before | After |
| --- | --- | --- |
| `build` / `typecheck` / `typecheck:bench` / `docs:check` | clean | clean |
| `git diff --check` | clean | clean |
| `lint` | 0 errors, 29 warnings | **0 problems** |
| `test` | 304 files, 2,733 passed, 5 skipped | 304 files, **2,739 passed**, 5 skipped |
