### PR TITLE
fix(cloud): a cloud block is not the same thing as a cloud connection

### DIFF
--- a/src/cli/auto-push.ts
+++ b/src/cli/auto-push.ts
@@ -2,6 +2,7 @@ import type { ProjectConfig } from '../core/types.js';
 import { readAutoPushConsent } from '../cloud/consent.js';
 import { computePushSnapshot, pushStaged } from '../cloud/publish.js';
 import { checkPublishGate } from '../cloud/publish-gate.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 export type AutoPushOutcome =
   | { status: 'skipped'; reason: 'not-connected' | 'no-consent' | 'gated' | 'nothing-staged' }
@@ -29,7 +30,7 @@ export async function maybeAutoPush(input: {
   projectRoot: string;
   config: ProjectConfig;
 }): Promise<AutoPushOutcome> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { status: 'skipped', reason: 'not-connected' };
 
   if (!await readAutoPushConsent(pointer.workspaceId)) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -64,6 +64,7 @@ import { runPull } from '../cloud/pull.js';
 import { computePushSnapshot, countStageable, pushStaged, stagePublish } from '../cloud/publish.js';
 import { retractItem } from '../cloud/retract.js';
 import { cloudStatus, formatCloudStatus } from '../cloud/status.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 import { verifyCustomModel } from '../ai/model-probe.js';
 import { announceProfileChange, shadowedByPresetNotice } from './config/profile-change.js';
 import { DEFAULT_DIVERGENCE_POLICY, DIVERGENCE_POLICIES } from '../store/import-policy.js';
@@ -417,7 +418,7 @@ program
       // process-wide one -- it opens and closes -- so calling it inside the block below would
       // close the database out from under everything after it. Constraint `defde27f6f234535` is
       // about the MCP path; this is the same hazard on the CLI path.
-      const cloud = config.cloud ? await cloudStatus(root, config) : null;
+      const cloud = cloudPointer(config) ? await cloudStatus(root, config) : null;
 
       await initDb(root);
 
@@ -893,7 +894,8 @@ cloudCommand
       // `exitCode` and return, never `process.exit`: a cloud verb can have loaded the embedder
       // before it fails, and exiting there aborts with UV_HANDLE_CLOSING and reports 127. Pinned
       // by `tests/cli/cloud-exit-codes.test.ts`, which reads this source.
