### PR TITLE
docs: describe what 5.0 actually does, and close three holes in the gate that hid it

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,8 +483,8 @@ knowl workspace init product      # create the workspace
 knowl workspace add product       # run inside each repo that joins it
                                   # ...or --default-visibility repo to keep its writes private
 
-knowl workspace promote --category decision           # preview what would be shared
-knowl workspace promote --category decision --apply   # publish it
+knowl workspace promote                               # pick what to share from a list
+knowl workspace promote --category decision --apply   # or name it outright
 ```
 
 Joining a workspace shares what the repo writes **from then on**, and says so when it does; pass

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -549,6 +549,31 @@ The incremental Tree-sitter index supports `.ts`, `.tsx`, `.js`, and `.jsx`. It 
 symbols and import/export relationships for local inspection; code indexing and symbol
 resolution never fan out to workspace peers.
 
+### Change impact, when two sessions touch the same code
+
+**Off by default.** `impact.enabled` is absent from a new configuration rather than present and
+false, so upgrading Knowl cannot switch it on. Turn it on with `knowl config set impact.enabled
+true`; the MCP tool below is registered only when it is on.
+
+While it is on, Knowl records which files a session actually read, and tells a session when
+another one has since changed code underneath it — the case where you are working from something
+that was true when you read it and is not any more.
+
+Findings come in three tiers. `certain` and `likely` are returned by default; `possible` is
+unmeasured path matching and is returned only when asked for by name. A `certain` finding also
+refuses the next edit to that file until you have re-read it, which is the one place this feature
+does more than report.
+
+- **`knowl_impact`** — `scope: "mine"` (the default) lists findings against reads still held open,
+  which is the work someone can still act on; `scope: "all"` includes findings whose session has
+  since ended and which nobody has adjudicated. Pass `resolve` to close one.
+
+Closing a finding is the only way it ever closes, and the resolution is the measurement:
+`repaired` (you reconciled your work with the change), `false_positive` (the change does not
+affect what you were doing), `dismissed` (it does, and you are proceeding anyway), or `expired`
+(the work it concerned is gone). `false_positive` is what makes a precision number possible, so
+it is worth using when it is the true answer.
+
 ### Pull-request drift and retrieval feedback
 
 Preview affected knowledge before changing freshness:
@@ -695,6 +720,7 @@ The replica is a replica: deleting it is always safe, and the next pull rebuilds
 | --- | --- |
 | `knowl cloud login [--api <host>]` | Sign in once, by device code. The credential lives in `~/.knowl`, never in `.knowl/config.json` |
 | `knowl cloud logout [--api <host>]` | Clear the stored credential |
+| `knowl cloud workspaces [--api <host>]` | List the workspaces this machine can reach, before connecting to one |
 | `knowl cloud connect [--workspace <id>] [--remote <name>] [--repo <name>]` | Point this project at a workspace. Publishes nothing |
 | `knowl cloud pull` | Fetch team knowledge into the local replica |
 | `knowl cloud stage [--id <ids...>] [--category <list>] [--apply]` | Queue knowledge for the team. Bare opens the same picker; naming flags dry-runs until `--apply` |
@@ -748,15 +774,60 @@ The pointer written into `.knowl/config.json` holds the API host, workspace and 
 `knowl cloud login`, and is in. Someone who clones without membership still gets a fully working local
 Knowl; the team half simply reports itself unavailable.
 
+### Knowledge stages itself; sending stays yours
+
+Once a repository is connected, knowledge written from then on is **queued for the team as it is
+written**. You do not have to remember to stage it. Nothing is sent by that: staging records an
+intent, and a separate push is what puts it in front of anyone.
+
+```
+knowl cloud status                # what is queued, and what a push is waiting for
+knowl cloud push                  # send it — only from an up-to-date default branch
+```
+
+Three ways to say "not this one", in the order you will want them:
+
+```
+knowl store "..." --local         # at write time: never publish this atom
+knowl cloud unstage <id>          # after the fact: take it back out of the queue
+knowl cloud unstage <id> --forever   # and never queue it again automatically
+```
+
+`--local` is the one to reach for. An atom that is only true of this machine — an absolute path,
+an environment quirk — has to say so when it is written, because that is the only moment anyone
+knows. An agent says the same thing with `local: true` on `knowl_store`.
+
+Turn the whole thing off for a repository with `knowl config set cloud.autoStage false`, or at
+connect time with `knowl cloud connect --no-auto-stage`.
+
+**Backfilling an existing store is a separate act.** Connecting queues nothing that already
+existed, so a store that predates the connection is caught up deliberately:
+
+```
+knowl cloud stage                                # pick categories from a list
+knowl cloud stage --category decision --apply    # or name them
+```
+
+A bare call opens a picker with the categories worth sharing already ticked and a count beside
+each; confirming it is the apply. Naming categories skips the picker and dry-runs until `--apply`.
+
 ### Publishing tracks the default branch, not your working tree
 
 Local knowledge describes the tree in front of you. Team knowledge has to describe the branch
-everyone shares, so publishing is two-phase, in the shape of git's own index and commit:
+everyone shares, so sending is gated where staging is not:
 
 ```
