### PR TITLE
fix: settings the docs promised, and a doctor verdict that means something

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1128,6 +1128,21 @@ stalling together?".
 The file is capped at 4MB, created owner-only (`0600`, in a `0700` directory), and removable
 with `--clear`. Set `KNOWL_DISABLE_STARTUP_TRACE=1` to turn it off entirely.
 
+### Update checks
+
+`knowl status` and `knowl doctor` ask the npm registry whether a newer Knowl exists and print a
+line when there is one. `status` caches the answer for a day; `doctor` always asks, because a
+diagnostic that reports a stale version is worse than one that takes an extra moment. The request
+times out after two seconds and fails silently, so being offline costs nothing.
+
+Only those two commands check. Hooks, MCP, and `knowl serve` never do.
+
+```bash
+knowl config set updateCheck.enabled false   # this repository
+KNOWL_NO_UPDATE_CHECK=1                      # one invocation, or exported
+NO_UPDATE_NOTIFIER=1                         # the cross-tool convention, also honoured
+```
+
 ## Local viewer
 
 `knowl view` starts a browser inspector on `127.0.0.1`:

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -24,9 +24,13 @@ export type ConfigKey =
   | 'memory.global.path'
   | 'impact.enabled'
   | 'impact.gate'
-  | 'capture.nudge';
+  | 'capture.nudge'
+  | 'cloud.autoStage'
+  | 'updateCheck.enabled';
 
-export type ConfigCategory = 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact' | 'Capture';
+export type ConfigCategory =
+  | 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact' | 'Capture'
+  | 'Cloud' | 'Updates';
 
 /**
  * How a value should be asked for. Without this the UI had only `parse`, so every field
@@ -243,6 +247,27 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(CAPTURE_NUDGE_MODES), defaultValue: 'off',
     label: 'Empty-session nudge',
     description: 'When a conversation has run for several turns and stored nothing durable: shadow records the nudge it would have sent, enforce withholds the stop once and asks the agent to store what it learned. Measurement runs either way.',
+  },
+  {
+    // Absent from DEFAULT_CONFIG on purpose, like the three above: merged in, it would write
+    // `cloud.autoStage` into every config on the machine, including repositories that have never
+    // been connected to anything. Here it only tells the editor what "unset" means -- which for
+    // this key is ON, because a connected repository stages as it writes unless told otherwise.
+    //
+    // The rest of the `cloud` block is deliberately NOT here. `apiHost`, `workspaceId`,
+    // `workspaceName`, `repo` and `remote` are a pointer written by `knowl cloud connect`, not
+    // preferences: hand-editing them points the repository at a workspace it never authenticated
+    // against, and every later command looks connected while every push fails.
+    key: 'cloud.autoStage', category: 'Cloud', type: 'boolean',
+    parse: booleanValue, defaultValue: true,
+    label: 'Stage new knowledge automatically',
+    description: 'In a connected repository, queue new knowledge for the team as it is written. Nothing is sent by this -- `knowl cloud push` still sends, and still asks. Off means staging explicitly with `knowl cloud stage`.',
+  },
+  {
+    key: 'updateCheck.enabled', category: 'Updates', type: 'boolean',
+    parse: booleanValue, defaultValue: DEFAULT_CONFIG.updateCheck?.enabled,
+    label: 'Check npm for updates',
+    description: 'Let `status` and `doctor` check npm once a day for a newer Knowl. Off makes both entirely offline.',
   },
 ];
 

--- a/src/cli/config/service.ts
+++ b/src/cli/config/service.ts
@@ -67,10 +67,35 @@ async function saveRawConfig(root: string, config: ConfigRecord) {
   await saveConfig(root, config as ProjectConfig);
 }
 
+/**
+ * What the file says, which for an unset key is nothing.
+ *
+ * The editor needs this rather than the effective value: it distinguishes stored from
+ * defaulted to decide what to mark as modified, and `search.vector.preset` specifically
+ * relies on an unset key reading as undefined so a repo initialised before presets existed
+ * can fall through to the model-derived answer.
+ */
 export async function getConfigValue(root: string, key: string): Promise<unknown> {
   const field = getConfigField(key);
   if (field.secret) return '********';
   return getAtPath(await loadRawConfig(root), key);
+}
+
+/**
+ * What the setting will actually do, which for an unset key is its default.
+ *
+ * `knowl config get` asks a behavioural question -- will this repository stage as it writes --
+ * and answering `undefined` does not answer it. Four keys are deliberately absent from
+ * `DEFAULT_CONFIG` (`cloud.autoStage`, `impact.enabled`, `impact.gate`, `capture.nudge`,
+ * whose comments in the schema explain that merging them in would write them into every
+ * config on the machine), so for those the file is silent even in a fully configured repo.
+ *
+ * Still one bare value on stdout, because this output is piped.
+ */
+export async function getEffectiveConfigValue(root: string, key: string): Promise<unknown> {
+  const stored = await getConfigValue(root, key);
+  if (stored !== undefined) return stored;
+  return getConfigField(key).defaultValue;
 }
 
 export async function setConfigValue(root: string, key: string, raw: string): Promise<unknown> {

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -139,11 +139,29 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         // is cleared either by retiring the item or by changing the security setting.
         : 'run `knowl audit` to list the records, then retire an item with `knowl supersede <itemId> <replacementId>` or adjust security settings with `knowl config`',
     });
