### PR TITLE
Client-side embedding: the client makes the vectors, both ways

### DIFF
--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -26,17 +26,29 @@ const MAX_EMBED_BATCH = 32;
  *
  * Attention allocates `batch Ã— heads Ã— seq Ã— seq`, so the largest single allocation this
  * module can ever request is one clipped item on its own: arctic-embed-m-v2 has 12 heads
- * and fp32 scores, giving `2,560Â² Ã— 12 Ã— 4 bytes â‰ˆ 315 MB`. Nothing else here can exceed
+ * and fp32 scores, giving `2,048Â² Ã— 12 Ã— 4 bytes â‰ˆ 201 MB`. Nothing else here can exceed
  * that, because the batch budget below is far smaller.
  *
  * A CHARACTER clip cannot make that promise. The old limit was 8,000 characters, justified
  * in a comment as "roughly 2k tokens" -- true of English prose and wrong by 3x of the paths,
  * JSON and code that knowledge atoms are full of. Measured with arctic's own tokeniser,
  * 8,000 characters is 1,925 tokens of English and 6,283 of JSON, and the second one asks
- * for 1.8 GB in a single forward pass. 2,560 tokens clips 0 of the 470 real atoms
- * (p99 1,808 estimated tokens, longest 2,085).
+ * for 1.8 GB in a single forward pass.
+ *
+ * **2,048 rather than 2,560 since 2026-08-12, and it is a PARITY decision rather than a tuning
+ * one.** `knowl-cloud` clips here too, and a client-supplied vector is interchangeable with a
+ * server-supplied one only if the cut is identical as well as the text -- see
+ * `src/core/embed-recipe.ts`. 2,048 was chosen over raising the server to 2,560 because a
+ * forward pass is priced by tokens and both sides pay it on every embed forever, where the
+ * re-clip is once.
+ *
+ * The cost of the change, stated because it is not nothing: over the 470 real atoms measured
+ * above (p99 1,808 estimated tokens, longest 2,085), 2,560 clipped none and 2,048 clips the
+ * longest one. Every store built before this is stale for atoms in that range -- safe only
+ * because `fingerprintProfile` hashes `EMBED_RECIPE_VERSION`, so those rows stop matching and
+ * `knowl reindex --vectors` repairs them without `--force`.
  */
-const MAX_EMBED_TOKENS = 2_560;
+const MAX_EMBED_TOKENS = 2_048;
 
 /**
  * Budget for `items Ã— longestÂ²`, in TOKENS. A THROUGHPUT bound, not the memory one.
@@ -89,8 +101,24 @@ export function estimateTokens(text: string): number {
   return tokens;
 }
 
-/** Clip to `MAX_EMBED_TOKENS`, cutting on a segment boundary, and report what is left. */
-function clipToTokenBudget(text: string): { text: string; tokens: number } {
+/**
+ * Clip to `MAX_EMBED_TOKENS`, cutting on a segment boundary where one exists, and report what
+ * is left.
+ *
+ * **A first segment that alone exceeds the budget is cut mid-segment rather than dropped.**
+ * Cutting only on boundaries returns `capped.slice(0, 0)` in that case -- the EMPTY STRING --
+ * so the atom embeds as nothing and stores a meaningless vector, with no error anywhere.
+ *
+ * Reachable, and narrower than it looks. `MAX_EMBED_CHARS` pre-clips to 8,000 characters, and
+ * `segmentTokens` charges a letter run `ceil(len/4)`, so the most one can ever cost is 2,000
+ * tokens -- under the budget, so letters never reach this path. A DIGIT run is charged
+ * `ceil(len/3)` and costs 2,667, which does. Base64, minified JSON, hashes and spaceless
+ * numeric dumps are all ordinary atom content.
+ *
+ * Exported for tests. It is a pure string function, and reaching it through `embed()` would
+ * make a model download a prerequisite for asserting a slice.
+ */
+export function clipToTokenBudget(text: string): { text: string; tokens: number } {
   const capped = text.length > MAX_EMBED_CHARS ? text.slice(0, MAX_EMBED_CHARS) : text;
 
   let tokens = 0;
@@ -98,7 +126,20 @@ function clipToTokenBudget(text: string): { text: string; tokens: number } {
   let match: RegExpExecArray | null;
   while ((match = TOKEN_SEGMENT.exec(capped)) !== null) {
     const cost = segmentTokens(match[0]);
-    if (tokens + cost > MAX_EMBED_TOKENS) return { text: capped.slice(0, match.index), tokens };
+    if (tokens + cost > MAX_EMBED_TOKENS) {
+      if (match.index === 0) {
+        // Cut inside the segment, at the character count this segment's own rate charges the
+        // whole budget for. Derived from the segment rather than assumed, because letters and
+        // digits are charged at different rates and a fixed chars-per-token would be wrong for
+        // one of them.
+        const charsPerToken = match[0].length / cost;
+        return {
+          text: capped.slice(0, Math.max(1, Math.floor(MAX_EMBED_TOKENS * charsPerToken))),
+          tokens: MAX_EMBED_TOKENS,
+        };
+      }
+      return { text: capped.slice(0, match.index), tokens };
+    }
     tokens += cost;
   }
   return { text: capped, tokens };

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1009,6 +1009,21 @@ cloudCommand
         await reportConnected(confirmed);
         return;
       }
+      if (result.status === 'profile-mismatch') {
+        // Nothing has been written: the pointer is only saved once the profiles agree, so this
+        // repository is left exactly as it was rather than connected-but-unable-to-publish.
+        console.error(
+          `This workspace embeds with ${result.workspace.model} `
+          + `(${result.workspace.dtype}, ${result.workspace.pooling}, recipe ${result.workspace.recipeVersion}).\n`
+          + `This repository uses ${result.repo.model} `
+          + `(${result.repo.dtype}, ${result.repo.pooling}, recipe ${result.repo.recipeVersion}).\n`
+          + `Differing: ${result.differing.join(', ')}.\n\n`
+          + 'Vectors are shared with the team, so they must be built the same way.\n'
+          + `Switch this repository to that model and re-embed its ${result.itemCount} item(s), `
+          + 'then connect again.',
+        );
+        process.exit(1);
+      }
 
       await reportConnected(result);
     } catch (error: any) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1110,6 +1110,16 @@ cloudCommand
         console.error(`${result.staged} item(s) stay staged. ${result.detail}`);
         process.exit(1);
       }
+      if (result.status === 'needs-embedding') {
+        // Nothing is lost: they stay staged and go out on the next push. Said out loud because a
+        // push that quietly sent nothing would look like success.
+        console.error(
+          `${result.count} staged item(s) have no vector for this repository's embedding profile, `
+          + 'so nothing was sent.\n'
+          + `Run \`${result.remedy}\`, then push again.`,
+        );
+        process.exit(1);
+      }
 
       console.log(`Published ${result.created} new and ${result.updated} updated item(s).`);
       for (const outcome of result.conflicts) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1081,6 +1081,19 @@ cloudCommand
       const snapshot = await computePushSnapshot({ projectRoot: root, config });
       const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
 
+      // Before the prompt, not after it. `snapshot.items` omits atoms with no vector, so showing
+      // the prompt first would ask a user to confirm a shorter list than they staged and then
+      // refuse the push anyway. Nothing is lost either way -- they stay staged -- but being told
+      // now, with the command that fixes it, is the difference between an answer and a puzzle.
+      if (snapshot.unembedded.length > 0) {
+        console.error(
+          `${snapshot.unembedded.length} staged item(s) have no vector for this repository's `
+          + 'embedding profile, so nothing was sent.\n'
+          + 'Run `knowl reindex --vectors`, then push again.',
+        );
+        process.exit(1);
+      }
+
       if (snapshot.items.length > 0 && !options.yes) {
         if (!isTTY) {
           // A prompt that cannot be answered must not block CI, and silence must not be read

--- a/src/cloud/api-client.ts
+++ b/src/cloud/api-client.ts
@@ -60,6 +60,22 @@ function toCredential(body: TokenResponseBody): CloudCredential {
 }
 
 export type CloudRole = 'owner' | 'admin' | 'editor' | 'reader';
+
+/**
+ * The profile a workspace's vectors are built with, as the server reports it.
+ *
+ * Five values, never a preset name: a name is only meaningful to whoever owns the table that
+ * expands it, and after 5.0 the server no longer owns one. `recipeVersion` is the field a
+ * model-only comparison cannot express -- it says what TEXT went into the model.
+ */
+export type WorkspaceProfile = {
+  provider: string;
+  model: string;
+  dtype: string;
+  pooling: string;
+  dimensions: number;
+  recipeVersion: number;
+};
 export type CloudWorkspace = { id: string; name: string; role: CloudRole };
 
 /** Carries the status so callers can branch: 401 means log in, 403 means not a member. */
@@ -98,6 +114,11 @@ export type CloudApi = {
     itemId: string;
     body: UpdateItemBody;
   }): Promise<{ outcome: PublishOutcome | null }>;
+  /** The profile this repo must match to publish. `reader` is enough to read it. */
+  workspaceProfile(input: {
+    workspaceId: string;
+    accessToken: string;
+  }): Promise<WorkspaceProfile>;
 };
 
 /**
@@ -253,6 +274,18 @@ export function createCloudApi(options: {
       );
       if (status !== 200) fail('/knowledge', status, body as { code?: string; message?: string });
       return { outcomes: body.outcomes ?? [], commitId: body.commitId ?? null };
+    },
+
+    async workspaceProfile(input) {
+      const { status, body } = await request<{ serving: WorkspaceProfile }>(
+        `/v1/workspaces/${encodeURIComponent(input.workspaceId)}/policy`,
+        { method: 'GET', accessToken: input.accessToken },
+      );
+      if (status !== 200) fail('/policy', status, body);
+      // `serving`, never `target`. Target is an in-flight admin state during a reindex, and a
+      // client that embedded against it would build vectors for a generation the workspace is
+      // not searching yet.
+      return body.serving;
     },
 
     /** `needsReview` answers `{ outcome: null }` -- it records an observation, not a revision. */

--- a/src/cloud/connect.ts
+++ b/src/cloud/connect.ts
@@ -1,5 +1,11 @@
 import { loadConfig, saveConfig } from '../core/config.js';
