### PR TITLE
fix(cloud): git is not a condition of connecting — name a project without a remote

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -692,7 +692,7 @@ The replica is a replica: deleting it is always safe, and the next pull rebuilds
 | --- | --- |
 | `knowl cloud login [--api <host>]` | Sign in once, by device code. The credential lives in `~/.knowl`, never in `.knowl/config.json` |
 | `knowl cloud logout [--api <host>]` | Clear the stored credential |
-| `knowl cloud connect [--workspace <id>] [--remote <name>]` | Point this repository at a workspace. Publishes nothing |
+| `knowl cloud connect [--workspace <id>] [--remote <name>] [--repo <name>]` | Point this project at a workspace. Publishes nothing |
 | `knowl cloud pull` | Fetch team knowledge into the local replica |
 | `knowl cloud stage [--id <ids...>] [--category <list>] [--apply]` | Stage knowledge for publication. Dry run without `--apply` |
 | `knowl cloud push` | Send staged knowledge, once its code is on the default branch |
@@ -713,10 +713,32 @@ export KNOWL_API_HOST=https://knowl.example.internal
 
 ### Identity and connection
 
-A repository is identified by its **normalized git remote**, not its directory name, so two
-people who cloned to different paths publish to the same place. A repository with no remote is
-refused: there is no stable identity to publish under. In a fork, `origin` is your fork and
-`upstream` is the team's — `--remote` picks, and the choice is recorded in config.
+A project publishes under one identity, resolved by the first of these that applies:
+
+1. `--repo <name>`, if you give one.
+2. Its **normalized git remote**, when it has one. This is the best answer available, because it is
+   identical for everyone who clones — two people who cloned to different paths publish to the same
+   place without anyone typing anything. In a fork, `origin` is yours and `upstream` is the team's;
+   `--remote` picks, and the choice is recorded in config. A project below the git root is qualified
+   with `#subpath`, so a monorepo's packages do not pool their knowledge.
+3. Its **directory name**.
+
+**Git is not required.** A folder of notes is a project, and so is work that has never been pushed
+anywhere; neither needs a remote, a `.git`, or git on `PATH`. The identity is a label the server
+groups by, not a claim about version control.
+
+A directory name is not unique across machines, so two people who each keep notes in `~/notes` and
+connect to one workspace would share a bucket. `knowl cloud connect` says when it fell back to the
+directory, and `--repo <name>` settles it.
+
+Because the identity is derived, it can move on its own — add a remote to a project that had none
+and the answer changes. `connect` refuses that rather than re-keying silently, because anything
+already pushed stays filed under the old name and the server rejects writes to it from a different
+one. Re-run with `--repo <old-name>` to keep publishing as before.
+
+Naming a remote that does not exist is still an error: `--remote upstream` on a repo without an
+`upstream` is a typo, and answering it with the directory name would file the knowledge somewhere
+nobody is looking.
 
 The pointer written into `.knowl/config.json` holds the API host, workspace and repo identity and
 **never a credential**. That file is deliberately committable, so a teammate clones, runs

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -944,7 +944,11 @@ cloudCommand
   .description('Point this repository at a cloud workspace (publishes nothing)')
   .option('--api <host>', 'API host (defaults to $KNOWL_API_HOST, else the hosted service)', defaultApiHost())
   .option('--workspace <id>', 'Workspace id, when you belong to more than one')
-  .option('--remote <name>', 'Git remote to derive repo identity from', 'origin')
+  // No default value on purpose. Commander would then make `--remote origin` and no flag at all
+  // indistinguishable, and they mean different things: a remote you named and haven't got is a
+  // typo, while no origin on a project that was never pushed anywhere is not a problem.
+  .option('--remote <name>', 'Git remote to derive the project identity from (default: origin)')
+  .option('--repo <name>', 'Name this project yourself, for one with no git remote')
   .option('--no-auto-stage', 'Do not stage new knowledge automatically; stage it explicitly instead')
   .action(async options => {
     try {
@@ -954,6 +958,7 @@ cloudCommand
         apiHost: options.api,
         workspaceId: options.workspace as string | undefined,
         remote: options.remote,
+        repo: options.repo,
       };
 
       // Shared by both entry paths -- the first attempt and the one that follows a pick -- so a
@@ -968,6 +973,12 @@ cloudCommand
           }
         }
         console.log(`Connected ${connected.pointer.repo} to ${connected.pointer.workspaceName} as ${connected.role}.`);
