### PR TITLE
fix(cli): a cloud failure exits 1, not 127

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -760,6 +760,36 @@ for (const [gone, replacement] of [
     });
 }
 
+/**
+ * Every failure in this group sets `process.exitCode` and returns. None of them calls
+ * `process.exit`, and that is deliberate.
+ *
+ * A cloud verb can have loaded the embedder before it fails: staging and pushing build vectors,
+ * connect compares profiles, pull decides what still needs embedding. Calling `process.exit(1)`
+ * there tears the process down while the runtime's async handle is mid-close, and libuv aborts on
+ * the way out:
+ *
+ *     Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
+ *
+ * The abort wins the race, so the shell sees **127** rather than 1. That is worse than an
+ * arbitrary wrong number, because 127 conventionally means "command not found" — so the first
+ * thing anyone debugging it checks is their PATH and their install, neither of which is the
+ * problem. Measured, not guessed: 3/3 aborts on `cloud push` against a mismatched workspace,
+ * while the same command on its success path exits 0 clean, which is what pins it to the exit
+ * and not to the command. `cloud retract`'s failure exits 1 clean because that path never loads
+ * the embedder, and a bare `cloud stage` refuses before loading it too.
+ *
+ * Setting `exitCode` lets the loop drain and the handles close on their own, and the process ends
+ * with 1 the way every other error path in this file already does.
+ *
+ * **The `return` is load-bearing.** `process.exit` stopped the command as a side effect; setting
+ * a code does not. Every conversion here is a guard with code after it, so dropping the return
+ * would carry on past a refusal — a worse bug than the one being fixed.
+ * `tests/cli/cloud-exit-codes.test.ts` holds that invariant.
+ *
+ * Scoped to this group on purpose. The other command groups exit from paths that never touch the
+ * embedder, and rewriting sixty-odd call sites to fix two would be a diff nobody can review.
+ */
 const cloudCommand = program.command('cloud').description('Publish to and read from a Knowl Cloud workspace');
 
 cloudCommand
