### PR TITLE
fix(cloud): connect and workspaces refresh the token instead of sending a dead one

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -50,7 +50,7 @@ import { getConfigValue, resetAllConfig, resetConfigValue, setConfigValue, setCo
 import { runConfigUi } from './config/ui.js';
 import { defaultApiHost, runLogin, runLogout } from '../cloud/login.js';
 import { createCloudApi } from '../cloud/api-client.js';
-import { readCredential } from '../cloud/credentials.js';
+import { ensureAccessToken } from '../cloud/token.js';
 import { excludeFromPublish } from '../cloud/exclusions.js';
 import { unstagePublish } from '../cloud/ledger.js';
 import { writeAutoPushConsent } from '../cloud/consent.js';
@@ -848,14 +848,20 @@ cloudCommand
   .option('--api <host>', 'API host (defaults to $KNOWL_API_HOST, else the hosted service)', defaultApiHost())
   .action(async options => {
     try {
-      const credential = await readCredential(options.api);
+      const api = createCloudApi({ apiHost: options.api });
+      // Refreshed rather than read. A stored access token lives about an hour, so reading it
+      // straight sent a dead one and reported "The credential is not valid" to somebody who was
+      // signed in perfectly well. Every other network path already refreshes.
+      const credential = await ensureAccessToken({
+        apiHost: options.api,
+        refresh: refreshToken => api.refresh(refreshToken),
+      });
       if (!credential) {
         console.error('Not signed in. Run knowl cloud login first.');
         process.exitCode = 1;
         return;
       }
-      const workspaces = await createCloudApi({ apiHost: options.api })
-        .listWorkspaces(credential.accessToken);
+      const workspaces = await api.listWorkspaces(credential.accessToken);
       if (workspaces.length === 0) {
         console.log('You do not belong to any workspace yet.');
         return;

--- a/src/cloud/connect.ts
+++ b/src/cloud/connect.ts
@@ -4,9 +4,10 @@ import {
 } from './api-client.js';
 import { EMBED_RECIPE_VERSION } from '../core/embed-recipe.js';
 import { resolveVectorProfile } from '../core/vector-profile.js';
+import { ensureAccessToken } from './token.js';
 import { getClient } from '../store/database.js';
 import type { ProjectConfig } from '../core/types.js';
-import { normalizeApiHost, readCredential } from './credentials.js';
+import { normalizeApiHost } from './credentials.js';
 import { resolveRepoIdentity } from './repo-identity.js';
 
 export type CloudPointer = {
@@ -80,10 +81,18 @@ export async function runConnect(input: ConnectInput): Promise<ConnectResult> {
     return { status: 'identity-changed', current: existing.cloud.repo, next: identity.identity };
   }
 
-  const credential = await readCredential(input.apiHost);
+  const api = input.api ?? createCloudApi({ apiHost: input.apiHost });
+
+  // Refreshed, not merely read. `readCredential` hands back whatever is stored, including an
+  // access token that expired an hour ago -- and connect then sent it and reported "The
+  // credential is not valid", which reads as "log in again" to someone who is signed in. Every
+  // other network path (`pull`, `push`, `retract`, drift reporting) already goes through this.
+  const credential = await ensureAccessToken({
+    apiHost: input.apiHost,
+    refresh: refreshToken => api.refresh(refreshToken),
+  });
   if (!credential) return { status: 'not-logged-in' };
 
-  const api = input.api ?? createCloudApi({ apiHost: input.apiHost });
   const workspaces = await api.listWorkspaces(credential.accessToken);
 
   // Belonging to none is a different situation from belonging to several, and the remedies

--- a/tests/cloud/connect.test.ts
+++ b/tests/cloud/connect.test.ts
@@ -58,6 +58,31 @@ describe('runConnect', () => {
       .toEqual({ status: 'not-logged-in' });
   });
 
+  it('refreshes an expired access token rather than sending the dead one', async () => {
+    // An access token lives about an hour. Reading it straight sent an expired one and the
+    // server answered "The credential is not valid" -- which reads as "log in again" to somebody
+    // who is signed in perfectly well, on the command they run precisely when onboarding.
+    await makeRepo('git@github.com:acme/web.git');
+    const { writeCredential } = await import('../../src/cloud/credentials.js');
+    await writeCredential(HOST, { ...credential, expiresAt: new Date(Date.now() - 60_000).toISOString() });
+
+    let refreshed = 0;
+    const sent: string[] = [];
+    const base = api([{ id: 'ws-1', name: 'Acme', role: 'owner' }]);
+    const refreshing: CloudApi = {
+      ...base,
+      refresh: async () => { refreshed += 1; return { ...credential, accessToken: 'FRESH-TOKEN-4d81aa' }; },
+      listWorkspaces: async (token: string) => { sent.push(token); return [{ id: 'ws-1', name: 'Acme', role: 'owner' as const }]; },
+    };
+
+    const result = await runConnect({ projectRoot: REPO, apiHost: HOST, workspaceId: 'ws-1', api: refreshing });
+
+    expect(result.status).toBe('connected');
+    expect(refreshed).toBe(1);
+    // The fresh token, never the expired one it started with.
+    expect(sent).toEqual(['FRESH-TOKEN-4d81aa']);
+  });
+
   it('connects when the caller belongs to exactly one workspace', async () => {
     await makeRepo('git@github.com:acme/web.git');
     await writeCredential(HOST, credential);


### PR DESCRIPTION
An access token lives about an hour. `runConnect` and `knowl cloud workspaces` both called `readCredential` and sent whatever was stored, so an hour after signing in they reported:

```
Connect failed: The credential is not valid.
```

That reads as "log in again" to somebody who is signed in perfectly well, and the refresh token sitting right beside it would have worked.

## How it was found

By using it. `knowl cloud workspaces` succeeded against production; forty minutes later the same command and `connect` both failed, while the credential was fine — the stored `expiresAt` had simply passed. `pull`, `push`, `retract` and drift reporting all already go through `ensureAccessToken`. These two were the ones that did not.

`connect` is the worse of the pair: it is the onboarding command, so it is disproportionately run by someone who logged in a while ago and came back to it — and the message it gave points them at re-authenticating rather than at the refresh that would have succeeded.

## Deliberately unchanged

`cloud status` and the doctor checks still call `readCredential` directly. Both must answer offline, and neither makes a network call for which a stale token matters.

## The test

Writes an already-expired credential, then asserts the **fresh** token is what reaches `listWorkspaces` — not merely that connect succeeded, which it would have done by accident had the fake ignored the token entirely.

## Verification

`typecheck` 0, `lint` 0, **325 test files green**. Also confirmed live: `cloud workspaces` and `cloud connect` both succeed against production with a credential that was expired before this change.

Blocks nothing, but belongs in 5.0.0 — it is a bug on the path a new user takes first.