### PR TITLE
fix(tests): carry the git identity on the invocation, so a fixture cannot rewrite this repo's config

### DIFF
--- a/scripts/e2e-cloud.ts
+++ b/scripts/e2e-cloud.ts
@@ -58,18 +58,19 @@ async function main(): Promise<void> {
   const ORIGIN = path.resolve('./.knowl-e2e-origin');
   await fs.rm(ORIGIN, { recursive: true, force: true }).catch(() => {});
   await fs.mkdir(ORIGIN, { recursive: true });
-  const inOrigin = (args: string[]) => spawnSync('git', args, { cwd: ORIGIN, encoding: 'utf8' });
+  // Identity carried on each invocation rather than written with `git config`. These fixtures sit
+  // inside this repository, and `git config` searches upward when the fixture has no `.git` yet --
+  // so a run interrupted at the wrong moment leaves a bogus `user.email` in knowl's own config,
+  // and the next commit made here goes out authored by it. See `tests/git-identity.ts`.
+  const IDENTITY = ['-c', 'user.name=Knowl-E2E', '-c', 'user.email=e2e@example.test'];
+  const inOrigin = (args: string[]) => spawnSync('git', [...IDENTITY, ...args], { cwd: ORIGIN, encoding: 'utf8' });
   inOrigin(['init', '-q', '-b', 'main']);
-  inOrigin(['config', 'user.email', 'e2e@example.com']);
-  inOrigin(['config', 'user.name', 'E2E']);
   await fs.writeFile(path.join(ORIGIN, 'a.txt'), 'one', 'utf8');
   inOrigin(['add', '.']);
   inOrigin(['commit', '-qm', 'one']);
   spawnSync('git', ['clone', '-q', ORIGIN, ROOT], { encoding: 'utf8' });
 
-  const git = (args: string[]) => spawnSync('git', args, { cwd: ROOT, encoding: 'utf8' });
-  git(['config', 'user.email', 'e2e@example.com']);
-  git(['config', 'user.name', 'E2E']);
+  const git = (args: string[]) => spawnSync('git', [...IDENTITY, ...args], { cwd: ROOT, encoding: 'utf8' });
   // The refs are what the gate reads; the URL is only what identity is derived from. Rewriting it
   // after cloning gives a realistic `github.com/acme/e2e` without losing `origin/main`.
   git(['remote', 'set-url', 'origin', 'git@github.com:acme/e2e.git']);

--- a/scripts/e2e-two-checkouts.ts
+++ b/scripts/e2e-two-checkouts.ts
@@ -44,7 +44,12 @@ function psql(sql: string): string {
   return result.stdout.trim();
 }
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+// Identity carried on each invocation rather than written with `git config`. These fixtures sit
+// inside this repository, and `git config` searches upward when the fixture has no `.git` yet --
+// so a run interrupted at the wrong moment leaves a bogus `user.email` in knowl's own config, and
+// the next commit made here goes out authored by it. See `tests/git-identity.ts`.
+const IDENTITY = ['-c', 'user.name=Knowl-E2E', '-c', 'user.email=e2e@example.test'];
+const git = (cwd: string, args: string[]) => spawnSync('git', [...IDENTITY, ...args], { cwd, encoding: 'utf8' });
 const step = (n: string, what: string) => console.log(`\n── ${n}. ${what}`);
 
 /** A clone with a real `origin/HEAD`, which is what the publish gate reads. */
@@ -52,14 +57,10 @@ async function makeCheckout(origin: string, clone: string, remoteUrl: string): P
   for (const dir of [origin, clone]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   await fs.mkdir(origin, { recursive: true });
   git(origin, ['init', '-q', '-b', 'main']);
-  git(origin, ['config', 'user.email', 'e2e@example.com']);
-  git(origin, ['config', 'user.name', 'E2E']);
   await fs.writeFile(path.join(origin, 'a.txt'), 'one', 'utf8');
   git(origin, ['add', '.']);
   git(origin, ['commit', '-qm', 'one']);
   spawnSync('git', ['clone', '-q', origin, clone], { encoding: 'utf8' });
-  git(clone, ['config', 'user.email', 'e2e@example.com']);
-  git(clone, ['config', 'user.name', 'E2E']);
   git(clone, ['remote', 'set-url', 'origin', remoteUrl]);
   await fs.mkdir(path.join(clone, '.knowl'), { recursive: true });
   await fs.writeFile(path.join(clone, '.knowl', 'config.json'), JSON.stringify({ version: 1 }), 'utf8');

--- a/tests/architecture/git-identity.test.ts
+++ b/tests/architecture/git-identity.test.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * No test or script may write a git identity into a config file.
+ *
+ * **`git config user.email X` aimed at a fixture can land on this repository.** `git config` with
+ * no `--file` searches upward for the repository the directory belongs to, so when the fixture has
+ * no `.git` at that instant -- the window between `git init` and the next line, or a run
+ * interrupted before it -- the write goes to the nearest enclosing repository. Fixtures here are
+ * routinely built at `path.resolve('./.knowl-...')`, which is inside knowl, so the nearest
+ * enclosing repository is knowl.
+ *
+ * It happened. On 2026-08-11 this repository's own `.git/config` carried
+ * `user.email = test@example.com`, matching `tests/store/drift-auto.test.ts` exactly. The next
+ * commit went out authored by it, GitHub resolved the address to an unrelated person's account,
+ * and the CLA check failed against a stranger who had never signed it. The commit had to be
+ * re-authored and force-pushed.
+ *
+ * Nothing caught it, because nothing was looking, and it is invisible once it lands: a local
+ * `user.email` silently overrides the developer's global one for every later commit. This is what
+ * looks. The alternative -- `git -c user.name=... -c user.email=...` on the invocation -- sets the
+ * value for one process and writes no file, so there is nowhere for it to land wrongly.
+ *
+ * Scoped to `tests/` and `scripts/` because those are what run against fixtures under this repo.
+ * `src/` never sets an identity at all; `docs/` holds design plans, which are a record of what was
+ * written at the time rather than code that runs.
+ */
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const SCANNED = ['tests', 'scripts'];
+
+/** `git config user.name`, `['config', 'user.email', ...]`, and the string-command forms. */
+const WRITES_IDENTITY = /config[^\n]{0,40}?user\.(?:name|email)/;
+
+/** This file quotes the forbidden pattern in order to describe it. */
+const SELF = path.join('tests', 'architecture', 'git-identity.test.ts');
+
+/**
+ * Comments are prose, not calls.
+ *
+ * Every place this rule is explained has to name the thing it forbids -- `tests/git-identity.ts`
+ * does, and so does the helper comment at each converted call site -- so a scan that could not
+ * tell a sentence from a statement would forbid documenting itself.
+ */
+const IS_COMMENT = /^\s*(?:\/\/|\/\*|\*)/;
+
+async function sourceFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+  const found = await Promise.all(entries.map(async entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return /\.(ts|mts|mjs|js)$/.test(entry.name) ? [full] : [];
+  }));
+  return found.flat();
+}
+
+describe('git identity in fixtures', () => {
+  it('is never written with `git config`, in any test or script', async () => {
+    const offenders: string[] = [];
+
+    for (const dir of SCANNED) {
+      for (const file of await sourceFiles(path.join(ROOT, dir))) {
+        const relative = path.relative(ROOT, file);
+        if (relative.split(path.sep).join(path.sep) === SELF) continue;
+
+        const source = await fs.readFile(file, 'utf-8');
+        source.split(/\r?\n/).forEach((line, index) => {
+          if (!IS_COMMENT.test(line) && WRITES_IDENTITY.test(line)) {
+            offenders.push(`${relative.replaceAll('\\', '/')}:${index + 1}: ${line.trim()}`);
+          }
+        });
+      }
+    }
+
+    // Named rather than counted: the fix is per line, and a bare number sends the next reader
+    // hunting for which one.
+    expect(offenders, [
+      'Use `git -c user.name=... -c user.email=...` on the invocation instead.',
+      'See tests/git-identity.ts for GIT_IDENTITY / gitArgs / GIT_IDENTITY_FLAGS.',
+      '',
+      ...offenders,
+    ].join('\n')).toEqual([]);
+  });
+});