-      if (!config.cloud) {
+      const pointer = cloudPointer(config);
+      if (!pointer) {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
         process.exitCode = 1;
         return;
@@ -907,8 +909,8 @@ cloudCommand
         let counts;
         try {
           counts = await countStageable(
-            config.cloud.workspaceId,
-            config.workspace?.repo ?? config.cloud.repo,
+            pointer.workspaceId,
+            config.workspace?.repo ?? pointer.repo,
           );
         } finally { await closeDb(); }
 
@@ -924,7 +926,7 @@ cloudCommand
 
         const chosen = await pickCategories({
           verb: 'stage',
-          destination: config.cloud.workspaceName ?? config.cloud.workspaceId,
+          destination: pointer.workspaceName ?? pointer.workspaceId,
           counts,
         });
         if (chosen === null) {
@@ -1010,13 +1012,14 @@ cloudCommand
     }
     const root = await findProjectRoot(process.cwd());
     const config = await loadConfig(root);
-    if (!config.cloud) {
+    const pointer = cloudPointer(config);
+    if (!pointer) {
       console.error('This repository is not connected to a cloud workspace.');
       process.exitCode = 1;
       return;
     }
-    await writeAutoPushConsent(config.cloud.workspaceId, state === 'on');
-    const workspace = config.cloud.workspaceName ?? config.cloud.workspaceId;
+    await writeAutoPushConsent(pointer.workspaceId, state === 'on');
+    const workspace = pointer.workspaceName ?? pointer.workspaceId;
     console.log(state === 'on'
       // Said plainly because the whole design turns on it: this is not a project setting and
       // does not travel to anyone else.
@@ -1033,14 +1036,15 @@ cloudCommand
     try {
       const root = await findProjectRoot(process.cwd());
       const config = await loadConfig(root);
-      if (!config.cloud) {
+      const pointer = cloudPointer(config);
+      if (!pointer) {
         console.error('This repository is not connected to a cloud workspace.');
         process.exitCode = 1;
         return;
       }
       await initDb(root);
       try {
-        const cleared = await unstagePublish(id, config.cloud.workspaceId);
+        const cleared = await unstagePublish(id, pointer.workspaceId);
         if (options.forever) await excludeFromPublish(id, 'knowl cloud unstage --forever');
         console.log(cleared ? `Unstaged ${id}.` : `${id} was not staged.`);
         if (options.forever) {
@@ -2133,7 +2137,8 @@ program
         // exclusion is paired with an unstage rather than trusting it to have lost the race.
         if (options.local) {
           await excludeFromPublish(result.item.id, 'knowl store --local');
-          if (config.cloud) await unstagePublish(result.item.id, config.cloud.workspaceId);
+          const connected = cloudPointer(config);
+          if (connected) await unstagePublish(result.item.id, connected.workspaceId);
         }
 
         console.log(`Stored ${options.category} ${result.item.id}: ${result.item.title}`);

--- a/src/cloud/auto-stage.ts
+++ b/src/cloud/auto-stage.ts
@@ -4,6 +4,7 @@ import type { ProjectConfig } from '../core/types.js';
 import { filterExcluded } from './exclusions.js';
 import { publishedVersion, restageForPublish, stageForPublish } from './ledger.js';
 import { currentBranchOf } from './publish-gate.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 /**
  * Queue an atom for the team, if this repo is connected and nothing says otherwise.
@@ -24,7 +25,7 @@ export async function maybeAutoStage(input: {
   alreadyPublished: boolean;
 }): Promise<void> {
   try {
-    const pointer = input.config.cloud;
+    const pointer = cloudPointer(input.config);
     if (!pointer) return;
     // Absent means on. Only an explicit false turns it off, so a repo connected before this
     // setting existed behaves like one connected after.
@@ -75,10 +76,11 @@ export async function autoStageAfterWrite(itemIds: string[], namespace?: string)
   try {
     const projectRoot = getProjectRoot();
     const config = await loadConfig(projectRoot);
-    if (!config.cloud) return;
+    const pointer = cloudPointer(config);
+    if (!pointer) return;
 
     for (const itemId of itemIds) {
-      const alreadyPublished = await publishedVersion(itemId, config.cloud.workspaceId) !== null;
+      const alreadyPublished = await publishedVersion(itemId, pointer.workspaceId) !== null;
       await maybeAutoStage({ projectRoot, config, itemId, namespace, alreadyPublished });
     }
   } catch {

--- a/src/cloud/auto-sync.ts
+++ b/src/cloud/auto-sync.ts
@@ -5,6 +5,7 @@ import { acquireLock } from './file-lock.js';
 import { runPull } from './pull.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 /**
  * Short, because arrival is announced rather than waited for.
@@ -53,7 +54,7 @@ function autoSyncLockPath(workspaceId: string): string {
  * database context would corrupt a request that had already returned its answer.
  */
 export function maybeAutoSync(input: { projectRoot: string; config: ProjectConfig; now?: () => number }): void {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return;
 
   void (async () => {

--- a/src/cloud/doctor-checks.ts
+++ b/src/cloud/doctor-checks.ts
@@ -7,6 +7,7 @@ import { listStaged } from './ledger.js';
 import { checkPublishGate } from './publish-gate.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 /**
  * Cloud status, without touching the network.
@@ -23,7 +24,7 @@ export async function cloudDoctorChecks(
   projectRoot: string,
   now: () => number = Date.now,
 ): Promise<DoctorCheck[]> {
-  const pointer = config.cloud;
+  const pointer = cloudPointer(config);
   if (!pointer) return [];
 
   const credential = await readCredential(pointer.apiHost);

--- a/src/cloud/drift-report.ts
+++ b/src/cloud/drift-report.ts
@@ -5,6 +5,7 @@ import { createCloudApi, type CloudApi } from './api-client.js';
 import { publishedVersion } from './ledger.js';
 import { checkPublishGate } from './publish-gate.js';
 import { ensureAccessToken } from './token.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 type Target = {
   api: CloudApi;
@@ -41,7 +42,7 @@ async function gatedTarget(
   itemId: string,
   suppliedApi?: CloudApi,
 ): Promise<Target | 'not-connected' | 'not-published' | 'gated' | 'not-logged-in'> {
-  const pointer = config.cloud;
+  const pointer = cloudPointer(config);
   if (!pointer) return 'not-connected';
 
   await initDb(projectRoot);

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -17,6 +17,7 @@ import { decodeVector as decodeStoredVectorValue } from '../store/vector.js';
 import { encodeVector as encodeVectorToBase64 } from './vector-codec.js';
 import { withTeamStore } from './team-store.js';
 import { ensureAccessToken } from './token.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 export type StageResult =
   | { status: 'not-connected' }
@@ -55,7 +56,7 @@ export async function stagePublish(input: {
   categories?: KnowledgeCategory[];
   apply?: boolean;
 }): Promise<StageResult> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { status: 'not-connected' };
 
   await initDb(input.projectRoot);
@@ -80,7 +81,7 @@ export async function stagePublishInRequest(input: {
   categories?: KnowledgeCategory[];
   apply?: boolean;
 }): Promise<StageResult> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { status: 'not-connected' };
   return stageInContext(input, pointer);
 }
@@ -270,7 +271,7 @@ export async function computePushSnapshot(input: {
   projectRoot: string;
   config: ProjectConfig;
 }): Promise<PushSnapshot> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { items: [], unembedded: [] };
 
   await initDb(input.projectRoot);
@@ -314,7 +315,7 @@ export async function pushStaged(input: {
   /** Refuse when the queue merely GREW, not only when a listed atom changed. */
   strict?: boolean;
 }): Promise<PushResult> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { status: 'not-connected' };
 
   await initDb(input.projectRoot);

--- a/src/cloud/pull.ts
+++ b/src/cloud/pull.ts
@@ -8,6 +8,7 @@ import { runSync, type SyncResult } from './sync.js';
 import { withTeamStore } from './team-store.js';
 import { getClient } from '../store/database.js';
 import { fingerprintProfile, resolveVectorProfile, type VectorProfile } from '../core/vector-profile.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 /**
  * The sync outcome is nested, not spread.
@@ -26,7 +27,7 @@ export async function runPull(input: {
   config: ProjectConfig;
   api?: CloudApi;
 }): Promise<PullResult> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { status: 'not-connected' };
 
   const api = input.api ?? createCloudApi({ apiHost: pointer.apiHost });

--- a/src/cloud/retract.ts
+++ b/src/cloud/retract.ts
@@ -5,6 +5,7 @@ import { publishedVersion, recordRetracted } from './ledger.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
 import { ensureAccessToken } from './token.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 export type RetractResult =
   | { status: 'retracted' }
@@ -46,7 +47,7 @@ export async function retractItem(input: {
   reason: string;
   api?: CloudApi;
 }): Promise<RetractResult> {
-  const pointer = input.config.cloud;
+  const pointer = cloudPointer(input.config);
   if (!pointer) return { status: 'not-connected' };
 
   await initDb(input.projectRoot);

--- a/src/cloud/status.ts
+++ b/src/cloud/status.ts
@@ -7,6 +7,7 @@ import { listStaged } from './ledger.js';
 import { checkPublishGate, type GateVerdict } from './publish-gate.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 /** Who the stored credential belongs to, cached at login. Null when 4.x wrote it. */
 export type StatusIdentity = { email: string; displayName: string } | null;
@@ -57,7 +58,7 @@ export type CloudStatus =
  * every fact it reports is already on this disk.
  */
 export async function cloudStatus(projectRoot: string, config: ProjectConfig): Promise<CloudStatus> {
-  const pointer = config.cloud;
+  const pointer = cloudPointer(config);
   if (!pointer) return await composeDisconnected();
 
   await initDb(projectRoot);
@@ -79,7 +80,7 @@ export async function cloudStatus(projectRoot: string, config: ProjectConfig): P
  * different request from the one that caused it. See constraint `defde27f6f234535`.
  */
 export async function cloudStatusInRequest(projectRoot: string, config: ProjectConfig): Promise<CloudStatus> {
-  const pointer = config.cloud;
+  const pointer = cloudPointer(config);
   if (!pointer) return await composeDisconnected();
 
   // The caller's context answers this; nothing is opened and nothing is closed.

--- a/src/core/cloud-pointer.ts
+++ b/src/core/cloud-pointer.ts
@@ -1,0 +1,49 @@
+import type { ProjectConfig } from './types.js';
+
+/**
+ * What is on disk, narrowed to the case where it points somewhere.
+ *
+ * Deliberately not `CloudPointer` from `connect.ts`: that type describes what `connect` writes,
+ * and the stored block also carries `autoStage`, which a caller reads from the same object.
+ */
+export type ConnectedCloud =
+  NonNullable<ProjectConfig['cloud']> & { apiHost: string; workspaceId: string };
+
+/**
+ * The cloud pointer, or null when this repository is not connected to one.
+ *
+ * `config.cloud` holds two different kinds of thing. `apiHost`, `workspaceId`, `workspaceName`,
+ * `repo` and `remote` are the pointer `knowl cloud connect` writes after it authenticates. But
+ * `autoStage` is a preference, and 5.0.1 made it settable -- so `knowl config set cloud.autoStage
+ * false` in a repository that was never connected leaves `cloud: { autoStage: false }` on disk:
+ * a `cloud` block that is not a connection.
+ *
+ * Every caller here used to read the block's mere presence as "connected", which turned that
+ * into `readCredential(undefined)` and a `Cannot read properties of undefined (reading 'trim')`
+ * out of `normalizeApiHost` -- reported by `doctor` as a FAIL with a JavaScript error where a
+ * diagnosis should be.
+ *
+ * Lives in `core/` rather than `cloud/` because `workspace/resolve.ts` needs it too, and `workspace`
+ * sits below `cloud` in the layering `tests/architecture/module-boundaries.test.ts` enforces -- so
+ * the predicate cannot live in the layer that happens to have named the concept.
+ *
+ * `apiHost` and `workspaceId` are the test because they are the two fields nothing works without:
+ * one names the deployment credentials are keyed by, the other names what to read and write.
+ * `workspaceName` is a label, and `repo`/`remote` describe identity rather than reachability.
+ */
+export function cloudPointer(config: ProjectConfig): ConnectedCloud | null {
+  const cloud = config.cloud;
+  if (!cloud?.apiHost || !cloud.workspaceId) return null;
+  return cloud as ConnectedCloud;
+}
+
+/**
+ * Whether a `cloud` block holds settings but no connection.
+ *
+ * Distinguished from "no block at all" so a repository in this state can be told what is wrong
+ * with it. Silence would be worse here than for a plainly disconnected repo: someone who ran
+ * `config set cloud.autoStage` has said out loud that they expect staging to happen.
+ */
+export function hasCloudSettingsWithoutPointer(config: ProjectConfig): boolean {
+  return config.cloud !== undefined && cloudPointer(config) === null;
+}

--- a/src/workspace/resolve.ts
+++ b/src/workspace/resolve.ts
@@ -10,6 +10,7 @@ import { teamStorePath } from '../core/paths.js';
 import { createManifest, readManifest, WorkspaceManifest } from './manifest.js';
 import { workspaceManifestPath } from './paths.js';
 import { isLinked } from './membership.js';
+import { cloudPointer } from '../core/cloud-pointer.js';
 
 export type PeerRepo = {
   name: string;
@@ -80,7 +81,12 @@ function synthesizedManifest(workspaceId: string, repo: string, config: ProjectC
 export async function resolveWorkspace(projectRoot: string, config?: ProjectConfig): Promise<ActiveWorkspace | null> {
   const effective = config ?? await loadConfig(projectRoot).catch(() => null);
   const link = effective?.workspace;
-  const pointer = effective?.cloud;
+  // Through the predicate, not `effective?.cloud` directly: `cloud.autoStage` is settable, so a
+  // repository that only ever set that preference has a `cloud` block with no pointer in it, and
+  // reading presence as connected built a `CloudPeer` around an undefined workspace id --
+  // `teamStorePath(undefined)` throwing "The path argument must be of type string" out of a
+  // `doctor` run that should have reported an ordinary unlinked project.
+  const pointer = effective ? cloudPointer(effective) : null;
 
   // Either reason is enough to be active, and neither implies the other: a repo can be linked
   // locally, connected to the cloud, both, or neither. Only "neither" keeps the null that

--- a/tests/cloud/pointer.test.ts
+++ b/tests/cloud/pointer.test.ts
@@ -1,0 +1,94 @@
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { cloudPointer, hasCloudSettingsWithoutPointer } from '../../src/core/cloud-pointer.js';
+import { cloudDoctorChecks } from '../../src/cloud/doctor-checks.js';
+import { cloudStatus } from '../../src/cloud/status.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * A `cloud` block is not the same thing as a cloud connection.
+ *
+ * 5.0.1 made `cloud.autoStage` settable, which was the point of that release -- and in doing so
+ * created a state nothing had ever seen: `knowl config set cloud.autoStage false` in a repository
+ * that was never connected writes `cloud: { autoStage: false }`, a block with no pointer in it.
+ *
+ * Every caller tested the block's presence. `doctor` therefore called `readCredential(undefined)`
+ * and reported `[FAIL] Cannot read properties of undefined (reading 'trim')` -- a JavaScript
+ * error printed where the diagnosis goes, on a repository whose only sin was setting a documented
+ * preference.
+ */
+/**
+ * A path that is never opened.
+ *
+ * Every call below returns before it touches disk -- that is the behaviour under test -- but
+ * passing `process.cwd()` would aim them at the real repository, and a suite that reaches the
+ * developer's own store is one bad early-return away from racing whichever other file vitest
+ * scheduled in the same worker. That is not hypothetical: it made `publish-stage.test.ts` fail
+ * in the full run while passing alone.
+ */
+const NOWHERE = path.join(os.tmpdir(), 'knowl-pointer-test-never-created');
+
+const settingsOnly = { version: 1, cloud: { autoStage: false } } as unknown as ProjectConfig;
+const connected = {
+  version: 1,
+  cloud: {
+    apiHost: 'https://api.knowl.cloud', workspaceId: 'ws-1', workspaceName: 'team',
+    repo: 'github.com/o/r', autoStage: false,
+  },
+} as unknown as ProjectConfig;
+
+describe('cloudPointer', () => {
+  it('is null for a repository that has never been connected', () => {
+    expect(cloudPointer({ version: 1 } as ProjectConfig)).toBeNull();
+  });
+
+  it('is null for a block holding only a preference', () => {
+    expect(cloudPointer(settingsOnly)).toBeNull();
+  });
+
+  it('is null when either half of the pointer is missing', () => {
+    // Both are required: one names the deployment credentials are keyed by, the other names
+    // what to read and write. A block carrying one of them points nowhere usable.
+    expect(cloudPointer({ version: 1, cloud: { apiHost: 'https://a' } } as unknown as ProjectConfig)).toBeNull();
+    expect(cloudPointer({ version: 1, cloud: { workspaceId: 'ws-1' } } as unknown as ProjectConfig)).toBeNull();
+  });
+
+  it('returns the block, preferences included, when it points somewhere', () => {
+    // `autoStage` rides along on the same object and callers read it from there, so narrowing
+    // must not erase it.
+    expect(cloudPointer(connected)?.workspaceId).toBe('ws-1');
+    expect(cloudPointer(connected)?.autoStage).toBe(false);
+  });
+
+  it('distinguishes settings-without-pointer from no block at all', () => {
+    expect(hasCloudSettingsWithoutPointer(settingsOnly)).toBe(true);
+    expect(hasCloudSettingsWithoutPointer({ version: 1 } as ProjectConfig)).toBe(false);
+    expect(hasCloudSettingsWithoutPointer(connected)).toBe(false);
+  });
+});
+
+describe('callers that used to read the block itself', () => {
+  it('doctor stays silent instead of crashing on a preference-only block', async () => {
+    // The reported failure, end to end. `cloudDoctorChecks` returning [] is what a repository
+    // with no cloud connection is supposed to produce -- Knowl is local-first and must not
+    // advertise the cloud to someone who never opted in.
+    await expect(cloudDoctorChecks(settingsOnly, NOWHERE)).resolves.toEqual([]);
+  });
+
+  it('status reports disconnected rather than throwing', async () => {
+    const status = await cloudStatus(NOWHERE, settingsOnly);
+    expect(status.connected).toBe(false);
+  });
+
+  it('workspace resolution treats it as unlinked instead of building a peer around nothing', async () => {
+    // The second site, and the reason the first fix looked complete when it was not: with
+    // `cloudDoctorChecks` guarded, `doctor` failed one line further down instead, on
+    // `teamStorePath(undefined)` -> `The "path" argument must be of type string`.
+    //
+    // `resolveWorkspace` cannot import the predicate from `cloud/` -- `workspace` sits below it
+    // in the enforced layering -- which is why the predicate lives in `core/`.
+    const { resolveWorkspace } = await import('../../src/workspace/resolve.js');
+    await expect(resolveWorkspace(NOWHERE, settingsOnly)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Regression introduced by 5.0.1, found while verifying that release against the published tarball.

## What broke

Making `cloud.autoStage` settable — the point of 5.0.1 — created a state nothing had seen before. In a repository that was never connected:

```
$ knowl config set cloud.autoStage false
Set cloud.autoStage = false
$ knowl doctor
[FAIL] Cannot read properties of undefined (reading 'trim')
Result: NOT READY
```

The config now holds `cloud: { autoStage: false }` — a `cloud` block with no pointer in it. Fifteen callers read the block's presence as "this repo is connected", so `doctor` called `readCredential(undefined)` and `normalizeApiHost` threw. `cloud status`, `cloud unstage`, auto-stage and auto-push read the same way.

## The fix

`cloudPointer(config)` is the single test, returning the block only when it carries both `apiHost` and `workspaceId` — the two fields nothing works without: one names the deployment credentials are keyed by, the other names what to read and write. It returns the stored shape rather than `CloudPointer`, because callers read `autoStage` off the same object and narrowing must not erase it.

It lives in `core/`, not `cloud/`. `workspace/resolve.ts` needs it too, and `workspace` sits below `cloud` in the layering `tests/architecture/module-boundaries.test.ts` enforces. That second site is why the first attempt looked complete when it wasn't: with `cloudDoctorChecks` guarded, doctor failed one line further down on `teamStorePath(undefined)` — `The "path" argument must be of type string`.

## Verified

The regression test asserts the reported symptom, not just the predicate, and was confirmed to fail without the fix. End to end on a built tarball, the sequence above now reports `READY` and exits 0.

`build`, `typecheck`, `lint`, `test` (327 files), `docs:check` all pass.

One test-hygiene fix included: the new suite first used `process.cwd()`, which aimed it at the real repository and made `publish-stage.test.ts` fail in the full run while passing alone. It uses a path that is never created instead.
