### PR TITLE
fix(drift): a file being edited is not evidence that anything became false

### DIFF
--- a/docs/superpowers/specs/2026-08-13-drift-signal-precision-design.md
+++ b/docs/superpowers/specs/2026-08-13-drift-signal-precision-design.md
@@ -1,0 +1,158 @@
+# Drift signal precision, and what to do with the result
+
+Status: accepted, 2026-08-13.
+
+## The problem, measured
+
+`runAutoDriftCheck` records a drift observation on `knowledge_items.last_drift_at`. Measured on
+this repository's own store:
+
+| | knowl | knowl-cloud |
+| --- | --- | --- |
+| active items | 867 | 297 |
+| carrying an unread drift observation | **339 (39%)** | **78 (26%)** |
+| of those, a cited path is **gone** | **42** | **2** |
+| of those, every cited path still exists | 226 | 72 |
+| `needs_review` actually set | 24 | 0 |
+
+Roughly 88% of what the detector says is not actionable. That is the band static-analysis
+research identifies as the point where developers stop reading a tool at all — false positives run
+18–86% of warnings across tools, non-actionable findings 35–91%, and the consequence is
+documented as alert fatigue and abandonment.
+
+**Nothing acts on this signal, and that was correct.** Flipping `freshness` was previously measured
+as corpus-wide ranking damage. The reason is breadth rather than depth: the priors are already
+gentle (`needs_review` 0.94, `stale` 0.88, both soft multipliers), but applying one to 39% of a
+corpus is what did the damage.
+
+## Root cause
+
+`knowledgeMentionsChangedPath` (`src/store/freshness.ts`) answers **"did a file this atom mentions
+change?"**. The question worth answering is **"is this atom still true?"**. Three specific defects
+follow:
+
+1. **Any edit counts as drift.** The most-cited paths among flagged items are simply the repo's
+   highest-churn files — `src/mcp/tools.ts` (34), `package.json` (28), `README.md` (23),
+   `src/cli/program.ts` (21). Reformatting `program.ts` does not invalidate a fact about ranking.
+2. **`source` is matched by raw substring.** `source.includes(changedPath)` against free text.
+   The intent is sound — `source` usually *is* a path list, e.g.
+   `"src/store/database.ts; src/store/bootstrap.ts; package.json"`, and 58 of the 71 items with no
+   `affectedPaths` are flagged legitimately through it. The mechanism is not: it matches prose too.
+3. **`tags` are matched as paths.** A tag is a topic label. It can only fire when the tag is
+   literally a top-level directory (`tests`, `docs`, `src`), which is 8 items — small in volume,
+   indefensible in principle.
+
+## Non-goals
+
+- **No new GC actions.** GC recommends nothing on either store today (Archive 0, Compress 0,
+  Purge 0) and there is nothing old enough to decay: 2 items cold past 30 days, **0 past 60**.
+  Age-based decay would act on nothing. Revisit when the corpus is older.
+- **No LLM dependency.** Knowl's AI configuration is optional, and staleness detection must not
+  require it. Classification here is deterministic.
+- **No automatic deletion anywhere**, and nothing server-side that removes a team's knowledge.
+
+## Phase 1 — make the signal mean something
+
+Deterministic, no model, no schema change beyond one column.
+
+1. **Drop tag-as-path matching.** Remove the `tags` branch from `knowledgeMentionsChangedPath`.
+2. **Parse `source` into path tokens** rather than substring-matching it. Split on `;`, trim, keep
+   tokens that look like paths, and match them with `pathMatches` like any other path. This
+   preserves the 58 legitimate matches and drops the prose ones.
+3. **Separate *gone* from *changed*.** These are different events sharing one column today. A
+   cited path that no longer exists is strong evidence; a cited path that was edited is weak.
+4. **Exclude high-churn paths** from counting as drift on their own: lockfiles, `CHANGELOG.md`,
+   `.github/**`, `dist/**`, `README.md`, and generated output. An atom that cites *only* churn
+   paths produces no drift candidate.
+
+## Phase 2 — classify, and drop the benign class
+
+Modelled on DocPrism's LCEF result, which cut a documentation-consistency flag rate from 98% to
+14% while raising accuracy from 14% to 94%. The mechanism that mattered was not a better model: it
+was categorising each finding and **discarding one whole category** — "under-promise", the natural
+gap between what code does and what docs claim, which was most of the volume.
+
+Knowl's equivalent of under-promise is *"a cited file changed but the assertion still holds"* —
+226 of 339 observations. Same shape, same remedy. Three classes:
+
+| class | meaning | actionable |
+| --- | --- | --- |
+| `removed` | a cited path no longer exists | **yes** |
+| `symbol-removed` | cited evidence names a symbol no longer in the file | **yes** |
+| `untracked-moved` | a cited untracked directory moved after the atom was written | **yes** |
+| `changed` | the file exists and was merely edited | **no — dropped** |
+
+Deterministic throughout: `removed` is a filesystem check, `symbol-removed` reuses the evidence
+already stored in `knowledge_evidence`.
+
+`untracked-moved` is exempt from the removal rule rather than subject to it, because it already
+carries its own precision: it compares a directory's mtime against the atom's `updated_at`, so it
+is time-scoped in a way the git path is not, and it only runs when a caller passes
+`includeUntracked` — which only `knowl pr check` does. Applying the removal filter on top would
+discard a signal that had already earned its place.
+
+**Measured against both real stores** by replaying the currently-flagged items through the shipped
+matcher and classifier (`scripts/measure-drift-precision.ts`):
+
+| | before | after | noise removed |
+| --- | --- | --- | --- |
+| knowl | 339 | **44** | **87.0%** |
+| knowl-cloud | 78 | **2** | **97.4%** |
+
+## Phase 3 — route the surviving signal into the prior that already exists
+
+No new ranking mechanism is needed. Both repos already demote softly and independently:
+
+- CLI: `FRESHNESS_PRIOR = { fresh: 1, needs_review: 0.94 }`, `FRESHNESS_PRIOR_STALE = 0.88`
+  (`src/store/agent-query.ts`)
+- Server: `if (candidate.freshness !== 'fresh') prior *= 0.88` (`src/knowledge/search/fuse.ts`)
+
+Surviving candidates set `needs_review` (0.94). `stale` stays reserved for explicit human
+judgement. Because Phase 2 removes the benign class, this applies to a small fraction of the
+corpus rather than 39% of it — which is precisely what made the earlier attempt harmful.
+
+## Phase 4a — report upward, but only what survived
+
+`reportDrift` and `reportReviewed` are complete, gated and tested, and have no production caller.
+They gain one, invoked only for candidates that survive Phase 2, and still behind
+`checkUpstreamGate` — a drift report retires knowledge for the whole team, so it keeps requiring an
+up-to-date default branch. The server side needs no change: `markNeedsReview`,
+`review_reported_at` and the four `review_*` provenance columns already exist.
+
+## Phase 4b — team-scale visibility, in knowl-cloud
+
+`src/knowledge/hygiene.ts` already reports what the team's memory looks like as a body of
+knowledge, and its own documentation names the next step: unread items are "candidates for review,
+and later for team-scale GC". It gains a staleness section — how many atoms carry an open review
+report, how long they have been open, and which are unread as well as flagged.
+
+**Reporting only.** No server-side deletion, and no retention sweep. `policy.retentionDays` already
+exists as a knob and is deliberately left alone here.
+
+**One property must be preserved.** Every figure in `hygiene.ts` is derived from
+`knowledge_access` and none of it reaches ranking, deliberately: a read-count prior is a feedback
+loop, where an atom that ranks high is read more and therefore ranks higher, with nothing in the
+loop asking whether it is true. The new section inherits that rule — it reports, it never ranks.
+
+## Testing
+
+Each phase is pinned by tests written before the change:
+
+- **Phase 1** — a tag equal to a directory no longer drifts; a `source` path list still does while
+  prose in `source` does not; a deleted path and an edited path produce different events; an atom
+  citing only `package.json` produces no candidate.
+- **Phase 2** — a `changed` candidate is dropped; `removed` and `symbol-removed` survive.
+- **Phase 3** — a surviving candidate lands on `needs_review`; a dropped one leaves freshness alone.
+- **Phase 4a** — nothing is sent from a feature branch or a behind checkout; only survivors are sent.
+- **Phase 4b** — the hygiene report counts open review reports and stays out of ranking.
+
+## Rejected alternatives
+
+- **Extend GC's age-based archive to more categories.** Measured: it would act on zero items.
+- **An LLM classifier for Phase 2.** Would make staleness detection depend on optional AI config.
+  The deterministic split captures the category that carries the volume; a model can be added later
+  behind the same interface if `changed` ever needs subdividing.
+- **Flipping `freshness` on every observation.** Already tried, already measured as harmful. Phase 2
+  exists so that this becomes safe by shrinking what qualifies.
+- **Server-side drift detection.** Structurally impossible: the server is deliberately git-blind and
+  has no working tree to compare against.

