### PR TITLE
fix(windows): retry the atomic-write rename, and stop maintaining two of them

### DIFF
--- a/src/cloud/credentials.ts
+++ b/src/cloud/credentials.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { writeFileAtomic } from '../core/atomic-write.js';
 import { knowlHome } from '../core/paths.js';
 
 export type CloudCredential = {
@@ -50,19 +51,20 @@ async function readFileOrEmpty(): Promise<CredentialFile> {
   }
 }
 
-/** Distinguishes two writes in flight in one process; the pid alone does not. */
-let temporaryCounter = 0;
-
+/**
+ * The shared helper rather than a second implementation of it.
+ *
+ * These were two copies of one idea -- stage beside the target, then rename -- and they had
+ * drifted: `writeFileAtomic` flushes the handle before renaming and this did not, so an
+ * interrupted write here could leave an empty credentials file where the other left none. They
+ * also failed the same way on Windows, and the retry that fixes it belongs in one place, which
+ * is the whole reason for collapsing them rather than patching both.
+ *
+ * `mode` unconditionally: `writeFileAtomic` applies it at open and again after, and swallows the
+ * `chmod` failure, so the `platform !== 'win32'` guard this used to carry is already handled.
+ */
 async function writeFileAtomically(file: CredentialFile): Promise<void> {
-  const target = credentialsPath();
-  await fs.mkdir(path.dirname(target), { recursive: true });
-  // Same directory, so the rename is on one filesystem and therefore atomic. A temp file in
-  // the OS temp dir can land on another volume, where rename degrades to copy-then-delete
-  // and a reader can observe a half-written file.
-  const temporary = `${target}.${process.pid}.${temporaryCounter++}.tmp`;
-  await fs.writeFile(temporary, `${JSON.stringify(file, null, 2)}\n`, 'utf8');
-  if (process.platform !== 'win32') await fs.chmod(temporary, 0o600);
-  await fs.rename(temporary, target);
+  await writeFileAtomic(credentialsPath(), `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
 }
 
 /**

--- a/src/core/atomic-write.ts
+++ b/src/core/atomic-write.ts
@@ -3,6 +3,48 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 /**
+ * Errors that mean "someone else has the destination open right now", not "this cannot work".
+ *
+ * Windows refuses a rename onto a path any other handle still holds, and the usual holder is an
+ * antivirus or the search indexer reading the temporary file this function just finished writing
+ * -- so the very act of creating the file is what provokes the block. It clears on its own in
+ * tens of milliseconds.
+ *
+ * Deliberately narrow. `ENOENT` means the staged file is gone, which is a bug rather than
+ * contention, and `ENOSPC` will not improve by asking again; retrying either would turn a clear
+ * failure into a slow one.
+ */
+const CONTENDED = new Set(['EPERM', 'EACCES', 'EBUSY']);
+
+/** Attempts, and the backoff before each retry. ~150 ms in the worst case, imperceptible. */
+const RENAME_ATTEMPTS = 5;
+const RENAME_BACKOFF_MS = 10;
+
+/**
+ * `fs.rename`, surviving a destination another process has open for a moment.
+ *
+ * Not platform-gated, though Windows is where it fires: a network or virtualised filesystem can
+ * report the same contention anywhere, and a retry that never triggers costs nothing.
+ *
+ * The original error is what escapes when the attempts run out. A wrapper naming the retry would
+ * put this function in front of the fact the caller needs -- which file, and why.
+ */
+async function renameWithRetry(staged: string, target: string): Promise<void> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await fs.rename(staged, target);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code ?? '';
+      if (attempt >= RENAME_ATTEMPTS || !CONTENDED.has(code)) throw error;
+      // Linear, not exponential: this waits out a virus scanner reading one small file, and the
+      // whole budget is smaller than a single exponential step would grow to.
+      await new Promise(resolve => setTimeout(resolve, RENAME_BACKOFF_MS * attempt));
+    }
+  }
+}
+
+/**
  * Replace a file's contents in one observable step.
  *
  * A direct `writeFile` truncates first, so an interrupted write leaves a half file that
@@ -12,6 +54,13 @@ import path from 'node:path';
  *
  * `mode` is applied at create time and again after, because a permissive umask can widen the
  * mode passed to `open`.
+ *
+ * **The rename retries, and that is load-bearing rather than defensive.** It was the single most
+ * frequent cause of a red Windows run in this repository -- `EPERM: operation not permitted,
+ * rename '<file>.tmp' -> '<file>'`, always a different file, never reproducible in isolation, and
+ * for months answered by re-running the leg. It is not only a test problem: every caller here
+ * writes a file a user cares about, so the same moment makes `knowl init` fail on a Windows
+ * machine with an antivirus, which is most of them.
  */
 export async function writeFileAtomic(
   target: string,
@@ -30,7 +79,7 @@ export async function writeFileAtomic(
       await handle.close();
     }
     if (options.mode !== undefined) await fs.chmod(staged, options.mode).catch(() => {});
-    await fs.rename(staged, target);
+    await renameWithRetry(staged, target);
   } catch (error) {
     await fs.rm(staged, { force: true }).catch(() => {});
     throw error;

--- a/tests/core/atomic-write.test.ts
+++ b/tests/core/atomic-write.test.ts
@@ -1,15 +1,23 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { writeFileAtomic } from '../../src/core/atomic-write.js';
 import { loadConfig, saveConfig } from '../../src/core/config.js';
 
 const TEST_ROOT = path.resolve('./.knowl-atomic-write-test');
 
+/** An `fs` error as Node reports it, since the retry decides on `code` alone. */
+const errno = (code: string): NodeJS.ErrnoException =>
+  Object.assign(new Error(`${code}: operation not permitted, rename`), { code });
+
 describe('atomic writes', () => {
   beforeAll(async () => {
     await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
     await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   afterAll(async () => {
@@ -34,5 +42,63 @@ describe('atomic writes', () => {
     await saveConfig(TEST_ROOT, { ai: { provider: 'openai', model: 'gpt-4o-mini' } } as any);
     expect((await fs.stat(path.join(TEST_ROOT, '.knowl', 'config.json'))).mode & 0o777).toBe(0o600);
     expect((await loadConfig(TEST_ROOT)).ai?.model).toBe('gpt-4o-mini');
+  });
+
+  /**
+   * The rename retry, which is why this file exists at all on Windows.
+   *
+   * Injected rather than provoked: the real cause is an antivirus opening the temporary file in
+   * the microsecond after it is closed, which cannot be arranged on demand -- it is exactly the
+   * "never reproducible in isolation" that had this answered by re-running CI for months.
+   */
+  describe('a destination another process holds open for a moment', () => {
+    it('retries the rename and completes the write', async () => {
+      const target = path.join(TEST_ROOT, 'contended.json');
+      const real = fs.rename;
+      let attempts = 0;
+      vi.spyOn(fs, 'rename').mockImplementation(async (from, to) => {
+        attempts += 1;
+        // Two refusals, then through -- the shape of a scanner releasing the handle.
+        if (attempts <= 2) throw errno('EPERM');
+        return real(from, to);
+      });
+
+      await writeFileAtomic(target, '{"survived":true}');
+
+      expect(attempts).toBe(3);
+      expect(await fs.readFile(target, 'utf8')).toBe('{"survived":true}');
+      expect((await fs.readdir(TEST_ROOT)).filter(entry => entry.includes('.tmp'))).toEqual([]);
+    });
+
+    it('gives up bounded, and throws the error the caller needs rather than one about retrying', async () => {
+      const target = path.join(TEST_ROOT, 'never-free.json');
+      let attempts = 0;
+      vi.spyOn(fs, 'rename').mockImplementation(async () => {
+        attempts += 1;
+        throw errno('EBUSY');
+      });
+
+      await expect(writeFileAtomic(target, '{}')).rejects.toThrow(/EBUSY/);
+
+      expect(attempts).toBe(5);
+      // The staged file is still cleaned up on the way out, so a wedged destination does not
+      // accumulate a temporary per attempt.
+      expect((await fs.readdir(TEST_ROOT)).filter(entry => entry.includes('.tmp'))).toEqual([]);
+    });
+
+    it('does not retry an error that will not clear', async () => {
+      // ENOENT means the staged file is gone, which is a bug rather than contention. Retrying it
+      // would turn an immediate, clear failure into a slow one.
+      const target = path.join(TEST_ROOT, 'not-contention.json');
+      let attempts = 0;
+      vi.spyOn(fs, 'rename').mockImplementation(async () => {
+        attempts += 1;
+        throw errno('ENOENT');
+      });
+
+      await expect(writeFileAtomic(target, '{}')).rejects.toThrow(/ENOENT/);
+
+      expect(attempts).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## The flake, and why it is now worth fixing

`EPERM: operation not permitted, rename '<file>.tmp' -> '<file>'` has been the most frequent
cause of a red Windows run here. Windows refuses a rename onto a path any other handle still
holds, and the usual holder is an antivirus or the search indexer reading the temporary file the
write has just finished producing — so creating the file is itself what provokes the block. It
clears on its own in tens of milliseconds.

It has been answered by re-running the leg since 2026-08-10, on an explicit recorded judgement
that a retry was not yet earned: *"if it starts appearing in more than roughly one run in ten"*.
**It now does.** Three local full runs on one machine within the hour on 2026-08-11:

| Run | Result |
| --- | --- |
| 1 | green — 304 files, 2,739 passed |
| 2 | **7 failed across 2 files** — `federated-query` on `config.json`, six `publish-push` tests downstream of `credentials.json` |
| 3 | **2 failed across 2 files** — `publish-push` on `credentials.json`, `query-lineage-and-miss` on `config.json` |

Every failure this shape, every one in a different file, and **the failing set differed between
runs** — which is what says race rather than regression.

## It is not only a test problem

That is the reason this is not simply a flake to re-run. Every caller writes a file a user cares
about:

- `saveConfig` (`src/core/config.ts`) — an ordinary `knowl init` or `knowl config set` fails on a
  Windows machine with an antivirus, which is most of them.
- `writeCredential` (`src/cloud/credentials.ts`) — a lost login.
- the skills trust file (`src/skills/trust.ts`).

## The fix

`writeFileAtomic` retries the rename: five attempts, linear 10 ms backoff, ~150 ms worst case
and imperceptible. Linear rather than exponential because this waits out a scanner reading one
small file, and the whole budget is smaller than a single exponential step would grow to.

**Narrow on purpose.** Only `EPERM`, `EACCES` and `EBUSY`, which mean "someone has it open right
now". `ENOENT` means the staged file is gone, which is a bug rather than contention, and `ENOSPC`
will not improve by asking again — retrying either turns a clear failure into a slow one. The
original error is what escapes when the attempts run out, because a wrapper naming the retry
would stand in front of the fact the caller needs: which file, and why.

## One helper, not two

`credentials.ts` carried a second implementation of the same idea. It is deleted rather than
given its own copy of the retry — the earlier investigation said the fix belongs *"in the
atomic-write helper, not at the call sites"*, and that is only true while there is one.

They had already drifted, which is the argument in miniature: `writeFileAtomic` flushes the
handle before renaming and that one did not, so an interrupted write there could leave an **empty
credentials file** where the other left none. That is fixed as a side effect of collapsing them.

## Tests

The retry is **injected, not provoked**. The real cause is a scanner opening the file in the
microsecond after it is closed, which cannot be arranged on demand — exactly the "never
reproducible in isolation" that had this re-run for months. Three cases:

- two refusals then through — asserts the rename was attempted three times and the content landed
- refused forever — bounded at five attempts, the caller's own `EBUSY` escapes, and no temporary
  is left behind
- `ENOENT` — attempted once, not retried

Verified to discriminate: with the retry reverted to a plain `fs.rename`, the first two fail.

## Verification

`typecheck`, `lint`, `git diff --check` clean. Every `writeFileAtomic` caller's suite passes
(44 tests across 7 files). Full suite **305 files, 2,744 passed, 5 skipped, 0 failed** — with no
EPERM anywhere in the run.