-import { createCloudApi, type CloudApi, type CloudRole, type CloudWorkspace } from './api-client.js';
+import {
+  createCloudApi, type CloudApi, type CloudRole, type CloudWorkspace, type WorkspaceProfile,
+} from './api-client.js';
+import { EMBED_RECIPE_VERSION } from '../core/embed-recipe.js';
+import { resolveVectorProfile } from '../core/vector-profile.js';
+import { getClient } from '../store/database.js';
+import type { ProjectConfig } from '../core/types.js';
 import { normalizeApiHost, readCredential } from './credentials.js';
 import { resolveRepoIdentity } from './repo-identity.js';
 
@@ -24,7 +30,21 @@ export type ConnectResult =
   | { status: 'not-logged-in' }
   | { status: 'no-workspaces' }
   | { status: 'unknown-workspace'; workspaceId: string; workspaces: CloudWorkspace[] }
-  | { status: 'ambiguous'; workspaces: CloudWorkspace[] };
+  | { status: 'ambiguous'; workspaces: CloudWorkspace[] }
+  /**
+   * This repository cannot produce vectors this workspace would accept.
+   *
+   * Refused BEFORE the pointer is written, deliberately. A repo pointed at a workspace it cannot
+   * publish to is worse than one pointed nowhere: every later command looks connected and every
+   * push fails.
+   */
+  | {
+    status: 'profile-mismatch';
+    workspace: WorkspaceProfile;
+    repo: { provider: string; model: string; dtype: string; pooling: string; recipeVersion: number };
+    differing: string[];
+    itemCount: number;
+  };
 
 /**
  * Point a repository at a cloud workspace. Publishes nothing.
@@ -63,6 +83,13 @@ export async function runConnect(input: ConnectInput): Promise<ConnectResult> {
   // another team's store, which there is no unpublish for.
   if (!chosen) return { status: 'ambiguous', workspaces };
 
+  // Before the pointer is written. Vectors are shared with the team, so a repo that embeds
+  // differently would either be refused on every push or -- worse, if anything ever stopped
+  // checking -- quietly poison the workspace's index.
+  const config = await loadConfig(input.projectRoot);
+  const mismatch = await profileMismatch(chosen.id, credential.accessToken, api, config);
+  if (mismatch) return mismatch;
+
   const pointer: CloudPointer = {
     // Normalized, because unlike a credential key this value is written into a committed file
     // and read by every teammate who clones. `--api https://API.knowl.cloud/` would otherwise
@@ -75,8 +102,48 @@ export async function runConnect(input: ConnectInput): Promise<ConnectResult> {
     remote: identity.remoteName,
   };
 
-  const config = await loadConfig(input.projectRoot);
   await saveConfig(input.projectRoot, { ...config, cloud: pointer });
 
   return { status: 'connected', pointer, role: chosen.role };
+}
+
+/**
+ * Compares this repository's embedding profile against the workspace's, or null when they match.
+ *
+ * All five fields, because four of them describe the model and the fifth describes the text fed
+ * to it -- two clients on an identical model that build different text produce incomparable
+ * vectors and differ in none of the first four.
+ *
+ * A server too old to serve the profile is treated as a match rather than a refusal: it cannot
+ * be running the validation either, so refusing here would break connecting to it for a rule it
+ * does not enforce.
+ */
+async function profileMismatch(
+  workspaceId: string,
+  accessToken: string,
+  api: CloudApi,
+  config: ProjectConfig,
+): Promise<Extract<ConnectResult, { status: 'profile-mismatch' }> | null> {
+  // Guarded rather than just caught: an api object without the method throws a TypeError
+  // synchronously, before a `.catch` can attach. Reachable from a stub and from any caller
+  // holding an older client object.
+  if (typeof api.workspaceProfile !== 'function') return null;
+  const workspace = await api.workspaceProfile({ workspaceId, accessToken }).catch(() => null);
+  if (!workspace) return null;
+
+  const profile = resolveVectorProfile(config);
+  const repo = { ...profile, recipeVersion: EMBED_RECIPE_VERSION };
+
+  const differing = (['provider', 'model', 'dtype', 'pooling', 'recipeVersion'] as const)
+    .filter(field => workspace[field] !== repo[field]);
+  if (differing.length === 0) return null;
+
+  // Reported so the offer can price the switch: re-embedding is the cost the user is agreeing to.
+  const counted = await countKnowledgeItems().catch(() => 0);
+  return { status: 'profile-mismatch', workspace, repo, differing: [...differing], itemCount: counted };
+}
+
+async function countKnowledgeItems(): Promise<number> {
+  const rows = await getClient().execute('SELECT COUNT(*) AS n FROM knowledge_items');
+  return Number(rows.rows[0]?.n ?? 0);
 }

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -11,6 +11,10 @@ import { readSyncState } from './sync-state.js';
 import { listAssertions } from '../store/assertions.js';
 import { listEvidenceForItem } from '../store/evidence-repository.js';
 import type { PublishAssertion, PublishEvidence, PublishItem, PublishOutcome } from './sync-contract.js';
+import { EMBED_RECIPE_VERSION } from '../core/embed-recipe.js';
+import { fingerprintProfile, resolveVectorProfile, type VectorProfile } from '../core/vector-profile.js';
+import { decodeVector as decodeStoredVectorValue } from '../store/vector.js';
+import { encodeVector as encodeVectorToBase64 } from './vector-codec.js';
 import { withTeamStore } from './team-store.js';
 import { ensureAccessToken } from './token.js';
 
@@ -153,6 +157,17 @@ export type PushResult =
   | { status: 'not-logged-in' }
   | { status: 'gated'; reason: string; detail: string; staged: number }
   | { status: 'forbidden'; role: string }
+  /**
+   * Staged atoms that have no vector under this repo's current embedding profile.
+   *
+   * Not an error and not silence. They stay staged and go out as soon as they are embedded --
+   * but a push that said nothing would report success for work it did not do, which is the
+   * failure `loadPublishItem` returning a bare `null` used to cause.
+   *
+   * The server refuses these too. This is the same verdict one round trip earlier, with a
+   * message that names the command that fixes it.
+   */
+  | { status: 'needs-embedding'; count: number; remedy: string }
   | {
     /**
      * The queue is not what the human confirmed. Nothing was sent.
@@ -220,6 +235,14 @@ export type PushSnapshot = {
     /** The exact bytes that will be sent. */
     payload: PublishItem;
   }>;
+  /**
+   * Staged atoms that have no vector under this repository's current embedding profile.
+   *
+   * Captured here rather than recomputed at send time for the same reason the payloads are: the
+   * snapshot is what the human was shown, and a fresh read between the prompt and the send is
+   * exactly the window this type exists to close.
+   */
+  unembedded: string[];
 };
 
 /** The hashes of the atoms currently staged, for comparison against a snapshot. */
