### PR TITLE
fix(cloud): publishing adds knowledge, so it stops waiting for the default branch

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,7 +29,7 @@ which parts of a restore are deliberately not restored.
 | [Tasks, sessions, lifecycle](#tasks-sessions-and-agent-lifecycle) | [Work loops](#manual-work-loops) · [Retention and promotion](#session-retention-recovery-and-promotion) · [Handoffs and resume keys](#leaving-work-for-later) · [Transcript search](#searchable-session-transcripts-optional-off-by-default) · [Host behavior](#host-and-subagent-behavior) |
 | [Evidence, code, drift](#evidence-code-intelligence-and-drift) | [Evidence and symbols](#evidence-and-symbols) · [PR drift and feedback](#pull-request-drift-and-retrieval-feedback) |
 | [Workspaces](#workspaces) | [Federation and ownership](#federation-and-ownership) · [Ownership stamping](#ownership) |
-| [Knowl Cloud](#knowl-cloud) | [Identity and connection](#identity-and-connection) · [Publishing and the default branch](#publishing-tracks-the-default-branch-not-your-working-tree) · [Staying current](#staying-current) |
+| [Knowl Cloud](#knowl-cloud) | [Identity and connection](#identity-and-connection) · [Publishing and drift](#publishing-works-from-any-branch-reporting-drift-does-not) · [Staying current](#staying-current) |
 | [Learned skills and synthesis](#learned-skills-and-synthesis) | [File-backed skills](#file-backed-skills) · [Deterministic synthesis](#deterministic-synthesis) |
 | [Portability and maintenance](#portability-and-maintenance) | [Export and import](#jsonl-export-and-import) · [Garbage collection](#garbage-collection) · [Snapshots, audit, doctor](#snapshots-audit-and-doctor) |
 | [Local viewer](#local-viewer) · [Architecture](#architecture-and-security-boundaries) | Inspector, component diagram, security boundaries, [write durability](#write-durability) |
@@ -724,7 +724,7 @@ The replica is a replica: deleting it is always safe, and the next pull rebuilds
 | `knowl cloud connect [--workspace <id>] [--remote <name>] [--repo <name>]` | Point this project at a workspace. Publishes nothing |
 | `knowl cloud pull` | Fetch team knowledge into the local replica |
 | `knowl cloud stage [--id <ids...>] [--category <list>] [--apply]` | Queue knowledge for the team. Bare opens the same picker; naming flags dry-runs until `--apply` |
-| `knowl cloud push` | Send staged knowledge, once its code is on the default branch |
+| `knowl cloud push` | Send staged knowledge. Works from any branch |
 | `knowl cloud retract <id> --reason <text>` | Remove a published atom for good. Works from any branch |
 | `knowl cloud status` | What is connected, how stale the replica is, and what is staged |
 
@@ -781,8 +781,8 @@ written**. You do not have to remember to stage it. Nothing is sent by that: sta
 intent, and a separate push is what puts it in front of anyone.
 
 ```
-knowl cloud status                # what is queued, and what a push is waiting for
-knowl cloud push                  # send it — only from an up-to-date default branch
+knowl cloud status                # what is queued
+knowl cloud push                  # send it — from any branch
 ```
 
 Three ways to say "not this one", in the order you will want them:
@@ -811,14 +811,24 @@ knowl cloud stage --category decision --apply    # or name them
 A bare call opens a picker with the categories worth sharing already ticked and a count beside
 each; confirming it is the apply. Naming categories skips the picker and dry-runs until `--apply`.
 
-### Publishing tracks the default branch, not your working tree
+### Publishing works from any branch; reporting drift does not
 
-Local knowledge describes the tree in front of you. Team knowledge has to describe the branch
-everyone shares, so sending is gated where staging is not:
+Staging and sending are both ungated:
 
 ```
-knowl cloud push                  # only from an up-to-date default branch
+knowl cloud push                  # from any branch, at any time
 ```
+
+Publishing **adds** an atom, and the worst case is knowledge that arrives early — which an update,
+a supersede or `knowl cloud retract` all answer. This used to refuse from anything but an
+up-to-date default branch. The gate could not tell knowledge about code from knowledge about
+anything else, so a pricing decision or a piece of market research waited on a merge it had
+nothing to do with, and auto-push skipped without saying why.
+
+**Reporting drift upward is still gated**, and the line is what the act does rather than which
+branch you are on. A drift report **retires** a colleague's atom for the whole workspace, and from
+a checkout behind the default branch, code that was merged and code that was deleted look
+identical. Adding from a bad vantage is recoverable; retiring from one is not.
 
 `knowl cloud push` shows what it is about to send and asks, because sending cannot be undone
 except by `knowl cloud retract`, which is a hard delete. `--yes` skips the question; without a
@@ -826,8 +836,8 @@ terminal it is required, so silence is never read as consent.
 
 **Automatic sending is off, and turning it on is per machine.** `knowl cloud autopush on` records
 standing consent for this workspace **on this machine only** — it is not written to
-`.knowl/config.json` and no teammate or CI inherits it. It never relaxes the branch gate, and it
-still sends only what it showed itself: a queue that changed underneath it is refused, not sent.
+`.knowl/config.json` and no teammate or CI inherits it. It still sends only what it showed
+itself: a queue that changed underneath it is refused, not sent.
 
 ### Two kinds of sharing, and they are independent
 
@@ -840,10 +850,8 @@ state lives in a local ledger rather than in `visibility`.
 Neither implies the other. Promoting publishes nothing, and publishing does not make your other
 local repositories see it.
 
-`knowl cloud stage` records an intent and sends nothing. `knowl cloud push` refuses from a feature
-branch, because an atom describing code only you have would be false for everyone else — and
-there is no unpublish. It also refuses from a checkout behind its remote, because being behind is
-indistinguishable from the code having been deleted.
+`knowl cloud stage` records an intent and sends nothing. `knowl cloud push` sends it, from any
+branch and whatever state your checkout is in.
 
 Only atoms this repository wrote can be published. A reader is refused before anything is sent.
 A version conflict names the atom and stops rather than overwriting; a detected secret fails the
@@ -861,11 +869,10 @@ it on their next sync. It cannot be undone, and the id can never be used again �
 knowledge that must not remain readable, not for knowledge that stopped being true. Supersede that
 instead, which keeps the lineage.
 
-**It is the one upward path with no branch gate, deliberately.** Publishing and drift reports are
-gated because they assert something about code only you have. A removal is true from every vantage,
-and the case that brings you here is a secret sitting in a shared workspace right now — answering
-that with "switch to the default branch and pull first" would hold the leak open for the length of
-a rebase.
+**It has no branch gate, deliberately.** Only drift reports do, because they retire knowledge the
+rest of the team is relying on. A removal is true from every vantage, and the case that brings you
+here is a secret sitting in a shared workspace right now — answering that with "switch to the
+default branch and pull first" would hold the leak open for the length of a rebase.
 
 `--reason` is required and stored on the tombstone. `expectedVersion` comes from the local ledger,
 so if a colleague edited the atom after you published it the retraction stops with a conflict
@@ -883,9 +890,8 @@ Once a repository is connected, the MCP server offers one more tool:
   queue, and is always safe — it sends nothing and unpublishes nothing.
 
 It stops there deliberately. Sending, pulling, connecting and signing in stay yours to run —
-sending because it is irreversible and gated on a branch state the agent cannot see the whole of,
-the other three because two need a browser and pulling already happens on its own. Asked to send,
-the agent relays the command instead.
+sending because it is irreversible, the other three because two need a browser and pulling already
+happens on its own. Asked to send, the agent relays the command instead.
 
 Because knowledge stages itself as it is written, an agent needs a way to say "not this one" at
 write time: `knowl_store` takes `local: true`, the tool-side equivalent of `knowl store --local`,
@@ -911,9 +917,10 @@ immediately, a refresh runs in the background, and a `TEAM UPDATE:` notice tells
 something landed that it may want to re-query for. `knowl cloud pull` forces the refresh when you
 know a colleague has just published.
 
-Drift travels the same gate. When a local check finds a published atom's code has moved, it is
-reported upward from the default branch only, and the workspace sees it — so one person noticing
-protects everyone.
+Drift is the one upward path that is gated. When a local check finds a published atom's code has
+moved, it is reported upward from an up-to-date default branch only, and the workspace sees it —
+so one person noticing protects everyone, and nobody retires an atom over code they simply have
+not pulled yet.
 
 ## Learned skills and synthesis
 

--- a/src/cli/auto-push.ts
+++ b/src/cli/auto-push.ts
@@ -1,30 +1,32 @@
 import type { ProjectConfig } from '../core/types.js';
 import { readAutoPushConsent } from '../cloud/consent.js';
 import { computePushSnapshot, pushStaged } from '../cloud/publish.js';
-import { checkPublishGate } from '../cloud/publish-gate.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
 
 export type AutoPushOutcome =
-  | { status: 'skipped'; reason: 'not-connected' | 'no-consent' | 'gated' | 'nothing-staged' }
+  | { status: 'skipped'; reason: 'not-connected' | 'no-consent' | 'nothing-staged' }
   | { status: 'pushed'; created: number; updated: number }
   | { status: 'failed'; detail: string };
 
 /**
- * Send what was just staged, but only when every gate agrees.
+ * Send what was just staged, when consent and the snapshot both agree.
  *
  * CLI-only, deliberately. Decision `9a2fe8a011d6423b` says an agent may stage and only a human
  * may send; consent is the human's standing answer to that, given once per machine, and the MCP
  * surface has no route to this function at all.
  *
- * Four conditions, all required:
+ * Three conditions, all required:
  *
  * 1. a cloud pointer, or there is nothing to send to;
  * 2. **consent stored under `knowlHome()`** -- never read from project config, which is
  *    committable and would let one person enable this for a whole team;
- * 3. the publish gate, unrelaxed. Auto-push waits for the default branch like every other push;
- * 4. a snapshot that still matches. Consent replaces the PROMPT, not the binding -- an automatic
+ * 3. a snapshot that still matches. Consent replaces the PROMPT, not the binding -- an automatic
  *    push that sent whatever was in the queue at send time would reintroduce exactly the race
  *    the snapshot closes.
+ *
+ * There was a fourth: the default-branch gate. Removed 2026-08-13 with the gate itself, because
+ * it silently dropped a colleague's non-code knowledge and reported only `gated` to a caller
+ * that shows the user nothing.
  */
 export async function maybeAutoPush(input: {
   projectRoot: string;
@@ -36,10 +38,6 @@ export async function maybeAutoPush(input: {
   if (!await readAutoPushConsent(pointer.workspaceId)) {
     return { status: 'skipped', reason: 'no-consent' };
   }
-
-  // Checked here as well as inside `pushStaged` so a skip can be reported as "waiting on the
-  // branch" rather than as a failed push.
-  if (!checkPublishGate(input.projectRoot).ok) return { status: 'skipped', reason: 'gated' };
 
   const snapshot = await computePushSnapshot({ projectRoot: input.projectRoot, config: input.config });
   if (snapshot.items.length === 0) return { status: 'skipped', reason: 'nothing-staged' };

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1286,11 +1286,6 @@ cloudCommand
         process.exitCode = 1;
         return;
       }
-      if (result.status === 'gated') {
-        console.error(`${result.staged} item(s) stay staged. ${result.detail}`);
-        process.exitCode = 1;
-        return;
-      }
       if (result.status === 'needs-embedding') {
         // Nothing is lost: they stay staged and go out on the next push. Said out loud because a
         // push that quietly sent nothing would look like success.

--- a/src/cloud/doctor-checks.ts
+++ b/src/cloud/doctor-checks.ts
@@ -4,7 +4,6 @@ import { withDbPath } from '../store/database.js';
 import { resolveStorage } from '../store/storage-roles.js';
 import { readCredential } from './credentials.js';
 import { listStaged } from './ledger.js';
-import { checkPublishGate } from './publish-gate.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
@@ -72,26 +71,28 @@ export async function cloudDoctorChecks(
 }
 
 /**
- * Staged work that the gate is currently refusing to send.
+ * Staged work that nobody has sent yet.
  *
- * A developer who staged on a feature branch and moved on has no other prompt -- the atoms are
- * in a table nobody reads, and the push they were waiting for is a command they have to
- * remember to run. Reported through doctor because doctor is a command they already run.
+ * A developer who staged and moved on has no other prompt -- the atoms sit in a table nobody
+ * reads, and the push is a command they have to remember to run. Reported through doctor because
+ * doctor is a command they already run.
  *
- * Silent when nothing is staged, and silent when the gate would pass: a WARN that fires on the
- * happy path is furniture, and the one time it matters nobody reads it.
+ * Until 2026-08-13 this consulted `checkPublishGate` and stayed silent unless it refused, because
+ * the gate was the only thing that could hold staged work back. Publishing is ungated now, so the
+ * only remaining cause is that no push has happened -- and quoting a git verdict here would name
+ * a reason that no longer applies and send the reader to change branch for nothing.
+ *
+ * Silent when nothing is staged: a WARN that fires on the happy path is furniture, and the one
+ * time it matters nobody reads it.
  */
 async function stagedCheck(workspaceId: string, projectRoot: string): Promise<DoctorCheck[]> {
   const staged = await withDbPath(resolveStorage(projectRoot).knowledge, () => listStaged(workspaceId))
     .catch(() => []);
   if (staged.length === 0) return [];
 
-  const verdict = checkPublishGate(projectRoot);
-  if (verdict.ok) return [];
-
   return [{
     status: 'WARN',
-    message: `Cloud: ${staged.length} item(s) staged but not sent. ${verdict.detail}`,
-    fix: 'Run knowl cloud status',
+    message: `Cloud: ${staged.length} item(s) staged but not sent.`,
+    fix: 'Run knowl cloud push',
   }];
 }

--- a/src/cloud/drift-report.ts
+++ b/src/cloud/drift-report.ts
@@ -3,7 +3,7 @@ import type { ProjectConfig } from '../core/types.js';
 import { closeDb, initDb } from '../store/database.js';
 import { createCloudApi, type CloudApi } from './api-client.js';
 import { publishedVersion } from './ledger.js';
-import { checkPublishGate } from './publish-gate.js';
+import { checkUpstreamGate } from './publish-gate.js';
 import { ensureAccessToken } from './token.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
 
@@ -56,7 +56,7 @@ async function gatedTarget(
   }
   if (!known) return 'not-published';
 
-  if (!checkPublishGate(projectRoot).ok) return 'gated';
+  if (!checkUpstreamGate(projectRoot).ok) return 'gated';
 
   const commit = headOf(projectRoot);
   // Both verbs carry a commit -- one required by the contract, one that makes a bad report

--- a/src/cloud/publish-gate.ts
+++ b/src/cloud/publish-gate.ts
@@ -28,7 +28,7 @@ function git(cwd: string, args: string[]): string | null {
  * `origin/HEAD` is the answer when the remote published one, which a fresh clone records. The
  * `main`/`master` fallback exists because that symbolic ref is local state a clone can be missing
  * -- an old clone, a `git remote set-head` never run -- and guessing wrong there is cheap while
- * refusing to publish at all is not.
+ * refusing every drift report is not.
  */
 export function defaultBranchOf(projectRoot: string): string | null {
   const head = git(projectRoot, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']);
@@ -65,19 +65,25 @@ export function commitsBehindRemote(projectRoot: string, branch: string): number
 }
 
 /**
- * Whether this checkout may speak for the team.
+ * Whether this checkout may RETIRE knowledge on the team's behalf.
+ *
+ * Named `checkPublishGate` until 2026-08-13, when publishing stopped consulting it. `reportDrift`
+ * is the only caller left, and that is the whole distinction: publishing ADDS an atom, where the
+ * worst case is knowledge that is premature and which supersede and retract both undo. A drift
+ * report RETIRES someone else's atom for everyone, and a wrong vantage there destroys instead of
+ * adding. Same git facts, opposite blast radius.
  *
  * Two conditions, and the second is the one that looks optional and is not. Being behind the
  * remote default branch is INDISTINGUISHABLE from the code having been deleted: the file the
- * team just published about is genuinely not here. Publishing or reporting drift from that
- * vantage retires knowledge that is still correct for everyone who is current.
+ * team just published about is genuinely not here. Reporting drift from that vantage retires
+ * knowledge that is still correct for everyone who is current.
  *
  * This repository has shipped that collapse before -- `fileContentHash` caught every read
  * error and returned null, `currentStateOf` mapped null to `gone`, and an antivirus lock on
  * Windows became "the file you read is deleted", fired as the strongest notice the system has
  * about an intact file.
  */
-export function checkPublishGate(projectRoot: string): GateVerdict {
+export function checkUpstreamGate(projectRoot: string): GateVerdict {
   let current: string | null;
   let target: string | null;
   try {
@@ -89,7 +95,7 @@ export function checkPublishGate(projectRoot: string): GateVerdict {
       reason: 'git-unavailable',
       detail:
         `Could not run git in ${projectRoot}: ${error.message}. ` +
-        'Publishing is gated on the default branch, so git has to be on PATH.',
+        'Drift is reported only from the default branch, so git has to be on PATH.',
     };
   }
 
@@ -112,8 +118,8 @@ export function checkPublishGate(projectRoot: string): GateVerdict {
       reason: 'not-default-branch',
       detail:
         `This checkout is on ${current ?? 'a detached HEAD'}, not ${target}. ` +
-        'Knowledge about code only this branch has would be false for everyone on ' +
-        `${target}, and there is no unpublish.`,
+        'Code that only this branch has looks deleted from here, so marking the team\'s ' +
+        `knowledge stale would retire what is still true on ${target}.`,
     };
   }
 

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -6,7 +6,7 @@ import {
   listStaged, publishedVersion, recordPushed, restageForPublish, stageForPublish,
 } from './ledger.js';
 import { filterExcluded } from './exclusions.js';
-import { checkPublishGate, currentBranchOf } from './publish-gate.js';
+import { currentBranchOf } from './publish-gate.js';
 import { readSyncState } from './sync-state.js';
 import { listAssertions } from '../store/assertions.js';
 import { listEvidenceForItem } from '../store/evidence-repository.js';
@@ -129,10 +129,9 @@ async function stageInContext(
   const skippedExcluded = items.length - eligible.length;
 
   if (input.apply && eligible.length > 0) {
-    // Swallowed on purpose, and only here. The branch is what the push's refusal quotes back,
-    // not what it decides on -- `checkPublishGate` re-reads git itself and reports being
-    // unable to run it as its own verdict. Failing to record an intent because git is missing
-    // would refuse the one half of publishing that is safe from every vantage.
+    // Swallowed on purpose, and only here. `staged_on_branch` is a record of where an intent was
+    // formed -- displayed by `cloud status`, read by nothing that decides anything. Failing to
+    // record an intent because git is missing would refuse a step that never needed git at all.
     let branch: string | null;
     try { branch = currentBranchOf(input.projectRoot); } catch { branch = null; }
 
@@ -157,7 +156,6 @@ async function stageInContext(
 export type PushResult =
   | { status: 'not-connected' }
   | { status: 'not-logged-in' }
-  | { status: 'gated'; reason: string; detail: string; staged: number }
   | { status: 'forbidden'; role: string }
   /**
    * Staged atoms that have no vector under this repo's current embedding profile.
@@ -322,16 +320,8 @@ export async function pushStaged(input: {
   try {
     const staged = await listStaged(pointer.workspaceId);
 
-    // Before the gate, deliberately. Reporting `gated` when there is nothing to send would be a
-    // refusal about nothing -- it would tell a developer on a feature branch to go and pull, for
-    // a push that had no work in it either way.
     if (staged.length === 0) {
       return { status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [] };
-    }
-
-    const verdict = checkPublishGate(input.projectRoot);
-    if (!verdict.ok) {
-      return { status: 'gated', reason: verdict.reason, detail: verdict.detail, staged: staged.length };
     }
 
     // The role rides on every sync response, so refusing a reader here costs nothing and saves a

--- a/src/cloud/retract.ts
+++ b/src/cloud/retract.ts
@@ -23,13 +23,14 @@ export type RetractResult =
  * deletion as a row of its own. This is the only path that removes something from the team, and
  * it cannot be undone from either side.
  *
- * **Deliberately NOT behind the publish gate, and that is the whole point of the command.**
- * `checkPublishGate` exists because publishing from a feature branch asserts something about code
- * only you have, which is false for everyone else. Removal is the opposite act: it is true from
- * every vantage, and the case that brings someone here is a leaked name or a secret sitting in a
- * shared workspace right now. Answering that with "switch to the default branch and pull first"
- * would hold the leak open for the length of a rebase. Staging is ungated for the mirror-image
- * reason -- an intent is safe to record from anywhere -- and this is safe to *send* from anywhere.
+ * **Deliberately NOT behind any git gate**, and until 2026-08-13 that made this command the
+ * exception. It no longer is: publishing was ungated the same day, leaving `checkUpstreamGate`
+ * with one caller, `reportDrift`. The line it draws is not which branch you are on but what the
+ * act does -- adding an atom and removing your own are both true from every vantage, while
+ * retiring someone else's knowledge needs a vantage that can tell deleted from not-yet-pulled.
+ * The case that brings someone here is a leaked name or a secret sitting in a shared workspace
+ * right now, and answering that with "switch to the default branch and pull first" would hold
+ * the leak open for the length of a rebase.
  *
  * The ledger check still comes first: an atom this machine never pushed has no server-side row,
  * so there is nothing to retract and sending the user to log in could not help.

--- a/src/cloud/status.ts
+++ b/src/cloud/status.ts
@@ -4,7 +4,6 @@ import { AUTO_SYNC_INTERVAL_MS } from './auto-sync.js';
 import { listCredentialHosts, normalizeApiHost, readCredential } from './credentials.js';
 import { defaultApiHost } from './login.js';
 import { listStaged } from './ledger.js';
-import { checkPublishGate, type GateVerdict } from './publish-gate.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
@@ -42,7 +41,6 @@ export type CloudStatus =
       stagedCorrections: number;
       /** The branch the staged atoms were staged on, when they all agree. */
       stagedOnBranch: string | null;
-      gate: GateVerdict;
       signedIn: boolean;
       identity: StatusIdentity;
       tokenExpiresAt: string | null;
@@ -146,11 +144,10 @@ async function composeStatus(
     nextSyncDueAt: lastSynced === null || Number.isNaN(lastSynced)
       ? new Date().toISOString()
       : new Date(lastSynced + AUTO_SYNC_INTERVAL_MS).toISOString(),
-    // Named only when every staged atom agrees. Two branches make "waiting on X" a false
-    // statement about the others, and the gate's own detail already names the branch the
-    // checkout is on, which is the one that actually decides.
+    // Named only when every staged atom agrees, because "staged on X" is a false statement
+    // about the others otherwise. Reported as provenance, not as a condition: since 2026-08-13
+    // the branch decides nothing about whether a push goes out.
     stagedOnBranch: branches.size === 1 ? [...branches][0] : null,
-    gate: checkPublishGate(projectRoot),
   };
 }
 
@@ -197,12 +194,11 @@ export function formatCloudStatus(status: CloudStatus): string {
     ` (${status.stagedNew} new, ${status.stagedCorrections} correction(s))` +
     `${status.stagedOnBranch ? ` on ${status.stagedOnBranch}` : ''}, not yet sent.`,
   );
-  // What is holding it, named. A developer who staged on a branch and moved on has no other
-  // prompt: the atoms sit in a table nobody reads, and a status line that reported the count
-  // without the reason would leave them there.
-  lines.push(status.gate.ok
-    ? '           Ready to send. Run knowl cloud push.'
-    : `           ${status.gate.detail}`);
+  // The next step, named. A developer who staged and moved on has no other prompt: the atoms sit
+  // in a table nobody reads, and a line that reported the count without the command would leave
+  // them there. Unconditional since 2026-08-13 -- staged work is now always one push from sent,
+  // where this used to print the gate's refusal and send a reader off to change branch instead.
+  lines.push('           Ready to send. Run knowl cloud push.');
   // Only while something is staged, so the warning still means something when it appears. It no
   // longer says publishing cannot be undone -- `knowl cloud retract` wires the server's delete
   // verb -- but undoing is a hard delete plus a tombstone that bars the id forever, which is a

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -89,8 +89,10 @@ export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
  * One tool rather than four, for the reason `knowl_impact` is one: every registered tool costs
  * guidance-card space in every session of every user, so a capability earns a name, not a verb.
  *
- * It deliberately stops at the local half of publishing. `push` sends to the team and is gated on
- * default-branch state the agent cannot see the whole of. `retract` exists now and is worse to
+ * It deliberately stops at the local half of publishing. `push` sends to the team, and decision
+ * `9a2fe8a011d6423b` reserves sending for a human. It was ALSO gated on default-branch state
+ * until 2026-08-13; that gate is gone and the reservation is untouched, because it never rested
+ * on the gate -- an agent may see and stage, only a human may send. `retract` exists now and is worse to
  * call by mistake, not better: it hard-deletes the row and writes a tombstone that bars the id
  * forever. `connect`, `login` and `pull` are likewise operator actions: two need a browser, and
  * pulling already happens on its own. Staging is the half that is safe from every vantage, so it

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -346,9 +346,9 @@ const SCHEMA_STATEMENTS = [
    *
    * Two-phase, matching git's index-then-commit. `staged_at` records an intent, formed on any
    * branch at any time; `pushed_at` records that the server accepted it. `staged_on_branch` sits
-   * between them because the push is gated on the default branch and the refusal has to be able
-   * to say what it is waiting for -- an atom staged on a feature branch describes code nobody
-   * else has yet, and there is no unpublish.
+   * between them and is **provenance, not a condition**: it was written for a default-branch
+   * push gate that was removed on 2026-08-13, and since then `cloud status` displays it and
+   * nothing reads it to decide anything.
    *
    * `remote_version` is the only place on this machine that the server's version number lives,
    * and every republish needs it: a republish with no `expectedVersion` is treated as a conflict

--- a/tests/cli/auto-push.test.ts
+++ b/tests/cli/auto-push.test.ts
@@ -89,12 +89,19 @@ describe('maybeAutoPush', () => {
       .toEqual({ status: 'skipped', reason: 'not-connected' });
   });
 
-  it('does not send from a feature branch, because consent does not relax the gate', async () => {
+  it('is not stopped by a feature branch, so the branch no longer decides what is sent', async () => {
     await writeAutoPushConsent(WS, true);
     git(CLONE, ['checkout', '-qb', 'feature/whatever']);
 
+    // The queue is emptied so this asserts about the BRANCH and nothing else: reaching
+    // `nothing-staged` proves the push ran and looked, where the gate used to refuse before
+    // looking at all. It also keeps the case offline -- `maybeAutoPush` takes no injectable api.
+    await initDb(CLONE);
+    try { await getClient().execute('DELETE FROM cloud_published'); }
+    finally { await closeDb(); }
+
     expect(await maybeAutoPush({ projectRoot: CLONE, config: connected }))
-      .toEqual({ status: 'skipped', reason: 'gated' });
+      .toEqual({ status: 'skipped', reason: 'nothing-staged' });
   });
 
   it('reports nothing-staged rather than attempting an empty send', async () => {

--- a/tests/cli/workspace-report.test.ts
+++ b/tests/cli/workspace-report.test.ts
@@ -96,7 +96,6 @@ describe('formatStatusReport wiring', () => {
         connected: true, workspace: 'Acme Core', role: 'owner',
         lastSyncedAt: null, lastError: null,
         staged: 3, stagedNew: 2, stagedCorrections: 1, stagedOnBranch: 'main',
-        gate: { ok: true, reason: 'ok', detail: '' } as never,
         signedIn: true, identity: { email: 'd@e.com', displayName: 'Dev' },
         tokenExpiresAt: null, nextSyncDueAt: null,
       },

--- a/tests/cloud/doctor-checks.test.ts
+++ b/tests/cloud/doctor-checks.test.ts
@@ -3,8 +3,12 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeCredential } from '../../src/cloud/credentials.js';
 import { cloudDoctorChecks } from '../../src/cloud/doctor-checks.js';
+import { stageForPublish } from '../../src/cloud/ledger.js';
 import { withTeamStore } from '../../src/cloud/team-store.js';
 import { writeSyncState } from '../../src/cloud/sync-state.js';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import * as repo from '../../src/store/repository.js';
 import type { ProjectConfig } from '../../src/core/types.js';
 
 const HOME = path.resolve('./.knowl-doctor-home');
@@ -43,6 +47,20 @@ describe('cloudDoctorChecks', () => {
       lastSyncedAt: '2026-08-09T11:00:00.000Z',
       lastError,
     }));
+  };
+
+  /** One real atom staged in the ledger, the only state `stagedCheck` reports on. */
+  const stageOne = async (workspaceId: string) => {
+    await initDb(ROOT);
+    try {
+      const project = await repo.createProject(ROOT, `doctor-${workspaceId}`);
+      const stored = await storeKnowledgeItemDeduped(project.id, {
+        category: 'fact', title: 'Queued', content: 'Something worth sending, at a believable length.',
+      });
+      await stageForPublish([stored.item.id], workspaceId, 'feature/whatever');
+    } finally {
+      await closeDb();
+    }
   };
 
   it('says nothing at all when the repo is not connected', async () => {
@@ -118,6 +136,26 @@ describe('cloudDoctorChecks', () => {
     expect(checks[0].status).toBe('WARN');
     expect(checks[0].message).toContain('network down');
     expect(checks[0].fix).toContain('knowl cloud pull');
+  });
+
+  it('warns about staged work and points at the push, not at the branch', async () => {
+    // This check used to quote `checkPublishGate`'s git verdict, because the gate was the only
+    // reason staged work could sit unsent. Publishing is ungated as of 2026-08-13, so the one
+    // remaining reason is that nobody has pushed -- and naming a branch here would be a lie.
+    const config = pointer('w-staged');
+    await writeCredential(HOST, {
+      accessToken: 'a', refreshToken: 'r', sessionId: 'sess-1',
+      expiresAt: new Date(NOW + 3_600_000).toISOString(),
+    });
+    await synced('w-staged');
+    await stageOne('w-staged');
+
+    const checks = await cloudDoctorChecks(config, ROOT, () => NOW);
+    const staged = checks.find(check => check.message.includes('staged but not sent'));
+
+    expect(staged?.status).toBe('WARN');
+    expect(staged?.fix).toBe('Run knowl cloud push');
+    expect(staged?.message).not.toMatch(/branch|git|pull/i);
   });
 
   it('makes no network call, so doctor stays fast and works offline', async () => {

--- a/tests/cloud/publish-gate.test.ts
+++ b/tests/cloud/publish-gate.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { gitArgs } from '../git-identity.js';
-import { checkPublishGate, currentBranchOf } from '../../src/cloud/publish-gate.js';
+import { checkUpstreamGate, currentBranchOf } from '../../src/cloud/publish-gate.js';
 
 const ORIGIN = path.resolve('./.knowl-gate-origin');
 const CLONE = path.resolve('./.knowl-gate-clone');
@@ -20,7 +20,7 @@ async function makeOriginAndClone(): Promise<void> {
   git(process.cwd(), ['clone', '-q', ORIGIN, CLONE]);
 }
 
-describe('checkPublishGate', () => {
+describe('checkUpstreamGate', () => {
   beforeEach(async () => {
     for (const dir of [ORIGIN, CLONE]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
     await makeOriginAndClone();
@@ -30,7 +30,7 @@ describe('checkPublishGate', () => {
   });
 
   it('passes on an up-to-date default branch', async () => {
-    expect(checkPublishGate(CLONE)).toEqual({ ok: true });
+    expect(checkUpstreamGate(CLONE)).toEqual({ ok: true });
   });
 
   it('refuses on a feature branch, because that code is nobody else\'s yet', async () => {
@@ -38,7 +38,7 @@ describe('checkPublishGate', () => {
     // false for every colleague on main, and there is no unpublish.
     git(CLONE, ['checkout', '-qb', 'feature/rollback']);
 
-    const verdict = checkPublishGate(CLONE);
+    const verdict = checkUpstreamGate(CLONE);
     expect(verdict).toMatchObject({ ok: false, reason: 'not-default-branch' });
     expect((verdict as { detail: string }).detail).toContain('feature/rollback');
   });
@@ -53,7 +53,7 @@ describe('checkPublishGate', () => {
     git(ORIGIN, ['commit', '-qm', 'two']);
     git(CLONE, ['fetch', '-q']);
 
-    const verdict = checkPublishGate(CLONE);
+    const verdict = checkUpstreamGate(CLONE);
     expect(verdict).toMatchObject({ ok: false, reason: 'behind-remote' });
   });
 
@@ -63,13 +63,13 @@ describe('checkPublishGate', () => {
     git(ORIGIN, ['commit', '-qm', 'two']);
     git(CLONE, ['pull', '-q']);
 
-    expect(checkPublishGate(CLONE)).toEqual({ ok: true });
+    expect(checkUpstreamGate(CLONE)).toEqual({ ok: true });
   });
 
   it('reports git being unavailable as its own reason, not as a branch problem', async () => {
     // The misdiagnosis this repo has already shipped twice: "could not determine" reported as
     // a confident wrong answer.
-    const verdict = checkPublishGate(path.resolve('./.knowl-gate-not-a-repo'));
+    const verdict = checkUpstreamGate(path.resolve('./.knowl-gate-not-a-repo'));
     expect(verdict).toMatchObject({ ok: false, reason: 'git-unavailable' });
   });
 

--- a/tests/cloud/publish-push.test.ts
+++ b/tests/cloud/publish-push.test.ts
@@ -181,29 +181,32 @@ describe('pushStaged', () => {
     for (const dir of [ORIGIN, CLONE]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('refuses from a feature branch and names it, without sending anything', async () => {
-    // The scenario the gate exists for. An atom describing code only this branch has would be
-    // false for every colleague on main, and there is no unpublish.
+  it('publishes from a feature branch, because adding knowledge is true from every vantage', async () => {
+    // Reversed 2026-08-13. Publishing ADDS an atom, and the worst case is knowledge that is
+    // premature -- which supersede and retract both undo. `reportDrift` keeps this gate because
+    // it RETIRES someone else's atom, where a wrong vantage destroys instead of adding.
     git(CLONE, ['checkout', '-qb', 'feature/rollback']);
     let sent = false;
 
     const result = await pushStaged({
-      projectRoot: CLONE, config: connected, api: fakeApi([], () => { sent = true; }),
+      projectRoot: CLONE, config: connected,
+      api: fakeApi([{ id: ids.decision, status: 'created', version: 1 }], () => { sent = true; }),
     });
 
-    expect(result).toMatchObject({ status: 'gated', reason: 'not-default-branch' });
-    expect((result as any).detail).toContain('feature/rollback');
-    expect(sent).toBe(false);
+    expect(result).toMatchObject({ status: 'pushed', created: 1 });
+    expect(sent).toBe(true);
   });
 
-  it('refuses from a checkout behind its remote', async () => {
-    // Behind main is indistinguishable from the code having been deleted, and this repo has
-    // shipped that collapse before in `fileContentHash`.
+  it('publishes from a checkout behind its remote', async () => {
+    // Being behind main makes CODE ambiguous -- deleted and not-yet-pulled look identical from
+    // here. That ambiguity is a reason to withhold a drift report, not to withhold an atom.
     await commitToOrigin('b.txt');
     git(CLONE, ['fetch', '-q']);
 
-    expect(await pushStaged({ projectRoot: CLONE, config: connected, api: fakeApi([]) }))
-      .toMatchObject({ status: 'gated', reason: 'behind-remote' });
+    expect(await pushStaged({
+      projectRoot: CLONE, config: connected,
+      api: fakeApi([{ id: ids.decision, status: 'created', version: 1 }]),
+    })).toMatchObject({ status: 'pushed', created: 1 });
   });
 
   it('refuses a reader before sending anything', async () => {

--- a/tests/cloud/status.test.ts
+++ b/tests/cloud/status.test.ts
@@ -176,6 +176,19 @@ describe('cloudStatus', () => {
     expect(text).toContain('feature/rollback');
   });
 
+  it('tells a feature branch its staged work is ready, because the branch no longer holds it', async () => {
+    // Until 2026-08-13 this line printed the publish gate's refusal. Publishing is ungated now,
+    // so that sentence would be false twice over: it names a blocker that is gone, and it sends
+    // the reader off to change branch and pull for a push that would have worked.
+    git(CLONE, ['checkout', '-qb', 'feature/rollback']);
+    await stagePublish({ projectRoot: CLONE, config: connected, ids: [id], apply: true });
+
+    const text = formatCloudStatus(await cloudStatus(CLONE, connected));
+
+    expect(text).toContain('Ready to send. Run knowl cloud push.');
+    expect(text).not.toMatch(/not main|no unpublish|Pull first/i);
+  });
+
   it('warns that sending is irreversible whenever anything is staged', async () => {
     // A product requirement, not a nicety. `knowl cloud retract` now wires the server's delete
     // verb, so this no longer says publishing cannot be undone -- but undoing means a hard delete


### PR DESCRIPTION
Reported from a linked workspace: a colleague on a feature branch could not publish knowledge that had nothing to do with code — pricing research — and the tool told them nothing about why.

## What was wrong

`checkPublishGate` refused every push from anything but an up-to-date default branch. The decision that introduced it (2026-08-09) said only code-coupled atoms should wait:

> Only code-coupled atoms are gated. An atom with `affectedPaths` or code evidence describes code and waits for the merge; one without ("we chose Postgres") is true when decided and pushes immediately. The gate keys on evidence, never on category.

That half was never implementable through the signature it was given:

```ts
export function checkPublishGate(projectRoot: string): GateVerdict
```

It takes a project root and never sees an atom, so it cannot key on evidence. `publish.ts` said as much in its own words — *"The gate is checked ONCE, before the batch."* One verdict for the whole checkout, applied to pricing decisions and module refactors alike.

## Why the obvious repair was rejected

Making the gate evidence-keyed, as specified, would not have unblocked the reported case. `affectedPaths` cannot tell code from prose: an atom citing `docs/research/competitor-web-teardown-2026-08-12.md` has a non-empty `affectedPaths` and gates exactly like one citing a module.

The refusal also argued from *"there is no unpublish"*, which stopped being true when `knowl cloud retract` shipped.

## The fix

The gate goes, on the principle that survives the details:

> **Publishing ADDS an atom. Reporting drift RETIRES someone else's.**

Adding from a bad vantage gives the team knowledge that is merely premature, and supersede and retract both undo it. Retiring from a bad vantage destroys what is still true for everyone current — and from a checkout behind `main`, merged code and deleted code are indistinguishable. Same git facts, opposite blast radius. `retract` already sat outside the gate on exactly this reasoning.

`reportDrift` keeps it and is now its only caller, so `checkPublishGate` becomes `checkUpstreamGate` and its messages describe retiring knowledge rather than publishing it. A gate named for a thing it no longer gates is a trap for the next reader.

## Two surfaces were reporting the gate as the blocker

Both would have become false the moment the gate went, so they change with it:

- **`cloud status`** printed the refusal verbatim on a feature branch — *"This checkout is on feature/rollback, not main… and there is no unpublish."* False twice over: it names a blocker that is gone, and sends the reader off to change branch for a push that would have worked. Now unconditionally "Ready to send." `CloudStatus.gate` is removed.
- **doctor's `stagedCheck`** warned ONLY when the gate refused, quoting its git verdict as the reason work sat unsent. It had **no test coverage at all**. It now warns on any staged work and points at `knowl cloud push`, with a test.

`auto-push` loses its fourth condition. It was skipping with `reason: 'gated'` into a caller that shows the user nothing — which is how a colleague's knowledge got dropped in silence.

`docs/reference.md` is corrected in seven places, including a section heading and its TOC anchor, that told users publishing was branch-gated.

## The cost, stated plainly

An atom published from a branch that is later abandoned stays in the team store, and a squashed or rebased `sourceCommit` can dangle. Both are staleness rather than corruption — but note that automatic correction is weaker than it looks: `reportDrift` currently has **no production caller**, so nothing retires a stale published atom on its own today. Supersede and retract are the working remedies. Wiring that path is follow-up work, not part of this change, and the gap predates it.

## Verified

`build`, `typecheck`, `lint`, `docs:check` and `test` (327 files, 2949 tests) all pass, re-run after rebasing onto 5.0.2 rather than before.