+    // Resolved here rather than at its first use below, because the severity of a missing
+    // embeddings table depends on whether anything was going to read it.
+    const vectorEnabled = isVectorSearchEnabled(config);
+
     try {
       await (getDb() as any).all(sql`SELECT 1 FROM knowledge_embeddings LIMIT 1`);
       checks.push({ status: 'OK', message: 'Database schema includes knowledge_embeddings' });
     } catch {
-      checks.push({ status: 'WARN', message: 'Database schema missing knowledge_embeddings; run knowl upgrade' });
+      // FAIL when vector search is on: there is no table for an embedding to live in, so
+      // semantic retrieval cannot work at all and no amount of reindexing will change that
+      // until the schema is upgraded. The coverage check below cannot report this itself --
+      // its own query reads the same missing table, so it throws into the outer catch and the
+      // report ends early on a raw SQL error instead of naming the problem.
+      //
+      // WARN when vector search is off, where the absent table is a database older than a
+      // feature the project does not use.
+      checks.push({
+        status: vectorEnabled ? 'FAIL' : 'WARN',
+        message: vectorEnabled
+          ? 'Database schema is missing knowledge_embeddings, so vector search has nowhere to store or read embeddings and cannot return anything; run knowl upgrade'
+          : 'Database schema missing knowledge_embeddings; run knowl upgrade',
+        fix: 'run `knowl upgrade`',
+      });
     }
     try {
       await (getDb() as any).all(sql`SELECT 1 FROM code_symbols LIMIT 1`);
@@ -171,7 +189,7 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
     // and a store where they disagreed about which profile that is would report a gap in one and
     // full coverage in the other. Null means vector search is off, which the lexical check reads
     // as "there is no semantic fallback".
-    const vectorFingerprint = isVectorSearchEnabled(config)
+    const vectorFingerprint = vectorEnabled
       ? fingerprintProfile(resolveVectorProfile(config))
       : null;
 
@@ -265,7 +283,7 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         : 'MCP tool surface should expose knowl_skill_list, knowl_skill_read, and knowl_skill_run',
     });
 
