### PR TITLE
fix(transcripts): say what --all left behind, and match a Codex worktree the way the Claude half does

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -99,7 +99,7 @@ import {
   listCandidates,
   planExtraction,
 } from '../transcripts/extract-candidates.js';
-import { approveCandidates, discardCandidates } from '../transcripts/approve-candidates.js';
+import { APPROVE_ALL_LIMIT, approveCandidates, discardCandidates } from '../transcripts/approve-candidates.js';
 import { applyTranscriptConfigTransition, describeTranscriptTeardown } from '../transcripts/teardown.js';
 
 // Load environment variables (.env file)
@@ -1940,7 +1940,7 @@ transcripts
 transcripts
   .command('approve [ids...]')
   .description('Promote staged candidates into the knowledge store')
-  .option('--all', 'Approve every pending candidate')
+  .option('--all', `Approve up to ${APPROVE_ALL_LIMIT} pending candidates`)
   .action(async (ids: string[], options) => {
     try {
       if (!options.all && (!ids || ids.length === 0)) {
@@ -1956,6 +1956,11 @@ transcripts
       console.log(`Approved ${result.approved} candidate(s).`);
       if (result.deduped > 0) console.log(`${result.deduped} merged into knowledge the store already held.`);
       for (const failure of result.failed) console.log(`Failed ${failure.id}: ${failure.reason}`);
+      // Said out loud, because `--all` stops at a cap and a first run over a real archive
+      // produces atoms on that order. "Approved 1000 candidate(s)" alone reads as finished.
+      if (result.remaining > 0) {
+        console.log(`${result.remaining} still pending. Run approve --all again to continue.`);
+      }
       await closeTranscriptDbs();
     } catch (error: any) {
       console.error(`Error approving: ${error.message}`);

--- a/src/transcripts/approve-candidates.ts
+++ b/src/transcripts/approve-candidates.ts
@@ -24,12 +24,28 @@ import { candidateToAtom, listCandidates, type ExtractionCandidate } from './ext
  * accept work that has already been paid for.
  */
 
+/** How many candidates one `--all` run promotes before stopping. */
+export const APPROVE_ALL_LIMIT = 1_000;
+
 export type ApprovalResult = {
   approved: number;
   /** Candidates the merge path folded into an item that already said this. */
   deduped: number;
   failed: { id: string; reason: string }[];
   itemIds: string[];
+  /**
+   * Candidates still `pending` when this run finished.
+   *
+   * Reported because `--all` does not mean all: it promotes `APPROVE_ALL_LIMIT` at most, and the
+   * first run over a real archive produces atoms on that order -- so the cap lands on precisely
+   * the run it was written for. Saying only "Approved 1000 candidate(s)" reads as completion, and
+   * the operator who believes it stops with the rest of their archive unreviewed and no signal
+   * that anything remains.
+   *
+   * Counts failures too, which are also still pending: what this number answers is "is there more
+   * to decide", and a candidate that refused to promote is exactly that.
+   */
+  remaining: number;
 };
 
 function parseTags(raw: unknown): string[] | null {
@@ -84,12 +100,12 @@ export async function approveCandidates(
   selection: { ids?: string[]; all?: boolean; limit?: number },
 ): Promise<ApprovalResult> {
   const targets = selection.all
-    ? (await listCandidates(db, { status: 'pending', limit: selection.limit ?? 1_000 }))
+    ? (await listCandidates(db, { status: 'pending', limit: selection.limit ?? APPROVE_ALL_LIMIT }))
       .map(candidate => candidate.id)
     : selection.ids ?? [];
 
   const candidates = await loadCandidates(db, targets);
-  const result: ApprovalResult = { approved: 0, deduped: 0, failed: [], itemIds: [] };
+  const result: ApprovalResult = { approved: 0, deduped: 0, failed: [], itemIds: [], remaining: 0 };
 
   for (const candidate of candidates) {
     try {
@@ -131,6 +147,12 @@ export async function approveCandidates(
       result.failed.push({ id: candidate.id, reason: (error as Error).message });
     }
   }
+
+  // Counted from the store after the run rather than derived from the cap, so it stays right
+  // whatever a concurrent extraction added and whatever failed.
+  result.remaining = Number((await db.execute(
+    `SELECT COUNT(*) AS n FROM transcript_candidates WHERE status = 'pending'`,
+  )).rows[0]?.n ?? 0);
 
   return result;
 }

--- a/src/transcripts/paths.ts
+++ b/src/transcripts/paths.ts
@@ -190,17 +190,24 @@ async function collectCodexFiles(dir: string, found: string[], depth: number): P
  * Roots are compared with `foldPath`, which the Claude path already needs for the same reason and
  * which matters more here: this archive records both `D:\coding\knowl` and `d:\coding\knowl` for
  * one repository, because the drive letter's case follows however the agent was launched.
+ *
+ * `uncanonicalise` is taken rather than skipped, and its absence here was a real gap. A `cwd` is
+ * whatever the agent's shell had, so it is the UN-resolved form -- exactly what `realpath` cannot
+ * produce from git's canonical answer. Without it a sibling worktree that git names only as
+ * `/private/var/folders/X-wt` matched no Codex session recorded in `/var/folders/X-wt`, on the
+ * same platforms and for the same reason the Claude path already handled.
  */
-async function scanCodexArchive(sessionsDir: string, roots: string[]): Promise<TranscriptScan> {
+async function scanCodexArchive(
+  sessionsDir: string,
+  roots: string[],
+  uncanonicalise: Uncanonicalise,
+): Promise<TranscriptScan> {
   const paths: string[] = [];
   const degraded = await collectCodexFiles(sessionsDir, paths, 0);
 
   const wanted = new Set<string>();
   for (const root of roots) {
-    const resolved = path.resolve(root);
-    wanted.add(foldPath(resolved));
-    const real = await fs.realpath(resolved).catch(() => null);
-    if (real) wanted.add(foldPath(real));
+    for (const form of await rootSpellings(root, uncanonicalise)) wanted.add(foldPath(form));
   }
 
   const files: TranscriptFile[] = [];
@@ -251,6 +258,65 @@ const foldPath = (target: string) =>
 const foldText = (text: string) => CASE_INSENSITIVE_PATHS ? text.toLowerCase() : text;
 
 const samePath = (left: string, right: string) => foldPath(left) === foldPath(right);
+
+/** Maps a canonical path back to the form an agent on this machine would have recorded. */
+type Uncanonicalise = (target: string) => string | null;
+
+/**
+ * The inverse of `realpath` for this machine, or a function that always declines.
+ *
+ * `realpath` only maps TOWARD the real path, but an archive is often named for the UN-canonical
+ * one: on macOS an agent launched in `/var/folders/X` records `/var/folders/X`, while
+ * `git worktree list` reports its sibling worktree only as `/private/var/folders/X-wt`. No amount
+ * of resolving git's answer produces the form the agent wrote. What is needed is the inverse
+ * substitution, and the project root is what reveals it -- knowing `/private/var` stands for
+ * `/var` here lets every canonical root be expressed the way the agent would have written it.
+ *
+ * Derived from the one pair we can see both halves of: the project root as given and as resolved,
+ * by taking their longest common tail. What is left in front is the substitution -- `/private/var`
+ * for `/var` on macOS, `C:\Users\runneradmin` for `C:\Users\RUNNER~1` on Windows. A whole-path
+ * prefix would not do, because a worktree is a SIBLING of the repo rather than a child of it.
+ *
+ * Measured before it was relied on: without this, every worktree session went unindexed on macOS
+ * and Windows while ubuntu, whose paths are already canonical, saw nothing wrong for months.
+ */
+async function deriveUncanonicalise(projectRoot: string): Promise<Uncanonicalise> {
+  const givenRoot = path.resolve(projectRoot);
+  const realGivenRoot = await fs.realpath(givenRoot).catch(() => givenRoot);
+  if (foldPath(realGivenRoot) === foldPath(givenRoot)) return () => null;
+
+  let shared = 0;
+  while (
+    shared < realGivenRoot.length && shared < givenRoot.length
+    && foldText(realGivenRoot[realGivenRoot.length - 1 - shared]) === foldText(givenRoot[givenRoot.length - 1 - shared])
+  ) shared += 1;
+  const realHead = realGivenRoot.slice(0, realGivenRoot.length - shared);
+  const givenHead = givenRoot.slice(0, givenRoot.length - shared);
+
+  return (target: string) => {
+    // `foldText`, because `realHead` is a leading fragment rather than a path and the slice below
+    // indexes into `target` by its raw length -- a comparison that had normalised either side
+    // would be measuring a different string than the one being cut.
+    if (!foldText(target).startsWith(foldText(realHead))) return null;
+    return givenHead + target.slice(realHead.length);
+  };
+}
+
+/**
+ * Every spelling of one root an agent might have recorded: as given, as resolved, and as
+ * un-resolved.
+ *
+ * Shared by both archives rather than written twice, which is the point: the Claude half had all
+ * three and the Codex half had only the first two, so a sibling worktree that git names only
+ * canonically matched a Claude session and silently missed the Codex sessions beside it. The two
+ * differ only in what they do with the forms -- Claude encodes them into a directory name, Codex
+ * compares them against the `cwd` inside each file.
+ */
+async function rootSpellings(root: string, uncanonicalise: Uncanonicalise): Promise<string[]> {
+  const resolved = path.resolve(root);
+  const forms = [resolved, await fs.realpath(resolved).catch(() => null), uncanonicalise(resolved)];
+  return forms.filter((form): form is string => Boolean(form));
+}
 
 /**
  * The path with every symlink and short name resolved away, or the path itself if it cannot be.
@@ -451,33 +517,12 @@ export async function scanTranscriptArchive(
   // `/private/var` stands for `/var` on macOS, `C:\Users\runneradmin` for `C:\Users\RUNNER~1`
   // on Windows. A whole-path prefix would not do, because a worktree is a SIBLING of the repo
   // rather than a child of it.
-  const givenRoot = path.resolve(projectRoot);
-  const realGivenRoot = await fs.realpath(givenRoot).catch(() => givenRoot);
-  let realHead = '';
-  let givenHead = '';
-  if (foldPath(realGivenRoot) !== foldPath(givenRoot)) {
-    let shared = 0;
-    while (
-      shared < realGivenRoot.length && shared < givenRoot.length
-      && foldText(realGivenRoot[realGivenRoot.length - 1 - shared]) === foldText(givenRoot[givenRoot.length - 1 - shared])
-    ) shared += 1;
-    realHead = realGivenRoot.slice(0, realGivenRoot.length - shared);
-    givenHead = givenRoot.slice(0, givenRoot.length - shared);
-  }
-  const uncanonicalise = (target: string): string | null => {
-    if (!realHead) return null;
-    // `foldText`, because `realHead` is a leading fragment rather than a path and the slice below
-    // indexes into `target` by its raw length -- a comparison that had normalised either side
-    // would be measuring a different string than the one being cut.
-    if (!foldText(target).startsWith(foldText(realHead))) return null;
-    return givenHead + target.slice(realHead.length);
-  };
+  const uncanonicalise = await deriveUncanonicalise(projectRoot);
 
   const wanted = new Set<string>();
   for (const root of rootSet.roots) {
-    const resolvedRoot = path.resolve(root);
-    for (const form of [resolvedRoot, await fs.realpath(resolvedRoot).catch(() => null), uncanonicalise(resolvedRoot)]) {
-      if (form) wanted.add(encodeProjectDir(form).toLowerCase());
+    for (const form of await rootSpellings(root, uncanonicalise)) {
+      wanted.add(encodeProjectDir(form).toLowerCase());
     }
   }
   const found: TranscriptFile[] = [];
@@ -541,7 +586,7 @@ export async function scanTranscriptArchive(
   const codexSessionsDir = options.codexSessionsDir
     ?? (options.projectsDir ? null : defaultCodexSessionsDir());
   if (codexSessionsDir) {
-    const codex = await scanCodexArchive(codexSessionsDir, rootSet.roots);
+    const codex = await scanCodexArchive(codexSessionsDir, rootSet.roots, uncanonicalise);
     found.push(...codex.files);
     degraded = degraded || codex.degraded;
   }

--- a/tests/transcripts/candidate-approval.test.ts
+++ b/tests/transcripts/candidate-approval.test.ts
@@ -126,6 +126,41 @@ describe('approving a staged candidate', () => {
     // The failure stays pending: retryable, and never silently reported as a decision.
     expect((await listCandidates(db, { status: 'pending' })).map(row => row.id)).toEqual([bad]);
   });
+
+  /**
+   * `--all` does not mean all, and the number that says so.
+   *
+   * The cap is deliberate -- approval writes atoms one at a time and an unbounded run over a
+   * whole archive is worse -- but the first run over a real archive produces atoms on that
+   * order, so the cap lands on precisely the run it exists for. Reporting only "Approved N"
+   * reads as completion, and the operator who believes it stops with the rest unreviewed.
+   */
+  it('says how many are still pending when --all stops at its cap', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      await stage(db, { title: `Atom ${index}`, content: `A distinct fact number ${index} worth keeping.` });
+    }
+
+    const first = await approveCandidates(db, projectId, DEFAULT_CONFIG, { all: true, limit: 2 });
+
+    expect(first.approved).toBe(2);
+    expect(first.remaining).toBe(3);
+
+    const second = await approveCandidates(db, projectId, DEFAULT_CONFIG, { all: true, limit: 10 });
+
+    expect(second.approved).toBe(3);
+    // Nothing left, and the caller can tell that apart from "I stopped early".
+    expect(second.remaining).toBe(0);
+  });
+
+  it('counts a failed candidate as still pending, because it is still a decision to make', async () => {
+    const bad = await stage(db, { category: 'not-a-category', title: 'Bad', content: 'Nonsense.' });
+    const good = await stage(db, { title: 'Fine', content: 'An ordinary fact that promotes cleanly.' });
+
+    const result = await approveCandidates(db, projectId, DEFAULT_CONFIG, { ids: [bad, good] });
+
+    expect(result.approved).toBe(1);
+    expect(result.remaining).toBe(1);
+  });
 });
 
 describe('the cold-start probe', () => {

--- a/tests/transcripts/codex-discovery.test.ts
+++ b/tests/transcripts/codex-discovery.test.ts
@@ -144,6 +144,47 @@ describe('Codex transcript discovery', () => {
     expect(found).toHaveLength(1);
   });
 
+  it('matches a worktree recorded under the un-resolved path, as the Claude half already did', async () => {
+    // The gap this closes. A `cwd` is whatever the agent's shell had, so it is the UN-resolved
+    // form -- and `git worktree list` answers canonically, which `realpath` cannot invert. On
+    // macOS that is `/var/folders/X` against git's `/private/var/folders/X-wt`; here it is built
+    // explicitly so the case is covered on every platform rather than only the one with a
+    // symlinked temp directory.
+    const real = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-real-'));
+    const link = path.join(path.dirname(real), `${path.basename(real)}-link`);
+    try {
+      // A junction on Windows, where an unprivileged symlink is refused; both resolve under
+      // `realpath`, which is all this needs.
+      await fs.symlink(real, link, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch {
+      return; // No link available on this machine; the behaviour is unobservable here.
+    }
+
+    try {
+      const repo = path.join(real, 'repo');
+      const worktree = path.join(real, 'repo-wt');
+      await fs.mkdir(repo, { recursive: true });
+      await fs.mkdir(worktree, { recursive: true });
+
+      // What the agent recorded: the sibling worktree, spelled through the link.
+      await writeSession('2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-1111-7e93-886c-2429599f27cd.jsonl',
+        path.join(link, 'repo-wt'));
+
+      const found = await discoverTranscriptFiles(
+        // The project root as given (through the link) is what reveals the substitution; the
+        // worktree is supplied the way git reports it, canonically and only canonically.
+        path.join(link, 'repo'),
+        { projectsDir, codexSessionsDir, roots: [path.join(link, 'repo'), worktree] },
+      );
+
+      expect(found).toHaveLength(1);
+      expect(found[0].harness).toBe('codex');
+    } finally {
+      await fs.rm(link, { recursive: true, force: true }).catch(() => {});
+      await fs.rm(real, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
   it('skips a file with no readable header rather than claiming it', async () => {
     const target = path.join(codexSessionsDir, '2026/03/22/rollout-2026-03-22T21-16-47-019d15e7-eeee-7e93-886c-2429599f27cd.jsonl');
     await fs.mkdir(path.dirname(target), { recursive: true });


### PR DESCRIPTION
The two gaps named as out of scope when the archive-reader fixes landed in #76, now closed.

## `approve --all` stops at a cap and did not say so

It promotes **1,000 candidates at most**, and a first run over a real archive produces atoms on
that order — so the cap lands on precisely the run it exists for. The output was:

```
Approved 1000 candidate(s).
```

which reads as completion. An operator who believes it stops with the rest of their archive
unreviewed and nothing to suggest otherwise — on the one command whose whole purpose is bulk
cold-start.

**The cap itself is right and stays.** Approval writes atoms one at a time through the deduping
writer, and an unbounded run over a whole archive is the worse failure. What was wrong was the
silence.

`ApprovalResult` now carries `remaining`, **counted from the store after the run** rather than
derived from the cap, so it stays correct whatever a concurrent extraction added. Failures count
toward it too — a candidate that refused to promote is still a decision to make. The CLI prints
it, and `--all`'s own description now names the bound:

```
Approved 1000 candidate(s).
412 still pending. Run approve --all again to continue.
```

## `scanCodexArchive` matched two spellings of a root where the Claude half matched three

A `cwd` is whatever the agent's shell had, so it is the **un-resolved** form. `git worktree list`
answers canonically, and `realpath` only maps *toward* the real path — it cannot invert it. The
Claude path already derives that inverse substitution from the one pair it can see both halves
of, the project root as given and as resolved. The Codex path never got it.

So a sibling worktree that git names only as `/private/var/folders/X-wt` matched **no** Codex
session recorded in `/var/folders/X-wt` — on the same platforms, and for the same reason, that
once left every worktree session unindexed on macOS and Windows while ubuntu saw nothing wrong
for months.

The substitution moves out of `scanTranscriptArchive` into `deriveUncanonicalise`, and the three
spellings of a root into `rootSpellings`, so both archives use one implementation. That *is* the
fix rather than tidying beside it: the halves differ only in what they do with the forms — Claude
encodes them into a directory name, Codex compares them against the `cwd` inside each file — and
keeping the derivation inside one of them is what let them diverge in the first place.

## Tests

Both verified to fail with their fix reverted, not merely to pass:

```
× Codex transcript discovery > matches a worktree recorded under the un-resolved path…
× approving a staged candidate > says how many are still pending when --all stops at its cap
× approving a staged candidate > counts a failed candidate as still pending…
```

The worktree case builds the link explicitly — a junction on Windows, where an unprivileged
symlink is refused — so it is covered on every platform rather than only the one whose temp
directory happens to be symlinked. It returns early rather than failing if no link can be made
at all.

## Verification

`build`, `typecheck`, `lint`, `docs:check` and `git diff --check` clean.
Full suite **305 files, 2,747 passed, 5 skipped, 0 failed**.