--- a/tests/architecture/git-identity.test.ts
+++ b/tests/architecture/git-identity.test.ts
@@ -84,4 +84,24 @@ describe('git identity in fixtures', () => {
       ...offenders,
     ].join('\n')).toEqual([]);
   });
+
+  /**
+   * The environment carries an identity, so a call site that forgets one still commits.
+   *
+   * This is the half that a per-call-site convention cannot give you, and the gap cost a CI run:
+   * converting the suites that called `git config` left the git commands those same files ran
+   * *elsewhere* with no identity, and it passed locally because a developer's global
+   * `~/.gitconfig` supplies one. A CI runner has none, so `git commit` failed there with
+   * "Author identity unknown" on both ubuntu legs while every local run was green.
+   *
+   * Asserted in a worker rather than trusted from `setup`, because inheritance across the
+   * worker boundary is the property being relied on -- the same one `os.tmpdir()` depends on.
+   */
+  it('reaches the workers, so a call site that forgets one still commits', () => {
+    expect(process.env.GIT_AUTHOR_NAME).toBeTruthy();
+    expect(process.env.GIT_AUTHOR_EMAIL).toBeTruthy();
+    // Both halves: git requires AUTHOR and COMMITTER separately and refuses on either alone.
+    expect(process.env.GIT_COMMITTER_NAME).toBeTruthy();
+    expect(process.env.GIT_COMMITTER_EMAIL).toBeTruthy();
+  });
 });

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -608,8 +608,8 @@ describe('CLI Integration', () => {
         });
 
         await fs.writeFile(path.join(prDir, 'src', 'billing.ts'), 'export const version = 2;\n', 'utf-8');