-    if (isVectorSearchEnabled(config)) {
+    if (vectorEnabled) {
       const vector = getVectorSearchConfig(config);
       // Coverage, not configuration. "Enabled" was always true and told the user nothing
       // about whether their knowledge is actually reachable by semantic search.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -46,7 +46,7 @@ import { discoverRepos } from './repo-discovery.js';
 import { applyDoctorRemedies } from './doctor-fix.js';
 import { formatSweepReport, sweepRepos } from './upgrade-all.js';
 import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../ai/embeddings.js';
-import { getConfigValue, resetAllConfig, resetConfigValue, setConfigValue, setConfigValues } from './config/service.js';
+import { getEffectiveConfigValue, resetAllConfig, resetConfigValue, setConfigValue, setConfigValues } from './config/service.js';
 import { runConfigUi } from './config/ui.js';
 import { defaultApiHost, runLogin, runLogout } from '../cloud/login.js';
 import { createCloudApi } from '../cloud/api-client.js';
@@ -2337,7 +2337,7 @@ configCommand
   .argument('<key>')
   .action(async (key) => {
     try {
-      const value = await getConfigValue(await findProjectRoot(process.cwd()), key);
+      const value = await getEffectiveConfigValue(await findProjectRoot(process.cwd()), key);
       console.log(typeof value === 'string' ? value : JSON.stringify(value));
     } catch (error: any) {
       console.error(`❌ Configuration error: ${error.message}`);

--- a/src/cli/vector-coverage.ts
+++ b/src/cli/vector-coverage.ts
@@ -1,6 +1,6 @@
 import type { DoctorRemedy } from './doctor-remedy.js';
 
-export type VectorCoverageCheck = { status: 'OK' | 'WARN'; message: string; fix?: string; remedy?: DoctorRemedy };
+export type VectorCoverageCheck = { status: 'OK' | 'WARN' | 'FAIL'; message: string; fix?: string; remedy?: DoctorRemedy };
 
 /**
  * Whether vector search actually covers this project's knowledge.
@@ -40,6 +40,38 @@ export function vectorCoverageCheck(input: {
     return {
       status: 'OK',
       message: `Vector search enabled with ${input.model}; all ${input.activeItems} active item(s) embedded`,
+    };
+  }
+
+  /*
+   * Most of the store missing is a different condition from a tail of it missing, and only the
+   * second one is a warning.
+   *
+   * The house rule elsewhere in doctor is that one index missing while the other covers the item
+   * is degradation, and only an item in NEITHER index is a failure -- `lexicalCoverageCheck`
+   * argues exactly that, and this deliberately does not contradict it for a small gap. An item
+   * without an embedding is still reachable by keyword.
+   *
+   * What that reasoning does not cover is a store where embedding has never worked. Measured on
+   * knowl-cloud production, 2026-08-13: 345 atoms, zero vectors, for twelve hours. Every embed
+   * had failed on an `EACCES` nobody saw, and the check for it reported an advisory warning under
+   * a READY verdict -- the one line most people read. Nothing about that report said the product's
+   * primary retrieval path was dead.
+   *
+   * The line is the majority, not zero. A strict `embedded === 0` is defeated by a single stray
+   * row: one item written after some query happened to download the model would score 1 of 345 as
+   * merely advisory. And the majority is where the harm changes character. Below it, semantic
+   * search reaches most of the store and the rest is a tail to backfill. Above it, most queries
+   * are answered from a minority of the knowledge while still returning plausible-looking
+   * results -- so a partial index misleads in a way an absent one cannot, because there is no
+   * symptom to notice.
+   */
+  if (missing * 2 > input.activeItems) {
+    return {
+      status: 'FAIL',
+      message: `Vector search is enabled with ${input.model} but only ${input.embeddedItems} of ${input.activeItems} active item(s) are embedded, so semantic search reaches a minority of this project's knowledge and its results are not representative of what is stored. Nothing embeds these retroactively.`,
+      fix: 'run `knowl reindex --vectors`',
+      remedy: { kind: 'reindex-vectors' },
     };
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -241,10 +241,10 @@ export interface Project {
 
 export interface ProjectConfig {
   version: number;
-  project?: {
-    name?: string;
-    description?: string;
-  };
+  // `project` used to hold a name and description. Nothing has read either for a long time and
+  // `stripDeprecatedConfigFields` deletes the block on every load, so declaring it here described
+  // a field the product does not have. The strip stays: it is what cleans the key out of configs
+  // written before this.
   ai?: {
     provider: 'openai' | 'anthropic' | 'ollama' | 'custom';
     model: string;

--- a/tests/cli/config-service.test.ts
+++ b/tests/cli/config-service.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { DEFAULT_CONFIG, NEW_PROJECT_CONFIG, upgradeConfigDefaults } from '../../src/core/config.js';
 import { resolveVectorProfile } from '../../src/core/vector-profile.js';
 import { CONFIG_FIELDS } from '../../src/cli/config/schema.js';
-import { getConfigValue, resetAllConfig, resetConfigValue, setConfigValue, setConfigValues } from '../../src/cli/config/service.js';
+import { getConfigValue, getEffectiveConfigValue, resetAllConfig, resetConfigValue, setConfigValue, setConfigValues } from '../../src/cli/config/service.js';
 import { CONFIG_UI_QUIT, CONFIG_UI_SAVE, ConfigFieldView, ConfigPrompts, modelChoices, presetChoices, runConfigUi } from '../../src/cli/config/ui.js';
 
 const ROOT = path.resolve('.knowl-config-service-test');
@@ -79,6 +79,27 @@ describe('config service', () => {
     await writeConfig();
     expect(await getConfigValue(ROOT, 'search.vector.enabled')).toBe(true);
     await expect(getConfigValue(ROOT, 'search.unknown')).rejects.toThrow('Unknown config key');
+  });
+
+  it('answers what an unset setting will do, rather than that it is unset', async () => {
+    // Four keys are deliberately kept out of DEFAULT_CONFIG, so in a perfectly normal repo the
+    // file says nothing about them. `config get cloud.autoStage` therefore printed `undefined`
+    // for a repository that does stage as it writes -- the opposite of the truth.
+    await writeConfig();
+
+    expect(await getConfigValue(ROOT, 'cloud.autoStage')).toBeUndefined();     // the file
+    expect(await getEffectiveConfigValue(ROOT, 'cloud.autoStage')).toBe(true); // the behaviour
+  });
+
+  it('prefers the stored value over the default once one is set', async () => {
+    await writeConfig();
+    await setConfigValue(ROOT, 'cloud.autoStage', 'false');
+    expect(await getEffectiveConfigValue(ROOT, 'cloud.autoStage')).toBe(false);
+  });
+
+  it('still refuses an unknown key when asked for the effective value', async () => {
+    await writeConfig();
+    await expect(getEffectiveConfigValue(ROOT, 'search.unknown')).rejects.toThrow('Unknown config key');
   });
 
   it('sets typed values and creates a backup', async () => {

--- a/tests/cli/config-surface.test.ts
+++ b/tests/cli/config-surface.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { CONFIG_FIELDS } from '../../src/cli/config/schema.js';
+
+/**
+ * Every setting in `ProjectConfig` is either editable or deliberately not.
+ *
+ * `ProjectConfig` (`src/core/types.ts`) is what the code reads; `CONFIG_FIELDS` is a separate
+ * hand-maintained list that decides what `knowl config` shows and what `config set` accepts.
+ * Nothing connected the two, and nothing failed when they diverged — `cloud.autoStage` shipped in
+ * 5.0.0 with `docs/reference.md` telling people to run `knowl config set cloud.autoStage false`,
+ * a command that answered `Unknown config key`. `updateCheck.enabled` had been unreachable for
+ * longer than that.
+ *
+ * A source assertion rather than a runtime one, because TypeScript types do not exist at runtime
+ * and the alternative — deriving the list from a value like `DEFAULT_CONFIG` — cannot see the
+ * three keys deliberately kept out of it (`impact.enabled`, `impact.gate`, `capture.nudge`, whose
+ * comments explain that merging them in would arm a write gate in every repository on the
+ * machine). `tests/cli/cloud-exit-codes.test.ts` reads source for the same class of reason.
+ *
+ * This does not decide anything. It forces a decision: a new field must be given a UI or an entry
+ * below saying why it has none.
+ */
+const SOURCE = readFileSync(new URL('../../src/core/types.ts', import.meta.url), 'utf8');
+
+/**
+ * Settings a person must not edit by hand, and the reason for each.
+ *
+ * Not a suppression list. Everything here is written by a command that also does something else —
+ * authenticating, joining, migrating — so a hand-edited value would describe a state the rest of
+ * the system never entered.
+ */
+const NOT_EDITABLE: Record<string, string> = {
+  'version': 'schema version of the file itself, owned by the config loader',
+  'cloud.apiHost': 'pointer written by `knowl cloud connect`, after authenticating against it',
+  'cloud.workspaceId': 'pointer written by `knowl cloud connect`',
+  'cloud.workspaceName': 'label that travels with the pointer `connect` wrote',
+  'cloud.repo': 'publication identity, derived from the git remote or `--repo` at connect time',
+  'cloud.remote': 'records which remote the identity came from, for inspection',
+  'workspace.workspace': 'membership, written by `knowl workspace add` / `join`',
+  'workspace.repo': 'this repo\'s name within that workspace, written by the same commands',
+};
+
+/** Leaf paths of `ProjectConfig`, as the interface declares them. */
+function projectConfigLeaves(): string[] {
+  const start = SOURCE.indexOf('export interface ProjectConfig {');
+  expect(start, 'ProjectConfig not found — this suite would otherwise pass by describing nothing')
+    .toBeGreaterThan(-1);
+
+  const lines = SOURCE.slice(start).split('\n');
+  const leaves: string[] = [];
+  const path: string[] = [];
+  let depth = 0;
+
+  for (const raw of lines.slice(1)) {
+    const line = raw.trim();
+    if (line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')) continue;
+
+    if (line === '}' || line === '};') {
+      if (depth === 0) break;      // end of the interface
+      depth -= 1;
+      path.pop();
+      continue;
+    }
+
+    // A whole object on one line — `organization?: { enabled?: boolean; path?: string };` — is
+    // as nested as the multi-line form and has to expand the same way. Reading it as a leaf
+    // named `memory.organization` was this parser's own first bug.
+    const inline = /^([a-zA-Z]+)\??:\s*\{(.+)\};$/.exec(line);
+    if (inline) {
+      for (const part of inline[2].split(';')) {
+        const inner = /^\s*([a-zA-Z]+)\??:/.exec(part);
+        if (inner) leaves.push([...path, inline[1], inner[1]].join('.'));
+      }
+      continue;
+    }
+
+    // `name?: {` opens a nested block; `name?: string;` is a leaf.
+    const opens = /^([a-zA-Z]+)\??:\s*\{$/.exec(line);
+    if (opens) {
+      path.push(opens[1]);
+      depth += 1;
+      continue;
+    }
+
+    const leaf = /^([a-zA-Z]+)\??:\s*[^{].*;$/.exec(line);
+    if (leaf) leaves.push([...path, leaf[1]].join('.'));
+  }
+
+  return leaves;
+}
+
+describe('the config surface', () => {
+  const leaves = projectConfigLeaves();
+  const editable = new Set(CONFIG_FIELDS.map(field => field.key as string));
+
+  it('reads the interface at all, so a rename cannot make this vacuous', () => {
+    expect(leaves.length).toBeGreaterThan(15);
+    // Spot-check one from each shape: top level, nested twice, nested three deep.
+    expect(leaves).toContain('version');
+    expect(leaves).toContain('security.rejectSecrets');
+    expect(leaves).toContain('search.vector.preset');
+  });
+
+  it('gives every setting a UI or a stated reason for having none', () => {
+    const orphans = leaves.filter(key => !editable.has(key) && !(key in NOT_EDITABLE));
+    expect(
+      orphans,
+      `These exist in ProjectConfig but are neither editable nor listed in NOT_EDITABLE. `
+      + `Add a CONFIG_FIELDS entry, or an entry saying why a person must not set it: ${orphans.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('does not claim a setting is uneditable while also offering it', () => {
+    // Both lists are hand-maintained, so they can contradict each other as easily as they can
+    // fall out of date.
+    const both = Object.keys(NOT_EDITABLE).filter(key => editable.has(key));
+    expect(both, `listed as not editable while CONFIG_FIELDS offers it: ${both.join(', ')}`).toEqual([]);
+  });
+
+  it('offers no key that ProjectConfig does not declare', () => {
+    const declared = new Set(leaves);
+    const phantom = [...editable].filter(key => !declared.has(key));
+    expect(phantom, `CONFIG_FIELDS offers keys no longer in ProjectConfig: ${phantom.join(', ')}`).toEqual([]);
+  });
+
+  it('reaches the two that shipped unreachable', () => {
+    expect(editable.has('cloud.autoStage')).toBe(true);
+    expect(editable.has('updateCheck.enabled')).toBe(true);
+  });
+});

--- a/tests/cli/doctor-report.test.ts
+++ b/tests/cli/doctor-report.test.ts
@@ -25,6 +25,10 @@ async function setup(vector: Record<string, unknown>): Promise<string> {
     JSON.stringify({ ...DEFAULT_CONFIG, search: { vector } }),
     'utf-8',
   );
+  // Otherwise the guidance check FAILs in every test in this suite, which is invisible while
+  // the assertions only read one check's status -- and silently makes any `ready` assertion
+  // pass or fail for a reason that has nothing to do with vectors.
+  await installKnowlProjectGuidance(root);
   await initDb(root);
   const project = await repo.createProject(root, 'doctor-report');
   await repo.createKnowledgeItem(project.id, {
@@ -81,8 +85,10 @@ describe('doctor vector coverage', () => {
 
     const check = coverageCheck((await runDoctor(root)).checks);
 
-    expect(check.status).toBe('WARN');
-    expect(check.message).toContain('1 of 1');
+    // FAIL rather than WARN because the whole store is uncovered, not because a fingerprint
+    // is null: what this test pins is that the row is COUNTED as missing at all.
+    expect(check.status).toBe('FAIL');
+    expect(check.message).toContain('0 of 1');
     expect(check.fix).toContain('knowl reindex --vectors');
   });
 
@@ -98,8 +104,46 @@ describe('doctor vector coverage', () => {
 
     const check = coverageCheck((await runDoctor(root)).checks);
 
-    expect(check.status).toBe('WARN');
-    expect(check.message).toContain('1 of 1');
+    expect(check.status).toBe('FAIL');
+    expect(check.message).toContain('0 of 1');
+  });
+
+  it('gates the verdict, so an unembedded store cannot report READY', async () => {
+    // The point of the change, and the thing a status line actually carries. Reporting the
+    // gap while still printing READY is what let knowl-cloud serve 345 atoms and zero vectors
+    // for twelve hours: the advisory line was there, above a verdict that contradicted it.
+    await setup(ARCTIC);
+    await closeDb();
+
+    const result = await runDoctor(root);
+
+    expect(result.ready).toBe(false);
+    // Named, not just counted: a `ready === false` assertion passes for any FAIL anywhere in
+    // the report, so on its own it would keep passing if this check went back to advisory.
+    expect(result.checks.filter(check => check.status === 'FAIL').map(check => check.message))
+      .toEqual([expect.stringMatching(/^Vector search/)]);
+  });
+
+  it('keeps READY when only a tail is unembedded, which is degradation and not breakage', async () => {
+    // The other half of the rule. Three of four covered: semantic search still reaches most
+    // of the store, and the missing one is reachable by keyword.
+    const projectId = await setup(ARCTIC);
+    const fingerprint = fingerprintProfile(resolveVectorProfile(
+      { version: 1, search: { vector: ARCTIC } } as unknown as ProjectConfig,
+    ));
+    await writeEmbedding(await onlyItemId(), fingerprint);
+    for (const title of ['Second item', 'Third item', 'Fourth item']) {
+      const created = await repo.createKnowledgeItem(projectId, {
+        category: 'fact', title, content: `Content for ${title}.`,
+      });
+      if (title !== 'Fourth item') await writeEmbedding(created.id, fingerprint);
+    }
+    await closeDb();
+
+    const result = await runDoctor(root);
+
+    expect(coverageCheck(result.checks).status).toBe('WARN');
+    expect(result.ready).toBe(true);
   });
 
   it('reports full coverage for a row written under the current profile', async () => {

--- a/tests/cli/vector-coverage.test.ts
+++ b/tests/cli/vector-coverage.test.ts
@@ -18,14 +18,41 @@ describe('vector coverage check', () => {
     expect(vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 0, embeddedItems: 0 }).status).toBe('OK');
   });
 
-  it('warns when active items have no embedding, naming how many', () => {
+  it('warns about a tail of unembedded items, naming how many', () => {
     // The case that was silently reported as healthy: write-time embedding refuses to
     // download the model, nothing else downloads it until the first query, and every item
     // written before that is permanently invisible to vector search.
-    const check = vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 10, embeddedItems: 4 });
+    //
+    // Still a warning at this size, deliberately: the item is reachable by keyword, which is
+    // the same reasoning `lexicalCoverageCheck` uses in the other direction.
+    const check = vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 10, embeddedItems: 7 });
     expect(check.status).toBe('WARN');
-    expect(check.message).toContain('6');
+    expect(check.message).toContain('3');
     expect(check.message).toMatch(/vector search/i);
+  });
+
+  it('fails when most of the store is unembedded, because search then misrepresents it', () => {
+    const check = vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 10, embeddedItems: 4 });
+    expect(check.status).toBe('FAIL');
+    expect(check.message).toContain('4');
+    expect(check.message).toContain('10');
+  });
+
+  it('turns on the majority, so half embedded is still only advisory', () => {
+    // The boundary stated as a test rather than left to be re-derived from `missing * 2 >
+    // active`: at exactly half, semantic search still reaches half the store.
+    expect(vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 10, embeddedItems: 5 }).status)
+      .toBe('WARN');
+    expect(vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 11, embeddedItems: 5 }).status)
+      .toBe('FAIL');
+  });
+
+  it('fails a store where one stray row is embedded and nothing else is', () => {
+    // Why the rule is the majority and not `embedded === 0`. This is the production shape --
+    // embedding never worked, then a single query downloaded the model and one later write
+    // succeeded -- and a strict zero test would grade it advisory.
+    expect(vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 345, embeddedItems: 1 }).status)
+      .toBe('FAIL');
   });
 
   it('does not warn when write-time embedding was deliberately switched off', () => {
@@ -43,9 +70,20 @@ describe('vector coverage check', () => {
     expect(check.fix).toContain('knowl reindex --vectors');
   });
 
-  it('warns when nothing at all is embedded, which is the fresh-project case', () => {
+  it('fails when nothing at all is embedded', () => {
+    // Was a warning under a READY verdict. On knowl-cloud production this exact state -- 345
+    // atoms, zero vectors, every embed failing on an unlogged EACCES -- was reported as healthy
+    // for twelve hours.
     const check = vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 3, embeddedItems: 0 });
-    expect(check.status).toBe('WARN');
+    expect(check.status).toBe('FAIL');
     expect(check.message).toContain('3');
+  });
+
+  it('still reports OK for a store with nothing in it, which is not a broken one', () => {
+    // `0 * 2 > 0` is false, so an empty project does not trip the majority rule. Asserted
+    // because a fresh `knowl init` reporting NOT READY is the exact false alarm that made
+    // WARN stop deciding the verdict in the first place.
+    expect(vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 0, embeddedItems: 0 }).status)
+      .toBe('OK');
   });
 });


### PR DESCRIPTION
Two fixes to the surfaces that tell you what Knowl is doing.

## Settings that existed but could not be set

`docs/reference.md` told people to run `knowl config set cloud.autoStage false`. That command answered `Unknown config key` — I shipped the documentation in 5.0.0 without the schema entry. `updateCheck.enabled` had been readable, defaulted and unreachable for longer.

Both are in `CONFIG_FIELDS` now. The rest of the `cloud` block deliberately is not: `apiHost`, `workspaceId`, `workspaceName`, `repo` and `remote` are a pointer `cloud connect` writes *after* authenticating, and hand-editing them aims a repository at a workspace it never authenticated against — every later command looks connected while every push fails.

`config get` now answers with the effective value instead of `undefined`. Four keys are kept out of `DEFAULT_CONFIG` on purpose, so in an ordinary repository the file says nothing about them, and `get cloud.autoStage` printed `undefined` for a repository that does stage as it writes. The interactive editor keeps reading raw values — it has to tell stored from defaulted, and `search.vector.preset` relies on an unset key reading as undefined so a repo predating presets falls through to the model-derived answer.

`tests/cli/config-surface.test.ts` is the guard: every leaf of `ProjectConfig` is either editable or listed with a reason for not being. This was the third hand-maintained enumeration of the same shape to drift, and nothing failed when it did.

## A READY that means something

`doctor` reported unembedded knowledge as an advisory warning under `Result: READY`. knowl-cloud production sat at 345 atoms and zero vectors for twelve hours reading exactly that way — the warning was printed, above a verdict contradicting it.

Coverage is proportional now:

| state | verdict | why |
|---|---|---|
| all embedded | OK | |
| a tail missing | WARN | still reachable by keyword — the same reasoning `lexicalCoverageCheck` applies in reverse |
| the majority missing | **FAIL** | semantic search answers from a minority of the store while still returning plausible results |

The line is the majority rather than zero because a strict `embedded === 0` is defeated by one stray row — a single item written after some query happened to download the model would grade 1-of-345 as advisory.

A missing `knowledge_embeddings` table is FAIL too, but only when vector search is enabled; with it off, the absent table is just a database older than a feature the project does not use. That check has to report it itself, because the coverage query reads the same missing table and would otherwise throw into the outer catch and end the report on a raw SQL error.

**Everything else stays advisory, having been reviewed:** `code_symbols` and `memory_sessions` schema, stale sessions, `.gitignore`, host instructions and lifecycle hooks, and every cloud and workspace state. None of them makes this repository's own stored knowledge unreachable, which is the line between the two.

## Verified

`build`, `typecheck`, `lint`, `test` (326 files), `docs:check`, `check:lockfile` all pass. Ran `doctor` against this repo: 858/858 embedded, still READY, so the stricter rule does not fire on a healthy store.

Also fixed a fixture bug found on the way: the vector-coverage suite never installed project guidance, so the guidance check FAILed in every one of its tests. Invisible while the assertions read a single check's status — and it would have made any `ready` assertion pass or fail for a reason unrelated to vectors.