@@ -247,26 +270,35 @@ export async function computePushSnapshot(input: {
   config: ProjectConfig;
 }): Promise<PushSnapshot> {
   const pointer = input.config.cloud;
-  if (!pointer) return { items: [] };
+  if (!pointer) return { items: [], unembedded: [] };
 
   await initDb(input.projectRoot);
   try {
+    const profile = resolveVectorProfile(input.config);
+    const fingerprint = fingerprintProfile(profile);
     const staged = await listStaged(pointer.workspaceId);
     const hashes = await stagedHashes(staged.map(row => row.itemId));
     const items: PushSnapshot['items'] = [];
+    const unembedded: string[] = [];
     for (const row of staged) {
-      const payload = await loadPublishItem(row.itemId, pointer.workspaceId);
+      const loaded = await loadPublishItem(row.itemId, pointer.workspaceId, profile, fingerprint);
       // A staged id whose row is gone cannot be shown or sent. Skipped here for the same reason
       // the push skips it: the ledger records intent, and this command does not edit it.
-      if (!payload) continue;
+      if (!('item' in loaded)) {
+        // An atom with no current vector is a different case: it exists, it is staged, and the
+        // push will refuse because of it. Carried out so the prompt can say so rather than
+        // quietly showing a shorter list than the user staged.
+        if (loaded.skipped === 'no-vector') unembedded.push(row.itemId);
+        continue;
+      }
       items.push({
         itemId: row.itemId,
         contentHash: hashes.get(row.itemId)?.contentHash ?? null,
         lifecycleHash: hashes.get(row.itemId)?.lifecycleHash ?? null,
-        payload,
+        payload: loaded.item,
       });
     }
-    return { items };
+    return { items, unembedded };
   } finally {
     await closeDb();
   }
@@ -317,7 +349,14 @@ export async function pushStaged(input: {
     });
     if (!credential) return { status: 'not-logged-in' };
 
+    // Read once for the whole batch rather than per atom: every item in this push is embedded by
+    // the same local profile, and resolving it is not free.
+    const profile = resolveVectorProfile(input.config);
+    const fingerprint = fingerprintProfile(profile);
+
     let items: PublishItem[];
+    let unembedded: string[];
+
     if (input.snapshot) {
       const promised = new Map(input.snapshot.items.map(entry => [entry.itemId, entry]));
       const stagedNow = new Set(staged.map(row => row.itemId));
@@ -347,15 +386,31 @@ export async function pushStaged(input: {
       items = input.snapshot.items
         .filter(entry => stagedNow.has(entry.itemId))
         .map(entry => entry.payload);
+      // Carried from the snapshot rather than recomputed. `computePushSnapshot` already did the
+      // work of finding them, and re-reading here would reopen the very window the snapshot
+      // exists to close -- an atom embedded between the prompt and the send would slip through.
+      unembedded = input.snapshot.unembedded.filter(id => stagedNow.has(id));
     } else {
       items = [];
+      unembedded = [];
       for (const record of staged) {
-        const item = await loadPublishItem(record.itemId, pointer.workspaceId);
+        const loaded = await loadPublishItem(
+          record.itemId, pointer.workspaceId, profile, fingerprint,
+        );
         // A staged id whose row is gone cannot be published and must not be invented. It stays in
         // the ledger rather than being swept: the ledger is a record of intent, and deleting the
         // intent here would be this command silently editing what the user asked for.
-        if (item) items.push(item);
+        if ('item' in loaded) items.push(loaded.item);
+        // An atom that exists but has no vector under the current profile is a different case
+        // with a different remedy, and reporting it is the whole reason this is not a bare null.
+        else if (loaded.skipped === 'no-vector') unembedded.push(record.itemId);
       }
+    }
+
+    // One rule on both paths: an unembedded staged atom blocks the push and names the fix.
+    // Refused here rather than at the server -- same verdict, one round trip earlier.
+    if (unembedded.length > 0) {
+      return { status: 'needs-embedding', count: unembedded.length, remedy: 'knowl reindex --vectors' };
     }
     if (items.length === 0) {
       return { status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [] };
@@ -406,7 +461,25 @@ export async function pushStaged(input: {
  * not exist. On a republish the ledger's number is the only copy on this machine, and the server
  * treats a republish without one as a conflict deliberately.
  */
-async function loadPublishItem(itemId: string, workspace: string): Promise<PublishItem | null> {
+/**
+ * What a staged id yielded, and why it yielded nothing.
+ *
+ * `null` used to mean "the row is gone", and that was the only reason. There is a second one
+ * now -- the atom has no vector under the current profile -- and the two have different
+ * remedies: nothing can be done about a deleted row, while an unembedded one is
+ * `knowl reindex --vectors`. Collapsing both to null made the second invisible, and a push
+ * would report success for atoms it never sent.
+ */
+export type LoadedPublishItem =
+  | { item: PublishItem }
+  | { skipped: 'missing' | 'no-vector' };
+
+async function loadPublishItem(
+  itemId: string,
+  workspace: string,
+  profile: VectorProfile,
+  fingerprint: string,
+): Promise<LoadedPublishItem> {
   const result = await getClient().execute({
     sql: `SELECT id, category, title, content, reasoning, alternatives, tags, source, source_commit,
                  affected_paths, content_hash, lifecycle_hash, status, freshness, confidence, tier,
@@ -415,7 +488,26 @@ async function loadPublishItem(itemId: string, workspace: string): Promise<Publi
     args: [itemId],
   });
   const row = result.rows[0] as Record<string, unknown> | undefined;
-  if (!row) return null;
+  if (!row) return { skipped: 'missing' };
+
+  // READ, never recompute. The vector was built when the atom was written; re-embedding here
+  // would spend a forward pass to reproduce a value already on disk -- and would produce a
+  // DIFFERENT one if the local profile changed since, which is exactly the corruption the
+  // fingerprint exists to prevent.
+  //
+  // Filtered on the current fingerprint, so a row built by an older profile or an older RECIPE
+  // does not match and the atom is correctly treated as unembedded. `EMBED_RECIPE_VERSION` is
+  // part of that hash, which is what makes a recipe change visible here at all.
+  const embedding = await getClient().execute({
+    sql: `SELECT vector, dimensions FROM knowledge_embeddings
+          WHERE knowledge_item_id = ? AND profile_fingerprint = ?`,
+    args: [itemId, fingerprint],
+  });
+  const stored = embedding.rows[0] as Record<string, unknown> | undefined;
+  if (!stored) return { skipped: 'no-vector' };
+
+  const values = decodeStoredVector(stored.vector);
+  if (!values) return { skipped: 'no-vector' };
 
   // Citations travel with the atom. `sync-apply.ts` has always written them on the way DOWN, so
   // leaving them out here made the pipe one-directional: every atom this client published arrived
@@ -465,7 +557,7 @@ async function loadPublishItem(itemId: string, workspace: string): Promise<Publi
 
   const expectedVersion = await publishedVersion(itemId, workspace);
 
-  return {
+  const item: PublishItem = {
     id: String(row.id),
     category: String(row.category),
     title: String(row.title),
@@ -492,5 +584,26 @@ async function loadPublishItem(itemId: string, workspace: string): Promise<Publi
     ...(evidence.length > 0 ? { evidence } : {}),
     ...(assertions.length > 0 ? { assertions } : {}),
     ...(expectedVersion === null ? {} : { expectedVersion }),
+    vector: encodeVectorToBase64(values),
+    profileFingerprint: {
+      provider: profile.provider,
+      model: profile.model,
+      dtype: profile.dtype,
+      pooling: profile.pooling,
+      recipeVersion: EMBED_RECIPE_VERSION,
+    },
   };
+  return { item };
+}
+
+/**
+ * The stored vector as numbers, whichever encoding the row happens to hold.
+ *
+ * `src/store/vector.ts` writes packed float32 and still reads the JSON arrays older builds wrote,
+ * so this defers to it rather than assuming one shape.
+ */
+function decodeStoredVector(value: unknown): number[] | null {
+  const decoded = decodeStoredVectorValue(value);
+  if (!decoded) return null;
+  return Array.from(decoded);
 }

--- a/src/cloud/pull.ts
+++ b/src/cloud/pull.ts
@@ -6,6 +6,8 @@ import { createCloudApi, type CloudApi } from './api-client.js';
 import { ensureAccessToken } from './token.js';
 import { runSync, type SyncResult } from './sync.js';
 import { withTeamStore } from './team-store.js';
+import { getClient } from '../store/database.js';
+import { fingerprintProfile, resolveVectorProfile, type VectorProfile } from '../core/vector-profile.js';
 
 /**
  * The sync outcome is nested, not spread.
@@ -40,6 +42,7 @@ export async function runPull(input: {
     configRoot: input.projectRoot,
     api,
     accessToken: credential.accessToken,
+    vectors: await localVectorContext(input.projectRoot, input.config, pointer.workspaceId),
   });
 
   await embedReplica(input.projectRoot, input.config, pointer.workspaceId, result);
@@ -48,19 +51,60 @@ export async function runPull(input: {
 }
 
 /**
- * Embed what just landed, best-effort and after the rows are already stored.
+ * What a received vector should be stored as, and how wide it must be.
  *
- * Exactly how local writes are embedded: a forward pass is slow, and failing it must not lose
- * knowledge that is already committed. The replica stays lexically searchable either way --
- * the FTS mirror is trigger-maintained, so it was populated by the apply itself -- and the next
- * pull closes the gap.
+ * The fingerprint written locally is the LOCAL one, which is correct rather than a shortcut:
+ * this client only connected because its profile matches the workspace's, so a vector the server
+ * built genuinely belongs to the local space and must be filterable by local search like any
+ * other row.
+ *
+ * The width comes from what this repository has already produced, because knowl's presets do not
+ * record one -- it appears only in their prose labels. A repo with no embeddings yet has nothing
+ * to be inconsistent with, so `null` accepts whatever arrives.
+ */
+async function localVectorContext(
+  projectRoot: string,
+  config: ProjectConfig,
+  workspaceId: string,
+): Promise<{ profile: VectorProfile; fingerprint: string; dimensions: number | null } | undefined> {
+  if (!isVectorSearchEnabled(config)) return undefined;
+
+  const profile = resolveVectorProfile(config);
+  const fingerprint = fingerprintProfile(profile);
+  const dimensions = await withTeamStore(workspaceId, projectRoot, async () => {
+    const row = await getClient().execute({
+      sql: 'SELECT dimensions FROM knowledge_embeddings WHERE profile_fingerprint = ? LIMIT 1',
+      args: [fingerprint],
+    });
+    return row.rows[0] ? Number(row.rows[0].dimensions) : null;
+  }).catch(() => null);
+
+  return { profile, fingerprint, dimensions };
+}
+
+/**
+ * Embed only what arrived WITHOUT a usable vector.
+ *
+ * Narrowed rather than deleted. The design's first draft said this function disappears once the
+ * feed carries vectors; it does not, because every row of a workspace mid-reindex arrives
+ * text-only by design -- so removing it would break pull during exactly the operation it most
+ * needs to survive. It also covers a client that connected while some atoms were still
+ * unindexed server-side.
+ *
+ * The narrowing needs no id list: `reindexKnowledgeEmbeddings` already skips any item whose
+ * stored row carries the current fingerprint, and the apply has just written exactly those. So
+ * the rows that arrived with a vector are skipped for free, and only `needEmbedding` costs a
+ * forward pass.
+ *
+ * Best-effort and after the rows are already stored: a forward pass is slow, and failing it must
+ * not lose knowledge that is already committed. The replica stays lexically searchable either
+ * way -- the FTS mirror is trigger-maintained, so the apply populated it -- and the next pull
+ * closes the gap.
  *
  * The project id is the synthetic `LOCAL_PROJECT_ID` rather than a row looked up from the
  * replica: this schema has no projects table, and `getProjectByRootPath` returns that same
  * constant for every root. The embedder is built from the *project's* config and root, not the
- * replica's, so team rows land in the same vector space as local ones -- embedded under any
- * other profile they would be filtered out by the local ranker and the replica would silently
- * contribute nothing.
+ * replica's, so team rows land in the same vector space as local ones.
  */
 async function embedReplica(
   projectRoot: string,
@@ -68,7 +112,7 @@ async function embedReplica(
   workspaceId: string,
   result: SyncResult,
 ): Promise<void> {
-  if (result.upserted === 0 || !isVectorSearchEnabled(config)) return;
+  if (result.needEmbedding.length === 0 || !isVectorSearchEnabled(config)) return;
 
   await withTeamStore(workspaceId, projectRoot, async () => {
     const embedder = await createLocalEmbeddingProvider(config, projectRoot);

--- a/src/cloud/sync-apply.ts
+++ b/src/cloud/sync-apply.ts
@@ -1,8 +1,45 @@
 ﻿import type { InValue } from '@libsql/client';
 import { getClient } from '../store/database.js';
 import type { SyncAtom, SyncRow } from './sync-contract.js';
+import type { VectorProfile } from '../core/vector-profile.js';
+import { decodeVector, VectorDecodeError } from './vector-codec.js';
 
-export type ApplyOutcome = { upserted: number; deleted: number };
+/**
+ * The received vector, or null when there is nothing usable to store.
+ *
+ * A wrong-width or malformed vector is refused rather than stored: the replica's column has no
+ * width constraint, so it would sit there ranking as noise forever. Refusing it costs one local
+ * forward pass and is the recoverable direction.
+ */
+function decodeIfUsable(value: string | undefined, dimensions: number | null): Float32Array | null {
+  if (value === undefined) return null;
+  try {
+    // A null expectation still goes through the codec: base64 validity and a whole number of
+    // float32s are checked regardless, and only the width comparison is skipped.
+    const bytes = Buffer.from(value, 'base64');
+    return decodeVector(value, dimensions ?? bytes.byteLength / 4);
+  } catch (error) {
+    if (error instanceof VectorDecodeError) return null;
+    throw error;
+  }
+}
+
+/** float32 bytes, the packing `src/store/vector.ts` reads back. */
+function packVector(values: Float32Array): Uint8Array {
+  return new Uint8Array(values.buffer, values.byteOffset, values.byteLength);
+}
+
+export type ApplyOutcome = {
+  upserted: number;
+  deleted: number;
+  /**
+   * Ids that arrived WITHOUT a usable vector and still need embedding locally.
+   *
+   * Empty on the normal path. Non-empty while a workspace is mid-reindex, where the feed sends
+   * every row text-only by design -- which is the case `embedReplica` now exists to cover.
+   */
+  needEmbedding: string[];
+};
 
 /**
  * One statement, in the shape both `batch` and this module's own bookkeeping need.
@@ -76,10 +113,26 @@ function upsertStatement(item: SyncAtom) {
   };
 }
 
-export async function applySyncRows(rows: SyncRow[]): Promise<ApplyOutcome> {
-  if (rows.length === 0) return { upserted: 0, deleted: 0 };
+export async function applySyncRows(
+  rows: SyncRow[],
+  vectors?: {
+    profile: VectorProfile;
+    fingerprint: string;
+    /**
+     * The width this repository's own embeddings use, or null when it has none yet.
+     *
+     * knowl's presets do not record a dimension -- it appears only in their prose labels -- so
+     * the authoritative source is what this repo has actually produced. Null means there is
+     * nothing to be inconsistent with, so whatever the server sends is accepted; the client
+     * only connected because the two profiles match.
+     */
+    dimensions: number | null;
+  },
+): Promise<ApplyOutcome> {
+  if (rows.length === 0) return { upserted: 0, deleted: 0, needEmbedding: [] };
 
   const statements: Statement[] = [];
+  const needEmbedding: string[] = [];
   let upserted = 0;
 
   for (const row of rows) {
@@ -115,6 +168,33 @@ export async function applySyncRows(rows: SyncRow[]): Promise<ApplyOutcome> {
           args: [row.item.id, evidence.id, evidence.relationship ?? DEFAULT_RELATIONSHIP],
         });
       }
+      // A vector the server built with the profile it is serving. Stored under the LOCAL
+      // fingerprint, which is correct rather than a shortcut: this client only accepted the
+      // workspace because the two profiles match, so the vector genuinely belongs to the local
+      // space and must be filterable by local search like any other row.
+      //
+      // A malformed or wrong-width vector is not fatal -- the atom is already stored and text
+      // -searchable, so it falls back to being embedded locally rather than failing the page.
+      const decoded = vectors ? decodeIfUsable(row.item.vector, vectors.dimensions) : null;
+      if (decoded && vectors) {
+        statements.push({
+          sql: `INSERT INTO knowledge_embeddings
+                  (knowledge_item_id, provider, model, profile_fingerprint, dimensions, vector, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(knowledge_item_id) DO UPDATE SET
+                  provider = excluded.provider, model = excluded.model,
+                  profile_fingerprint = excluded.profile_fingerprint,
+                  dimensions = excluded.dimensions, vector = excluded.vector,
+                  updated_at = excluded.updated_at`,
+          args: [
+            row.item.id, vectors.profile.provider, vectors.profile.model, vectors.fingerprint,
+            decoded.length, packVector(decoded), new Date().toISOString(),
+          ],
+        });
+      } else {
+        needEmbedding.push(row.item.id);
+      }
+
       upserted += 1;
     } else {
       // Tolerated when it matches nothing: reachable on a first sync from a non-zero watermark
@@ -137,5 +217,5 @@ export async function applySyncRows(rows: SyncRow[]): Promise<ApplyOutcome> {
       ? total + Number(result.rowsAffected ?? 0)
       : total, 0);
 
-  return { upserted, deleted: deletedRows };
+  return { upserted, deleted: deletedRows, needEmbedding };
 }

--- a/src/cloud/sync-contract.ts
+++ b/src/cloud/sync-contract.ts
@@ -29,6 +29,15 @@ export type SyncEvidence = {
 };
 
 export type SyncAtom = {
+  /**
+   * The atom's vector, base64 float32, **only when the server built it with the profile the
+   * workspace is currently serving**.
+   *
+   * Absent otherwise, and this client embeds the text itself. Not a degraded path: it is what
+   * every row looks like while a workspace is mid-reindex, and a vector the workspace no longer
+   * considers current would rank badly here with nothing to notice.
+   */
+  vector?: string;
   id: string;
   category: string;
   title: string;
@@ -149,6 +158,29 @@ export type PublishItem = {
    * overwrite rights by not knowing the field exists.
    */
   expectedVersion?: number;
+  /**
+   * This atom's vector, base64 of a little-endian Float32Array -- see `vector-codec.ts`.
+   *
+   * Read from `knowledge_embeddings` rather than computed at push time. It was built when the
+   * atom was written; recomputing would spend a forward pass to reproduce a value already on
+   * disk, and would produce a DIFFERENT one if the local profile changed since -- which is
+   * precisely the corruption `profileFingerprint` exists to prevent.
+   */
+  vector?: string;
+  /**
+   * What produced `vector`, in five fields, never a preset name.
+   *
+   * The server compares all five against the workspace's own and refuses the whole request on a
+   * difference. `recipeVersion` is the one a model-only fingerprint cannot express: it says what
+   * TEXT went into the model, where the other four say which model.
+   */
+  profileFingerprint?: {
+    provider: string;
+    model: string;
+    dtype: string;
+    pooling: string;
+    recipeVersion: number;
+  };
 };
 
 /**

--- a/src/cloud/sync.ts
+++ b/src/cloud/sync.ts
@@ -1,6 +1,7 @@
 import type { CloudApi } from './api-client.js';
 import { applySyncRows } from './sync-apply.js';
 import { readSyncState, writeSyncState } from './sync-state.js';
+import type { VectorProfile } from '../core/vector-profile.js';
 import { dropTeamStore, withTeamStore } from './team-store.js';
 
 /** A safety stop, not a page budget: a traversal that never returns a null cursor is a bug. */
@@ -16,9 +17,28 @@ export type SyncInput = {
   api: CloudApi;
   accessToken: string;
   maxPages?: number;
+  /**
+   * What to store a received vector as, and what width to insist on.
+   *
+   * Omitted entirely by callers that do not want vectors stored -- every row then lands in
+   * `needEmbedding` and the local embedder handles them, which is exactly the pre-vector
+   * behaviour.
+   */
+  vectors?: {
+    profile: VectorProfile;
+    fingerprint: string;
+    dimensions: number | null;
+  };
 };
 
 export type SyncResult = {
+  /**
+   * Rows that arrived without a usable vector and must be embedded locally.
+   *
+   * Empty on the normal path. Every row of a workspace mid-reindex lands here by design, which
+   * is what keeps sync flowing while a profile change is in progress.
+   */
+  needEmbedding: string[];
   status: 'synced' | 'incomplete' | 'resynced';
   upserted: number;
   deleted: number;
@@ -63,6 +83,7 @@ async function traverse(input: SyncInput): Promise<SyncResult | typeof RESYNC_RE
     let since = state?.since ?? null;
     let cursor = state?.cursor ?? null;
     let upserted = 0;
+    const needEmbedding: string[] = [];
     let deleted = 0;
     let pages = 0;
     // Carried across pages rather than read from the last one alone: a traversal that fails
@@ -102,9 +123,10 @@ async function traverse(input: SyncInput): Promise<SyncResult | typeof RESYNC_RE
       if (page.resyncRequired) return RESYNC_REQUIRED;
 
       pages += 1;
-      const outcome = await applySyncRows(page.rows);
+      const outcome = await applySyncRows(page.rows, input.vectors);
       upserted += outcome.upserted;
       deleted += outcome.deleted;
+      needEmbedding.push(...outcome.needEmbedding);
 
       if (page.cursor === null) {
         since = page.nextSeq;
@@ -131,6 +153,7 @@ async function traverse(input: SyncInput): Promise<SyncResult | typeof RESYNC_RE
     return {
       status: complete ? 'synced' : 'incomplete',
       upserted,
+      needEmbedding,
       deleted,
       pages,
       since: complete ? since : (state?.since ?? null),

--- a/src/cloud/vector-codec.ts
+++ b/src/cloud/vector-codec.ts
@@ -1,0 +1,65 @@
+/**
+ * base64 of a little-endian Float32Array -- the encoding `knowl-cloud` reads and writes.
+ *
+ * Not a JSON array of numbers: 384 dimensions is ~1.5 KB binary and ~4.6 KB as JSON text, so a
+ * thousand-atom publish is a 2 MB request instead of a 5 MB one for identical data.
+ *
+ * Duplicated rather than shared, like the embedding recipe: this repo cannot depend on the
+ * proprietary contract package. The fixed expected value in the test is what keeps the two
+ * honest -- a round-trip through our own decoder would pass for any self-consistent encoding,
+ * including one the server cannot read.
+ */
+export class VectorDecodeError extends Error {
+  readonly name = 'VectorDecodeError';
+  constructor(readonly reason: 'not-base64' | 'not-float32' | 'wrong-dimensions', message: string) {
+    super(message);
+  }
+}
+
+export function encodeVector(values: Float32Array | number[]): string {
+  const floats = values instanceof Float32Array ? values : Float32Array.from(values);
+  return Buffer.from(floats.buffer, floats.byteOffset, floats.byteLength).toString('base64');
+}
+
+/**
+ * `expectedDimensions` is required, not optional.
+ *
+ * The replica's `knowledge_embeddings` has no width constraint either, so a vector of the wrong
+ * length would store happily and every later local cosine against it would be meaningless -- with
+ * no error, ever. This is the only place that can catch it, so a caller may not skip it by
+ * accident.
+ */
+export function decodeVector(base64: string, expectedDimensions: number): Float32Array {
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(base64, 'base64');
+    // Node's base64 decoder is lenient and silently drops invalid characters, so re-encoding and
+    // comparing is the only way to tell a real payload from a mangled one.
+    if (buffer.toString('base64').replace(/=+$/, '') !== base64.replace(/=+$/, '')) {
+      throw new Error('not base64');
+    }
+  } catch {
+    throw new VectorDecodeError('not-base64', 'Vector is not valid base64.');
+  }
+
+  if (buffer.byteLength % 4 !== 0) {
+    throw new VectorDecodeError(
+      'not-float32',
+      `Vector is ${buffer.byteLength} bytes, which is not a whole number of float32 values.`,
+    );
+  }
+
+  const dimensions = buffer.byteLength / 4;
+  if (dimensions !== expectedDimensions) {
+    throw new VectorDecodeError(
+      'wrong-dimensions',
+      `Vector has ${dimensions} dimensions; this repository embeds at ${expectedDimensions}.`,
+    );
+  }
+
+  // Copied rather than viewed. `Buffer.from` may return a view into a pooled ArrayBuffer at a
+  // non-zero byteOffset, and a Float32Array over that reads a neighbour's bytes.
+  const copy = new ArrayBuffer(buffer.byteLength);
+  Buffer.from(copy).set(buffer);
+  return new Float32Array(copy);
+}

--- a/src/core/embed-recipe.ts
+++ b/src/core/embed-recipe.ts
@@ -1,0 +1,41 @@
+/**
+ * The exact text an atom becomes before it reaches the model, and the version of that decision.
+ *
+ * **This is a cross-repo contract.** `knowl-cloud` holds a byte-identical copy, because the
+ * server still embeds on three occasions -- knowledge created in its web UI, a workspace reindex,
+ * and query strings -- and those vectors land in the same corpus as client-published ones. Two
+ * recipes means two vector spaces from one model, which nothing downstream can detect: the
+ * fingerprint records provider, model, dtype and pooling, and every one of them would match.
+ *
+ * So the recipe travels as a fifth fingerprint field. Any change here -- field order, separators,
+ * labels, which fields are included, or the token budget the embedder clips to -- is a new
+ * version, and a vector built under version N is not comparable to one built under N+1.
+ *
+ * Version 1 is `knowl`'s historical text shape, adopted by `knowl-cloud` in the same change. The
+ * server previously dropped tags entirely and left reasoning unlabelled, so every atom carrying
+ * either produced a different vector on the two sides from an identical model.
+ */
+export const EMBED_RECIPE_VERSION = 1;
+
+export type EmbedRecipeInput = {
+  title: string;
+  content: string;
+  reasoning?: string | null;
+  tags?: string[] | null;
+};
+
+/**
+ * Labels rather than bare concatenation, deliberately.
+ *
+ * `Reasoning:` and `Tags:` tell the model what the following span is. Bare concatenation reads as
+ * one continuous document, which ranks a rationale as though it were an assertion.
+ *
+ * Not truncated here. Clipping happens in the embedder, one layer down, so it is on the path
+ * every text takes -- including query text -- rather than the one an author's atom happens to
+ * travel.
+ */
+export function buildEmbedText(input: EmbedRecipeInput): string {
+  const reasoning = input.reasoning ? `\nReasoning: ${input.reasoning}` : '';
+  const tags = input.tags?.length ? `\nTags: ${input.tags.join(', ')}` : '';
+  return `${input.title}\n${input.content}${reasoning}${tags}`;
+}

--- a/src/core/vector-profile.ts
+++ b/src/core/vector-profile.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { EMBED_RECIPE_VERSION } from './embed-recipe.js';
 import type { ProjectConfig } from './types.js';
 
 export type VectorPooling = 'mean' | 'cls';
@@ -278,9 +279,18 @@ const EMBEDDING_BATCH_POLICY = 'single';
  * produced it. provider and model alone are not enough: dtype and pooling both
  * change the numbers, so without them a dtype-only switch leaves old rows
  * matching the filter and being scored against incompatible query vectors.
+ *
+ * `EMBED_RECIPE_VERSION` is in here for the same reason `EMBEDDING_BATCH_POLICY` is: the model
+ * is not the only thing that decides a vector. The recipe decides what text reaches the model
+ * at all -- field order, labels, which fields are included, the token budget it is clipped to --
+ * and a recipe change without a fingerprint change leaves every stored row matching a space it
+ * is no longer in. `vector-index.ts` calls that "staleness the fingerprint cannot see" and
+ * offers `reindex --force` as the workaround; including the version is the fix, so a recipe
+ * change invalidates its own rows and the ordinary reindex repairs them.
  */
 export function fingerprintProfile(profile: VectorProfile): string {
   const canonical =
-    `${profile.provider}|${profile.model}|${profile.dtype}|${profile.pooling}|${EMBEDDING_BATCH_POLICY}`;
+    `${profile.provider}|${profile.model}|${profile.dtype}|${profile.pooling}` +
+    `|${EMBEDDING_BATCH_POLICY}|r${EMBED_RECIPE_VERSION}`;
   return createHash('sha256').update(canonical).digest('hex').slice(0, 16);
 }

--- a/src/store/vector-index.ts
+++ b/src/store/vector-index.ts
@@ -1,3 +1,4 @@
+import { buildEmbedText } from '../core/embed-recipe.js';
 import { KnowledgeItem } from '../core/types.js';
 import { getClient } from './database.js';
 import { iterateKnowledgeItemsForIndexing } from './index-scan.js';
@@ -67,10 +68,22 @@ export type VectorReindexOptions = {
   force?: boolean;
 };
 
+/**
+ * The adapter from a `KnowledgeItem` to the recipe module.
+ *
+ * Kept as a named function rather than replaced at its call sites: it has callers across
+ * indexing, reindexing and the retrieval probe, and the text it builds is now a CROSS-REPO
+ * contract that `knowl-cloud` holds a byte-identical copy of. Its shape lives in
+ * `src/core/embed-recipe.ts` so that one module is the only thing either repo has to keep in
+ * step; this stays here because `KnowledgeItem` does not belong in that module.
+ */
 export function buildKnowledgeEmbeddingText(item: KnowledgeItem): string {
-  const tags = item.tags?.length ? `\nTags: ${item.tags.join(', ')}` : '';
-  const reasoning = item.reasoning ? `\nReasoning: ${item.reasoning}` : '';
-  return `${item.title}\n${item.content}${reasoning}${tags}`;
+  return buildEmbedText({
+    title: item.title,
+    content: item.content,
+    reasoning: item.reasoning,
+    tags: item.tags,
+  });
 }
 
 /**

--- a/tests/ai/embeddings.test.ts
+++ b/tests/ai/embeddings.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
 import { DEFAULT_CONFIG } from '../../src/core/config.js';
 import {
-  createLocalEmbeddingProvider, EMBEDDING_LIMITS, estimateTokens, getVectorSearchConfig, planEmbeddingBatches,
-  queryPrefixFor, resetLocalEmbeddingPipeline,
+  clipToTokenBudget, createLocalEmbeddingProvider, EMBEDDING_LIMITS, estimateTokens,
+  getVectorSearchConfig, planEmbeddingBatches, queryPrefixFor, resetLocalEmbeddingPipeline,
 } from '../../src/ai/embeddings.js';
 import type { ProjectConfig } from '../../src/core/types.js';
 
@@ -386,5 +386,51 @@ describe('query prefix', () => {
       .toBe('Represent this sentence for searching relevant passages: ');
     expect(queryPrefixFor('onnx-community/granite-embedding-small-english-r2-ONNX')).toBe('');
     expect(queryPrefixFor('')).toBe('');
+  });
+});
+
+describe('clipping to the token budget', () => {
+  it('clips at 2,048 tokens, the budget knowl-cloud also uses', () => {
+    // Parity, not tuning. A vector is interchangeable between the two repos only if the cut is
+    // identical as well as the text.
+    expect(EMBEDDING_LIMITS.maxTokens).toBe(2_048);
+  });
+
+  it('cuts mid-segment when the first segment alone exceeds the budget', () => {
+    // DIGITS, not letters, and that is the whole subtlety. `segmentTokens` charges letters
+    // ceil(len/4) and digits ceil(len/3), and MAX_EMBED_CHARS pre-clips to 8,000 -- so the most
+    // a letter run can ever cost is 2,000 tokens, which is UNDER the budget and never triggers
+    // this path. A digit run costs 2,667 and does. A letter probe here would pass without the
+    // fix and prove nothing.
+    const spaceless = '1'.repeat(9_000);
+
+    const clipped = clipToTokenBudget(spaceless);
+
+    expect(clipped.text.length).toBeGreaterThan(0);
+    expect(clipped.text.startsWith('111')).toBe(true);
+  });
+
+  it('reports the budget it charged for a mid-segment cut', () => {
+    const clipped = clipToTokenBudget('1'.repeat(9_000));
+    expect(clipped.tokens).toBe(EMBEDDING_LIMITS.maxTokens);
+  });
+
+  it('still cuts on a boundary when one is available inside the budget', () => {
+    // Two-letter words, not four. MAX_EMBED_CHARS pre-clips to 8,000 characters first, and
+    // `word ` is 5 chars costing 1 token -- so 8,000 characters of it is only 1,600 tokens and
+    // never reaches the budget at all. `ab ` is 3 chars costing 1 token, so 8,000 characters is
+    // ~2,666 tokens and the boundary cut actually fires.
+    const words = 'ab '.repeat(4_000);
+
+    const clipped = clipToTokenBudget(words);
+
+    expect(clipped.tokens).toBeLessThanOrEqual(EMBEDDING_LIMITS.maxTokens);
+    expect(clipped.text.length).toBeGreaterThan(0);
+    // Cut on a boundary: the text ends on a whole word, never mid-'ab'.
+    expect(clipped.text.trimEnd().endsWith('ab')).toBe(true);
+  });
+
+  it('leaves a text inside the budget untouched', () => {
+    expect(clipToTokenBudget('a short atom').text).toBe('a short atom');
   });
 });

--- a/tests/cloud/connect.test.ts
+++ b/tests/cloud/connect.test.ts
@@ -203,3 +203,81 @@ describe('runConnect', () => {
     })).rejects.toThrow(/no git remote/i);
   });
 });
+
+describe('runConnect and the workspace embedding profile', () => {
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    for (const dir of [HOME, REPO]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await makeRepo('git@github.com:acme/web.git');
+    await writeCredential(HOST, {
+      accessToken: 'at', refreshToken: 'rt', sessionId: 's',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+  });
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    for (const dir of [HOME, REPO]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  /**
+   * Derived from what this repository actually resolves to, not hardcoded.
+   *
+   * A config with no `search.vector.preset` does not resolve to today's default -- it resolves by
+   * matching its model string, which is what keeps an existing repo on the model its vectors were
+   * built with. Hardcoding the current default here asserted a profile this fixture never has.
+   */
+  async function localProfile() {
+    const { resolveVectorProfile } = await import('../../src/core/vector-profile.js');
+    const { EMBED_RECIPE_VERSION } = await import('../../src/core/embed-recipe.js');
+    const profile = resolveVectorProfile(await loadConfig(REPO));
+    return { ...profile, dimensions: 384, recipeVersion: EMBED_RECIPE_VERSION };
+  }
+
+  const apiWithProfile = (profile: Record<string, unknown>) => ({
+    listWorkspaces: async () => [{ id: 'ws-1', name: 'Acme', role: 'owner' as const }],
+    workspaceProfile: async () => profile,
+  }) as never;
+
+  it('connects when the profiles match', async () => {
+    const result = await runConnect({
+      projectRoot: REPO, apiHost: HOST, api: apiWithProfile(await localProfile()),
+    });
+    expect(result.status).toBe('connected');
+  });
+
+  it('refuses rather than connecting when the model differs', async () => {
+    const result = await runConnect({
+      projectRoot: REPO, apiHost: HOST,
+      api: apiWithProfile({ ...(await localProfile()), model: 'a-different-model' }),
+    });
+
+    expect(result.status).toBe('profile-mismatch');
+    expect((result as { differing: string[] }).differing).toEqual(['model']);
+
+    // Nothing written: a repo pointed at a workspace it cannot publish to is worse than one
+    // pointed nowhere, because every later command looks connected and every push fails.
+    const config = await loadConfig(REPO);
+    expect(config.cloud).toBeUndefined();
+  });
+
+  it('refuses on a recipe difference even when every model field matches', async () => {
+    // The case no model-only comparison can see, and the whole reason the fingerprint has five
+    // fields: an older client on the same model builds different text.
+    const result = await runConnect({
+      projectRoot: REPO, apiHost: HOST,
+      api: apiWithProfile({ ...(await localProfile()), recipeVersion: 99 }),
+    });
+    expect(result.status).toBe('profile-mismatch');
+    expect((result as { differing: string[] }).differing).toEqual(['recipeVersion']);
+  });
+
+  it('connects against a server too old to report a profile', async () => {
+    // It cannot be running the validation either, so refusing here would break connecting to it
+    // for a rule it does not enforce.
+    const result = await runConnect({
+      projectRoot: REPO, apiHost: HOST,
+      api: { listWorkspaces: async () => [{ id: 'ws-1', name: 'Acme', role: 'owner' as const }] } as never,
+    });
+    expect(result.status).toBe('connected');
+  });
+});

--- a/tests/cloud/publish-push.test.ts
+++ b/tests/cloud/publish-push.test.ts
@@ -1,7 +1,7 @@
 ﻿import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { gitArgs } from '../git-identity.js';
 import { CloudApiError, type CloudApi, type CloudRole } from '../../src/cloud/api-client.js';
 import type { PublishOutcome } from '../../src/cloud/sync-contract.js';
@@ -40,6 +40,32 @@ let WS: string;
 let connected: ProjectConfig;
 
 let ids: { decision: string; fact: string };
+
+
+/**
+ * Gives every seeded atom a vector under this repo's CURRENT profile.
+ *
+ * `pushStaged` reads the vector rather than computing one, and refuses to send an atom that has
+ * none -- so without this every case here would stop at `needs-embedding` instead of exercising
+ * what it is about.
+ *
+ * Written directly rather than by embedding: these tests are about the publish protocol, and
+ * running a real forward pass per atom would add a model download to a suite that needs no model
+ * at all. The values are arbitrary; only their width and their fingerprint matter.
+ */
+async function seedEmbeddings(itemIds: string[]): Promise<void> {
+  const { fingerprintProfile, resolveVectorProfile } = await import('../../src/core/vector-profile.js');
+  const { upsertKnowledgeEmbeddings } = await import('../../src/store/vector.js');
+  const profile = resolveVectorProfile(connected);
+  await upsertKnowledgeEmbeddings(itemIds.map((id, index) => ({
+    knowledgeItemId: id,
+    provider: profile.provider,
+    model: profile.model,
+    profileFingerprint: fingerprintProfile(profile),
+    dimensions: 384,
+    vector: new Array(384).fill(0.01 * (index + 1)),
+  })));
+}
 
 function fakeApi(outcomes: PublishOutcome[], onPublish?: (body: any) => void): CloudApi {
   return {
@@ -90,11 +116,11 @@ async function stageMany(count: number): Promise<void> {
         args: [`bulk-${index}`, `Bulk atom ${index}`, `Body ${index}`, now, now],
       });
     }
-    await stageForPublish(
-      Array.from({ length: count }, (_, index) => `bulk-${index}`),
-      WS,
-      'main',
-    );
+    const bulkIds = Array.from({ length: count }, (_, index) => `bulk-${index}`);
+    // Every atom needs a vector under the current profile, or `pushStaged` refuses the whole push
+    // with `needs-embedding` and this test never reaches the chunking it is about.
+    await seedEmbeddings(bulkIds);
+    await stageForPublish(bulkIds, WS, 'main');
   } finally { await closeDb(); }
 }
 
@@ -136,6 +162,7 @@ describe('pushStaged', () => {
     });
     ids = { decision: decision.item.id, fact: fact.item.id };
     await getClient().execute("UPDATE knowledge_items SET origin_repo = 'github.com/acme/web'");
+    await seedEmbeddings([ids.decision, ids.fact]);
     await closeDb();
 
     await writeCredential(API_HOST, {
@@ -287,6 +314,79 @@ describe('pushStaged', () => {
     expect(sizes.every(size => size <= 200)).toBe(true);
     // 250 staged bulk ids plus the decision the fixture already staged.
     expect(sizes.reduce((a, b) => a + b, 0)).toBe(251);
+  });
+
+
+  it('attaches the stored vector and the five-field fingerprint', async () => {
+    let sent: any;
+    await pushStaged({
+      projectRoot: CLONE, config: connected,
+      api: fakeApi([], (body: any) => { sent = body; }),
+    });
+
+    const { fingerprintProfile, resolveVectorProfile } = await import('../../src/core/vector-profile.js');
+    const { EMBED_RECIPE_VERSION } = await import('../../src/core/embed-recipe.js');
+    const { encodeVector } = await import('../../src/cloud/vector-codec.js');
+    const profile = resolveVectorProfile(connected);
+
+    expect(sent.items[0].vector).toBe(encodeVector(new Array(384).fill(0.01)));
+    expect(sent.items[0].profileFingerprint).toEqual({
+      provider: profile.provider,
+      model: profile.model,
+      dtype: profile.dtype,
+      pooling: profile.pooling,
+      recipeVersion: EMBED_RECIPE_VERSION,
+    });
+    // Never `fingerprintProfile`'s hash on the wire: the server compares five values, not a hash
+    // it has no way to reproduce.
+    expect(JSON.stringify(sent)).not.toContain(fingerprintProfile(profile));
+  });
+
+  it('reads the vector rather than embedding at push time', async () => {
+    const embeddings = await import('../../src/ai/embeddings.js');
+    const spy = vi.spyOn(embeddings, 'createLocalEmbeddingProvider');
+
+    try {
+      await pushStaged({ projectRoot: CLONE, config: connected, api: fakeApi([]) });
+    } finally { spy.mockRestore(); }
+
+    // The vector was built when the atom was written. Recomputing here would spend a forward pass
+    // to reproduce a value already on disk -- and produce a DIFFERENT one if the profile moved.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('refuses to push an atom whose vector was built by a stale profile', async () => {
+    await initDb(CLONE);
+    try {
+      await getClient().execute({
+        sql: 'UPDATE knowledge_embeddings SET profile_fingerprint = ? WHERE knowledge_item_id = ?',
+        args: ['a-fingerprint-from-another-profile', ids.decision],
+      });
+    } finally { await closeDb(); }
+
+    let called = false;
+    const result = await pushStaged({
+      projectRoot: CLONE, config: connected, api: fakeApi([], () => { called = true; }),
+    });
+
+    // Not silence and not a lie: the atom stays staged and the message names the fix.
+    expect(result.status).toBe('needs-embedding');
+    expect((result as any).remedy).toContain('reindex');
+    expect(called).toBe(false);
+  });
+
+  it('refuses to push an atom with no vector at all', async () => {
+    await initDb(CLONE);
+    try {
+      await getClient().execute({
+        sql: 'DELETE FROM knowledge_embeddings WHERE knowledge_item_id = ?',
+        args: [ids.decision],
+      });
+    } finally { await closeDb(); }
+
+    const result = await pushStaged({ projectRoot: CLONE, config: connected, api: fakeApi([]) });
+    expect(result.status).toBe('needs-embedding');
+    expect((result as any).count).toBe(1);
   });
 
   it('sends evidence, and the citation survives a round trip into a replica', async () => {

--- a/tests/cloud/publish-snapshot.test.ts
+++ b/tests/cloud/publish-snapshot.test.ts
@@ -95,6 +95,23 @@ describe('a push bound to a snapshot', () => {
         category: 'fact', title, content: `A durable observation about ${title}, long enough to be real.`,
       });
       await getClient().execute("UPDATE knowledge_items SET origin_repo = 'github.com/acme/web'");
+      // A vector under this repo's current profile. `pushStaged` reads one rather than computing
+      // it, and refuses any atom that has none -- so without this every case here stops at
+      // `needs-embedding` instead of exercising the snapshot binding it is about.
+      //
+      // Written directly rather than embedded: these tests are about the push protocol, and a
+      // real forward pass per atom would add a model download to a suite that needs no model.
+      const { fingerprintProfile, resolveVectorProfile } = await import('../../src/core/vector-profile.js');
+      const { upsertKnowledgeEmbeddings } = await import('../../src/store/vector.js');
+      const profile = resolveVectorProfile(connected);
+      await upsertKnowledgeEmbeddings([{
+        knowledgeItemId: stored.item.id,
+        provider: profile.provider,
+        model: profile.model,
+        profileFingerprint: fingerprintProfile(profile),
+        dimensions: 384,
+        vector: new Array(384).fill(0.02),
+      }]);
       return stored.item.id;
     } finally { await closeDb(); }
   };

--- a/tests/cloud/sync-apply.test.ts
+++ b/tests/cloud/sync-apply.test.ts
@@ -214,72 +214,72 @@ describe('applySyncRows', () => {
 
     expect(count).toBe(1);
   });
-});
 
-describe('vectors that arrive with a row', () => {
-  const PROFILE = { provider: 'local', model: 'granite', dtype: 'q8', pooling: 'cls' as const };
-  const CONTEXT = { profile: PROFILE, fingerprint: 'fp-local', dimensions: 4 };
-  const VECTOR = [0.25, -0.5, 0.75, 1];
+  describe('vectors that arrive with a row', () => {
+    const PROFILE = { provider: 'local', model: 'granite', dtype: 'q8', pooling: 'cls' as const };
+    const CONTEXT = { profile: PROFILE, fingerprint: 'fp-local', dimensions: 4 };
+    const VECTOR = [0.25, -0.5, 0.75, 1];
 
-  it('stores a received vector under the LOCAL fingerprint', async () => {
-    await inStore('vec-store', async () => {
-      const outcome = await applySyncRows(
-        [{ op: 'upsert', seq: '1', item: atom({ id: 'a', vector: encodeVector(VECTOR) }) }],
-        CONTEXT,
-      );
+    it('stores a received vector under the LOCAL fingerprint', async () => {
+      await inStore('vec-store', async () => {
+        const outcome = await applySyncRows(
+          [{ op: 'upsert', seq: '1', item: atom({ id: 'a', vector: encodeVector(VECTOR) }) }],
+          CONTEXT,
+        );
 
-      // Nothing left for the local embedder: the vector arrived and was kept.
-      expect(outcome.needEmbedding).toEqual([]);
+        // Nothing left for the local embedder: the vector arrived and was kept.
+        expect(outcome.needEmbedding).toEqual([]);
 
-      const row = await getClient().execute({
-        sql: 'SELECT profile_fingerprint, dimensions, vector FROM knowledge_embeddings WHERE knowledge_item_id = ?',
-        args: ['a'],
+        const row = await getClient().execute({
+          sql: 'SELECT profile_fingerprint, dimensions, vector FROM knowledge_embeddings WHERE knowledge_item_id = ?',
+          args: ['a'],
+        });
+        // The LOCAL fingerprint, not the server's: this client only connected because the profiles
+        // match, so the vector belongs to the local space and local search must be able to filter
+        // it like any other row.
+        expect(String(row.rows[0]!.profile_fingerprint)).toBe('fp-local');
+        expect(Number(row.rows[0]!.dimensions)).toBe(4);
+        expect(Array.from(decodeStored(row.rows[0]!.vector)!)).toEqual(VECTOR);
       });
-      // The LOCAL fingerprint, not the server's: this client only connected because the profiles
-      // match, so the vector belongs to the local space and local search must be able to filter
-      // it like any other row.
-      expect(String(row.rows[0]!.profile_fingerprint)).toBe('fp-local');
-      expect(Number(row.rows[0]!.dimensions)).toBe(4);
-      expect(Array.from(decodeStored(row.rows[0]!.vector)!)).toEqual(VECTOR);
     });
-  });
 
-  it('reports a row that arrived without one, rather than inventing a vector', async () => {
-    await inStore('vec-absent', async () => {
-      const outcome = await applySyncRows(
-        [{ op: 'upsert', seq: '1', item: atom({ id: 'b' }) }],
-        CONTEXT,
-      );
+    it('reports a row that arrived without one, rather than inventing a vector', async () => {
+      await inStore('vec-absent', async () => {
+        const outcome = await applySyncRows(
+          [{ op: 'upsert', seq: '1', item: atom({ id: 'b' }) }],
+          CONTEXT,
+        );
 
-      // Every row looks like this while a workspace is mid-reindex. Not a failure -- the atom is
-      // stored and text-searchable, and the local embedder closes the gap.
-      expect(outcome.needEmbedding).toEqual(['b']);
-    });
-  });
-
-  it('refuses a vector of the wrong width rather than storing noise', async () => {
-    await inStore('vec-width', async () => {
-      const outcome = await applySyncRows(
-        [{ op: 'upsert', seq: '1', item: atom({ id: 'c', vector: encodeVector([1, 2, 3, 4, 5, 6]) }) }],
-        CONTEXT,
-      );
-
-      // The replica's column has no width constraint, so a 6-dim vector in a 4-dim store would
-      // rank as noise forever. Falling back to a local embed is the recoverable direction.
-      expect(outcome.needEmbedding).toEqual(['c']);
-      const row = await getClient().execute({
-        sql: 'SELECT 1 FROM knowledge_embeddings WHERE knowledge_item_id = ?', args: ['c'],
+        // Every row looks like this while a workspace is mid-reindex. Not a failure -- the atom is
+        // stored and text-searchable, and the local embedder closes the gap.
+        expect(outcome.needEmbedding).toEqual(['b']);
       });
-      expect(row.rows).toHaveLength(0);
     });
-  });
 
-  it('stores nothing when the caller asked for no vectors, which is the pre-vector behaviour', async () => {
-    await inStore('vec-off', async () => {
-      const outcome = await applySyncRows(
-        [{ op: 'upsert', seq: '1', item: atom({ id: 'd', vector: encodeVector(VECTOR) }) }],
-      );
-      expect(outcome.needEmbedding).toEqual(['d']);
+    it('refuses a vector of the wrong width rather than storing noise', async () => {
+      await inStore('vec-width', async () => {
+        const outcome = await applySyncRows(
+          [{ op: 'upsert', seq: '1', item: atom({ id: 'c', vector: encodeVector([1, 2, 3, 4, 5, 6]) }) }],
+          CONTEXT,
+        );
+
+        // The replica's column has no width constraint, so a 6-dim vector in a 4-dim store would
+        // rank as noise forever. Falling back to a local embed is the recoverable direction.
+        expect(outcome.needEmbedding).toEqual(['c']);
+        const row = await getClient().execute({
+          sql: 'SELECT 1 FROM knowledge_embeddings WHERE knowledge_item_id = ?', args: ['c'],
+        });
+        expect(row.rows).toHaveLength(0);
+      });
+    });
+
+    it('stores nothing when the caller asked for no vectors, which is the pre-vector behaviour', async () => {
+      await inStore('vec-off', async () => {
+        const outcome = await applySyncRows(
+          [{ op: 'upsert', seq: '1', item: atom({ id: 'd', vector: encodeVector(VECTOR) }) }],
+        );
+        expect(outcome.needEmbedding).toEqual(['d']);
+      });
     });
   });
 });

--- a/tests/cloud/sync-apply.test.ts
+++ b/tests/cloud/sync-apply.test.ts
@@ -5,6 +5,8 @@ import { getClient } from '../../src/store/database.js';
 import { withTeamStore } from '../../src/cloud/team-store.js';
 import { applySyncRows } from '../../src/cloud/sync-apply.js';
 import type { SyncAtom, SyncRow } from '../../src/cloud/sync-contract.js';
+import { encodeVector } from '../../src/cloud/vector-codec.js';
+import { decodeVector as decodeStored } from '../../src/store/vector.js';
 
 const HOME = path.resolve('./.knowl-sync-apply-home');
 const ROOT = path.resolve('./.knowl-sync-apply-root');
@@ -211,5 +213,73 @@ describe('applySyncRows', () => {
     });
 
     expect(count).toBe(1);
+  });
+});
+
+describe('vectors that arrive with a row', () => {
+  const PROFILE = { provider: 'local', model: 'granite', dtype: 'q8', pooling: 'cls' as const };
+  const CONTEXT = { profile: PROFILE, fingerprint: 'fp-local', dimensions: 4 };
+  const VECTOR = [0.25, -0.5, 0.75, 1];
+
+  it('stores a received vector under the LOCAL fingerprint', async () => {
+    await inStore('vec-store', async () => {
+      const outcome = await applySyncRows(
+        [{ op: 'upsert', seq: '1', item: atom({ id: 'a', vector: encodeVector(VECTOR) }) }],
+        CONTEXT,
+      );
+
+      // Nothing left for the local embedder: the vector arrived and was kept.
+      expect(outcome.needEmbedding).toEqual([]);
+
+      const row = await getClient().execute({
+        sql: 'SELECT profile_fingerprint, dimensions, vector FROM knowledge_embeddings WHERE knowledge_item_id = ?',
+        args: ['a'],
+      });
+      // The LOCAL fingerprint, not the server's: this client only connected because the profiles
+      // match, so the vector belongs to the local space and local search must be able to filter
+      // it like any other row.
+      expect(String(row.rows[0]!.profile_fingerprint)).toBe('fp-local');
+      expect(Number(row.rows[0]!.dimensions)).toBe(4);
+      expect(Array.from(decodeStored(row.rows[0]!.vector)!)).toEqual(VECTOR);
+    });
+  });
+
+  it('reports a row that arrived without one, rather than inventing a vector', async () => {
+    await inStore('vec-absent', async () => {
+      const outcome = await applySyncRows(
+        [{ op: 'upsert', seq: '1', item: atom({ id: 'b' }) }],
+        CONTEXT,
+      );
+
+      // Every row looks like this while a workspace is mid-reindex. Not a failure -- the atom is
+      // stored and text-searchable, and the local embedder closes the gap.
+      expect(outcome.needEmbedding).toEqual(['b']);
+    });
+  });
+
+  it('refuses a vector of the wrong width rather than storing noise', async () => {
+    await inStore('vec-width', async () => {
+      const outcome = await applySyncRows(
+        [{ op: 'upsert', seq: '1', item: atom({ id: 'c', vector: encodeVector([1, 2, 3, 4, 5, 6]) }) }],
+        CONTEXT,
+      );
+
+      // The replica's column has no width constraint, so a 6-dim vector in a 4-dim store would
+      // rank as noise forever. Falling back to a local embed is the recoverable direction.
+      expect(outcome.needEmbedding).toEqual(['c']);
+      const row = await getClient().execute({
+        sql: 'SELECT 1 FROM knowledge_embeddings WHERE knowledge_item_id = ?', args: ['c'],
+      });
+      expect(row.rows).toHaveLength(0);
+    });
+  });
+
+  it('stores nothing when the caller asked for no vectors, which is the pre-vector behaviour', async () => {
+    await inStore('vec-off', async () => {
+      const outcome = await applySyncRows(
+        [{ op: 'upsert', seq: '1', item: atom({ id: 'd', vector: encodeVector(VECTOR) }) }],
+      );
+      expect(outcome.needEmbedding).toEqual(['d']);
+    });
   });
 });

--- a/tests/cloud/vector-codec.test.ts
+++ b/tests/cloud/vector-codec.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { decodeVector, encodeVector, VectorDecodeError } from '../../src/cloud/vector-codec.js';
+
+describe('vector codec', () => {
+  it('encodes to base64 of a little-endian Float32Array', () => {
+    // A FIXED expected value, not a round-trip through our own decoder -- that would pass for any
+    // self-consistent encoding, including one knowl-cloud cannot read. This literal is the
+    // contract; verify it once by decoding it there, then treat it as a constant.
+    expect(encodeVector([1, 2])).toBe('AACAPwAAAEA=');
+  });
+
+  it('round-trips without loss', () => {
+    const original = Float32Array.from([0.5, -0.25, 0, 1]);
+    expect(Array.from(decodeVector(encodeVector(original), 4))).toEqual([0.5, -0.25, 0, 1]);
+  });
+
+  it('accepts a plain number array on the way in', () => {
+    expect(encodeVector(Float32Array.from([1, 2]))).toBe(encodeVector([1, 2]));
+  });
+
+  it('produces four bytes per dimension', () => {
+    expect(Buffer.from(encodeVector(new Array(384).fill(0)), 'base64').byteLength).toBe(384 * 4);
+  });
+
+  it('refuses a payload that is not base64', () => {
+    expect(() => decodeVector('not base64 !!!', 4)).toThrow(VectorDecodeError);
+  });
+
+  it('refuses a byte length that is not a whole number of floats', () => {
+    expect(() => decodeVector(Buffer.from([1, 2, 3]).toString('base64'), 1)).toThrow(/float32/i);
+  });
+
+  it('refuses the right encoding at the wrong dimension', () => {
+    // The replica's vector column has no width constraint either, so a 768-dim vector from a
+    // workspace on another model would store happily and rank as noise forever.
+    expect(() => decodeVector(encodeVector([1, 2, 3]), 384)).toThrow(/dimension/i);
+  });
+
+  it('names the reason, so a caller can say something useful', () => {
+    try {
+      decodeVector(encodeVector([1]), 384);
+      throw new Error('should have thrown');
+    } catch (error) {
+      expect((error as VectorDecodeError).reason).toBe('wrong-dimensions');
+    }
+  });
+
+  it('does not read a neighbour\'s bytes when the buffer is pooled', () => {
+    const vectors = Array.from({ length: 64 }, (_, i) => [i, i + 0.5, i + 0.25, i + 0.125]);
+    for (const values of vectors) {
+      expect(Array.from(decodeVector(encodeVector(values), 4))).toEqual(values);
+    }
+  });
+});

--- a/tests/core/embed-recipe.test.ts
+++ b/tests/core/embed-recipe.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { buildEmbedText, EMBED_RECIPE_VERSION } from '../../src/core/embed-recipe.js';
+
+/**
+ * THE CROSS-REPO FIXTURE.
+ *
+ * `knowl-cloud/tests/knowledge/embed-recipe.test.ts` holds a byte-identical copy of this atom
+ * and of `EXPECTED`. They are duplicated by value and never imported across repos, because an
+ * OSS repo cannot depend on the proprietary one -- and because two independent copies are what
+ * turn a drift into a failing test instead of a silent change on one side.
+ *
+ * Changing either constant here REQUIRES the same change there and a bump of
+ * `EMBED_RECIPE_VERSION` in both. A vector built under version N is not comparable to one built
+ * under N+1, and nothing else in either system can detect that.
+ */
+const FIXTURE = {
+  title: 'SQLite WAL checkpointing',
+  content: 'A checkpoint must run before copying the database file.',
+  reasoning: 'Otherwise the copy misses committed pages still in the WAL.',
+  tags: ['sqlite', 'backup'],
+};
+
+const EXPECTED =
+  'SQLite WAL checkpointing\n' +
+  'A checkpoint must run before copying the database file.\n' +
+  'Reasoning: Otherwise the copy misses committed pages still in the WAL.\n' +
+  'Tags: sqlite, backup';
+
+describe('embed recipe v1', () => {
+  it('builds exactly the fixture string', () => {
+    expect(buildEmbedText(FIXTURE)).toBe(EXPECTED);
+  });
+
+  it('is version 1', () => {
+    expect(EMBED_RECIPE_VERSION).toBe(1);
+  });
+
+  it('omits the reasoning line entirely when there is none', () => {
+    expect(buildEmbedText({ title: 'T', content: 'C', reasoning: null, tags: ['a'] }))
+      .toBe('T\nC\nTags: a');
+  });
+
+  it('omits the tags line entirely when the array is empty', () => {
+    expect(buildEmbedText({ title: 'T', content: 'C', reasoning: 'R', tags: [] }))
+      .toBe('T\nC\nReasoning: R');
+  });
+
+  it('treats absent and empty the same way, so an optional field cannot change the shape', () => {
+    expect(buildEmbedText({ title: 'T', content: 'C' }))
+      .toBe(buildEmbedText({ title: 'T', content: 'C', reasoning: null, tags: [] }));
+  });
+
+  it('joins tags with a comma and a space, in the order given', () => {
+    expect(buildEmbedText({ title: 'T', content: 'C', tags: ['b', 'a'] }))
+      .toBe('T\nC\nTags: b, a');
+  });
+});

--- a/tests/core/vector-profile.test.ts
+++ b/tests/core/vector-profile.test.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_PRESET_ID, PRESET_IDS, VECTOR_PRESETS, fingerprintProfile, resolveVectorProfile,
 } from '../../src/core/vector-profile.js';
@@ -129,5 +129,41 @@ describe('bench:embeddings preset list', () => {
     // against VECTOR_PRESETS rather than PRESET_IDS.
     expect(PRESET_IDS.filter(id => id !== 'custom').sort()).toEqual([...inScript].sort());
     expect(inScript).toContain(DEFAULT_PRESET_ID);
+  });
+});
+
+describe('the fingerprint covers the embedding recipe', () => {
+  const profile = { provider: 'local', model: 'm', dtype: 'q8', pooling: 'cls' } as const;
+
+  afterEach(() => { vi.resetModules(); vi.doUnmock('../../src/core/embed-recipe.js'); });
+
+  it('changes when the recipe version changes, so a recipe change invalidates stored vectors', async () => {
+    const before = fingerprintProfile(profile);
+
+    vi.resetModules();
+    vi.doMock('../../src/core/embed-recipe.js', () => ({
+      EMBED_RECIPE_VERSION: 2,
+      buildEmbedText: () => '',
+    }));
+    const { fingerprintProfile: withV2 } = await import('../../src/core/vector-profile.js');
+
+    // Without this, a recipe change produces different vectors under an UNCHANGED fingerprint,
+    // so search goes on scoring new query text against old-recipe vectors -- what
+    // `vector-index.ts` calls "staleness the fingerprint cannot see".
+    expect(withV2(profile)).not.toBe(before);
+  });
+
+  it('is stable for one profile at one recipe version', () => {
+    expect(fingerprintProfile(profile)).toBe(fingerprintProfile({ ...profile }));
+  });
+
+  it('still separates two models at the same recipe version', () => {
+    expect(fingerprintProfile({ ...profile, model: 'a' }))
+      .not.toBe(fingerprintProfile({ ...profile, model: 'b' }));
+  });
+
+  it('still separates two poolings, which is the difference nothing else would notice', () => {
+    expect(fingerprintProfile({ ...profile, pooling: 'cls' }))
+      .not.toBe(fingerprintProfile({ ...profile, pooling: 'mean' }));
   });
 });


### PR DESCRIPTION
Client half of the client-side embedding design. **Pairs with https://github.com/dat999zx/knowl-cloud/pull/41 — neither merges alone.**

Implements **Plan 0 (client half), Plan 2, and Plan 3 (client half)**.

## The problem

Every client re-embedded every atom it pulled (`pull.ts` → `embedReplica`), and the sync contract carried no vectors at all. So a ten-person workspace embedded each shared atom **eleven times** — once by its author, once by the server, and once by each of the nine others. Forever, on people's laptops.

And this repo and knowl-cloud built the text they embed **four different ways**, so most published atoms already sat in two vector spaces. Same model, same fingerprint, different vectors, with nothing able to see it.

## What ships

**Plan 0 — one recipe.** `src/core/embed-recipe.ts`, byte-identical to knowl-cloud's. `MAX_EMBED_TOKENS` 2,560 → 2,048 to match the server. `clipToTokenBudget` cuts mid-segment where it returned the **empty string**, so a spaceless atom embedded as *nothing*. And `fingerprintProfile` now hashes `EMBED_RECIPE_VERSION` — which is what makes the budget change safe.

**Plan 2 — publish carries the vector.** Read from `knowledge_embeddings`, never recomputed: it was built when the atom was written, and re-embedding would produce a *different* vector if the profile moved since. `knowl cloud connect` compares all five profile fields against the workspace's and refuses before writing the pointer.

**Plan 3 (client) — pull stores the team's vectors.** `embedReplica` narrows to the rows that arrived without one, rather than being deleted as the design first said.

## Four things worth a reviewer's attention

**The clip probe uses digits, not letters, and that is load-bearing.** `MAX_EMBED_CHARS` pre-clips to 8,000, and a letter run costs `ceil(len/4)` = 2,000 tokens — *under* the budget, so it never reaches the empty-string branch. Only a digit run (`ceil(len/3)` = 2,667) does. A letter probe passes without the fix.

**`loadPublishItem` returns a discriminated result instead of `null`.** Null meant "the row is gone"; there is now a second cause with a different remedy. Collapsing both made the second invisible, and a push would report success for atoms it never sent. It surfaces as `needs-embedding` and the CLI prints `knowl reindex --vectors`.

**`embedReplica` is narrowed, not deleted.** Every row of a workspace mid-reindex arrives text-only by design, so deleting it would break pull during exactly the operation it most needs to survive. The narrowing needs no id list — `reindexKnowledgeEmbeddings` already skips rows carrying the current fingerprint.

**The width comes from what this repo has produced.** knowl's presets don't record a dimension — it appears only in their prose labels — so the authoritative source is an existing local row. A repo with none accepts whatever arrives.

## Release note needed

Stored vectors stop matching on upgrade, for atoms between 2,048 and 2,560 tokens. Self-repairing — they leave vector search rather than ranking wrongly — but a user who never runs `knowl reindex --vectors` keeps searching on BM25 alone and won't know why.

## Verification

`npm run build && npm test` — **307 files, 2,783 passed, 5 skipped** (baseline 305 / 2,747). `tsc --noEmit` clean. `git diff --check` clean.