-knowl cloud stage --category decision --apply   # stage: any time, any branch
-knowl cloud push                                # send: only from an up-to-date default branch
+knowl cloud push                  # only from an up-to-date default branch
 ```
+
+`knowl cloud push` shows what it is about to send and asks, because sending cannot be undone
+except by `knowl cloud retract`, which is a hard delete. `--yes` skips the question; without a
+terminal it is required, so silence is never read as consent.
+
+**Automatic sending is off, and turning it on is per machine.** `knowl cloud autopush on` records
+standing consent for this workspace **on this machine only** — it is not written to
+`.knowl/config.json` and no teammate or CI inherits it. It never relaxes the branch gate, and it
+still sends only what it showed itself: a queue that changed underneath it is refused, not sent.
 
 ### Two kinds of sharing, and they are independent
 
@@ -1418,7 +1489,10 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl workspace list` | List machine-local workspaces |
 | `knowl workspace status [--verbose]` | Show membership and resolved peers |
 | `knowl workspace remove <repo-name> [--export-first]` | Unlink the current repository |
-| `knowl workspace promote (--category <list> \| --id <id...>) [--apply]` | Preview or promote locally owned knowledge |
+| `knowl workspace promote [--category <list> \| --id <id...>] [--apply]` | Share locally owned knowledge with linked repos. Bare opens a picker; naming flags dry-runs until `--apply` |
+| `knowl workspace demand [--limit <n>] [--json]` | What the linked repos have queried each other for — the readout that says which knowledge this repo owes its peers |
+| `knowl workspace repin-embedding [--force]` | Repoint the workspace at this repository's embedding profile |
+| `knowl workspace set [--default-visibility <repo\|workspace>]` | Change this repo's recorded nature in the workspace manifest |
 
 ### Memory and retrieval
 
@@ -1443,13 +1517,22 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl task checkpoint <task-id> <summary> [options]` | Store resumable progress, blockers, artifacts, and verification state |
 | `knowl task finish <task-id> <summary>` | Finish a manual work loop |
 | `knowl task run <title> -- <command...>` | Wrap one bounded command in a work loop |
-| `knowl session start\|event\|finish\|recover` | Manage bounded, expiring session scratch and recovery |
+| `knowl session start <title>` | Open a bounded, expiring session scratchpad |
+| `knowl session event <id> <type>` | Record one event against an open session |
+| `knowl session finish <id> --status <s>` | Close a session and promote what it earned |
+| `knowl session recover` | Reclaim sessions abandoned by a crashed host |
 
 ### Skills, code, and optional AI
 
 | Command | Description |
 | --- | --- |
-| `knowl skill list\|read\|create\|run` | Manage file-backed learned skills and their entrypoints |
+| `knowl skill list` | List learned skill packages |
+| `knowl skill read <name>` | Read one learned skill package |
+| `knowl skill create <name>` | Create a file-backed skill package and index it |
+| `knowl skill run <name> [args...]` | Run an approved skill package's entrypoint |
+| `knowl skill approve <name>` | Approve a package for execution, pinned to its current contents |
+| `knowl skill revoke <name>` | Withdraw approval, so the entrypoint stops being runnable |
+| `knowl skill trust` | List the packages currently approved to run |
 | `knowl index-code` | Incrementally index TS/JS symbols and import/export edges |
 | `knowl symbols <path>` | Print indexed symbols for one repository-relative file |
 | `knowl synthesize --scope <tag>` | Create or refresh one deterministic tag-scoped understanding |
@@ -1463,7 +1546,10 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl export <path>` | Write portable, checksum-verified JSONL |
 | `knowl import <path> [--dry-run] [--on-divergence newer\|skip\|theirs\|fail]` | Import JSONL with an explicit divergence policy |
 | `knowl snapshot create` / `knowl snapshot restore <path> --confirm` | Create a checksummed SQLite snapshot, or restore one after verifying its manifest, size, checksum, and SQLite integrity |