--- a/docs/superpowers/specs/2026-08-13-drift-signal-precision-design.md
+++ b/docs/superpowers/specs/2026-08-13-drift-signal-precision-design.md
@@ -77,10 +77,23 @@ Knowl's equivalent of under-promise is *"a cited file changed but the assertion 
 
 | class | meaning | actionable |
 | --- | --- | --- |
-| `removed` | a cited path no longer exists | **yes** |
+| `removed` | a cited path no longer exists **and was not renamed** | **yes** |
 | `symbol-removed` | cited evidence names a symbol no longer in the file | **yes** |
 | `untracked-moved` | a cited untracked directory moved after the atom was written | **yes** |
+| `moved` | git renamed the cited path; the atom is still true, its path is stale | **no — dropped** |
 | `changed` | the file exists and was merely edited | **no — dropped** |
+
+**`moved` exists because the first cut of this design shipped without it and was wrong.** Auditing
+its 44 survivors found only 14 real: **30 were renames**, nearly all from one refactor moving
+`src/store/host-lifecycle.ts` and its neighbours into `src/session/`. A rename leaves the old path
+absent from the tree, so existence alone cannot tell it from a deletion — precision was 32%, not
+the ~100% the rule implied.
+
+Renames come from `git diff --name-status -M` over the same range that produced the changed files,
+so the cost is one extra git call per check and no history scan. Note that
+`git log --find-renames -- <path>` does **not** work: the pathspec limits the diff and hides the
+destination, reporting every rename as a plain delete. That is what made the first audit report
+zero renames.
 
 Deterministic throughout: `removed` is a filesystem check, `symbol-removed` reuses the evidence
 already stored in `knowledge_evidence`.
@@ -96,8 +109,14 @@ matcher and classifier (`scripts/measure-drift-precision.ts`):
 
 | | before | after | noise removed |
 | --- | --- | --- | --- |
-| knowl | 339 | **44** | **87.0%** |
-| knowl-cloud | 78 | **2** | **97.4%** |
+| knowl | 339 | **14** | **95.9%** |
+| knowl-cloud | 78 | **1** | **98.7%** |
+
+A recall spot-check read 8 of the 290 items dropped as "the cited file still exists": *"CLI
+entrypoint is `src/index.ts`"*, *"MCP server is thin tool wiring"*, *"Knowledge search uses SQLite
+FTS5 and BM25"*, *"Knowl build and verification commands"*. All still true, and all would have sat
+permanently flagged under the old rule. Indicative rather than conclusive — recall cannot be
+measured without ground truth.
 
 ## Phase 3 — route the surviving signal into the prior that already exists
 

--- a/scripts/measure-drift-precision.ts
+++ b/scripts/measure-drift-precision.ts
@@ -5,14 +5,41 @@
  * classifier, so the noise-reduction claim is measured against production data rather than
  * against fixtures. Run: npx tsx scripts/measure-drift-precision.ts <path-to-repo>
  */
+import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { createClient } from '@libsql/client';
-import { sourcePaths } from '../src/store/freshness.js';
+import { normalizePathForKnowledge, sourcePaths } from '../src/store/freshness.js';
 import { classifyDriftPaths, isChurnPath } from '../src/store/drift.js';
 
 const repoRoot = process.argv[2];
 if (!repoRoot) throw new Error('usage: measure-drift-precision.ts <path-to-repo>');
+
+/**
+ * Every rename in the whole history, as a set of the paths renames moved AWAY from.
+ *
+ * Production reads renames from the same window diff that produced the changed files. A
+ * retrospective replay has no window, so it asks history — and it must ask with a whole-tree diff,
+ * because `git log -- <path>` limits the diff to that pathspec and hides the destination, which is
+ * exactly what made the first audit of this rule report zero renames when 30 of 44 flagged items
+ * were renames.
+ */
+function renamedPaths(): Set<string> {
+  const sources = new Set<string>();
+  try {
+    const log = execFileSync('git', ['log', '--all', '-M40%', '--diff-filter=R', '--name-status', '--format='],
+      { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+    for (const line of log.split(/\r?\n/)) {
+      const match = /^R\d*\t(.+?)\t(.+)$/.exec(line);
+      if (match) sources.add(normalizePathForKnowledge(match[1]));
+    }
+  } catch {
+    // No git, or a repo too large to buffer: report without rename awareness rather than not at all.
+  }
+  return sources;
+}
+
+const renamedFrom = renamedPaths();
 
 const db = createClient({ url: `file:${path.join(repoRoot, '.knowl', 'knowl.db').replace(/\\/g, '/')}` });
 
@@ -34,6 +61,7 @@ let survives = 0;
 let droppedNoCitation = 0;
 let droppedChurnOnly = 0;
 let droppedStillThere = 0;
+let droppedMoved = 0;
 
 for (const row of rows) {
   // Exactly what the matcher now considers: affectedPaths plus parsed source paths, no tags.
@@ -49,8 +77,13 @@ for (const row of rows) {
     continue;
   }
 
-  const { removed } = classifyDriftPaths(informative, candidate => existsSync(path.join(repoRoot, candidate)));
+  const { removed, moved } = classifyDriftPaths(
+    informative,
+    candidate => existsSync(path.join(repoRoot, candidate)),
+    renamedFrom,
+  );
   if (removed.length > 0) survives++;
+  else if (moved.length > 0) droppedMoved++;
   else droppedStillThere++;
 }
 
@@ -59,6 +92,7 @@ console.log(`\nrepo: ${repoRoot}`);
 console.log(`observations the OLD rule produced: ${rows.length}`);
 console.log(`  survive the new rule (a cited path is gone): ${survives}  (${pct(survives)})`);
 console.log(`  dropped -- cited file still exists:          ${droppedStillThere}  (${pct(droppedStillThere)})`);
+console.log(`  dropped -- cited file only MOVED:            ${droppedMoved}  (${pct(droppedMoved)})`);
 console.log(`  dropped -- cites only churn paths:           ${droppedChurnOnly}  (${pct(droppedChurnOnly)})`);
 console.log(`  dropped -- cites nothing once tags are out:  ${droppedNoCitation}  (${pct(droppedNoCitation)})`);
 console.log(`\n  noise removed: ${pct(rows.length - survives)} of what was reported before`);

--- a/scripts/measure-drift-precision.ts
+++ b/scripts/measure-drift-precision.ts
@@ -1,0 +1,66 @@
+/**
+ * What the new rule would say about the observations the old one produced.
+ *
+ * Read-only. Replays the real store's currently-flagged items through the shipped matcher and
+ * classifier, so the noise-reduction claim is measured against production data rather than
+ * against fixtures. Run: npx tsx scripts/measure-drift-precision.ts <path-to-repo>
+ */
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { sourcePaths } from '../src/store/freshness.js';
+import { classifyDriftPaths, isChurnPath } from '../src/store/drift.js';
+
+const repoRoot = process.argv[2];
+if (!repoRoot) throw new Error('usage: measure-drift-precision.ts <path-to-repo>');
+
+const db = createClient({ url: `file:${path.join(repoRoot, '.knowl', 'knowl.db').replace(/\\/g, '/')}` });
+
+const rows = (await db.execute(`
+  SELECT id, affected_paths, source, tags
+  FROM knowledge_items
+  WHERE status='active' AND last_drift_at IS NOT NULL AND freshness='fresh'`)).rows;
+
+const parse = (value: unknown): string[] => {
+  try {
+    const decoded = JSON.parse(String(value ?? '[]'));
+    return Array.isArray(decoded) ? decoded : [];
+  } catch {
+    return [];
+  }
+};
+
+let survives = 0;
+let droppedNoCitation = 0;
+let droppedChurnOnly = 0;
+let droppedStillThere = 0;
+
+for (const row of rows) {
+  // Exactly what the matcher now considers: affectedPaths plus parsed source paths, no tags.
+  const cited = [...parse(row.affected_paths), ...sourcePaths(row.source as string | null)];
+  if (cited.length === 0) {
+    droppedNoCitation++;
+    continue;
+  }
+
+  const informative = cited.filter(candidate => !isChurnPath(candidate));
+  if (informative.length === 0) {
+    droppedChurnOnly++;
+    continue;
+  }
+
+  const { removed } = classifyDriftPaths(informative, candidate => existsSync(path.join(repoRoot, candidate)));
+  if (removed.length > 0) survives++;
+  else droppedStillThere++;
+}
+
+const pct = (n: number) => `${((n / rows.length) * 100).toFixed(1)}%`;
+console.log(`\nrepo: ${repoRoot}`);
+console.log(`observations the OLD rule produced: ${rows.length}`);
+console.log(`  survive the new rule (a cited path is gone): ${survives}  (${pct(survives)})`);
+console.log(`  dropped -- cited file still exists:          ${droppedStillThere}  (${pct(droppedStillThere)})`);
+console.log(`  dropped -- cites only churn paths:           ${droppedChurnOnly}  (${pct(droppedChurnOnly)})`);
+console.log(`  dropped -- cites nothing once tags are out:  ${droppedNoCitation}  (${pct(droppedNoCitation)})`);
+console.log(`\n  noise removed: ${pct(rows.length - survives)} of what was reported before`);
+console.log('  (symbol evidence and the untracked opt-in are not replayed here: both survive on');
+console.log('   their own and would only add to the surviving count.)');

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -78,7 +78,7 @@ import { listForgetLog, pruneForgetLog } from '../store/forget-log.js';
 import { truncateText } from '../core/token-budget.js';
 import { getAccessSummary } from '../store/access-feedback.js';
 import { checkpointWorkLoop, finishWorkLoop, startWorkLoop, WorkLoopMemoryHit } from '../store/work-loop.js';
-import { checkKnowledgeDrift, DriftCheckResult, getCurrentGitCommit, listChangedFilesSince } from '../store/drift.js';
+import { checkKnowledgeDrift, DriftCheckResult, getCurrentGitCommit, listChangedFilesSince, listRenamedPathsSince } from '../store/drift.js';
 import { indexSkillPackage, recordSkillRun } from '../skills/knowledge-index.js';
 import { createSkillPackage, listSkillPackages, readSkillPackage, runSkillPackage, SkillEntrypoint } from '../skills/registry.js';
 import { approveSkill, listTrust, revokeSkill } from '../skills/trust.js';
@@ -3509,6 +3509,9 @@ program
         changedFiles,
         apply: !options.dryRun,
         projectRoot: root,
+        // A rename leaves the old path absent from the tree, so without this a refactor reads as
+        // a mass deletion of everything it touched.
+        renamedFrom: listRenamedPathsSince(root, options.since, currentCommit),
         // `pr check` is the deliberate, on-demand pass, so it also examines affected paths git
         // cannot diff -- untracked or ignored working directories an atom names. The automatic
         // session-start check still does NOT ask for this; it passes `projectRoot` alone, which

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -62,6 +62,7 @@ import { recommendedTotal, WITHHELD_BY_DEFAULT } from '../core/sharing-defaults.
 import { runConnect } from '../cloud/connect.js';
 import { runPull } from '../cloud/pull.js';
 import { computePushSnapshot, countStageable, pushStaged, stagePublish } from '../cloud/publish.js';
+import { reportDrift } from '../cloud/drift-report.js';
 import { retractItem } from '../cloud/retract.js';
 import { cloudStatus, formatCloudStatus } from '../cloud/status.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
@@ -3507,15 +3508,53 @@ program
         currentCommit,
         changedFiles,
         apply: !options.dryRun,
+        projectRoot: root,
         // `pr check` is the deliberate, on-demand pass, so it also examines affected paths git
         // cannot diff -- untracked or ignored working directories an atom names. The automatic
-        // session-start check deliberately does NOT pass this yet: that path returns early when
-        // HEAD has not moved, and relaxing its gating is a separate decision with the noise
-        // measurements in drift-auto.ts behind it.
-        projectRoot: root,
+        // session-start check still does NOT ask for this; it passes `projectRoot` alone, which
+        // since 2026-08-13 buys it removal-vs-edit classification without the extra scan.
+        includeUntracked: true,
       });
 
       printPrCheckResult(result);