+        // Only when nobody chose the name. Saying where it came from matters here because a folder
+        // name is not unique across machines, and the fix is a flag the user may not know exists.
+        if (!connected.pointer.remote && !options.repo) {
+          console.log('That name came from the project directory, as there is no git remote to read.');
+          console.log('Pass --repo <name> to publish under something else.');
+        }
         console.log(options.autoStage === false
           ? 'Nothing has been published, and new knowledge will not stage itself. Use knowl cloud stage.'
           : 'Nothing has been published. New knowledge stages itself; send it with knowl cloud push.');
@@ -1022,6 +1033,14 @@ cloudCommand
           + `Switch this repository to that model and re-embed its ${result.itemCount} item(s), `
           + 'then connect again.',
         );
+        process.exit(1);
+      }
+      if (result.status === 'identity-changed') {
+        console.error(`This project publishes as "${result.current}", but now resolves to "${result.next}".`);
+        console.error('Anything already pushed stays filed under the old name, and the server will');
+        console.error('refuse writes to it from a different one. To keep publishing as before:');
+        console.error(`  knowl cloud connect --repo ${result.current}`);
+        console.error('Re-run with the new name only if you mean to start a separate history.');
         process.exit(1);
       }
 

--- a/src/cloud/connect.ts
+++ b/src/cloud/connect.ts
@@ -14,7 +14,8 @@ export type CloudPointer = {
   workspaceId: string;
   workspaceName: string;
   repo: string;
-  remote: string;
+  /** Absent when the identity did not come from a remote, matching how config stores it. */
+  remote?: string;
 };
 
 export type ConnectInput = {
@@ -22,6 +23,8 @@ export type ConnectInput = {
   apiHost: string;
   workspaceId?: string;
   remote?: string;
+  /** Names the project outright: one with no remote, or one that wants a different label. */
+  repo?: string;
   api?: CloudApi;
 };
 
@@ -44,17 +47,38 @@ export type ConnectResult =
     repo: { provider: string; model: string; dtype: string; pooling: string; recipeVersion: number };
     differing: string[];
     itemCount: number;
-  };
+  }
+  | { status: 'identity-changed'; current: string; next: string };
 
 /**
- * Point a repository at a cloud workspace. Publishes nothing.
+ * Point a project at a cloud workspace. Publishes nothing.
  *
- * Identity is resolved BEFORE the network call, so a repository with no remote is refused
- * without spending a request or half-writing config. The pointer is written last, so a
- * failure anywhere leaves the repo exactly as it was.
+ * Identity is resolved BEFORE the network call, so a project that cannot be named at all is
+ * refused without spending a request or half-writing config. The pointer is written last, so a
+ * failure anywhere leaves the project exactly as it was.
  */
 export async function runConnect(input: ConnectInput): Promise<ConnectResult> {
-  const identity = resolveRepoIdentity(input.projectRoot, { remote: input.remote });
+  const identity = resolveRepoIdentity(input.projectRoot, {
+    remote: input.remote,
+    repo: input.repo,
+  });
+
+  /*
+   * Re-connecting must not silently re-key what this project publishes under.
+   *
+   * Identity is DERIVED, so it can move without anyone deciding to move it: add a remote to a
+   * project that had none and the answer goes from the folder name to the remote URL. Everything
+   * already pushed stays filed under the old name, and the server refuses a write carrying a
+   * different origin as `foreign_origin` -- so the next push half-fails on atoms this machine still
+   * believes it owns, with an error about ownership rather than about renaming.
+   *
+   * Changing workspace is the ordinary reason to re-run connect and does not trip this, because the
+   * identity does not change. `--repo <old-name>` is the way through when the rename is intended.
+   */
+  const existing = await loadConfig(input.projectRoot);
+  if (existing.cloud?.repo && existing.cloud.repo !== identity.identity) {
+    return { status: 'identity-changed', current: existing.cloud.repo, next: identity.identity };
+  }
 
   const credential = await readCredential(input.apiHost);
   if (!credential) return { status: 'not-logged-in' };
@@ -86,6 +110,10 @@ export async function runConnect(input: ConnectInput): Promise<ConnectResult> {
   // Before the pointer is written. Vectors are shared with the team, so a repo that embeds
   // differently would either be refused on every push or -- worse, if anything ever stopped
   // checking -- quietly poison the workspace's index.
+  //
+  // A second read rather than reusing the copy taken for the identity check above: the network
+  // calls between them are the slowest part of this function, and config is a file another
+  // process can have written meanwhile.
   const config = await loadConfig(input.projectRoot);
   const mismatch = await profileMismatch(chosen.id, credential.accessToken, api, config);
   if (mismatch) return mismatch;
@@ -99,7 +127,9 @@ export async function runConnect(input: ConnectInput): Promise<ConnectResult> {
     workspaceId: chosen.id,
     workspaceName: chosen.name,
     repo: identity.identity,
-    remote: identity.remoteName,
+    // Omitted rather than nulled when there is no remote, so the committed file carries no field
+    // claiming the identity came from one.
+    remote: identity.remoteName ?? undefined,
   };
 
   await saveConfig(input.projectRoot, { ...config, cloud: pointer });

--- a/src/cloud/repo-identity.ts
+++ b/src/cloud/repo-identity.ts
@@ -1,15 +1,35 @@
+import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 export type RepoIdentity = {
-  /** `host[:port]/path`, plus `#subpath` when the project is not at the git root. */
+  /**
+   * What this project publishes under. `host[:port]/path` when derived from a remote, plus
+   * `#subpath` when the project sits below the git root; otherwise the name that was asked for,
+   * or the project directory's own.
+   */
   identity: string;
-  remoteName: string;
-  remoteUrl: string;
+  /**
+   * Which of the three routes decided it, recorded rather than re-derived later. A pointer saying
+   * only `notes` cannot answer "was that my folder name, or did somebody type it".
+   */
+  source: 'explicit' | 'remote' | 'directory';
+  /** Null unless the identity came from a remote. */
+  remoteName: string | null;
+  remoteUrl: string | null;
   subpath: string | null;
 };
 
+/**
+ * A remote was named and is not there.
+ *
+ * Only raised for a remote the caller ASKED for. A missing `origin` on a project nobody said
+ * anything about is not an error -- version control is not a condition of using this product.
+ */
 export class NoGitRemoteError extends Error {}
+
+/** No identity could be formed at all, so the caller has to say what to use. */
+export class UnnameableProjectError extends Error {}
 
 /**
  * Git could not be run at all -- distinct from git running and reporting no remote.
@@ -75,7 +95,8 @@ function git(cwd: string, args: string[]): string | null {
   if (result.error) {
     throw new GitUnavailableError(
       `Could not run git: ${result.error.message}. ` +
-      'Knowl derives a cloud repository identity from the git remote, so git has to be on PATH.',
+      'This project is a git repository, so Knowl would normally read its identity from a remote. ' +
+      'Put git on PATH, or pass --repo <name> to name the project yourself.',
     );
   }
   if (result.status !== 0) return null;
@@ -83,31 +104,61 @@ function git(cwd: string, args: string[]): string | null {
 }
 
 /**
- * Which remote, and therefore which bucket this repo publishes into.
+ * What this project publishes under, by one of three routes.
  *
- * `origin` by default and overridable, because in a fork workflow `origin` is the fork and
- * `upstream` is the team's. Whichever was used is recorded on the result and written into
- * config, so the answer stays inspectable rather than being re-derived differently later.
+ * A remote is the best answer WHEN THERE IS ONE: it is identical for everyone who clones, so a
+ * team lands in one bucket without anybody typing anything, and `#subpath` keeps a monorepo's
+ * packages apart. It was also, until this change, the ONLY answer — a project with no remote was
+ * refused outright, which made git a condition of using the cloud. It is not one. A directory of
+ * notes is a project; so is work that has never been pushed anywhere. People pay for how much they
+ * store, not for keeping it in a shape this tool recognises.
+ *
+ * So the remote is now a default rather than a requirement, and the routes are, in order:
+ * an explicit `--repo` name; the named-or-default remote; the project directory's own name.
  */
 export function resolveRepoIdentity(
   projectRoot: string,
-  options: { remote?: string } = {},
+  options: { remote?: string; repo?: string } = {},
 ): RepoIdentity {
-  const remoteName = options.remote ?? 'origin';
-  const remoteUrl = git(projectRoot, ['config', '--get', `remote.${remoteName}.url`]);
+  // Named outright, so no git runs at all -- the route for a project that is not a repository, or
+  // is one with nowhere to push. First, because a caller who says what they want should not have
+  // the answer overridden by whatever git happens to report.
+  if (options.repo !== undefined) {
+    return {
+      identity: sanitizeName(options.repo, 'The --repo name'),
+      source: 'explicit',
+      remoteName: null,
+      remoteUrl: null,
+      subpath: null,
+    };
+  }
+
+  // Asked-for versus assumed, and the difference decides whether a miss is an error. `--remote
+  // upstream` against a repo with no `upstream` is a typo worth reporting; no `origin` on a project
+  // nobody said anything about is just a project with nowhere to push.
+  const requested = options.remote;
+  const remoteName = requested ?? 'origin';
+  const remoteUrl = readRemote(projectRoot, remoteName);
+
   if (!remoteUrl) {
-    throw new NoGitRemoteError(
-      `No git remote "${remoteName}" in ${projectRoot}. ` +
-      'A cloud workspace keys published knowledge on the remote URL, so a repository with ' +
-      'no remote has no stable identity to publish under. Add a remote, or pass --remote ' +
-      'to name a different one.',
-    );
+    if (requested !== undefined) {
+      throw new NoGitRemoteError(
+        `No git remote "${requested}" in ${projectRoot}. ` +
+        'Check the name against `git remote -v`, drop the flag to use origin, or pass ' +
+        '--repo <name> to name this project without a remote.',
+      );
+    }
+    return fromDirectory(projectRoot);
   }
 
   const identity = normalizeRemoteUrl(remoteUrl);
   if (!identity) {
+    // The remote exists and cannot be reduced to an identity. Deliberately NOT replaced by the
+    // directory name: a project carrying a remote plainly means to publish under it, and quietly
+    // filing it somewhere else would put a team's knowledge in a bucket nobody is reading.
     throw new NoGitRemoteError(
-      `Could not read a repository identity from remote "${remoteName}" (${remoteUrl}).`,
+      `Could not read a repository identity from remote "${remoteName}" (${remoteUrl}). ` +
+      'Pass --repo <name> to name this project explicitly.',
     );
   }
 
@@ -118,8 +169,69 @@ export function resolveRepoIdentity(
 
   return {
     identity: subpath ? `${identity}#${subpath}` : identity,
+    source: 'remote',
     remoteName,
     remoteUrl,
     subpath,
   };
+}
+
+/**
+ * Reads a remote, treating "this is not a git repository" as an answer rather than a failure.
+ *
+ * The `.git` test is what keeps a missing git binary meaningful. `GitUnavailableError` exists so a
+ * machine without git is not told to add a remote it already has, and that is still right for a
+ * repository -- but a plain directory has no remote to be wrong about, and refusing to connect over
+ * a tool it does not need would be the same overreach as demanding a remote. So: a repository and
+ * no git, complain; no repository, fall through to the name.
+ */
+function readRemote(projectRoot: string, remoteName: string): string | null {
+  const looksLikeRepo = existsSync(path.join(projectRoot, '.git'));
+  try {
+    return git(projectRoot, ['config', '--get', `remote.${remoteName}.url`]);
+  } catch (error) {
+    if (error instanceof GitUnavailableError && !looksLikeRepo) return null;
+    throw error;
+  }
+}
+
+/**
+ * The project's own directory name.
+ *
+ * Stable for as long as the folder is called what it is called, which is all an identity has to be:
+ * the server treats this value as a label for grouping, not as a claim about anything. It is not
+ * unique across machines, so two people who each keep notes in `~/notes` and connect to one
+ * workspace share a bucket. That is visible in the connect output and fixed by naming one of them
+ * with `--repo`, which is a better trade than refusing to run.
+ */
+function fromDirectory(projectRoot: string): RepoIdentity {
+  const base = path.basename(path.resolve(projectRoot));
+  return {
+    identity: sanitizeName(base, `The project directory name ("${base}")`),
+    source: 'directory',
+    remoteName: null,
+    remoteUrl: null,
+    subpath: null,
+  };
+}
+
+/**
+ * Lowercased and whitespace-collapsed, matching what `normalizeRemoteUrl` does to a remote so the
+ * routes cannot produce two identities for one project. Length is bounded here because the server
+ * accepts 200 characters, and a value refused there would fail at push -- long after connect said
+ * yes, and with a message about a limit the user never saw.
+ */
+function sanitizeName(raw: string, subject: string): string {
+  const cleaned = raw.trim().toLowerCase().replace(/\s+/g, '-');
+  if (!cleaned) {
+    throw new UnnameableProjectError(
+      `${subject} is empty, so there is nothing to publish under. Pass --repo <name>.`,
+    );
+  }
+  if (cleaned.length > 200) {
+    throw new UnnameableProjectError(
+      `${subject} is ${cleaned.length} characters and the limit is 200. Pass a shorter --repo <name>.`,
+    );
+  }
+  return cleaned;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -288,9 +288,16 @@ export interface ProjectConfig {
     apiHost: string;
     workspaceId: string;
     workspaceName?: string;
-    /** Normalized git remote identity this repo publishes under. */
+    /**
+     * What this project publishes under: a normalized remote identity when there is a remote,
+     * otherwise a name that was given or taken from the project directory. A label, not a claim
+     * about version control -- the server accepts any non-empty string here.
+     */
     repo: string;
-    /** Which remote it was derived from, so a fork's choice stays inspectable. */
+    /**
+     * Which remote it was derived from, so a fork's choice stays inspectable. Absent when the
+     * identity did not come from one, which is not the same as `origin`.
+     */
     remote?: string;
     /**
      * Stage new knowledge as it is written. Absent means on; only an explicit false disables it.

--- a/tests/cloud/connect.test.ts
+++ b/tests/cloud/connect.test.ts
@@ -192,15 +192,94 @@ describe('runConnect', () => {
     expect((await loadConfig(REPO)).cloud).toBeUndefined();
   });
 
-  it('refuses a repo with no git remote', async () => {
+  /*
+   * This asserted `refuses a repo with no git remote` until the requirement was dropped. Connecting
+   * used to be gated on git, for a product people pay for by how much they store; the server has
+   * only ever validated `originRepo` as a non-empty string and treats it as a label.
+   */
+  it('connects a repo with no git remote, naming it after the directory', async () => {
     await makeRepo(null);
     await writeCredential(HOST, credential);
 
-    await expect(runConnect({
+    const result = await runConnect({
       projectRoot: REPO,
       apiHost: HOST,
       api: api([{ id: 'w1', name: 'Acme', role: 'editor' }]),
-    })).rejects.toThrow(/no git remote/i);
+    });
+
+    expect(result.status).toBe('connected');
+    const pointer = (await loadConfig(REPO)).cloud;
+    expect(pointer?.repo).toBe(path.basename(REPO).toLowerCase());
+    // Absent, not 'origin': recording a remote it never read would make the pointer claim the
+    // identity is shared when it is one machine's folder name.
+    expect(pointer?.remote).toBeUndefined();
+  });
+
+  it('publishes under an explicit name when one is given', async () => {
+    await makeRepo(null);
+    await writeCredential(HOST, credential);
+
+    const result = await runConnect({
+      projectRoot: REPO,
+      apiHost: HOST,
+      repo: 'Team Notes',
+      api: api([{ id: 'w1', name: 'Acme', role: 'editor' }]),
+    });
+
+    expect(result.status).toBe('connected');
+    expect((await loadConfig(REPO)).cloud?.repo).toBe('team-notes');
+  });
+
+  /*
+   * The trap the fallback introduces, and the reason connect guards rather than just writing.
+   *
+   * Identity is derived, so adding a remote to a project that had none moves it — from the folder
+   * name to the remote URL — with nobody deciding to move it. Atoms already pushed stay filed under
+   * the old name, and the server refuses a write carrying a different origin as `foreign_origin`,
+   * so the next push half-fails with an ownership error rather than anything about renaming.
+   */
+  it('refuses to re-key a project whose identity has moved, and says how to keep it', async () => {
+    await makeRepo(null);
+    await writeCredential(HOST, credential);
+    await runConnect({
+      projectRoot: REPO,
+      apiHost: HOST,
+      repo: 'original-name',
+      api: api([{ id: 'w1', name: 'Acme', role: 'editor' }]),
+    });
+
+    const result = await runConnect({
+      projectRoot: REPO,
+      apiHost: HOST,
+      api: api([{ id: 'w1', name: 'Acme', role: 'editor' }]),
+    });
+
+    expect(result).toEqual({
+      status: 'identity-changed',
+      current: 'original-name',
+      next: path.basename(REPO).toLowerCase(),
+    });
+    // And the pointer is left exactly as it was, so the refusal costs nothing to recover from.
+    expect((await loadConfig(REPO)).cloud?.repo).toBe('original-name');
+  });
+
+  it('still re-connects when only the workspace changes', async () => {
+    // The ordinary reason to re-run connect. It must not be caught by the guard above, or changing
+    // workspace would require naming the repo you already publish as.
+    await makeRepo('git@github.com:acme/web.git');
+    await writeCredential(HOST, credential);
+    const workspaces = [
+      { id: 'w1', name: 'Acme', role: 'editor' as const },
+      { id: 'w2', name: 'Beta', role: 'editor' as const },
+    ];
+    await runConnect({ projectRoot: REPO, apiHost: HOST, workspaceId: 'w1', api: api(workspaces) });
+
+    const result = await runConnect({
+      projectRoot: REPO, apiHost: HOST, workspaceId: 'w2', api: api(workspaces),
+    });
+
+    expect(result.status).toBe('connected');
+    expect((await loadConfig(REPO)).cloud?.workspaceId).toBe('w2');
   });
 });
 

--- a/tests/cloud/repo-identity.test.ts
+++ b/tests/cloud/repo-identity.test.ts
@@ -1,10 +1,12 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   GitUnavailableError,
   NoGitRemoteError,
+  UnnameableProjectError,
   normalizeRemoteUrl,
   resolveRepoIdentity,
 } from '../../src/cloud/repo-identity.js';
@@ -92,10 +94,80 @@ describe('resolveRepoIdentity', () => {
     expect(identity.identity).toBe('github.com/acme/mono#packages/api');
   });
 
-  it('refuses a repo with no remote instead of inventing an identity', async () => {
+  /*
+   * This used to assert the opposite -- `refuses a repo with no remote instead of inventing an
+   * identity`. The premise was that a cloud workspace keys knowledge on the remote URL, so a repo
+   * without one has nothing stable to publish under. Both halves were wrong: the server validates
+   * `originRepo` as any non-empty string up to 200 characters and treats it as a label for
+   * grouping, and a folder name is stable for exactly as long as the folder is called that.
+   *
+   * What the refusal actually did was make git a condition of using the product, for people who
+   * pay by how much they store.
+   */
+  it('falls back to the directory name for a repo with no remote', async () => {
     await makeGitRepo(REPO, {});
 
+    const identity = resolveRepoIdentity(REPO);
+
+    expect(identity.identity).toBe('.knowl-identity-repo');
+    expect(identity.source).toBe('directory');
+    expect(identity.remoteName).toBeNull();
+  });
+
+  /*
+   * The fixture lives outside the checkout, and that is load-bearing rather than tidiness.
+   *
+   * `git config --get remote.origin.url` run in a directory with no `.git` SEARCHES UPWARD. A
+   * fixture under this repo would therefore be answered with knowl's own origin, and the test would
+   * pass by reading the developer's checkout instead of the directory it created. Same rule as
+   * `tests/cli/project-marker.test.ts`, which was red locally and green in CI for this reason.
+   */
+  it('names a plain directory that is not a git repository at all', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-notes-'));
+    try {
+      const identity = resolveRepoIdentity(outside);
+
+      expect(identity.source).toBe('directory');
+      expect(identity.identity).toBe(path.basename(outside).toLowerCase());
+      expect(identity.remoteUrl).toBeNull();
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('takes an explicit name over anything git would have said', async () => {
+    // A repo WITH a usable remote, so this proves precedence rather than fallback.
+    await makeGitRepo(REPO, { origin: 'git@github.com:acme/web.git' });
+
+    const identity = resolveRepoIdentity(REPO, { repo: 'My Notes' });
+
+    // Lowercased and whitespace-collapsed, the same treatment a remote gets, so one project cannot
+    // end up with two identities depending on which route named it.
+    expect(identity.identity).toBe('my-notes');
+    expect(identity.source).toBe('explicit');
+    expect(identity.remoteName).toBeNull();
+  });
+
+  it('still refuses a remote that was named and is not there', async () => {
+    // The distinction the fallback must not swallow: a missing `origin` nobody asked about is a
+    // project with nowhere to push, but `--remote upstream` against a repo that has no `upstream`
+    // is a typo, and answering it with the folder name would file the knowledge somewhere silently.
+    await makeGitRepo(REPO, { origin: 'git@github.com:acme/web.git' });
+
+    expect(() => resolveRepoIdentity(REPO, { remote: 'upstream' })).toThrow(NoGitRemoteError);
+  });
+
+  it('refuses a remote it cannot reduce to an identity rather than renaming the project', async () => {
+    await makeGitRepo(REPO, { origin: 'not a url' });
+
     expect(() => resolveRepoIdentity(REPO)).toThrow(NoGitRemoteError);
+  });
+
+  it('refuses a name that the server would reject at push time', async () => {
+    await makeGitRepo(REPO, {});
+
+    expect(() => resolveRepoIdentity(REPO, { repo: '   ' })).toThrow(UnnameableProjectError);
+    expect(() => resolveRepoIdentity(REPO, { repo: 'x'.repeat(201) })).toThrow(UnnameableProjectError);
   });
 
   it('says git is missing rather than blaming a remote that is really there', async () => {
@@ -111,6 +183,23 @@ describe('resolveRepoIdentity', () => {
       expect(() => resolveRepoIdentity(REPO)).not.toThrow(NoGitRemoteError);
     } finally {
       process.env.PATH = realPath;
+    }
+  });
+
+  it('does not demand git from a project that is not a repository', async () => {
+    // The complement of the test above, and the reason the `.git` check exists. Missing git is a
+    // real problem for a repository whose remote cannot then be read, and no problem at all for a
+    // directory of notes -- refusing over a tool the project does not use would be the same
+    // overreach as refusing over a missing remote.
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-nogit-'));
+    const realPath = process.env.PATH;
+    process.env.PATH = '';
+
+    try {
+      expect(resolveRepoIdentity(outside).source).toBe('directory');
+    } finally {
+      process.env.PATH = realPath;
+      await fs.rm(outside, { recursive: true, force: true }).catch(() => {});
     }
   });
 });


### PR DESCRIPTION
## The bug

`knowl cloud connect` refuses to run without a git remote, and there is no flag to get past it.

`runConnect` resolves an identity as its **first statement**, before auth and before any network call, and `resolveRepoIdentity` throws `NoGitRemoteError` whenever `git config --get remote.origin.url` comes back empty. So connect fails outright for:

- a folder with no `.git` at all
- a git repository with no remote — local-only work, never pushed
- a machine with no `git` on `PATH`

The error even states the premise: *"A cloud workspace keys published knowledge on the remote URL, so a repository with no remote has no stable identity to publish under."*

**The server never required that.** `originRepo` is validated as `z.string().min(1).max(200)` and treated as a label for grouping and filtering — `filters.repos`, and the `foreign_origin` check that stops a misconfigured client overwriting another project's atoms. The requirement was invented client-side.

A directory of notes is a project. So is work that has never been pushed anywhere. People pay for how much they store, not for keeping it in a shape this tool recognises.

## What changes

`resolveRepoIdentity` tries three routes in order:

1. **`--repo <name>`** — explicit, and runs no git at all
2. **the named-or-default remote** — unchanged, `#subpath` monorepo qualifier and all
3. **the project directory's own name**

A remote is still the best answer *when there is one*: identical for everyone who clones, so a team lands in one bucket without anybody typing anything. It is now a default rather than a requirement. `RepoIdentity` gains `source: 'explicit' | 'remote' | 'directory'`, recorded rather than re-derived — a pointer reading just `notes` otherwise cannot say whether that was a folder name or something somebody typed.

## Two refusals kept on purpose

A fallback that swallowed these would silently file knowledge where nobody is looking:

- **`--remote upstream` on a repo with no `upstream`** is a typo, not a project with nowhere to push. Telling those apart meant dropping commander's `'origin'` default on `--remote`, since with it `--remote origin` and no flag at all were indistinguishable.
- **a remote that exists and cannot be reduced to an identity.** That project plainly means to publish under it.

`GitUnavailableError` also survives, narrowed by an `existsSync('.git')` test. A repository whose remote cannot be read because git is missing is a real problem and still says so; a plain directory does not need a tool it never uses. Both directions have a test.

## The trap the fallback introduces, and the guard for it

Identity is **derived**, so it can move without anyone deciding to move it: add a remote to a project that had none and the answer goes from the folder name to the remote URL. Everything already pushed stays filed under the old name, and the server rejects a write carrying a different origin as `foreign_origin` — so the next push half-fails with an *ownership* error, nothing about renaming.

`connect` now returns `identity-changed` instead of re-keying, and tells you the way through:

```
This project publishes as "original-name", but now resolves to "my-folder".
Anything already pushed stays filed under the old name, and the server will
refuse writes to it from a different one. To keep publishing as before:
  knowl cloud connect --repo original-name
```

Changing workspace is the ordinary reason to re-run connect and does **not** trip this, since the identity does not change. That case has its own test.

## Smaller things

- `CloudPointer.remote` becomes optional rather than nullable, matching how `config.cloud.remote` was already typed. A pointer records no remote it never read — absent, not `'origin'`.
- Explicit and directory-derived names get the same lowercasing and whitespace collapsing a remote gets, so one project cannot end up with two identities depending on which route named it. Length is checked against the server's 200 characters here, rather than failing at push with a message about a limit the user never saw.
- Connect prints where a fallback name came from, since a folder name is not unique across machines and `--repo` is the fix.
- `docs/reference.md`'s identity section asserted the old rule and is rewritten. The 2026-08-09 plan file that introduced the behaviour is left alone — it is a record of what was done at the time.

## Tests

`tests/cloud/repo-identity.test.ts`'s `'refuses a repo with no remote instead of inventing an identity'` becomes `'falls back to the directory name'`, with a comment recording why the old assertion was wrong. Added: a plain non-git directory, explicit-name precedence over a usable remote, the named-remote refusal, the unreducible-remote refusal, name sanitisation limits, and no-git-binary on a non-repository.

One detail worth flagging for review: the non-git fixtures live in `os.tmpdir()`, not under the checkout. `git config --get` in a directory with no `.git` **searches upward**, so a fixture inside this repo would be answered with knowl's own origin and the test would pass by reading the developer's checkout. Same rule as `tests/cli/project-marker.test.ts`.

## Verification

**305 test files / 2756 passed**, 5 skipped. `lint`, `typecheck`, `docs:check` and `check:lockfile` all clean. Run with `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` pointed at an empty file, since a developer's global identity otherwise hides failures that CI sees.

## Context

The server side of the same question landed in knowl-cloud as [#37](https://github.com/dat999zx/knowl-cloud/issues/37), closed with the decision that `origin_repo` stays a free-text label rather than becoming a verified identity — `0016_review_provenance.sql` already committed to that principle ("the server has no working tree and no git graph … must not learn to"). This is the client half: the server was merely trusting the name, while the CLI was refusing to run without one.