-| `knowl config` / `get <key>` / `set <key> <value>` / `reset [key]` | Edit configuration interactively or from scripts |
+| `knowl config` | Edit configuration interactively |
+| `knowl config get <key>` | Print one configuration value |
+| `knowl config set <key> <value>` | Set one configuration value |
+| `knowl config reset [key]` | Restore one key, or all of them, to the default |
 | `knowl config set-model <model>` | Verify, download and select a custom embedding model |
 | `knowl reindex --vectors` | Prepare the local model and embed items that have no current vector; `--force` re-embeds every item |
 | `knowl reindex --transcripts [--budget <minutes>]` | Build or update the optional session transcript index; resumable, so a budget is a stopping point rather than a rollback |

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -20,7 +20,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
 import { DEFAULT_PRESET_ID, VECTOR_PRESETS } from '../src/core/vector-profile.js';
 import { stripManagedKnowlGuidance } from '../src/core/agents-guidance.js';
 import { renderManagedKnowlGuidanceSection } from '../src/core/knowl-guidance.js';
@@ -75,7 +75,13 @@ for (const [id, [file, body]] of Object.entries(regions)) {
  * happened three times before the counts were reconciled by hand.
  */
 const referenceText = fs.readFileSync(REFERENCE, 'utf8');
-for (const tool of [...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ...CLOUD_TOOL_DEFINITIONS, ...WORKSPACE_TOOL_DEFINITIONS]) {
+// Every gated set, named. `knowl_impact` was missing from this list and from the reference for
+// as long as both existed -- the check reported "every tool is documented" while knowing
+// nothing about it. Adding a set to `tool-definitions.ts` means adding it here.
+for (const tool of [
+  ...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ...CLOUD_TOOL_DEFINITIONS,
+  ...WORKSPACE_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS,
+]) {
   if (!referenceText.includes(`\`${tool.name}\``)) {
     failures.push(`docs/reference.md documents no tool named ${tool.name}`);
   }
@@ -83,25 +89,47 @@ for (const tool of [...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ..
 
 /** Same rule for the CLI. Built output only -- the help text is what a user actually sees. */
 const distEntry = path.join(root, 'dist', 'index.js');
-if (fs.existsSync(distEntry)) {
-  const help = execFileSync(process.execPath, [distEntry, '--help'], {
+
+/**
+ * The command names one `--help` screen lists.
+ *
+ * Commander indents a command name by exactly two spaces and wraps its description far to the
+ * right. Matching on `trim()` would read every wrapped word as a command -- it did, and asked
+ * the reference to document "knowl the".
+ */
+function commandsListedBy(argv: string[]): string[] {
+  const help = execFileSync(process.execPath, [distEntry, ...argv, '--help'], {
     encoding: 'utf8',
     env: { ...process.env, NO_COLOR: '1' },
   });
   const marker = help.indexOf('Commands:');
-  if (marker === -1) throw new Error('Could not find a "Commands:" section in `knowl --help`.');
-  // Commander indents a command name by exactly two spaces and wraps its description far to
-  // the right. Matching on `trim()` would read every wrapped word as a command -- it did, and
-  // asked the reference to document "knowl the".
-  const commands = help.slice(marker + 'Commands:'.length)
+  // A leaf command lists no subcommands, which is not an error -- only the root must have some.
+  if (marker === -1) {
+    if (argv.length === 0) throw new Error('Could not find a "Commands:" section in `knowl --help`.');
+    return [];
+  }
+  return [...new Set(help.slice(marker + 'Commands:'.length)
     .split('\n')
     .map(line => /^ {2}(\S+)/.exec(line)?.[1] ?? '')
     .map(name => name.split(/[|[<]/)[0])
-    .filter(name => /^[a-z][a-z-]+$/.test(name));
-  for (const command of new Set(commands)) {
-    if (command === 'help') continue;
+    .filter(name => /^[a-z][a-z-]+$/.test(name))
+    .filter(name => name !== 'help'))];
+}
+
+if (fs.existsSync(distEntry)) {
+  // Descends one level into every group, because this used to read the TOP-LEVEL screen only.
+  // `knowl cloud` appeared in the reference, so the whole group passed -- and `cloud workspaces`,
+  // `cloud unstage` and `cloud autopush` shipped undocumented behind a green gate. A gate that
+  // enumerates one level while reporting on all of them is worse than no gate, because it is
+  // believed.
+  for (const command of commandsListedBy([])) {
     if (!referenceText.includes(`knowl ${command}`)) {
       failures.push(`docs/reference.md documents no command named "knowl ${command}"`);
+    }
+    for (const sub of commandsListedBy([command])) {
+      if (!referenceText.includes(`knowl ${command} ${sub}`)) {
+        failures.push(`docs/reference.md documents no command named "knowl ${command} ${sub}"`);
+      }
     }
   }
 } else {

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -15,6 +15,9 @@ import { UNTRUSTED_NOTICE } from '../core/untrusted.js';
  */
 export type ToolDefinition = { name: string; description: string; inputSchema: Record<string, unknown> };
 
+/** The only ways a change-impact finding is ever closed. Named here beside the schema that offers them. */
+export const IMPACT_RESOLUTIONS = ['repaired', 'dismissed', 'expired', 'false_positive'];
+
 /**
  * Ceilings named inside the schemas below, so they travel with the text that quotes them.
  *
@@ -93,6 +96,7 @@ export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
  * pulling already happens on its own. Staging is the half that is safe from every vantage, so it
  * is the half exposed.
  */
+
 export const CLOUD_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_cloud',
@@ -119,6 +123,43 @@ export const CLOUD_TOOL_DEFINITIONS: ToolDefinition[] = [
               forever: {
                 type: 'boolean',
                 description: 'unstage only. Also exclude the atom, so nothing stages it again automatically. Use this for knowledge that is only true of this machine and was queued before anyone noticed; `local` on knowl_store is the way to say so at write time instead.',
+              },
+            },
+          },
+        },
+];
+
+// Registered only when the repo turned change impact on. One tool, not two: `types.ts:267-271`
+// records that every registered tool costs guidance-card space in every session of every user,
+// so reading findings and adjudicating one share a surface rather than splitting into a pull
+// tool and a resolve tool.
+export const IMPACT_TOOL_DEFINITIONS: ToolDefinition[] = [
+        {
+          name: 'knowl_impact',
+          description: 'Change-impact findings: code a live session read that has since moved underneath it. Pass resolve to adjudicate one. A certain-tier finding also refuses the next edit to that file until you re-read it, so listing them here is how you see what is about to be blocked and why.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              scope: {
+                type: 'string', enum: ['mine', 'all'],
+                description: 'mine (default): findings against reads still held open -- the work someone can still act on. all: every open finding, including ones whose read was released when its session ended and which nobody has adjudicated yet.',
+              },
+              tier: {
+                type: 'string', enum: ['certain', 'likely', 'possible'],
+                description: 'One tier. Omit for certain + likely; `possible` is unmeasured path matching and is returned only when asked for by name.',
+              },
+              resolve: {
+                type: 'object',
+                description: 'Adjudicate one finding. This is the only way a finding is ever closed -- the write gate deliberately leaves them open -- and the resolutions are the measurement: false_positive is what makes a precision number possible, so use it when it is the true answer.',
+                properties: {
+                  id: { type: 'string', minLength: 1, maxLength: 64, description: 'The finding id, exactly as it was returned.' },
+                  resolution: {
+                    type: 'string', enum: IMPACT_RESOLUTIONS,
+                    description: 'repaired: you reconciled your work with the change. false_positive: the change does not affect what you were doing. dismissed: it does affect you and you are proceeding anyway. expired: the work it concerned is gone.',
+                  },
+                },
+                required: ['id', 'resolution'],
+                additionalProperties: false,
               },
             },
           },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -43,7 +43,7 @@ import { isTranscriptSearchEnabled } from '../transcripts/config.js';
 import { hasIndexableArchive } from '../transcripts/paths.js';
 import { handleSessionList, handleTranscriptRead, handleTranscriptSearch } from '../transcripts/mcp-handlers.js';
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
-import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
 import { teamUpdateNotice } from '../cloud/team-update.js';
 import { maybeAutoSync } from '../cloud/auto-sync.js';
 import { cloudStatusInRequest } from '../cloud/status.js';
@@ -125,7 +125,6 @@ export function describeWriteReconciliation(result: {
 
 
 /** Resolutions `knowl_impact` accepts, matching `ImpactResolution` in the store. */
-const IMPACT_RESOLUTIONS = ['repaired', 'dismissed', 'expired', 'false_positive'];
 
 /**
  * The default tier set: everything measured, and nothing that is not.
@@ -148,42 +147,6 @@ const MAX_IMPACT_SIGNATURE_CHARS = 200;
 const IMPACT_DISABLED_MESSAGE =
   'Change-impact detection is not enabled for this repository. Enable impact.enabled with `knowl config`.';
 
-// Registered only when the repo turned change impact on. One tool, not two: `types.ts:267-271`
-// records that every registered tool costs guidance-card space in every session of every user,
-// so reading findings and adjudicating one share a surface rather than splitting into a pull
-// tool and a resolve tool.
-const IMPACT_TOOLS: ToolDefinition[] = [
-        {
-          name: 'knowl_impact',
-          description: 'Change-impact findings: code a live session read that has since moved underneath it. Pass resolve to adjudicate one. A certain-tier finding also refuses the next edit to that file until you re-read it, so listing them here is how you see what is about to be blocked and why.',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              scope: {
-                type: 'string', enum: ['mine', 'all'],
-                description: 'mine (default): findings against reads still held open -- the work someone can still act on. all: every open finding, including ones whose read was released when its session ended and which nobody has adjudicated yet.',
-              },
-              tier: {
-                type: 'string', enum: ['certain', 'likely', 'possible'],
-                description: 'One tier. Omit for certain + likely; `possible` is unmeasured path matching and is returned only when asked for by name.',
-              },
-              resolve: {
-                type: 'object',
-                description: 'Adjudicate one finding. This is the only way a finding is ever closed -- the write gate deliberately leaves them open -- and the resolutions are the measurement: false_positive is what makes a precision number possible, so use it when it is the true answer.',
-                properties: {
-                  id: { type: 'string', minLength: 1, maxLength: 64, description: 'The finding id, exactly as it was returned.' },
-                  resolution: {
-                    type: 'string', enum: IMPACT_RESOLUTIONS,
-                    description: 'repaired: you reconciled your work with the change. false_positive: the change does not affect what you were doing. dismissed: it does affect you and you are proceeding anyway. expired: the work it concerned is gone.',
-                  },
-                },
-                required: ['id', 'resolution'],
-                additionalProperties: false,
-              },
-            },
-          },
-        },
-];
 
 /**
  * The published tool surface.
@@ -237,7 +200,7 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
   }
 
   if (config && isImpactEnabled(config)) {
-    tools.push(...IMPACT_TOOLS);
+    tools.push(...IMPACT_TOOL_DEFINITIONS);
   }
 
   if (config?.cloud) {
@@ -262,7 +225,7 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
  */
 const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
   [
-    ...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOLS,
+    ...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS,
     ...CLOUD_TOOL_DEFINITIONS, ...WORKSPACE_TOOL_DEFINITIONS,
   ]
     .map(tool => [tool.name, tool.inputSchema]),


### PR DESCRIPTION
`docs:check` was green while the reference described the previous release and a whole feature had no documentation at all. Both halves of that are fixed here.

## The reference described the pre-5.0 model

It presented publishing as a two-phase act the user drives:

```
knowl cloud stage --category decision --apply   # stage: any time, any branch
knowl cloud push                                # send
```

with no mention that knowledge now stages itself as it is written. That is not incomplete, it is **wrong** — a reader would conclude they must stage manually. Rewritten around what actually happens: the three ways to say "not this one" (`--local` at write time, `unstage` after the fact, `unstage --forever`), how to turn the whole thing off, and the fact that backfilling an existing store is a separate deliberate act.

`knowl cloud autopush` was documented **nowhere**, including the machine-local property that is the entire reason it is safe to have.

## Three holes in the gate, all the same shape

A gate that enumerates one level while reporting on all of them is worse than no gate, because it is believed.

**1. The CLI check read `knowl --help` only.** `knowl cloud` appeared in the reference, so the whole group passed — and `cloud workspaces`, `cloud unstage` and `cloud autopush` shipped undocumented behind a green check. It now descends into every group, which immediately found ten more: `workspace demand`, `repin-embedding` and `set`, plus the compact pipe-form rows for `session` and `skill` that were hiding `approve`, `revoke` and `trust`.

**2. The tool coverage loop named four of the five tool sets.** `knowl_impact` was in neither the loop nor the reference, for as long as both have existed. `IMPACT_TOOL_DEFINITIONS` now lives in `tool-definitions.ts` beside every other set rather than alone in `tools.ts` — being the odd one out is precisely why it was missed.

**3. Change impact had no user-facing documentation anywhere** — only a plan doc. A whole feature, gated behind `impact.enabled`, with nothing telling anyone it exists, that `certain` findings block the next edit, or that resolving one is the only way it ever closes.

## Verification

`typecheck` 0, `lint` 0, `docs:check` current under the stricter gate, **324 test files green**.

One full run showed a single failure in `tests/cloud/publish-snapshot.test.ts` that passes in isolation; a different file failed the same way on earlier runs, which is the signature of the known Windows contention flake rather than a regression.