+
+      /**
+       * Tell the team, from the one place that should.
+       *
+       * `reportDrift` shipped complete, gated and tested with no production caller at all. It gets
+       * one here rather than at session start, because this is the deliberate pass a human runs:
+       * session start must stay offline, and a network call per session on a signal nobody asked
+       * for is how the last version of this became noise.
+       *
+       * Every refusal is silent by design. `reportDrift` returns `not-connected` for a local repo,
+       * `not-published` for an atom the team has never seen, and `gated` off the default branch or
+       * behind its remote -- a drift report retires knowledge for everyone, so it keeps the vantage
+       * requirement that publishing gave up. None of those is a failure of `pr check`, and none
+       * should make it exit non-zero.
+       */
+      const prCheckConfig = await loadConfig(root);
+      if (prCheckConfig.cloud && !options.dryRun && result.candidates.length > 0) {
+        const reported: string[] = [];
+        for (const candidate of result.candidates) {
+          // The reason is stored on the report and read by whoever reviews it, so it names the
+          // evidence rather than restating the verdict: which cited paths went away, and the kind
+          // of drift this was.
+          const evidence = candidate.removedPaths.length > 0
+            ? candidate.removedPaths.join(', ')
+            : candidate.matchedPaths.join(', ');
+          const outcome = await reportDrift({
+            projectRoot: root,
+            config: prCheckConfig,
+            itemId: candidate.itemId,
+            reason: `${candidate.kind}: ${evidence}`,
+          }).catch(() => 'not-connected' as const);
+          if (outcome === 'reported') reported.push(candidate.itemId);
+        }
+        if (reported.length > 0) {
+          console.log(`Reported ${reported.length} of ${result.candidates.length} to the team.`);
+        }
+      }
+
       await closeDb();
     } catch (error: any) {
       try {

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -1,5 +1,5 @@
 import { getClient } from './database.js';
-import { checkKnowledgeDrift, getCurrentGitCommit, listChangedFilesSince } from './drift.js';
+import { checkKnowledgeDrift, getCurrentGitCommit, listChangedFilesSince, listRenamedPathsSince } from './drift.js';
 
 export type AutoDriftResult = {
   /** False on the run that only learns the baseline; nothing was compared. */
@@ -15,25 +15,27 @@ export type AutoDriftResult = {
 const WARNING_TITLE_LIMIT = 3;
 
 /**
- * The drift check that `pr check` runs by hand, run automatically at session start —
- * as DETECTION ONLY.
+ * The drift check that `pr check` runs by hand, run automatically at session start.
  *
  * `checkKnowledgeDrift` has existed since the pr command shipped, but its only caller was
  * a command someone had to remember to type, so in practice knowledge went stale exactly
  * as if the check did not exist. The session boundary is the right chokepoint: it is the
  * moment before an agent starts relying on memory.
  *
- * Why detection does not auto-apply: measured on a real, documentation-heavy repository,
- * one commit window matched 36 of 301 atoms and fifteen windows matched a third of the
- * store — atoms annotate hot files, hot files change every day, and an automatic flip
- * would hold those atoms at needs_review permanently. Run by hand after a PR, that flag
- * volume is a review worklist; applied silently at every session start, it is corpus-wide
- * ranking damage and a warning that cries wolf. So the automatic path names what moved
- * and the exact command to review it, and flipping freshness stays a deliberate act.
+ * **This was detection-only until 2026-08-13, and that was right for the signal that existed.**
+ * Measured on a documentation-heavy repository, one commit window matched 36 of 301 atoms and
+ * fifteen windows matched a third of the store — atoms annotate hot files, hot files change
+ * every day, and an automatic flip would have held those atoms at needs_review permanently.
  *
- * "Detection only" is about `freshness`, not about writing nothing: each candidate's
- * `last_drift_at` is stamped (see `recordDriftObservation`). Nothing reads that column at
- * retrieval time, so it costs none of the ranking damage the paragraph above refuses.
+ * What changed is the signal, not the appetite for risk. A file being edited no longer counts;
+ * only a cited path that is gone does, and a path that a rename merely moved does not count
+ * either. On the same store that produced 339 observations, the classified rule leaves 44 —
+ * and auditing those found 30 were renames from one refactor, which is why `renamedFrom` is
+ * passed below rather than left to existence checks. What remains is small enough that a 6%
+ * ranking prior on it is a worklist rather than corpus-wide damage.
+ *
+ * `last_drift_at` is still stamped per candidate (see `recordDriftObservation`). Nothing reads
+ * that column at retrieval time, so it remains the cheap record a later pass can act on.
  *
  * The watermark is the last git commit a check ran against, keyed by project root.
  * rowid-style head tracking (change-watermark.ts) does not work here: the thing that
@@ -86,8 +88,7 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
        * corpus-wide ranking damage, because 339 of 867 active items qualified. The damage was
        * breadth, not depth -- the prior is a 6% nudge (`FRESHNESS_PRIOR.needs_review = 0.94`),
        * which is only destructive when it lands on 39% of the corpus. Replayed against the same
-       * store, the classified rule leaves 44, about 5%, and every one of them cites a file that
-       * is genuinely gone.
+       * store, the classified rule leaves 44 before renames are excluded, about 5%.
        *
        * A signal nothing acts on is the state this whole change exists to leave.
        */
@@ -97,6 +98,9 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
       // every edited file reports as drift, which is what made this path produce 339 unread
       // observations against 42 real ones on this repo's own store.
       projectRoot,
+      // Without this a refactor reads as a mass deletion: auditing the first cut found 30 of 44
+      // survivors were one move of `src/store/` files into `src/session/`, every atom still true.
+      renamedFrom: listRenamedPathsSince(projectRoot, watermark, current),
     });
     candidateCount = result.candidates.length;
     candidateTitles = result.candidates.slice(0, WARNING_TITLE_LIMIT).map(candidate => candidate.title);

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -79,7 +79,24 @@ export async function runAutoDriftCheck(projectId: string, projectRoot: string):
       sinceCommit: watermark,
       currentCommit: current,
       changedFiles,
-      apply: false,
+      /**
+       * Marks survivors `needs_review`, where this was detection-only until 2026-08-13.
+       *
+       * The old refusal was correct for the old signal: flipping freshness was measured as
+       * corpus-wide ranking damage, because 339 of 867 active items qualified. The damage was
+       * breadth, not depth -- the prior is a 6% nudge (`FRESHNESS_PRIOR.needs_review = 0.94`),
+       * which is only destructive when it lands on 39% of the corpus. Replayed against the same
+       * store, the classified rule leaves 44, about 5%, and every one of them cites a file that
+       * is genuinely gone.
+       *
+       * A signal nothing acts on is the state this whole change exists to leave.
+       */
+      apply: true,
+      // The tree, for removal-vs-edit classification only -- `includeUntracked` is deliberately
+      // not set, so this keeps its git-only scope. Without a root nothing can be classified and
+      // every edited file reports as drift, which is what made this path produce 339 unread
+      // observations against 42 real ones on this repo's own store.
+      projectRoot,
     });
     candidateCount = result.candidates.length;
     candidateTitles = result.candidates.slice(0, WARNING_TITLE_LIMIT).map(candidate => candidate.title);

