### PR TITLE
fix(work-loop): a checkpoint is a snapshot, so it should replace the last one

### DIFF
--- a/src/store/work-loop.ts
+++ b/src/store/work-loop.ts
@@ -68,6 +68,36 @@ async function requireWorkLoopTask(taskId: string): Promise<KnowledgeItem> {
  * the store's own idiom (`search.ts`, `vector.ts`): tags serialize as a JSON array, so the
  * quoted needle cannot match a longer tag that merely starts with the same characters.
  */
+/**
+ * Retire this task's earlier step atoms in favour of the one just written.
+ *
+ * A checkpoint is a snapshot of where a task stands, not an entry in a log, so the previous
+ * snapshot stops being true the moment a new one is taken. Measured on this repository's own
+ * store before this existed: 54 active work-loop atoms across 18 tasks, one of them holding five
+ * checkpoints — 6% of the whole active corpus describing lifecycle rather than knowledge.
+ *
+ * **Superseded, never deleted.** `resolveDuplicate`'s invariant is that content is never silently
+ * discarded, and nothing else in this system removes knowledge automatically. The retired atoms
+ * stay queryable, so "what did this task actually do" still has an answer, and the memory session
+ * keeps the full event trail either way (`captureMemorySessionEvent`).
+ *
+ * **Keyed on the `task:<id>` tag, deliberately not on the title.** Work loops run in parallel, and
+ * matching titles would let one task retire another's checkpoints. The task's own anchor atom is
+ * tagged `task-start` rather than `task:<id>`, so it is excluded and `requireWorkLoopTask` keeps
+ * resolving.
+ */
+async function retirePriorSteps(taskId: string, replacementId: string): Promise<void> {
+  const rows = (await getClient().execute({
+    sql: `SELECT id FROM knowledge_items
+      WHERE tags LIKE ? AND status = 'active' AND id != ?`,
+    args: [`%"task:${taskId}"%`, replacementId],
+  })).rows;
+
+  for (const row of rows) {
+    await repo.supersedeKnowledgeItem(String(row.id), replacementId);
+  }
+}
+
 async function taskAlreadyFinished(taskId: string): Promise<boolean> {
   const rows = (await getClient().execute({
     sql: `SELECT 1 FROM knowledge_items
@@ -188,9 +218,14 @@ async function recordWorkLoopStep(
   }
   const now = new Date().toISOString();
   const taskState = normalizeTaskState(taskStateInput);
+  const taskName = task.title.replace(/^Work Loop: /, '');
   const item = await repo.createKnowledgeItem(projectId, {
     category: 'state',
-    title,
+    // The task, in the title. Every step atom used to be called exactly `Work Loop checkpoint`
+    // whatever it was about, so 38 of them collided in one store and none could be retrieved by
+    // the work it described. `recent-context.ts` filters them by the `Work Loop checkpoint%`
+    // prefix, which this keeps intact.
+    title: `${title}: ${taskName}`,
     content: [
       `Task ID: ${taskId}`,
       `Task: ${task.title.replace(/^Work Loop: /, '')}`,
@@ -206,6 +241,8 @@ async function recordWorkLoopStep(
   await repo.createKnowledgeCommit(projectId, commitMessage, [
     { itemId: item.id, action: 'insert', after: item },
   ]);
+
+  await retirePriorSteps(taskId, item.id);
 
   const sessionId = memorySessionId(task);
   if (sessionId) {

--- a/src/store/work-loop.ts
+++ b/src/store/work-loop.ts
@@ -1,6 +1,6 @@
-import type { KnowledgeItem } from '../core/types.js';
+import type { CommitChange, KnowledgeItem } from '../core/types.js';
 import { queryKnowledgeForAgent } from './agent-query.js';
-import { getClient } from './database.js';
+import { getClient, withClientTransaction } from './database.js';
 import * as repo from './repository.js';
 import { captureMemorySessionEvent } from './session-capture.js';
 import { finishMemorySession, startMemorySession } from './session-repository.js';
@@ -68,13 +68,23 @@ async function requireWorkLoopTask(taskId: string): Promise<KnowledgeItem> {
  * the store's own idiom (`search.ts`, `vector.ts`): tags serialize as a JSON array, so the
  * quoted needle cannot match a longer tag that merely starts with the same characters.
  */
+async function taskAlreadyFinished(taskId: string): Promise<boolean> {
+  const rows = (await getClient().execute({
+    sql: `SELECT 1 FROM knowledge_items
+      WHERE tags LIKE ? AND tags LIKE '%"finish"%'
+      LIMIT 1`,
+    args: [`%"task:${taskId}"%`],
+  })).rows;
+  return rows.length > 0;
+}
+
 /**
  * Retire this task's earlier step atoms in favour of the one just written.
  *
  * A checkpoint is a snapshot of where a task stands, not an entry in a log, so the previous
  * snapshot stops being true the moment a new one is taken. Measured on this repository's own
  * store before this existed: 54 active work-loop atoms across 18 tasks, one of them holding five
- * checkpoints — 6% of the whole active corpus describing lifecycle rather than knowledge.
+ * checkpoints -- 6% of the whole active corpus describing lifecycle rather than knowledge.
  *
  * **Superseded, never deleted.** `resolveDuplicate`'s invariant is that content is never silently
  * discarded, and nothing else in this system removes knowledge automatically. The retired atoms
@@ -84,28 +94,33 @@ async function requireWorkLoopTask(taskId: string): Promise<KnowledgeItem> {
  * **Keyed on the `task:<id>` tag, deliberately not on the title.** Work loops run in parallel, and
  * matching titles would let one task retire another's checkpoints. The task's own anchor atom is
  * tagged `task-start` rather than `task:<id>`, so it is excluded and `requireWorkLoopTask` keeps
- * resolving.
+ * resolving. The quoted needle is the same idiom `taskAlreadyFinished` documents above.
+ *
+ * Returns the changes rather than committing them, so the caller records the retirement in the
+ * same `knowledge_commits` entry as the insert that caused it. One transaction, because a partial
+ * sweep would leave two live snapshots of one task -- the state this exists to prevent.
  */
-async function retirePriorSteps(taskId: string, replacementId: string): Promise<void> {
+async function retirePriorSteps(taskId: string, replacementId: string): Promise<CommitChange[]> {
   const rows = (await getClient().execute({
     sql: `SELECT id FROM knowledge_items
       WHERE tags LIKE ? AND status = 'active' AND id != ?`,
     args: [`%"task:${taskId}"%`, replacementId],
   })).rows;
+  if (rows.length === 0) return [];
 
-  for (const row of rows) {
-    await repo.supersedeKnowledgeItem(String(row.id), replacementId);
-  }
-}
+  const priors = (await Promise.all(rows.map(row => repo.getKnowledgeItem(String(row.id)))))
+    .filter((item): item is KnowledgeItem => Boolean(item));
 
-async function taskAlreadyFinished(taskId: string): Promise<boolean> {
-  const rows = (await getClient().execute({
-    sql: `SELECT 1 FROM knowledge_items
-      WHERE tags LIKE ? AND tags LIKE '%"finish"%'
-      LIMIT 1`,
-    args: [`%"task:${taskId}"%`],
-  })).rows;
-  return rows.length > 0;
+  const changes: CommitChange[] = [];
+  await withClientTransaction(async conn => {
+    for (const prior of priors) {
+      await repo.updateKnowledgeItem(
+        prior.id, { status: 'superseded', supersededById: replacementId }, undefined, conn,
+      );
+      changes.push({ itemId: prior.id, action: 'supersede', before: prior });
+    }
+  });
+  return changes;
 }
 
 function stringList(value: unknown, maxItems = 20, maxLength = 500): string[] | undefined {
@@ -228,7 +243,7 @@ async function recordWorkLoopStep(
     title: `${title}: ${taskName}`,
     content: [
       `Task ID: ${taskId}`,
-      `Task: ${task.title.replace(/^Work Loop: /, '')}`,
+      `Task: ${taskName}`,
       `Recorded at: ${now}`,
       `Summary: ${summary}`,
       ...taskStateLines(taskState),
@@ -238,11 +253,13 @@ async function recordWorkLoopStep(
     confidence: 1.0,
   });
 
+  // Retire first, then record both in one commit: the insert is what caused the retirement, and
+  // splitting them left the supersessions absent from the audit log entirely.
+  const retired = await retirePriorSteps(taskId, item.id);
   await repo.createKnowledgeCommit(projectId, commitMessage, [
     { itemId: item.id, action: 'insert', after: item },
+    ...retired,
   ]);
-
-  await retirePriorSteps(taskId, item.id);
 
   const sessionId = memorySessionId(task);
   if (sessionId) {

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -434,8 +434,10 @@ describe('CLI Integration', () => {
       encoding: 'utf-8',
     });
     expect(stateOutput).toContain('Work Loop: Implement search UI');
-    expect(stateOutput).toContain('Work Loop checkpoint');
     expect(stateOutput).toContain('Work Loop finish');
+    // And NOT the checkpoint. A finished task leaves one active step atom rather than a trail:
+    // the checkpoint is superseded by the finish, still queryable, just no longer live state.
+    expect(stateOutput).not.toContain('Work Loop checkpoint');
 
     await fs.rm(workLoopDir, { recursive: true, force: true });
   }, 60_000);

--- a/tests/mcp/impact-tool.test.ts
+++ b/tests/mcp/impact-tool.test.ts
@@ -133,7 +133,8 @@ async function resolutionOf(findingId: string): Promise<string | null> {
 
 async function finishItemCount(taskId: string): Promise<number> {
   const rows = await getClient().execute({
-    sql: "SELECT COUNT(*) AS n FROM knowledge_items WHERE title = 'Work Loop finish' AND content LIKE ?",
+    // Prefix, not equality: a step atom's title carries its task name since 2026-08-13.
+    sql: "SELECT COUNT(*) AS n FROM knowledge_items WHERE title LIKE 'Work Loop finish%' AND content LIKE ?",
     args: [`%Task ID: ${taskId}%`],
   });
   return Number(rows.rows[0]?.n ?? 0);

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -940,8 +940,10 @@ describe('MCP Server Layer', () => {
 
     const items = await repo.listKnowledgeItems();
     expect(items.some(item => item.title === 'Work Loop: Implement search UI')).toBe(true);
-    expect(items.some(item => item.title === 'Work Loop checkpoint')).toBe(true);
-    expect(items.some(item => item.title === 'Work Loop finish')).toBe(true);
+    // Step atoms name their task. Every one used to be called exactly `Work Loop checkpoint`
+    // whatever it described, which is how 38 of them collided in one store.
+    expect(items.some(item => item.title === 'Work Loop checkpoint: Implement search UI')).toBe(true);
+    expect(items.some(item => item.title === 'Work Loop finish: Implement search UI')).toBe(true);
   });
 
   it('should create, read, list, and run learned skills through stable MCP tools', async () => {

--- a/tests/store/work-loop.test.ts
+++ b/tests/store/work-loop.test.ts
@@ -127,6 +127,28 @@ describe('work loop session capture', () => {
       expect(String(active[0].id)).toBe(finished.itemId);
     });
 
+    it('records the retirement in the same commit as the insert that caused it', async () => {
+      // The audit log is the only place a supersession is visible after the fact. Retiring after
+      // the commit was written left these absent from it entirely -- the store would show a new
+      // checkpoint appearing and the previous one silently not-active, with nothing joining them.
+      const project = await repo.createProject(TEST_ROOT, 'Work loop audit trail');
+      const started = await startWorkLoop(project.id, 'Ship the audit trail', 'audit');
+      const first = await checkpointWorkLoop(project.id, started.taskId, 'step one');
+      const second = await checkpointWorkLoop(project.id, started.taskId, 'step two');
+
+      const rows = (await getClient().execute({
+        sql: `SELECT ci.item_id, ci.action FROM knowledge_commit_items ci
+              WHERE ci.item_id IN (?, ?)`,
+        args: [first.itemId, second.itemId],
+      })).rows;
+
+      const actionsFor = (id: string) => rows
+        .filter(row => String(row.item_id) === id)
+        .map(row => String(row.action));
+      expect(actionsFor(second.itemId)).toContain('insert');
+      expect(actionsFor(first.itemId)).toContain('supersede');
+    });
+
     it('never touches another task running at the same time', async () => {
       // The reason superseding keys on the `task:<id>` tag and not on the title. Users run work
       // loops in parallel; keying on the title would make one loop retire another's checkpoints.

--- a/tests/store/work-loop.test.ts
+++ b/tests/store/work-loop.test.ts
@@ -73,4 +73,76 @@ describe('work loop session capture', () => {
     await expect(checkpointWorkLoop(project.id, started.taskId, 'zombie checkpoint'))
       .rejects.toThrow(/already finished/i);
   });
+
+  /**
+   * A finished task should leave one atom, not a pile.
+   *
+   * Measured on this repository's own store before these were written: 54 active work-loop atoms
+   * across 18 tasks, every one of them titled `Work Loop checkpoint` or `Work Loop finish`
+   * regardless of which task it belonged to. `recent-context.ts` already filters them out by title
+   * prefix, which is the codebase conceding they are noise rather than knowledge.
+   */
+  describe('step atoms collapse per task', () => {
+    /** Every work-loop atom for one task, newest first. */
+    const stepsFor = async (taskId: string) => (await getClient().execute({
+      sql: `SELECT id, title, status, superseded_by_id FROM knowledge_items
+            WHERE tags LIKE ? ORDER BY created_at DESC`,
+      args: [`%task:${taskId}%`],
+    })).rows;
+
+    it('names the task in the title, so two tasks are told apart', async () => {
+      const project = await repo.createProject(TEST_ROOT, 'Work loop titles');
+      const started = await startWorkLoop(project.id, 'Ship the parser', 'parser');
+      await checkpointWorkLoop(project.id, started.taskId, 'half done');
+
+      const titles = (await stepsFor(started.taskId)).map(row => String(row.title));
+      expect(titles.some(title => title.includes('Ship the parser'))).toBe(true);
+    });
+
+    it('supersedes the previous checkpoint rather than accumulating', async () => {
+      const project = await repo.createProject(TEST_ROOT, 'Work loop collapse');
+      const started = await startWorkLoop(project.id, 'Ship the indexer', 'indexer');
+      const first = await checkpointWorkLoop(project.id, started.taskId, 'step one');
+      const second = await checkpointWorkLoop(project.id, started.taskId, 'step two');
+
+      const rows = await stepsFor(started.taskId);
+      const firstRow = rows.find(row => row.id === first.itemId);
+      const secondRow = rows.find(row => row.id === second.itemId);
+
+      // Retired, not deleted: "what did this task do" stays answerable.
+      expect(String(firstRow?.status)).toBe('superseded');
+      expect(String(firstRow?.superseded_by_id)).toBe(second.itemId);
+      expect(String(secondRow?.status)).toBe('active');
+    });
+
+    it('leaves exactly one active atom once the task finishes', async () => {
+      const project = await repo.createProject(TEST_ROOT, 'Work loop finish collapse');
+      const started = await startWorkLoop(project.id, 'Ship the ranker', 'ranker');
+      await checkpointWorkLoop(project.id, started.taskId, 'step one');
+      await checkpointWorkLoop(project.id, started.taskId, 'step two');
+      const finished = await finishWorkLoop(project.id, started.taskId, 'shipped');
+
+      const active = (await stepsFor(started.taskId)).filter(row => String(row.status) === 'active');
+      expect(active).toHaveLength(1);
+      expect(String(active[0].id)).toBe(finished.itemId);
+    });
+
+    it('never touches another task running at the same time', async () => {
+      // The reason superseding keys on the `task:<id>` tag and not on the title. Users run work
+      // loops in parallel; keying on the title would make one loop retire another's checkpoints.
+      const project = await repo.createProject(TEST_ROOT, 'Work loop parallel');
+      const a = await startWorkLoop(project.id, 'Task A', 'a');
+      const b = await startWorkLoop(project.id, 'Task B', 'b');
+
+      const a1 = await checkpointWorkLoop(project.id, a.taskId, 'a one');
+      const b1 = await checkpointWorkLoop(project.id, b.taskId, 'b one');
+      await checkpointWorkLoop(project.id, a.taskId, 'a two');
+
+      // A's second checkpoint retired A's first and left B's alone.
+      const aRows = await stepsFor(a.taskId);
+      const bRows = await stepsFor(b.taskId);
+      expect(String(aRows.find(row => row.id === a1.itemId)?.status)).toBe('superseded');
+      expect(String(bRows.find(row => row.id === b1.itemId)?.status)).toBe('active');
+    });
+  });
 });


### PR DESCRIPTION
Found while auditing what GC would actually have to collect (see #97, #98). GC turned out to need no changes — but it surfaced this.

## The measurement

**54 active work-loop atoms across 18 tasks — 6.2% of the entire active corpus** — describing lifecycle rather than knowledge. One task held five checkpoints. Every atom was titled exactly `Work Loop checkpoint` or `Work Loop finish`, whatever task it belonged to:

```
x38  [state] Work Loop checkpoint
x16  [state] Work Loop finish
```

## Two problems, and duplication is the smaller one

**The titles carried no information.** Thirty-eight atoms sharing one title can't be told apart in a listing, can't be retrieved by the work they describe, and collide in every same-title grouping. `recent-context.ts` already filters them out by title prefix — the codebase quietly conceding they're noise. That filter still matches, because the prefix is unchanged.

**And they accumulated.** `recordWorkLoopStep` calls `repo.createKnowledgeItem` directly, so `resolveDuplicate` never sees these writes and nothing collapses them.

A checkpoint is a **snapshot of where a task stands**, not an entry in a log. The previous snapshot stops being true the moment a new one is taken. So each step retires this task's earlier steps, and a finished task leaves exactly one active atom.

**54 → 18 on this store.**

## Superseded, never deleted

`resolveDuplicate`'s invariant is that content is never silently discarded, and nothing else in this system removes knowledge on its own — GC purges only byte-identical duplicates, and `retract` is manual and irreversible. Auto-deleting would make the work loop the one path that destroys knowledge unprompted.

Retired atoms stay queryable, so *"what did this task actually do"* still has an answer, and the memory session keeps the full event trail via `captureMemorySessionEvent` regardless.

## Parallel safety, which is why this keys on the tag

Work loops run concurrently. Superseding is keyed on the **`task:<id>` tag, deliberately not on the title** — matching titles would let one task retire another's checkpoints. There's a test that starts two tasks, interleaves their checkpoints, and asserts A's second retired A's first while B's stayed active.

Two guards were checked before touching this, and both match on **tags** rather than titles, so neither is disarmed by the rename:

- `requireWorkLoopTask` resolves the anchor by id — and the anchor is tagged `task-start`, not `task:<id>`, so the sweep excludes it.
- `taskAlreadyFinished` looks for the `finish` tag and doesn't filter status.

## Second commit: four defects found reviewing the first

Worth reading as its own change. The third is the one that mattered.

1. **The supersessions never reached the audit log.** Retiring ran *after* `createKnowledgeCommit`, so the commit recorded the insert and nothing else — the store would show a new checkpoint appearing and the previous one silently inactive, with no entry joining them. The commit log is the only place a supersession is visible after the fact, and this PR is *about* retiring things. Now retires first and records both in one entry, with `action: 'supersede'` carrying `before`, as `knowledge-writer.ts` does.
2. **The sweep wasn't transactional.** A partial one leaves two live snapshots of a single task — the exact state this change exists to prevent. Now inside `withClientTransaction`.
3. **A pre-existing JSDoc was orphaned** — the new function landed between `taskAlreadyFinished`'s doc comment and the function it documented.
4. **A duplicated expression** left inline after `taskName` was introduced to replace it.

The audit-log behaviour is new, so it has a test: a second checkpoint's commit carries `insert` for the new atom and `supersede` for the retired one.

## On the changed tests

Three asserted the exact old titles and now match the prefix. A fourth asserted that `knowl state` shows the checkpoint after finishing — it now asserts the opposite, which is the change working: one active step atom per task, the checkpoint retired rather than displayed.

## Follow-up, not in this change

Superseded rows are never collected: GC's archive only touches `status='active'` and compress only touches `archived`. Harmless for retrieval, since queries filter to active — but **this is the first population GC would genuinely have material to work on**, unlike anything examined in #97. Worth a separate rule for cold superseded `state` atoms.

## Verified

327 test files, 2954 tests, typecheck, lint, build and `docs:check` all pass.