@@ -790,12 +820,14 @@ cloudCommand
       }
       if (result.status === 'expired') {
         console.error('The code expired before it was approved. Run knowl cloud login again.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       console.log(`Signed in to ${options.api}.`);
     } catch (error: any) {
       console.error(`Login failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -817,7 +849,8 @@ cloudCommand
       const credential = await readCredential(options.api);
       if (!credential) {
         console.error('Not signed in. Run knowl cloud login first.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       const workspaces = await createCloudApi({ apiHost: options.api })
         .listWorkspaces(credential.accessToken);
@@ -830,7 +863,8 @@ cloudCommand
       }
     } catch (error: any) {
       console.error(`Listing workspaces failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -854,7 +888,8 @@ cloudCommand
 
       if (result.status === 'not-connected') {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       for (const item of result.items) console.log(`  ${item.category}  ${item.title}`);
       if (result.skippedForeign > 0) {
@@ -882,7 +917,8 @@ cloudCommand
       }
     } catch (error: any) {
       console.error(`Staging failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -893,13 +929,15 @@ cloudCommand
   .action(async (state: string) => {
     if (state !== 'on' && state !== 'off') {
       console.error('Expected on or off.');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     const root = await findProjectRoot(process.cwd());
     const config = await loadConfig(root);
     if (!config.cloud) {
       console.error('This repository is not connected to a cloud workspace.');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     await writeAutoPushConsent(config.cloud.workspaceId, state === 'on');
     const workspace = config.cloud.workspaceName ?? config.cloud.workspaceId;
@@ -921,7 +959,8 @@ cloudCommand
       const config = await loadConfig(root);
       if (!config.cloud) {
         console.error('This repository is not connected to a cloud workspace.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       await initDb(root);
       try {
@@ -936,7 +975,8 @@ cloudCommand
       }
     } catch (error: any) {
       console.error(`Unstage failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -989,17 +1029,20 @@ cloudCommand
 
       if (result.status === 'not-logged-in') {
         console.error('Not signed in. Run knowl cloud login first.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'no-workspaces') {
         console.error('You are signed in but do not belong to any workspace yet.');
         console.error('Ask a workspace owner to invite you, or create one in the web console.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'unknown-workspace') {
         console.error(`No workspace with id "${result.workspaceId}". You belong to:`);
         for (const entry of result.workspaces) console.error(`  ${entry.id}  ${entry.name} (${entry.role})`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'ambiguous') {
         // The list is already in hand -- `runConnect` fetched it to discover the ambiguity -- so
@@ -1010,13 +1053,15 @@ cloudCommand
           // command gave before the picker existed.
           console.error('You belong to more than one workspace. Re-run with --workspace <id>:');
           for (const entry of result.workspaces) console.error(`  ${entry.id}  ${entry.name} (${entry.role})`);
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         // Re-entered with the choice made, rather than writing the pointer here as well.
         const confirmed = await runConnect({ ...connectInput, workspaceId: chosen });
         if (confirmed.status !== 'connected') {
           console.error(`Connect failed after choosing a workspace: ${confirmed.status}`);
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         await reportConnected(confirmed);
         return;
@@ -1038,13 +1083,15 @@ cloudCommand
         console.error('refuse writes to it from a different one. To keep publishing as before:');
         console.error(`  knowl cloud connect --repo ${result.current}`);
         console.error('Re-run with the new name only if you mean to start a separate history.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       await reportConnected(result);
     } catch (error: any) {
       console.error(`Connect failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -1059,11 +1106,13 @@ cloudCommand
 
       if (result.status === 'not-connected') {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'not-logged-in') {
         console.error('Not signed in. Run knowl cloud login first.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       const { sync } = result;
@@ -1078,7 +1127,8 @@ cloudCommand
       }
     } catch (error: any) {
       console.error(`Pull failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -1107,7 +1157,8 @@ cloudCommand
           + 'embedding profile, so nothing was sent.\n'
           + 'Run `knowl reindex --vectors`, then push again.',
         );
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       if (snapshot.items.length > 0 && !options.yes) {
@@ -1115,7 +1166,8 @@ cloudCommand
           // A prompt that cannot be answered must not block CI, and silence must not be read
           // as consent for something irreversible.
           console.error(`${snapshot.items.length} item(s) would be sent. Re-run with --yes to confirm.`);
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         console.log(`About to send ${snapshot.items.length} item(s) to ${config.cloud?.workspaceName ?? 'the workspace'}:`);
         for (const entry of snapshot.items) console.log(`  ${entry.payload.category}  ${entry.payload.title}`);
@@ -1133,26 +1185,31 @@ cloudCommand
 
       if (result.status === 'not-connected') {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'not-logged-in') {
         console.error('Not signed in. Run knowl cloud login first.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'snapshot-stale') {
         console.error('The queue changed while you were deciding, so nothing was sent.');
         if (result.changed.length > 0) console.error(`  ${result.changed.length} listed item(s) were edited.`);
         if (result.added.length > 0) console.error(`  ${result.added.length} new item(s) were staged.`);
         console.error('Run knowl cloud push again to see the current list.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'forbidden') {
         console.error(`You are a ${result.role} in this workspace, which cannot publish.`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'gated') {
         console.error(`${result.staged} item(s) stay staged. ${result.detail}`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'needs-embedding') {
         // Nothing is lost: they stay staged and go out on the next push. Said out loud because a
@@ -1162,7 +1219,8 @@ cloudCommand
           + 'so nothing was sent.\n'
           + `Run \`${result.remedy}\`, then push again.`,
         );
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       console.log(`Published ${result.created} new and ${result.updated} updated item(s).`);
@@ -1174,7 +1232,8 @@ cloudCommand
       }
     } catch (error: any) {
       console.error(`Push failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -1190,33 +1249,39 @@ cloudCommand
 
       if (result.status === 'not-connected') {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'not-logged-in') {
         console.error('Not signed in. Run knowl cloud login first.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'forbidden') {
         console.error(`You are a ${result.role} in this workspace, which cannot remove knowledge.`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'not-published') {
         console.error(`${id} was never pushed from this machine, so there is nothing in the workspace to remove.`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       if (result.status === 'conflict') {
         console.error(
           `${id} changed in the workspace after this machine published it (now version ${result.currentVersion}).`,
         );
         console.error('Run knowl cloud pull, read what it says now, and retract again if it should still go.');
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       console.log(`Removed ${id} from the workspace. Teammates lose it on their next sync.`);
       console.log('This cannot be undone, and the id can never be published again.');
     } catch (error: any) {
       console.error(`Retract failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 
@@ -1230,7 +1295,8 @@ cloudCommand
       console.log(formatCloudStatus(await cloudStatus(root, config)));
     } catch (error: any) {
       console.error(`Status failed: ${error.message}`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   });
 

--- a/tests/cli/cloud-exit-codes.test.ts
+++ b/tests/cli/cloud-exit-codes.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The cloud group must fail by setting `process.exitCode`, never by calling `process.exit`.
+ *
+ * A cloud verb can have loaded the embedder before it fails, and exiting there tears the process
+ * down while the runtime's async handle is mid-close. libuv aborts (`UV_HANDLE_CLOSING`) and the
+ * abort wins the race, so the shell sees 127 instead of 1 — a code that conventionally means
+ * "command not found", sending whoever debugs it to their PATH rather than to the refusal they
+ * were actually given.
+ *
+ * Source assertions rather than behavioural ones. Reproducing this needs a real embedder, a real
+ * server and a mismatched workspace, and it only manifests on Windows; a suite that could catch
+ * it is a suite that cannot run in CI. What is checkable everywhere is the shape of the code.
+ */
+const SOURCE = readFileSync(new URL('../../src/cli/program.ts', import.meta.url), 'utf8');
+const LINES = SOURCE.split('\n');
+
+const START = LINES.findIndex(line => line.startsWith('const cloudCommand = program.command'));
+const END = LINES.findIndex(line => line.startsWith('const workspaceCommand = program.command'));
+const CLOUD = LINES.slice(START, END);
+
+describe('the cloud command group never calls process.exit', () => {
+  it('finds the group at all, so a rename cannot make this suite vacuous', () => {
+    // Without this the slice above could silently become empty and every assertion below would
+    // pass by describing nothing.
+    expect(START).toBeGreaterThan(-1);
+    expect(END).toBeGreaterThan(START);
+    expect(CLOUD.length).toBeGreaterThan(200);
+  });
+
+  it('has no process.exit call left in it', () => {
+    const offenders = CLOUD
+      .map((line, index) => ({ line, at: START + index + 1 }))
+      .filter(entry => /^\s*process\.exit\(/.test(entry.line));
+
+    expect(
+      offenders.map(entry => `${entry.at}: ${entry.line.trim()}`),
+      'A cloud path calls process.exit again. On a path that has loaded the embedder that aborts '
+      + 'with UV_HANDLE_CLOSING and reports 127 instead of 1. Set process.exitCode and return.',
+    ).toEqual([]);
+  });
+
+  /**
+   * The half that is easy to lose. `process.exit` stopped the command as a side effect and
+   * `exitCode` does not, so every one of these guards has live code after it. A conversion that
+   * forgets the return carries on past a refusal — connecting after saying it would not, pushing
+   * after saying it could not — which is a worse bug than the exit code it set out to fix.
+   */
+  it('follows every exitCode assignment with a return', () => {
+    const unguarded: string[] = [];
+    CLOUD.forEach((line, index) => {
+      if (!/^\s*process\.exitCode = 1;\s*$/.test(line)) return;
+      const next = CLOUD[index + 1] ?? '';
+      if (!/^\s*return;\s*$/.test(next)) {
+        unguarded.push(`${START + index + 1}: ${line.trim()} -> ${next.trim() || '(end)'}`);
+      }
+    });
+
+    expect(
+      unguarded,
+      'process.exitCode was set without returning. Unlike process.exit it does not stop the '
+      + 'command, so execution continues past the refusal.',
+    ).toEqual([]);
+  });
+
+  it('still actually reports failure somewhere, rather than having dropped the code entirely', () => {
+    // The lazy way to make the two assertions above pass is to delete the failure handling. This
+    // is the counterweight: the group refuses in many places and each one must still say so.
+    const assignments = CLOUD.filter(line => /process\.exitCode = 1;/.test(line));
+    expect(assignments.length).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
`process.exit(1)` on a path that has loaded the embedder tears the process down while the runtime's async handle is mid-close, and libuv aborts on the way out:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

The abort wins the race, so the shell sees **127**. That is worse than an arbitrary wrong number: 127 conventionally means *"command not found"*, so the first thing anyone debugging a refused push checks is their PATH and their install — neither of which is the problem.

## Measured, not reasoned about

| path | before | after |
|---|---|---|
| `cloud push` vs mismatched workspace | **127** + abort (3/3) | **1**, clean |
| `cloud connect` vs mismatched workspace | **127** + abort | **1**, clean |
| `cloud push` success | 0, clean | 0, clean |
| `cloud stage` bare refusal | 1, clean | 1, clean |

The success path exiting 0 clean on the *same command* is what pins this to the exit rather than to the command. `cloud retract`'s failure already exited 1 because that path never loads the embedder, and a bare `cloud stage` refuses before loading it.

## Why the whole group, not the two proven paths

`fe45de9` fixed connect's `profile-mismatch` branch. It left the two paths people actually reach — the **push** refusal, which is the one that finds an existing user (they are already connected and never re-run `connect`), and connect's own catch-all.

Whether the embedder is loaded depends on what the command did before it failed, so a rule applied per-call-site has to be re-derived every time someone adds a guard, and it rots. Every exit in the cloud group now sets `exitCode` and returns.

Scoped to that group deliberately: the others exit from paths that never touch the embedder, and rewriting sixty-odd call sites to fix two is a diff nobody can review.

## The `return` is load-bearing

`process.exit` stopped the command as a side effect; setting a code does not. Every one of these guards has live code after it, so a conversion that forgets the return carries on past a refusal — connecting after saying it would not, pushing after saying it could not. That is a worse bug than the exit code.

`tests/cli/cloud-exit-codes.test.ts` holds both halves: no `process.exit` remains in the group, and every `exitCode` assignment is followed by a `return`. Plus two guards against the suite quietly becoming vacuous — one that fails if the group can no longer be located, and one that fails if the failure handling were simply deleted to make the first two pass.

Source assertions rather than behavioural ones, because reproducing this needs a real embedder, a real server and a mismatched workspace, and it only manifests on Windows. A suite that could catch it is a suite that cannot run in CI.

`npm test` — **322 files, 2900 passed, 5 skipped.** `tsc` and `eslint` clean.

> Heads up: `feat/sharing-picker` is changing `cloud stage`'s bare-call behaviour in the same file. This change is mechanical and confined to exit statements, so it should rebase cleanly, but it touches the same region.