--- a/src/store/drift.ts
+++ b/src/store/drift.ts
@@ -12,12 +12,60 @@ export interface SymbolEvidenceDrift {
   suggestedLocator?: string;
 }
 
+/**
+ * What kind of drift this is, which decides whether it is worth anyone's attention.
+ *
+ * `changed` is the class that used to be everything. Measured on this repo's store, 226 of 339
+ * observations were a cited file that had merely been edited -- most often the highest-churn files
+ * in the tree -- and a file being edited says nothing about whether an atom is still true. Those
+ * are dropped rather than reported, on the same reasoning that took DocPrism's documentation
+ * flag rate from 98% to 14%: name the benign category and discard it.
+ */
+export type DriftKind = 'removed' | 'symbol-removed' | 'untracked-moved' | 'changed';
+
 export interface DriftCandidate {
   itemId: string;
   title: string;
   freshness: KnowledgeFreshness;
   matchedPaths: string[];
+  /** Cited paths that are no longer in the tree. The evidence the candidate rests on. */
+  removedPaths: string[];
+  kind: DriftKind;
   symbolEvidence?: SymbolEvidenceDrift[];
+}
+
+/**
+ * Paths whose changing carries no information about whether an atom is still true.
+ *
+ * Not a heuristic about importance -- a lockfile bump is a real change -- but about *aboutness*.
+ * These were the most-cited paths among flagged items in the measured store (`package.json` 28,
+ * `README.md` 23, `CHANGELOG.md` 14) because they change on nearly every release, so they
+ * generated drift on a schedule rather than on an event.
+ */
+const CHURN_PATH =
+  /(^|\/)(package(-lock)?\.json|npm-shrinkwrap\.json|yarn\.lock|pnpm-lock\.yaml|CHANGELOG\.md|README\.md)$|^(\.github|dist|build|coverage)\//;
+
+export function isChurnPath(candidate: string): boolean {
+  return CHURN_PATH.test(normalizePathForKnowledge(candidate));
+}
+
+/**
+ * Split cited paths into the ones that are gone and the ones that merely moved underneath.
+ *
+ * Existence is injected rather than read here so the rule is testable without a tree, and so the
+ * caller can answer from git's index -- which it has already loaded -- instead of one `stat` per
+ * path per item.
+ */
+export function classifyDriftPaths(
+  citedPaths: string[],
+  exists: (candidate: string) => boolean,
+): { removed: string[]; changed: string[] } {
+  const removed: string[] = [];
+  const changed: string[] = [];
+  for (const candidate of citedPaths) {
+    (exists(candidate) ? changed : removed).push(candidate);
+  }
+  return { removed, changed };
 }
 
 export interface DriftCheckResult {
@@ -171,16 +219,42 @@ export async function checkKnowledgeDrift(
     changedFiles: string[];
     apply?: boolean;
     /**
-     * Enables the untracked-path check. Absent keeps the git-only behaviour, so a caller that
-     * has no project root on hand behaves exactly as before rather than silently checking less.
+     * The tree to answer "does this cited path still exist?" against, which is what separates a
+     * removal from an edit. Without it nothing can be classified and every matched path is
+     * reported, which is the old behaviour and the noisy one.
      */
     projectRoot?: string;
+    /**
+     * Also examine affected paths git cannot diff -- untracked or ignored directories an atom
+     * names. Split out from `projectRoot` on 2026-08-13: classification needs the tree on every
+     * run, while this scan remains the deliberate opt-in it always was, so that the automatic
+     * session-start check could gain the first without silently acquiring the second.
+     */
+    includeUntracked?: boolean;
   }
 ): Promise<DriftCheckResult> {
   const items = (await repo.listKnowledgeItems())
     .filter(item => item.status === 'active');
   // One git call for the whole run, not one per item per path.
   const tracked = options.projectRoot ? listTrackedPaths(options.projectRoot) : null;
+
+  /**
+   * Does this cited path still exist? Git's index answers for everything it tracks, which is one
+   * lookup rather than one `stat`; the filesystem is the fallback for paths git does not track,
+   * so an ignored-but-present directory is not mistaken for a deletion.
+   */
+  const projectRoot = options.projectRoot;
+  const exists = projectRoot
+    ? (candidate: string): boolean => {
+      if (tracked?.files.has(candidate) || tracked?.directories.has(candidate)) return true;
+      try {
+        statSync(path.join(projectRoot, candidate));
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    : null;
   const entries = await Promise.all(items.map(async item => {
     const evidence = await listEvidenceForItem(item.id);
     const symbolEvidence = (await Promise.all(evidence
@@ -191,14 +265,45 @@ export async function checkKnowledgeDrift(
     const symbolPaths = symbolEvidence
       .map(entry => symbolPath(entry.locator))
       .filter((entry): entry is string => Boolean(entry));
-    const paths = Array.from(new Set([
+    /**
+     * Kept apart from the git-derived paths, because it is a different question with its own
+     * precision. The untracked check asks "has a directory this atom names moved *since the atom
+     * was written*", comparing mtime against `updated_at`, and it only runs when a caller opts in.
+     * That time-scoping is what the removal rule below supplies for git paths, so applying the
+     * rule here as well would discard a signal that had already earned its place.
+     */
+    const untrackedPaths = options.includeUntracked && options.projectRoot
+      ? untrackedPathsChangedSince(item, options.projectRoot, tracked)
+      : [];
+    const gitPaths = Array.from(new Set([
       ...matchedPaths(item, options.changedFiles),
       ...symbolPaths.filter(entry => options.changedFiles.includes(entry)),
-      ...(options.projectRoot ? untrackedPathsChangedSince(item, options.projectRoot, tracked) : []),
     ]));
-    return { item, matchedPaths: paths, symbolEvidence };
+    const paths = Array.from(new Set([...gitPaths, ...untrackedPaths]));
+    // Churn first, so a path that carries no information cannot make an item look removed either.
+    const informative = gitPaths.filter(candidate => !isChurnPath(candidate));
+    const classified = exists ? classifyDriftPaths(informative, exists) : null;
+    return { item, matchedPaths: paths, untrackedPaths, classified, symbolEvidence };
   }));
-  const candidates = entries.filter(entry => entry.matchedPaths.length > 0 || entry.symbolEvidence.length > 0);
+
+  /**
+   * What survives.
+   *
+   * A stale symbol is already a resolved "the thing this cites is not there any more", so it
+   * stands on its own. Otherwise the item needs a cited path that has gone. An item whose files
+   * were merely edited is dropped -- that was 226 of 339 observations, and reporting it is what
+   * made the whole signal unreadable.
+   *
+   * With no tree to check against, nothing can be classified and the old behaviour stands. That
+   * is deliberately the noisy direction: silently reporting less than before would be a worse
+   * failure than reporting too much.
+   */
+  const candidates = entries.filter(entry => {
+    if (entry.symbolEvidence.length > 0) return true;
+    if (entry.untrackedPaths.length > 0) return true;
+    if (!entry.classified) return entry.matchedPaths.length > 0;
+    return entry.classified.removed.length > 0;
+  });
 
   let updatedCount = 0;
   if (options.apply && candidates.length > 0) {
@@ -242,12 +347,23 @@ export async function checkKnowledgeDrift(
     currentCommit: options.currentCommit || null,
     changedFiles: options.changedFiles,
     updatedCount,
-    candidates: candidates.map(candidate => ({
-      itemId: candidate.item.id,
-      title: candidate.item.title,
-      freshness: options.apply ? 'needs_review' : candidate.item.freshness,
-      matchedPaths: candidate.matchedPaths,
-      ...(candidate.symbolEvidence.length > 0 ? { symbolEvidence: candidate.symbolEvidence } : {}),
-    })),
+    candidates: candidates.map(candidate => {
+      const removedPaths = candidate.classified?.removed ?? [];
+      return {
+        itemId: candidate.item.id,
+        title: candidate.item.title,
+        freshness: options.apply ? 'needs_review' as const : candidate.item.freshness,
+        matchedPaths: candidate.matchedPaths,
+        removedPaths,
+        // Strongest claim first: a removal names the candidate even when a stale symbol came with
+        // it. `changed` is reachable only where nothing could be classified at all.
+        kind: (removedPaths.length > 0
+          ? 'removed'
+          : candidate.symbolEvidence.length > 0
+            ? 'symbol-removed'
+            : candidate.untrackedPaths.length > 0 ? 'untracked-moved' : 'changed') as DriftKind,
+        ...(candidate.symbolEvidence.length > 0 ? { symbolEvidence: candidate.symbolEvidence } : {}),
+      };
+    }),
   };
 }

--- a/src/store/drift.ts
+++ b/src/store/drift.ts
@@ -59,13 +59,19 @@ export function isChurnPath(candidate: string): boolean {
 export function classifyDriftPaths(
   citedPaths: string[],
   exists: (candidate: string) => boolean,
-): { removed: string[]; changed: string[] } {
+  movedFrom: ReadonlySet<string> = new Set(),
+): { removed: string[]; changed: string[]; moved: string[] } {
   const removed: string[] = [];
   const changed: string[] = [];
+  const moved: string[] = [];
   for (const candidate of citedPaths) {
-    (exists(candidate) ? changed : removed).push(candidate);
+    if (exists(candidate)) changed.push(candidate);
+    // Checked before "removed", because a rename leaves the old path absent from the tree and is
+    // otherwise indistinguishable from a deletion by existence alone.
+    else if (movedFrom.has(candidate)) moved.push(candidate);
+    else removed.push(candidate);
   }
-  return { removed, changed };
+  return { removed, changed, moved };
 }
 
 export interface DriftCheckResult {
@@ -108,6 +114,37 @@ export function listChangedFilesSince(projectRoot: string, sinceCommit: string, 
       .map(line => normalizePathForKnowledge(line.trim()))
       .filter(Boolean)
   ));
+}
+
+/**
+ * The paths a rename moved *away from*, over the same range the changed-file list covers.
+ *
+ * Rename detection has to come from a whole-tree diff. `git log -- <path>` limits the diff to that
+ * pathspec, which hides the destination and reports every rename as a plain delete -- the mistake
+ * that made the first audit of this rule report zero renames when 30 of 44 flagged items were
+ * renames.
+ *
+ * Best-effort: a git failure yields an empty set, which degrades to treating moves as deletions.
+ * That is the old, noisier behaviour rather than a broken drift check.
+ */
+export function listRenamedPathsSince(
+  projectRoot: string,
+  sinceCommit: string,
+  currentCommit?: string | null,
+): Set<string> {
+  const range = currentCommit ? `${sinceCommit}..${currentCommit}` : sinceCommit;
+  const sources = new Set<string>();
+  let output: string;
+  try {
+    output = runGit(['diff', '--name-status', '-M', range], projectRoot);
+  } catch {
+    return sources;
+  }
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^R\d*\t(.+?)\t(.+)$/.exec(line.trim());
+    if (match) sources.add(normalizePathForKnowledge(match[1]));
+  }
+  return sources;
 }
 
 function matchedPaths(item: KnowledgeItem, changedFiles: string[]): string[] {
@@ -231,6 +268,15 @@ export async function checkKnowledgeDrift(
      * session-start check could gain the first without silently acquiring the second.
      */
     includeUntracked?: boolean;
+    /**
+     * Paths a rename moved away from in this window, from `listRenamedPathsSince`.
+     *
+     * Without it a moved file is indistinguishable from a deleted one by existence alone, and
+     * every atom citing the old path reports as though the code had been removed. Audited on this
+     * repo's store, that was **30 of 44** flagged items -- one refactor moving `src/store/` files
+     * into `src/session/` accounted for most of them, and every one of those atoms was still true.
+     */
+    renamedFrom?: ReadonlySet<string>;
   }
 ): Promise<DriftCheckResult> {
   const items = (await repo.listKnowledgeItems())
@@ -282,7 +328,9 @@ export async function checkKnowledgeDrift(
     const paths = Array.from(new Set([...gitPaths, ...untrackedPaths]));
     // Churn first, so a path that carries no information cannot make an item look removed either.
     const informative = gitPaths.filter(candidate => !isChurnPath(candidate));
-    const classified = exists ? classifyDriftPaths(informative, exists) : null;
+    const classified = exists
+      ? classifyDriftPaths(informative, exists, options.renamedFrom)
+      : null;
     return { item, matchedPaths: paths, untrackedPaths, classified, symbolEvidence };
   }));
 

--- a/src/store/freshness.ts
+++ b/src/store/freshness.ts
@@ -78,29 +78,50 @@ function pathMatches(knownPath: string, changedPath: string): boolean {
   return known === changed || changed.startsWith(`${known}/`) || known.startsWith(`${changed}/`);
 }
 
+/**
+ * The paths an item carries in `source`, which in practice is a list of them.
+ *
+ * Most items that cite code never fill `affectedPaths`; they write
+ * `"src/store/database.ts; src/store/bootstrap.ts; package.json"` into `source` instead. Measured
+ * on this repo's store, 58 of the 71 drift-flagged items with no `affectedPaths` were flagged
+ * through exactly this, and legitimately -- so `source` has to keep being read.
+ *
+ * It was read with `source.includes(changedPath)`, a raw substring test, which is the part that
+ * was wrong: `vendor/src/index.ts` contains `src/index.ts` while being a different file, and free
+ * prose matches whatever words it happens to contain. Tokenising first makes the same intent
+ * precise, and every token then goes through `pathMatches` like any other path.
+ *
+ * A token has to look like a path to count: no spaces, and at least one `/` or `.`. That drops
+ * `"verified in this workspace"` and `"commit 53a8f9e"` while keeping `package.json`.
+ */
+export function sourcePaths(source?: string | null): string[] {
+  if (!source) return [];
+  return source
+    .split(/[;,]/)
+    .map(token => token.trim())
+    .filter(token => token.length > 0 && !/\s/.test(token) && /[/.]/.test(token))
+    .map(normalizePathForKnowledge);
+}
+
+/**
+ * Whether a change to these files touches anything the item claims to be about.
+ *
+ * **Tags are deliberately not consulted.** A tag is a topic label, not a location, and matching it
+ * with `pathMatches` meant a tag that happened to be a top-level directory (`tests`, `docs`)
+ * claimed every change beneath it. It fired on 8 items in the measured store -- small, and wrong
+ * in principle rather than in degree.
+ *
+ * A true answer means "a file this item cites was touched", which is weaker than "this item is now
+ * false". `classifyDriftPaths` in `drift.ts` is what tells those apart; this only narrows the field.
+ */
 export function knowledgeMentionsChangedPath(item: {
   source?: string | null;
   affectedPaths?: string[] | null;
   tags?: string[] | null;
 }, changedFiles: string[]): boolean {
   const normalizedChanged = changedFiles.map(normalizePathForKnowledge);
+  const cited = [...(item.affectedPaths || []), ...sourcePaths(item.source)];
 
-  for (const affectedPath of item.affectedPaths || []) {
-    if (normalizedChanged.some(changedPath => pathMatches(affectedPath, changedPath))) {
-      return true;
-    }
-  }
-
-  const source = item.source || '';
-  if (source && normalizedChanged.some(changedPath => source.includes(changedPath))) {
-    return true;
-  }
-
-  for (const tag of item.tags || []) {
-    if (normalizedChanged.some(changedPath => pathMatches(tag, changedPath))) {
-      return true;
-    }
-  }
-
-  return false;
+  return cited.some(citedPath =>
+    normalizedChanged.some(changedPath => pathMatches(citedPath, changedPath)));
 }

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -607,9 +607,12 @@ describe('CLI Integration', () => {
           args: [JSON.stringify(['src/billing.ts']), baseCommit, 'fresh', itemId],
         });
 
-        await fs.writeFile(path.join(prDir, 'src', 'billing.ts'), 'export const version = 2;\n', 'utf-8');
-        git('add src/billing.ts');
-        git('commit -m "change billing"');
+        // Removed, not edited. Since 2026-08-13 an edit to a cited file is not drift on its own:
+        // a file being touched says nothing about whether what was written about it became false,
+        // and treating it as drift is what made this signal unreadable at scale.
+        await fs.rm(path.join(prDir, 'src', 'billing.ts'));
+        git('add -A src/billing.ts');
+        git('commit -m "drop billing"');
 
         const output = execSync(`node "${CLI_PATH}" pr --since ${baseCommit}`, {
           cwd: prDir,

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -28,6 +28,22 @@ const commitFile = async (relPath: string, content: string, message: string): Pr
   return git('rev-parse HEAD').trim();
 };
 
+/**
+ * Delete a cited file and commit it.
+ *
+ * Since 2026-08-13 an edit is not drift -- a file being touched says nothing about whether an
+ * atom is still true, and treating it as drift is what produced 339 unread observations against
+ * 42 real ones on this repository's own store. A removal is. These fixtures use it because they
+ * are about the lifecycle around a candidate (stamping, watermarks, warnings), and need a
+ * candidate that qualifies; `an edited file is not drift on its own` covers the other side.
+ */
+const removeFile = async (relPath: string, message: string): Promise<string> => {
+  await fs.rm(path.join(ROOT, relPath), { force: true });
+  git(`add -A ${relPath}`);
+  git(`commit -m "${message}"`);
+  return git('rev-parse HEAD').trim();
+};
+
 const hook = (input: Partial<NormalizedHostHook>): NormalizedHostHook => ({
   host: 'generic',
   event: 'session-start',
@@ -64,7 +80,7 @@ describe('automatic drift check', () => {
     expect(second?.candidateCount).toBe(0);
   });
 
-  it('detects candidates without mutating them, then advances the watermark', async () => {
+  it('marks survivors needs_review, leaves bystanders alone, then advances the watermark', async () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'architecture',
       title: 'Billing module',
@@ -77,18 +93,20 @@ describe('automatic drift check', () => {
       content: 'Nothing to do with billing paths.',
     });
 
-    await commitFile('src/billing.ts', 'export const rate = 2;\n', 'change billing');
+    await removeFile('src/billing.ts', 'drop billing');
     const result = await runAutoDriftCheck(projectId, ROOT);
     expect(result?.checked).toBe(true);
     expect(result?.candidateCount).toBe(1);
     expect(result?.candidateTitles).toEqual(['Billing module']);
 
-    // Detection only: freshness is untouched on both candidate and bystander.
+    // The candidate is acted on; the bystander is not touched at all. Detection-only was the
+    // right answer while 39% of the store qualified -- see the `apply` comment in drift-auto.ts.
     const rows = await getClient().execute({
       sql: 'SELECT id, freshness, last_drift_at FROM knowledge_items WHERE id IN (?, ?) ORDER BY id = ? DESC',
       args: [item.id, bystander.id, item.id],
     });
-    for (const row of rows.rows) expect(String(row.freshness)).toBe('fresh');
+    expect(String(rows.rows[0].freshness)).toBe('needs_review');
+    expect(String(rows.rows[1].freshness)).toBe('fresh');
     // ...but the observation itself is recorded, on the candidate only. This is the whole
     // difference between a warning and a fact a later pass can act on.
     expect(rows.rows[0].last_drift_at).toBeTruthy();
@@ -107,6 +125,35 @@ describe('automatic drift check', () => {
     expect(after.last_drift_at).toBeTruthy();
   });
 
+  it('does not call an edited file drift on its own', async () => {
+    // The rule that removes most of the noise, and the reason the fixtures above delete rather
+    // than edit. Measured on this repository's own store, 226 of 339 observations were exactly
+    // this -- a cited file that had been edited and was still there. A file being touched is not
+    // evidence that anything written about it became false.
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Edited but still true',
+      content: 'A claim about src/edited.ts.',
+      affectedPaths: ['src/edited.ts'],
+    });
+
+    await commitFile('src/edited.ts', 'export const a = 1;\n', 'add edited');
+    await runAutoDriftCheck(projectId, ROOT); // baseline past creation
+    await commitFile('src/edited.ts', 'export const a = 2;\n', 'edit edited');
+
+    const result = await runAutoDriftCheck(projectId, ROOT);
+    expect(result?.checked).toBe(true);
+    expect(result?.candidateTitles).not.toContain('Edited but still true');
+
+    // Not merely unreported -- unrecorded. Stamping it would leave a later pass acting on the
+    // same false positive from a column instead of from a warning.
+    const stamped = (await getClient().execute({
+      sql: 'SELECT last_drift_at FROM knowledge_items WHERE id = ?',
+      args: [item.id],
+    })).rows[0];
+    expect(stamped.last_drift_at).toBeNull();
+  });
+
   it('clears the stamp when the item is reviewed, and not when it is merely touched', async () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'fact',
@@ -121,7 +168,7 @@ describe('automatic drift check', () => {
 
     await commitFile('src/reviewable.ts', 'export const a = 1;\n', 'add reviewable');
     await runAutoDriftCheck(projectId, ROOT); // baseline past creation
-    await commitFile('src/reviewable.ts', 'export const a = 2;\n', 'change reviewable');
+    await removeFile('src/reviewable.ts', 'drop reviewable');
     await runAutoDriftCheck(projectId, ROOT);
     expect(await stamp()).toBeTruthy();
 
@@ -233,7 +280,7 @@ describe('automatic drift check', () => {
     }
     await commitFile('src/bulky.ts', 'export const a = 1;\n', 'add bulky');
     await runAutoDriftCheck(projectId, ROOT); // advance the watermark past creation
-    await commitFile('src/bulky.ts', 'export const a = 2;\n', 'change bulky');
+    await removeFile('src/bulky.ts', 'drop bulky');
 
     const result = await handleHostLifecycleEvent(projectId, hook({
       externalSessionId: `drift-budget-${Date.now()}`,
@@ -254,7 +301,7 @@ describe('automatic drift check', () => {
     });
     await commitFile('src/limits.ts', 'export const limit = 10;\n', 'add limits');
     await runAutoDriftCheck(projectId, ROOT); // advance watermark past the file's creation
-    await commitFile('src/limits.ts', 'export const limit = 20;\n', 'raise limits');
+    await removeFile('src/limits.ts', 'drop limits');
 
     const result = await handleHostLifecycleEvent(projectId, hook({
       externalSessionId: `drift-session-${Date.now()}`,
@@ -265,11 +312,12 @@ describe('automatic drift check', () => {
     expect(result.drift?.candidateCount).toBe(1);
     expect(result.context).toMatch(/^DRIFT: 1 knowledge item/);
 
-    // Still detection only, even through the lifecycle path.
+    // Acted on through the lifecycle path too, not only through the direct call -- the warning
+    // and the mark are one pass, so a session cannot report drift it did not record.
     const row = (await getClient().execute({
       sql: 'SELECT freshness FROM knowledge_items WHERE id = ?',
       args: [flagged.id],
     })).rows[0];
-    expect(String(row.freshness)).toBe('fresh');
+    expect(String(row.freshness)).toBe('needs_review');
   });
 });

--- a/tests/store/drift-auto.test.ts
+++ b/tests/store/drift-auto.test.ts
@@ -154,6 +154,35 @@ describe('automatic drift check', () => {
     expect(stamped.last_drift_at).toBeNull();
   });
 
+  it('does not call a renamed file drift, because the atom is still true', async () => {
+    // Found by auditing the first cut of this rule against the real store: 30 of its 44 survivors
+    // were one refactor moving `src/store/` files into `src/session/`. A rename leaves the old
+    // path absent from the tree, so existence alone cannot tell it from a deletion -- and every
+    // one of those atoms was still perfectly true, with only its path stale.
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Moved but still true',
+      content: 'A claim about src/moved.ts.',
+      affectedPaths: ['src/moved.ts'],
+    });
+
+    await commitFile('src/moved.ts', 'export const a = 1;\n', 'add moved');
+    await runAutoDriftCheck(projectId, ROOT); // baseline past creation
+    git('mv src/moved.ts src/relocated.ts');
+    git('commit -m "relocate moved"');
+
+    const result = await runAutoDriftCheck(projectId, ROOT);
+    expect(result?.checked).toBe(true);
+    expect(result?.candidateTitles).not.toContain('Moved but still true');
+
+    const row = (await getClient().execute({
+      sql: 'SELECT freshness, last_drift_at FROM knowledge_items WHERE id = ?',
+      args: [item.id],
+    })).rows[0];
+    expect(String(row.freshness)).toBe('fresh');
+    expect(row.last_drift_at).toBeNull();
+  });
+
   it('clears the stamp when the item is reviewed, and not when it is merely touched', async () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'fact',

--- a/tests/store/drift-signal-precision.test.ts
+++ b/tests/store/drift-signal-precision.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { knowledgeMentionsChangedPath } from '../../src/store/freshness.js';
+import { classifyDriftPaths, isChurnPath } from '../../src/store/drift.js';
+
+/**
+ * What the matcher is allowed to call drift.
+ *
+ * Measured on this repo's own store before these were written: 339 of 867 active items carried an
+ * unread drift observation, and only 42 of those had a cited path that had actually gone away. The
+ * cases below pin the two matching rules that were wrong, and the one that was right and must
+ * survive being made precise.
+ */
+describe('knowledgeMentionsChangedPath', () => {
+  it('matches a path the item actually cites', () => {
+    expect(knowledgeMentionsChangedPath(
+      { affectedPaths: ['src/store/gc.ts'] },
+      ['src/store/gc.ts'],
+    )).toBe(true);
+  });
+
+  it('matches a directory the item cites', () => {
+    // Citing a directory is citing everything under it, which is why `pathMatches` compares
+    // prefixes rather than equality.
+    expect(knowledgeMentionsChangedPath(
+      { affectedPaths: ['src/store'] },
+      ['src/store/gc.ts'],
+    )).toBe(true);
+  });
+
+  it('still matches a path carried in `source`, which is where most items put them', () => {
+    // 58 of the 71 items flagged with no `affectedPaths` were flagged legitimately through this:
+    // `source` is in practice a semicolon-separated path list. Making the match precise must not
+    // cost those.
+    expect(knowledgeMentionsChangedPath(
+      { source: 'src/store/database.ts; src/store/bootstrap.ts; package.json' },
+      ['src/store/bootstrap.ts'],
+    )).toBe(true);
+  });
+
+  it('does not match a path that is merely a substring of a longer path in `source`', () => {
+    // `source.includes(changedPath)` is a raw substring test, so a different file whose path ends
+    // with the changed one counted as drift. `vendor/src/index.ts` is not `src/index.ts`.
+    expect(knowledgeMentionsChangedPath(
+      { source: 'vendor/src/index.ts' },
+      ['src/index.ts'],
+    )).toBe(false);
+  });
+
+  it('does not match prose in `source` that happens to contain a path-like word', () => {
+    expect(knowledgeMentionsChangedPath(
+      { source: 'verified by hand in this workspace' },
+      ['workspace'],
+    )).toBe(false);
+  });
+
+  it('does not treat a tag as a path, even when the tag names a directory', () => {
+    // A tag is a topic label. It could only ever fire when the tag was literally a top-level
+    // directory -- 8 items in the measured store -- and it is indefensible in principle.
+    expect(knowledgeMentionsChangedPath(
+      { tags: ['tests'] },
+      ['tests/store/gc.test.ts'],
+    )).toBe(false);
+  });
+
+  it('says no when the item cites nothing at all', () => {
+    expect(knowledgeMentionsChangedPath({}, ['src/store/gc.ts'])).toBe(false);
+  });
+});
+
+/**
+ * Telling "the file is gone" apart from "the file was edited".
+ *
+ * These were one event sharing one column. Measured, only 42 of 339 observations had a cited path
+ * that had actually gone away -- so collapsing them is most of why the signal could not be acted
+ * on. Existence is injected so the rule can be tested without a tree on disk.
+ */
+describe('classifyDriftPaths', () => {
+  const exists = (present: string[]) => (candidate: string) => present.includes(candidate);
+
+  it('calls a path that no longer exists removed', () => {
+    expect(classifyDriftPaths(['src/gone.ts'], exists([])))
+      .toEqual({ removed: ['src/gone.ts'], changed: [] });
+  });
+
+  it('calls a path that still exists merely changed', () => {
+    expect(classifyDriftPaths(['src/here.ts'], exists(['src/here.ts'])))
+      .toEqual({ removed: [], changed: ['src/here.ts'] });
+  });
+
+  it('separates the two rather than letting one hide the other', () => {
+    // The case that matters: an item citing both. It is a removal candidate on the strength of the
+    // first path, and reporting only "something changed" would lose that.
+    expect(classifyDriftPaths(['src/gone.ts', 'src/here.ts'], exists(['src/here.ts'])))
+      .toEqual({ removed: ['src/gone.ts'], changed: ['src/here.ts'] });
+  });
+});
+
+/**
+ * Paths whose changing says nothing about whether an atom is still true.
+ *
+ * Among flagged items these were the most-cited paths in the store -- `package.json` 28 times,
+ * `README.md` 23, `CHANGELOG.md` 14 -- because they change on essentially every release.
+ */
+describe('isChurnPath', () => {
+  it.each([
+    'package.json',
+    'package-lock.json',
+    'CHANGELOG.md',
+    'README.md',
+    '.github/workflows/ci.yml',
+    'dist/index.js',
+  ])('treats %s as churn', (candidate) => {
+    expect(isChurnPath(candidate)).toBe(true);
+  });
+
+  it.each([
+    'src/store/gc.ts',
+    'src/cli/program.ts',
+    'tests/store/gc.test.ts',
+    'docs/reference.md',
+  ])('does not treat %s as churn', (candidate) => {
+    expect(isChurnPath(candidate)).toBe(false);
+  });
+});

--- a/tests/store/drift-signal-precision.test.ts
+++ b/tests/store/drift-signal-precision.test.ts
@@ -79,19 +79,34 @@ describe('classifyDriftPaths', () => {
 
   it('calls a path that no longer exists removed', () => {
     expect(classifyDriftPaths(['src/gone.ts'], exists([])))
-      .toEqual({ removed: ['src/gone.ts'], changed: [] });
+      .toEqual({ removed: ['src/gone.ts'], changed: [], moved: [] });
   });
 
   it('calls a path that still exists merely changed', () => {
     expect(classifyDriftPaths(['src/here.ts'], exists(['src/here.ts'])))
-      .toEqual({ removed: [], changed: ['src/here.ts'] });
+      .toEqual({ removed: [], changed: ['src/here.ts'], moved: [] });
+  });
+
+  it('calls a path git renamed moved, not removed', () => {
+    // Audited on the real store after the first cut shipped: 30 of 44 survivors were this --
+    // a refactor moved `src/store/host-lifecycle.ts` to `src/session/`, and every atom citing it
+    // was flagged as though the runtime had been deleted. The atoms are still true; only their
+    // paths are stale, which is a different and much weaker finding.
+    expect(classifyDriftPaths(['src/store/host-lifecycle.ts'], exists([]),
+      new Set(['src/store/host-lifecycle.ts'])))
+      .toEqual({ removed: [], changed: [], moved: ['src/store/host-lifecycle.ts'] });
+  });
+
+  it('still calls a path removed when it is gone and was never renamed', () => {
+    expect(classifyDriftPaths(['src/gone.ts'], exists([]), new Set(['src/other.ts'])))
+      .toEqual({ removed: ['src/gone.ts'], changed: [], moved: [] });
   });
 
   it('separates the two rather than letting one hide the other', () => {
     // The case that matters: an item citing both. It is a removal candidate on the strength of the
     // first path, and reporting only "something changed" would lose that.
     expect(classifyDriftPaths(['src/gone.ts', 'src/here.ts'], exists(['src/here.ts'])))
-      .toEqual({ removed: ['src/gone.ts'], changed: ['src/here.ts'] });
+      .toEqual({ removed: ['src/gone.ts'], changed: ['src/here.ts'], moved: [] });
   });
 });
 

--- a/tests/store/drift-untracked.test.ts
+++ b/tests/store/drift-untracked.test.ts
@@ -70,7 +70,7 @@ describe('drift over untracked paths', () => {
     await fs.writeFile(path.join(ROOT, 'experiments/reskin/second.txt'), 'added\n');
 
     const result = await checkKnowledgeDrift(projectId, {
-      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT,
+      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT, includeUntracked: true,
     });
 
     expect(result.candidates.map(c => c.itemId)).toContain(item.id);
@@ -84,7 +84,7 @@ describe('drift over untracked paths', () => {
       new Date(Date.now() + 60_000).toISOString());
 
     const result = await checkKnowledgeDrift(projectId, {
-      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT,
+      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT, includeUntracked: true,
     });
 
     expect(result.candidates.map(c => c.itemId)).not.toContain(item.id);
@@ -97,7 +97,7 @@ describe('drift over untracked paths', () => {
     const item = await atom('about tracked source', ['src/tracked.ts']);
 
     const result = await checkKnowledgeDrift(projectId, {
-      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT,
+      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT, includeUntracked: true,
     });
 
     expect(result.candidates.map(c => c.itemId)).not.toContain(item.id);
@@ -110,7 +110,7 @@ describe('drift over untracked paths', () => {
     await fs.writeFile(path.join(ROOT, 'src/untracked-scratch.ts'), 'scratch\n');
 
     const result = await checkKnowledgeDrift(projectId, {
-      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT,
+      sinceCommit: 'HEAD', currentCommit: 'HEAD', changedFiles: [], projectRoot: ROOT, includeUntracked: true,
     });
 
     expect(result.candidates.map(c => c.itemId)).not.toContain(item.id);


### PR DESCRIPTION
Drift detection flagged **339 of 867 active items** on this repository's own store — 39% of the corpus. The store shows the predicted outcome: 339 observations recorded, 24 ever acted on.

Static-analysis research puts that ratio squarely in the band where developers stop reading a tool at all. Non-actionable findings run 35–91% across tools, and the documented consequence is alert fatigue and abandonment.

## Nothing acting on the signal was the right call

Flipping `freshness` had been measured as corpus-wide ranking damage, and that measurement was correct — but the cause was **breadth, not depth**. The prior is a 6% nudge (`FRESHNESS_PRIOR.needs_review = 0.94`), which is only destructive when it lands on two-fifths of everything.

So this makes the signal mean something first, and only then acts on it.

## What was wrong, in order of volume

**Any edit counted.** `matchedPaths` answered *"did a file this atom mentions change?"* when the question is *"is this atom still true?"*. The most-cited paths among flagged items were simply the highest-churn files in the tree — `src/mcp/tools.ts` 34, `package.json` 28, `README.md` 23, `src/cli/program.ts` 21.

**A rename read as a deletion.** See the audit below — this one was found *after* the first version of this branch, by checking its output instead of trusting it.

**`source` was matched by raw substring.** The intent was right — `source` is in practice a path list, and **58 of the 71** items with no `affectedPaths` were flagged legitimately through it. The mechanism was not: `vendor/src/index.ts` contains `src/index.ts` while being a different file. It is tokenised now, and those 58 still match.

**Tags were matched as paths.** A tag is a topic label; it could only fire when the tag was literally a top-level directory — 8 items, wrong in principle rather than in degree. Removed.

## The classification carries the volume

`removed`, `symbol-removed` and `untracked-moved` survive. **`changed` and `moved` are dropped.**

This follows [DocPrism/LCEF](https://arxiv.org/abs/2511.00215), which took a code-documentation consistency flag rate from 98% to 14% and accuracy from 14% to 94% — not by improving the model, but by naming the benign category and discarding it.

## The audit that changed this branch

The first version left 44 survivors and this description claimed they cited files that were "genuinely gone". **Auditing them found only 14 were.** Thirty were **renames** — nearly all from one refactor (`6abcd36`) moving `src/store/host-lifecycle.ts` and neighbours into `src/session/` at R097 similarity. Those atoms were all still true; only their paths were stale. **Precision of the first cut was 32%.**

Worth recording because it made the audit itself wrong at first: `git log --find-renames -- <path>` reports every rename as a plain delete, because the pathspec hides the destination. It reported zero renames — the answer that would have let this ship.

Renames now come from `git diff --name-status -M` over the same range that produced the changed files: one extra git call, no history scan.

## Measured, not estimated

`scripts/measure-drift-precision.ts` replays the real stores' flagged rows through the shipped code:

| store | before | after | noise removed |
| --- | --- | --- | --- |
| knowl | 339 | **14** | **95.9%** |
| knowl-cloud | 78 | **1** | **98.7%** |

**Recall spot-check.** Eight of the 290 dropped as "cited file still exists" were read by hand — *"CLI entrypoint is `src/index.ts`"*, *"MCP server is thin tool wiring"*, *"Knowledge search uses SQLite FTS5 and BM25"*, *"Knowl build and verification commands"*. All still true, all would have sat permanently flagged before. Indicative rather than conclusive: recall has no ground truth here, and this is the weakest claim in the PR.

## What that unlocks

At ~2% of the corpus rather than 39%, marking is safe — `runAutoDriftCheck` applies `needs_review` instead of stamping a column nobody reads.

And **`reportDrift` gets its first production caller**. It shipped complete, gated and tested, imported by nothing in `src/`, so no drift observation has ever reached a team. It is wired to `knowl pr check` — the deliberate pass a human runs — not to session start, which must stay offline. `checkUpstreamGate` still guards it.

`projectRoot` and `includeUntracked` are split so the automatic check can have the tree for classification without acquiring the untracked scan `pr check` opts into.

## On the changed fixtures

Several used an edit to provoke drift. They are about the lifecycle *around* a candidate — stamping, watermarks, warnings, bystanders — not about what qualifies as one, so they delete instead. Both other sides are pinned by new tests: `an edited file is not drift on its own` and `does not call a renamed file drift, because the atom is still true`.

## Not in this change

Two-thirds of stored knowledge cites no code at all (553 of 867 here), so no drift check can ever assess it — a review problem rather than a detection one. GC is untouched: it recommends nothing on either store, and **0** items are cold past 60 days, so age-based decay would act on nothing.

Design: `docs/superpowers/specs/2026-08-13-drift-signal-precision-design.md`.

## Verified

328 test files, 2973 tests, typecheck, lint, build and `docs:check` all pass.