-        execSync('git add src/billing.ts', { cwd: prDir, encoding: 'utf-8' });
-        execSync('git commit -m "change billing"', { cwd: prDir, encoding: 'utf-8' });
+        git('add src/billing.ts');
+        git('commit -m "change billing"');
 
         const output = execSync(`node "${CLI_PATH}" pr check --since ${baseCommit}`, {
           cwd: prDir,

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -4,6 +4,7 @@ import { createClient } from '@libsql/client';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { GIT_IDENTITY_FLAGS } from '../git-identity.js';
 
 const TEST_DIR = path.join(os.tmpdir(), 'knowl-cli-test');
 const AGENTS_TEST_DIR = path.join(os.tmpdir(), 'knowl-cli-agents-test');
@@ -574,12 +575,12 @@ describe('CLI Integration', () => {
     await fs.mkdir(path.join(prDir, 'src'), { recursive: true });
 
     try {
-      execSync('git init', { cwd: prDir, encoding: 'utf-8' });
-      execSync('git config user.email knowl@example.test', { cwd: prDir, encoding: 'utf-8' });
-      execSync('git config user.name "Knowl Test"', { cwd: prDir, encoding: 'utf-8' });
+      // Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+      const git = (args: string) => execSync(`git ${GIT_IDENTITY_FLAGS} ${args}`, { cwd: prDir, encoding: 'utf-8' });
+      git('init');
       await fs.writeFile(path.join(prDir, 'src', 'billing.ts'), 'export const version = 1;\n', 'utf-8');
-      execSync('git add src/billing.ts', { cwd: prDir, encoding: 'utf-8' });
-      execSync('git commit -m "base"', { cwd: prDir, encoding: 'utf-8' });
+      git('add src/billing.ts');
+      git('commit -m "base"');
       const baseCommit = execSync('git rev-parse HEAD', { cwd: prDir, encoding: 'utf-8' }).trim();
 
       execSync(`node "${CLI_PATH}" init --yes`, {

--- a/tests/cloud/drift-report.test.ts
+++ b/tests/cloud/drift-report.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import type { CloudApi } from '../../src/cloud/api-client.js';
 import type { UpdateItemBody } from '../../src/cloud/sync-contract.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
@@ -13,7 +14,8 @@ import type { ProjectConfig } from '../../src/core/types.js';
 
 const API_HOST = 'https://api.drift.test';
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+const git = (cwd: string, args: string[]) => spawnSync('git', gitArgs(args), { cwd, encoding: 'utf8' });
 const headOf = (cwd: string) => git(cwd, ['rev-parse', 'HEAD']).stdout.trim();
 
 // Fresh directories per test, for the same Windows reason `publish-push.test.ts` documents:
@@ -69,8 +71,6 @@ describe('reporting upward', () => {
 
     await fs.mkdir(ORIGIN, { recursive: true });
     git(ORIGIN, ['init', '-q', '-b', 'main']);
-    git(ORIGIN, ['config', 'user.email', 'test@example.com']);
-    git(ORIGIN, ['config', 'user.name', 'Test']);
     await commitToOrigin('a.txt');
     git(process.cwd(), ['clone', '-q', ORIGIN, CLONE]);
 

--- a/tests/cloud/publish-gate.test.ts
+++ b/tests/cloud/publish-gate.test.ts
@@ -2,24 +2,22 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { checkPublishGate, currentBranchOf } from '../../src/cloud/publish-gate.js';
 
 const ORIGIN = path.resolve('./.knowl-gate-origin');
 const CLONE = path.resolve('./.knowl-gate-clone');
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+const git = (cwd: string, args: string[]) => spawnSync('git', gitArgs(args), { cwd, encoding: 'utf8' });
 
 async function makeOriginAndClone(): Promise<void> {
   await fs.mkdir(ORIGIN, { recursive: true });
   git(ORIGIN, ['init', '-q', '-b', 'main']);
-  git(ORIGIN, ['config', 'user.email', 'test@example.com']);
-  git(ORIGIN, ['config', 'user.name', 'Test']);
   await fs.writeFile(path.join(ORIGIN, 'a.txt'), 'one', 'utf8');
   git(ORIGIN, ['add', '.']);
   git(ORIGIN, ['commit', '-qm', 'one']);
   git(process.cwd(), ['clone', '-q', ORIGIN, CLONE]);
-  git(CLONE, ['config', 'user.email', 'test@example.com']);
-  git(CLONE, ['config', 'user.name', 'Test']);
 }
 
 describe('checkPublishGate', () => {

--- a/tests/cloud/publish-push.test.ts
+++ b/tests/cloud/publish-push.test.ts
@@ -2,6 +2,7 @@
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { CloudApiError, type CloudApi, type CloudRole } from '../../src/cloud/api-client.js';
 import type { PublishOutcome } from '../../src/cloud/sync-contract.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
@@ -20,7 +21,8 @@ import type { ProjectConfig } from '../../src/core/types.js';
 
 const API_HOST = 'https://api.push.test';
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+const git = (cwd: string, args: string[]) => spawnSync('git', gitArgs(args), { cwd, encoding: 'utf8' });
 
 /**
  * Fresh directories and a fresh workspace id per test, rather than one pair wiped between them.
@@ -115,12 +117,8 @@ describe('pushStaged', () => {
 
     await fs.mkdir(ORIGIN, { recursive: true });
     git(ORIGIN, ['init', '-q', '-b', 'main']);
-    git(ORIGIN, ['config', 'user.email', 'test@example.com']);
-    git(ORIGIN, ['config', 'user.name', 'Test']);
     await commitToOrigin('a.txt');
     git(process.cwd(), ['clone', '-q', ORIGIN, CLONE]);
-    git(CLONE, ['config', 'user.email', 'test@example.com']);
-    git(CLONE, ['config', 'user.name', 'Test']);
 
     await fs.mkdir(path.join(CLONE, '.knowl'), { recursive: true });
     await fs.writeFile(path.join(CLONE, '.knowl', 'config.json'), JSON.stringify({ version: 1 }), 'utf8');

--- a/tests/cloud/retract.test.ts
+++ b/tests/cloud/retract.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import type { CloudApi } from '../../src/cloud/api-client.js';
 import type { UpdateItemBody } from '../../src/cloud/sync-contract.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
@@ -16,7 +17,8 @@ import type { ProjectConfig } from '../../src/core/types.js';
 const API_HOST = 'https://api.retract.test';
 const HOME = path.resolve('./.knowl-retract-home');
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+const git = (cwd: string, args: string[]) => spawnSync('git', gitArgs(args), { cwd, encoding: 'utf8' });
 
 // Fresh directories per test, for the Windows reason `publish-push.test.ts` documents: libSQL can
 // hold the database inside the clone, the `rm` is refused, and the next clone fails into a
@@ -68,8 +70,6 @@ describe('retracting a published atom', () => {
 
     await fs.mkdir(ORIGIN, { recursive: true });
     git(ORIGIN, ['init', '-q', '-b', 'main']);
-    git(ORIGIN, ['config', 'user.email', 'test@example.com']);
-    git(ORIGIN, ['config', 'user.name', 'Test']);
     await fs.writeFile(path.join(ORIGIN, 'a.txt'), 'a', 'utf8');
     git(ORIGIN, ['add', '.']);
     git(ORIGIN, ['commit', '-qm', 'a']);

--- a/tests/cloud/status.test.ts
+++ b/tests/cloud/status.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import * as repo from '../../src/store/repository.js';
@@ -14,7 +15,8 @@ import type { ProjectConfig } from '../../src/core/types.js';
 
 const API_HOST = 'https://api.status.test';
 
-const git = (cwd: string, args: string[]) => spawnSync('git', args, { cwd, encoding: 'utf8' });
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+const git = (cwd: string, args: string[]) => spawnSync('git', gitArgs(args), { cwd, encoding: 'utf8' });
 
 // Fresh directories per test, for the Windows reason `publish-push.test.ts` documents.
 let run = 0;
@@ -43,8 +45,6 @@ describe('cloudStatus', () => {
 
     await fs.mkdir(ORIGIN, { recursive: true });
     git(ORIGIN, ['init', '-q', '-b', 'main']);
-    git(ORIGIN, ['config', 'user.email', 'test@example.com']);
-    git(ORIGIN, ['config', 'user.name', 'Test']);
     await fs.writeFile(path.join(ORIGIN, 'a.txt'), 'one', 'utf8');
     git(ORIGIN, ['add', '.']);
     git(ORIGIN, ['commit', '-qm', 'one']);

--- a/tests/git-identity.ts
+++ b/tests/git-identity.ts
@@ -1,0 +1,38 @@
+/**
+ * The identity fixture repositories commit under, carried on the invocation rather than written
+ * into a config file.
+ *
+ * **`git config user.email X` in a fixture directory can escape into this repository.** `git
+ * config` with no `--file` searches upward for the repository it belongs to, so when the fixture
+ * has no `.git` at that moment -- the window between `git init` and the next line, or a run
+ * interrupted before it -- the write lands on the nearest enclosing repository, which for a
+ * fixture under the repo root is knowl itself. It then persists: a local `user.email` overrides
+ * the developer's global one for every later commit, silently.
+ *
+ * That is not hypothetical. On 2026-08-11 this repository's `.git/config` held
+ * `user.email = test@example.com`; the next commit went out authored by it, GitHub resolved the
+ * address to an unrelated person's account, and the CLA check failed against a stranger who had
+ * of course never signed. The commit had to be re-authored and force-pushed.
+ *
+ * `-c` cannot do that. It sets the value for one process and writes no file, so there is no file
+ * to land in the wrong place -- which makes this a fix for the mechanism rather than for the
+ * thirteen call sites that happened to have it. `tests/architecture/git-identity.test.ts` keeps
+ * `git config user.*` from coming back.
+ *
+ * One identity for every fixture, because no assertion anywhere reads one: each suite had
+ * invented its own address and every occurrence was the two lines setting it.
+ */
+export const GIT_IDENTITY = [
+  // No space in the name, deliberately: `GIT_IDENTITY_FLAGS` below interpolates these into a
+  // command string, where a space would need quoting that differs between cmd.exe and sh.
+  '-c', 'user.name=Knowl-Test',
+  '-c', 'user.email=knowl-test@example.test',
+] as const;
+
+/** `args`, with the identity flags in front. Git requires `-c` before the subcommand. */
+export function gitArgs(args: readonly string[]): string[] {
+  return [...GIT_IDENTITY, ...args];
+}
+
+/** The same, for the call sites that build a command string rather than an argument array. */
+export const GIT_IDENTITY_FLAGS = GIT_IDENTITY.join(' ');

--- a/tests/global-teardown.ts
+++ b/tests/global-teardown.ts
@@ -241,6 +241,31 @@ export async function setup(): Promise<void> {
     process.env[key] = runRoot;
   }
   process.env[RUN_ROOT_ENV] = runRoot;
+
+  // A git identity for every fixture repository, set the one way a call site cannot forget.
+  //
+  // **Not `git config`, ever.** `git config` with no `--file` searches upward for the repository
+  // the directory belongs to, so a fixture built at `path.resolve('./.knowl-...')` that has no
+  // `.git` yet -- the window between `git init` and the next line, or a run interrupted before
+  // it -- writes into THIS repository instead. That happened: knowl's own `.git/config` acquired
+  // `user.email = test@example.com` from a suite, the next commit went out authored by it,
+  // GitHub resolved the address to an unrelated person's account, and the CLA check failed
+  // against a stranger. See `tests/git-identity.ts` and the contract test beside it.
+  //
+  // **Here rather than at each call site, and that distinction cost a CI run.** Converting the
+  // thirteen suites that called `git config` to pass `-c` on their own helpers left the git
+  // commands those files run *elsewhere* with no identity at all -- and it passed locally,
+  // because a developer's global `~/.gitconfig` supplies one. CI runners have none, so
+  // `git commit` there failed with "Author identity unknown" on both ubuntu legs. These
+  // variables are inherited by every child process of every worker, so they reach the call sites
+  // nobody remembered, including ones not written yet.
+  //
+  // Both halves: git requires AUTHOR and COMMITTER separately, and setting only one still
+  // refuses the commit.
+  process.env.GIT_AUTHOR_NAME ??= 'Knowl-Test';
+  process.env.GIT_AUTHOR_EMAIL ??= 'knowl-test@example.test';
+  process.env.GIT_COMMITTER_NAME ??= 'Knowl-Test';
+  process.env.GIT_COMMITTER_EMAIL ??= 'knowl-test@example.test';
 }
 
 /** True when nothing has touched this directory for `minAgeMs`. */

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { GIT_IDENTITY_FLAGS } from '../git-identity.js';
 import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
 import { DEFAULT_CONTEXT_MAX_CHARS } from '../../src/core/token-budget.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
@@ -14,7 +15,9 @@ import * as repo from '../../src/store/repository.js';
 
 const ROOT = path.resolve('.knowl-drift-auto-test');
 
-const git = (args: string) => execSync(`git ${args}`, { cwd: ROOT, encoding: 'utf-8' });
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`. This suite is
+// the one that leaked: its values are what turned up in this repository's own `.git/config`.
+const git = (args: string) => execSync(`git ${GIT_IDENTITY_FLAGS} ${args}`, { cwd: ROOT, encoding: 'utf-8' });
 
 const commitFile = async (relPath: string, content: string, message: string): Promise<string> => {
   const filePath = path.join(ROOT, relPath);
@@ -42,8 +45,6 @@ describe('automatic drift check', () => {
     await fs.rm(ROOT, { recursive: true, force: true });
     await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
     git('init');
-    git('config user.email test@example.com');
-    git('config user.name Test');
     await commitFile('src/billing.ts', 'export const rate = 1;\n', 'add billing');
     await initDb(ROOT);
     projectId = (await repo.createProject(ROOT, 'Drift auto test')).id;

--- a/tests/store/impact-lifecycle.test.ts
+++ b/tests/store/impact-lifecycle.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
 import { renderChangeCard } from '../../src/session/change-card.js';
 import { listCodeSymbols } from '../../src/code/symbol-index.js';
@@ -66,8 +67,9 @@ let testIndex = 0;
 let projectId = '';
 let eventIndex = 0;
 
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
 function git(...args: string[]): void {
-  const result = spawnSync('git', args, { cwd: testRoot, encoding: 'utf-8', stdio: 'pipe' });
+  const result = spawnSync('git', gitArgs(args), { cwd: testRoot, encoding: 'utf-8', stdio: 'pipe' });
   if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr ?? ''}`);
 }
 
@@ -140,8 +142,6 @@ beforeEach(async () => {
   await fs.mkdir(path.join(testRoot, '.knowl'), { recursive: true });
 
   git('init', '-q', '.');
-  git('config', 'user.email', 'lane-h@example.test');
-  git('config', 'user.name', 'lane h');
   // The store lives inside the repo it indexes; without this, `git check-ignore` would let the
   // database's own sidecar files into the index.
   await write('.gitignore', '.knowl/\n');

--- a/tests/store/impact-precision.test.ts
+++ b/tests/store/impact-precision.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { indexFile, listCodeSymbols } from '../../src/code/symbol-index.js';
 import { detectCertainImpact } from '../../src/session/impact.js';
@@ -485,8 +486,9 @@ const BENIGN: Scenario[] = [
 let testRoot = '';
 let testIndex = 0;
 
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
 function git(root: string, ...args: string[]): void {
-  const result = spawnSync('git', args, { cwd: root, encoding: 'utf-8', stdio: 'pipe' });
+  const result = spawnSync('git', gitArgs(args), { cwd: root, encoding: 'utf-8', stdio: 'pipe' });
   if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr ?? ''}`);
 }
 
@@ -540,8 +542,6 @@ beforeEach(async () => {
   await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
   await fs.mkdir(path.join(testRoot, '.knowl'), { recursive: true });
   git(testRoot, 'init', '-q', '.');
-  git(testRoot, 'config', 'user.email', 'precision@example.test');
-  git(testRoot, 'config', 'user.name', 'precision');
   await write('.gitignore', '.knowl/\n');
   await initDb(testRoot);
 });

--- a/tests/store/impact.test.ts
+++ b/tests/store/impact.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { indexFile, listCodeSymbols } from '../../src/code/symbol-index.js';
 import {
@@ -54,8 +55,9 @@ const V1_BODY_EDITED = `export function createSession(user: User): Session {
 let testRoot = '';
 let testIndex = 0;
 
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
 function git(root: string, ...args: string[]): void {
-  const result = spawnSync('git', args, { cwd: root, encoding: 'utf-8', stdio: 'pipe' });
+  const result = spawnSync('git', gitArgs(args), { cwd: root, encoding: 'utf-8', stdio: 'pipe' });
   if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr ?? ''}`);
 }
 
@@ -110,8 +112,6 @@ beforeEach(async () => {
   await fs.mkdir(path.join(testRoot, '.knowl'), { recursive: true });
 
   git(testRoot, 'init', '-q', '.');
-  git(testRoot, 'config', 'user.email', 'lane-e@example.test');
-  git(testRoot, 'config', 'user.name', 'lane e');
   // The store lives inside the repo it indexes, so it has to be ignored or every working-tree
   // assertion below would be dominated by the database's own sidecar files.
   await write('.gitignore', '.knowl/\n');

--- a/tests/store/session-evidence.test.ts
+++ b/tests/store/session-evidence.test.ts
@@ -2,17 +2,21 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { GIT_IDENTITY_FLAGS } from '../git-identity.js';
 import { collectSessionGitEvidence } from '../../src/store/session-evidence.js';
 
 const ROOT = path.resolve('./.knowl-session-evidence-test');
 
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
+const git = (args: string) => execSync(`git ${GIT_IDENTITY_FLAGS} ${args}`, { cwd: ROOT });
+
 describe('session evidence', () => {
   beforeAll(async () => {
     await fs.rm(ROOT, { recursive: true, force: true }); await fs.mkdir(path.join(ROOT, 'src'), { recursive: true });
-    execSync('git init', { cwd: ROOT }); execSync('git config user.email test@example.test', { cwd: ROOT }); execSync('git config user.name Test', { cwd: ROOT });
+    git('init');
     await fs.writeFile(path.join(ROOT, 'src', 'app.ts'), 'export const version = 1;\n');
     await fs.writeFile(path.join(ROOT, '.env'), 'SECRET=value\n');
-    execSync('git add .', { cwd: ROOT }); execSync('git commit -m base', { cwd: ROOT });
+    git('add .'); git('commit -m base');
     await fs.writeFile(path.join(ROOT, 'src', 'app.ts'), 'export const version = 2;\n');
     await fs.writeFile(path.join(ROOT, '.env'), 'SECRET=changed\n');
     await fs.writeFile(path.join(ROOT, 'src', 'asset.bin'), Buffer.from([0, 1, 2]));

--- a/tests/store/write-gate.test.ts
+++ b/tests/store/write-gate.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gitArgs } from '../git-identity.js';
 import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
 import { listCodeSymbols, indexFile } from '../../src/code/symbol-index.js';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
@@ -75,8 +76,9 @@ const AT = '2026-08-05T00:00:00.000Z';
 let testRoot = '';
 let testIndex = 0;
 
+// Identity on every invocation, never `git config` -- see `tests/git-identity.ts`.
 function git(...args: string[]): void {
-  const result = spawnSync('git', args, { cwd: testRoot, encoding: 'utf-8', stdio: 'pipe' });
+  const result = spawnSync('git', gitArgs(args), { cwd: testRoot, encoding: 'utf-8', stdio: 'pipe' });
   if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr ?? ''}`);
 }
 
@@ -156,8 +158,6 @@ beforeEach(async () => {
   await fs.mkdir(path.join(testRoot, '.knowl'), { recursive: true });
 
   git('init', '-q', '.');
-  git('config', 'user.email', 'lane-l@example.test');
-  git('config', 'user.name', 'lane l');
   // The store lives inside the repo it indexes, so it has to be ignored.
   await write('.gitignore', '.knowl/\n');
   await write(SOURCE, V1);


### PR DESCRIPTION
> **Stacked on #76.** Base is `fix/archive-reader-silent-losses`, so the diff here is only this
> change. `scripts/e2e-cloud.ts` is touched by both, which is why this is stacked rather than
> branched from `main` — GitHub will retarget the base to `main` automatically when #76 merges.

## The bug this closes bit us while opening #76

`git config user.email X` run against a fixture directory can write into **this** repository.
`git config` with no `--file` searches upward for the repository the directory belongs to, so
when the fixture has no `.git` at that instant — the window between `git init` and the next
line, or a run interrupted before it — the write lands on the nearest enclosing repository.
Fixtures here are routinely built at `path.resolve('./.knowl-...')`, which is inside knowl.

It happened, and nothing caught it. This repository's `.git/config` held:

```
[user]
	name = Test
	email = test@example.com
```

— matching [drift-auto.test.ts:45-46](tests/store/drift-auto.test.ts#L45-L46) exactly. The next
commit went out authored by it, GitHub resolved `test@example.com` to an **unrelated person's
account**, and the `cla` check failed correctly against a stranger who had never signed it. The
commit had to be re-authored and force-pushed.

A local `user.email` silently overrides the developer's global one for every later commit, so
nothing about the working copy looks wrong afterwards. That is what makes it worth a guard
rather than a note.

## The fix, in two commits, and the second is the interesting one

**`a4a3d9c` — carry the identity on the invocation.** `git -c user.name=... -c user.email=...`
sets the value for one process and writes no file, so there is no file to land in the wrong
place. 26 call sites across five `tests/cloud/` suites, six `tests/store/` suites,
`tests/cli/cli.test.ts`, and both `scripts/e2e-*.ts`. The pattern was already here —
[index-pass.test.ts:205](tests/transcripts/index-pass.test.ts#L205) has always done it this way.

One identity for all of them rather than the nine each suite had invented, because **no
assertion anywhere reads one** — checked before collapsing them.

**`700b984` — put it in the environment, because the first commit was not enough, and only CI
could tell.** Converting each suite's helper covers the call sites you edited. It missed a
second, raw `execSync('git commit ...')` sixty lines below the helper in `cli.test.ts`. Every
local run passed, because a developer's global `~/.gitconfig` supplies an identity and the raw
call silently inherited it. CI runners have none:

```
fatal: empty ident name (for <runner@runnervmvrwv9...>) not allowed
```

Three legs — ubuntu 22, ubuntu 24, windows 22 — one test, one cause.

The lesson is about the shape of the fix rather than the one missed line: a convention every
call site must remember is one some call site will not, including sites not written yet. So the
identity now comes from `GIT_AUTHOR_*` and `GIT_COMMITTER_*` set in the vitest global setup,
beside the TMPDIR redirect and relying on the same property — workers inherit the parent
environment — so every existing and future git invocation is covered with no test-file change.
All four variables, because git requires AUTHOR and COMMITTER separately and refuses on either
alone.

The `-c` flags stay: they are what keeps `git config` out of the tree, and they are the only
mechanism available to `scripts/e2e-*.ts`, which do not run under vitest.

## The guard

`tests/architecture/git-identity.test.ts`, beside the module-boundary contract and for the same
stated reason: nothing was looking. Two halves:

1. **No `git config user.*` in `tests/` or `scripts/`.** Names the offending file and line
   rather than counting them (the fix is per line). Comment lines are exempt — every place this
   rule is explained has to name the thing it forbids.
2. **The identity reaches a worker.** Asserted in a worker rather than trusted from `setup`,
   because inheritance across the worker boundary is the property being relied on.

Verified to discriminate, not just to pass. Reintroducing a call:

```
tests/store/write-gate.test.ts:161: git('config', 'user.email', 'sneaky@example.test');
```

## Verification

`typecheck`, `lint`, `git diff --check` clean.

**Run under CI's condition rather than this machine's**, which is the check that was missing the
first time. With `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` pointed at an empty file, so no
global identity exists anywhere:

```
: > /tmp/empty-gitconfig
GIT_CONFIG_GLOBAL=/tmp/empty-gitconfig GIT_CONFIG_SYSTEM=/tmp/empty-gitconfig npx vitest run
→ 305 files, 2,741 passed, 5 skipped, 0 failed
```

The same command reproduces the CI failure on `a4a3d9c`, so it discriminates.

## Follow-up this surfaced, deliberately not in scope

Local full runs on this branch also hit `EPERM: operation not permitted, rename '<file>.tmp' ->
'<file>'` in files this PR never touches. That is the known Windows atomic-write flake, and it
has now crossed the threshold the earlier investigation set for it (*"more than roughly one run
in ten"*): two of three local full runs. **I initially mistook it for the whole story and missed
the identity regression underneath it** — worth saying, because the same reasoning error is
available to the next person.

The remedy that investigation named is a bounded retry around the rename in the atomic-write
helper — one place, since every call site goes through it — covering `src/core/config.ts:209`
and `src/cloud/credentials.ts:65`. It is a real product bug on Windows, not only test noise:
`saveConfig` throwing EPERM means an ordinary `knowl init` can fail. Left out because it changes
shipped code and is unrelated to git identity. Worth its own PR.
