### PR TITLE
feat(send): Argon2id derivation, sender visibility, and a tolerant error enum

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -726,7 +726,8 @@ The replica is a replica: deleting it is always safe, and the next pull rebuilds
 | `knowl cloud stage [--id <ids...>] [--category <list>] [--apply]` | Queue knowledge for the team. Bare opens the same picker; naming flags dry-runs until `--apply` |
 | `knowl cloud push` | Send staged knowledge. Works from any branch |
 | `knowl cloud retract <id> --reason <text>` | Remove a published atom for good. Works from any branch |
-| `knowl cloud send [--id <ids...>] [--query <text>] [--expires-in <hours>]` | Seal a few atoms for one person and print a code. Expires; collected once |
+| `knowl cloud send [--id <ids...>] [--query <text>] [--expires-in <hours>] [--words <count>]` | Seal a few atoms for one person and print a code. Expires; collected once |
+| `knowl cloud send --list` / `--revoke <code-or-id>` | What you have in flight and whether it was collected; destroy one early |
 | `knowl cloud receive <code>` | Collect atoms somebody sent you. Shows who and how many before taking it |
 | `knowl cloud status` | What is connected, how stale the replica is, and what is staged |
 
@@ -860,6 +861,18 @@ encryption key and a mailbox id from it under separate labels, and uploads only 
 sealed bytes. The code travels between two humans over whatever channel they already use, and it
 is printed once — it is not stored, not logged, and cannot be recovered if lost.
 
+**Guessing the code is made expensive, not just improbable.** Five words is about 2⁵⁵, which a
+GPU rig could once have ground through against a stolen database inside a bundle's own 24–72 hour
+life — because the derivation was fast. Both halves now come off **Argon2id at 64 MiB**, so each
+guess costs about a second and a rig's worth of memory rather than a hash. That is why `send` and
+`receive` pause for a moment before they do anything.
+
+`--words 6` mints a six-word code instead, about 2⁶⁶. Worth having alongside the slow derivation
+and no substitute for it: what made 2⁵⁵ reachable was the cost per guess.
+
+Codes minted by knowl 5.1.0 still work. A receiver looks for the new mailbox first and the old one
+second, so an in-flight bundle from an un-upgraded sender is collected exactly as before.
+
 **Both ends need a Knowl Cloud account; neither needs the same workspace.** That is the whole
 capability `push` does not have. Requiring an account is what makes guessing a code rate-limited
 and attributable, so possession of the code is never the only thing standing between a stranger
@@ -871,6 +884,23 @@ machinery `knowl import` uses, and it means a handoff cannot launder provenance.
 
 `--query` prints what it matched and asks before sealing: retrieval is fuzzy, and sending the
 wrong three atoms to a colleague is not undone by an expiry.
+
+**`--list` is how a leaked code announces itself.** It shows what you have in flight and whether
+each has been collected. A bundle you never handed to anybody, marked collected, means somebody
+else had the code — nothing can un-send it, so treat what was in it as disclosed.
+
+```
+knowl cloud send --list
+  2 bundle(s) in flight:
+    3f7c…  3 atom(s)  sent 2026-08-14T09:00:00Z  expires 2026-08-15T09:00:00Z
+    a19b…  1 atom(s)  sent 2026-08-14T09:04:00Z  collected 2026-08-14T09:31:00Z
+
+knowl cloud send --revoke owl-cascade-ridge-plum-tin
+  Revoked. The code is dead and whoever holds it now sees nothing.
+```
+
+`--revoke` takes either the code or an id from `--list`. The ids are opaque on purpose: codes are
+never stored, so the list answers *was anything taken*, not *which of mine was it*.
 
 ### Two kinds of sharing, and they are independent
 

--- a/docs/superpowers/specs/2026-08-14-send-argon2id-design.md
+++ b/docs/superpowers/specs/2026-08-14-send-argon2id-design.md
@@ -1,0 +1,165 @@
+# `knowl send` — Argon2id derivation, and the rest of issue #102
+
+Status: accepted, 2026-08-14. Supersedes the derivation section of
+[`2026-08-13-send-receive-cli-design.md`](2026-08-13-send-receive-cli-design.md); everything else
+in that document stands.
+
+## The gap
+
+The code is five BIP-39 words, about 2⁵⁵. Both the mailbox id and the sealing key come off it
+through HKDF-SHA256 — which is fast by design, because that is what a KDF for an already-strong
+key is for.
+
+Given a database snapshot, a serious GPU rig enumerates 2⁵⁵ against stored mailbox ids in
+hours-to-days: **inside a mailbox's own 24–72 hour lifetime**. The cheap KDF then yields the
+sealing key from the same code, so the ciphertext goes with the id.
+
+The original reasoning is correct as far as it goes — a drop box can be ground offline, unlike an
+interactive SPAKE2 exchange, so the entropy has to live in the code. What it did not account for
+is that **2⁵⁵ is only expensive if each guess is expensive.**
+
+Bitwarden Send, Yopass and ffsend are structurally immune: their keys are 128 *random* bits in a
+URL fragment, derived from nothing. We took a human-typed code instead, which is the right product
+call — and is exactly why the entropy has to be defended rather than assumed sufficient.
+
+## The derivation
+
+### One memory-hard pass, then a cheap split
+
+```
+master = Argon2id(normalizeCode(code), salt "knowl-send:v2", m=64 MiB, t=3, p=1) → 32 bytes
+id     = hex( HKDF-SHA256(master, "knowl-send:id:v2",  16) )
+key    =      HKDF-SHA256(master, "knowl-send:key:v2", 32)
+```
+
+The issue reads as two Argon2id calls, one per domain string. It is one, and the difference is
+free: **an attacker grinding the codespace against stored mailbox ids only ever needs the id
+derivation.** They compute one Argon2id per guess under either construction. Two separate calls
+cost the honest client double and the attacker nothing — 1.2 s instead of 0.6 s per send on Node
+24, 2.8 s instead of 1.4 s on Node 22.
+
+The versioned domain strings survive as the HKDF labels, which is where they do their work. `id`
+still cannot disclose `key`: `id` is a 16-byte HKDF output over a 256-bit master, so recovering
+`master` from the public id is the same infeasible step the v1 design already relied on.
+
+### Parameters, and why these
+
+`m=64 MiB, t=3, p=1` — measured at **603 ms** on the developer machine via the built-in, which is
+the middle of the 0.5–1 s the issue asks for. At 64 MiB per guess, 2⁵⁵ stops being economical for
+a large rig, which is the entire point of the change.
+
+`p=1` deliberately: parallelism helps a defender with cores to spare and helps an attacker with
+thousands, and a CLI deriving one key has nothing to parallelise.
+
+The salt is a fixed published constant, for the same reason it was in v1 — there is no per-user
+salt two humans can agree on out of band, and the code carries all the entropy. Its job is domain
+separation, and the `:v2` in it is what keeps a v2 master from ever colliding with a v3 one.
+
+### The backend
+
+`crypto.argon2Sync` when it exists (Node ≥ 24.7), `@noble/hashes` argon2id otherwise.
+
+The repository treats a package added for ten lines as a supply-chain surface added for ten lines,
+and the honest accounting is that this one is not for ten lines — it is the only way to keep the
+declared `engines: node >=22` floor while shipping a memory-hard KDF. `@noble/hashes` is audited,
+has zero dependencies of its own, and its argon2id was verified byte-identical to Node's before it
+was chosen. A test pins that equality on any runtime that has both, so the fallback cannot drift
+into deriving a different key from the same code.
+
+Rejected: bumping `engines` to `>=24.7` (drops Node 22 LTS, supported until April 2027, for every
+knowl user and needs a major); noble everywhere (1380 ms on a runtime with a 603 ms implementation
+sitting in its standard library); `scryptSync` (memory-hard and dependency-free, but not Argon2id,
+weaker against time-memory trade-off, and with no precedent in this tool class).
+
+## Staying compatible with v1
+
+### The receiver tries v2, then v1
+
+**The id is the lookup key, so the receiver has to choose a derivation before it can read
+anything.** No amount of self-description inside the bundle helps, because the bundle is only
+reachable once the id is already known.
+
+So: derive the v2 id and peek; on a miss, derive the v1 id and peek again. One round trip for a v2
+bundle, two for a v1 bundle or a mistyped code. No change to the code format, no change to the
+server, and a 5.1.0 sender keeps working against a 5.2.0 receiver indefinitely — which matters,
+because 5.1.0 clients stay in the wild long after the last v1 bundle expires.
+
+Rejected: a version marker inside the code (changes what a human reads aloud, and `normalizeCode`
+splitting on `-` makes a prefix token fragile); sending both candidate ids in one request (needs a
+server change, and the issue's premise is that the server needs none); dropping v1 outright (a
+5.1.0 sender and an upgraded receiver would fail silently, forever).
+
+### The version byte is a cross-check, not the discriminator
+
+Because the version is already established by *which id hit*, the byte in the bundle does a
+narrower job than "self-describe the derivation" suggests — and it is worth keeping anyway, as the
+thing that makes `unseal` assert rather than assume.
+
+```
+v2:  0x02 || nonce(12) || ciphertext || tag(16)      AAD = 0x02
+v1:          nonce(12) || ciphertext || tag(16)      no AAD
+```
+
+**Bound as GCM additional authenticated data, not merely prefixed.** A prefix a receiver reads and
+trusts is a byte an attacker can flip to steer the key schedule; AAD makes flipping it fail the
+tag. `unseal(sealed, code, version)` takes the version explicitly from the peek that succeeded and
+checks the prefix agrees with it.
+
+A version byte could not have been the discriminator regardless: a v1 bundle opens with a random
+nonce, whose first byte is `0x02` once in 256.
+
+### Deriving once per command
+
+`previewSend` returns the resolved `{ preview, mailboxId, version }` and `receiveKnowledge` takes
+it, rather than each deriving from the code independently. Without that, `knowl cloud receive`
+pays for four Argon2id passes — peek v2, peek v1, claim v2, claim v1 — where one will do.
+
+Threaded explicitly rather than memoised in a module-level cache: a process-lifetime map keyed by
+code, holding sealing keys, is a worse artefact than an extra function parameter.
+
+## The rest of #102
+
+### Unknown `reason` strings degrade to the server's message
+
+`SendRefusal` gains `conflict` and `rate_limited` and stops being a closed union.
+
+**This is a live bug, not future-proofing.** knowl-cloud v0.7.0 returns `rate_limited` for a full
+outbox today; the shipped 5.1.0 client's message map has no such key, so a sender at their quota
+is told "No bundle waiting on that code." Anything unrecognised now falls through to the `message`
+the server sent, so a future addition degrades to showing the truth rather than a wrong answer.
+
+### `--list` and `--revoke`
+
+`GET /v1/send` and `DELETE /v1/send/:id`, both live since knowl-cloud v0.7.0.
+
+`--list` is a **detection** surface before it is a convenience: a bundle the sender never handed
+off showing `claimedAt` is the tamper-evidence signal for a leaked or guessed code, and is printed
+as that rather than as a column.
+
+The listed ids are opaque to the sender — codes are never stored, which is deliberate and stays
+that way — so `--revoke` accepts **either** a mailbox id copied from the list **or** the code
+itself, resolving a code through the same v2-then-v1 walk the receiver uses.
+
+### The optional sixth word
+
+`--words 6` takes the code to 2048⁶ ≈ 2⁶⁶. Default stays 5.
+
+Cheap alongside Argon2id and pointless instead of it: the reason 2⁵⁵ was reachable was the cost
+per guess, and a sixth word buys 11 bits against an attack that Argon2id makes uneconomic outright.
+Nothing downstream changes — the derivation's output width is fixed, so the server never learns
+how long the code was.
+
+## Testing
+
+The properties that matter, in the layer only this repository can check:
+
+- Both Argon2id backends return identical bytes, skipped where only one exists.
+- A v2 bundle round-trips; a v1 bundle still round-trips under the v1 derivation.
+- A flipped version byte throws rather than selecting another key schedule.
+- A wrong code throws rather than returning plausible noise for `importKnowledge` to write.
+- The v2 id is 32 lowercase hex — the width the server's contract accepts.
+- A six-word code generates six words and derives without special-casing.
+- An unknown `reason` string reaches the user as the server's own message.
+
+Argon2id at 64 MiB is ~0.6–1.4 s per call, so cases that derive are kept few and deliberate. The
+suite's 30 s timeout covers them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@huggingface/transformers": "^4.2.0",
         "@libsql/client": "^0.17.4",
         "@modelcontextprotocol/sdk": "^1.30.0",
+        "@noble/hashes": "^2.3.0",
         "ai": "^7.0.22",
         "commander": "^14.0.3",
         "dotenv": "^17.4.2",
@@ -1661,6 +1662,18 @@
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
       "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
       "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@huggingface/transformers": "^4.2.0",
     "@libsql/client": "^0.17.4",
     "@modelcontextprotocol/sdk": "^1.30.0",
+    "@noble/hashes": "^2.3.0",
     "ai": "^7.0.22",
     "commander": "^14.0.3",
     "dotenv": "^17.4.2",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -64,7 +64,9 @@ import { runPull } from '../cloud/pull.js';
 import { computePushSnapshot, countStageable, pushStaged, stagePublish } from '../cloud/publish.js';
 import { reportDrift } from '../cloud/drift-report.js';
 import { retractItem } from '../cloud/retract.js';
-import { previewSend, receiveKnowledge, sendKnowledge } from '../cloud/send/transfer.js';
+import {
+  listSends, previewSend, receiveKnowledge, refusalMessage, revokeSend, sendKnowledge,
+} from '../cloud/send/transfer.js';
 import { cloudStatus, formatCloudStatus } from '../cloud/status.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
 import { verifyCustomModel } from '../ai/model-probe.js';
@@ -740,6 +742,61 @@ function parseDefaultVisibility(value: string | undefined): 'workspace' | 'repo'
   throw new Error(`--default-visibility must be "repo" or "workspace", not "${value}".`);
 }
 
+/** The two lines every cloud verb prints when it cannot get as far as a request. */
+function reportNoSession(state: 'not-connected' | 'not-logged-in') {
+  console.error(state === 'not-connected'
+    ? 'This repository is not connected to a cloud workspace. Run knowl cloud connect.'
+    : 'Not signed in. Run knowl cloud login first.');
+  process.exitCode = 1;
+}
+
+/**
+ * `knowl cloud send --list`.
+ *
+ * **A detection surface before a convenience.** A bundle showing `collected` that the sender never
+ * handed to anybody is how a leaked or guessed code announces itself, so that reading is printed
+ * rather than left for the reader to reach on their own.
+ *
+ * The ids are opaque here on purpose: codes are never stored, so this answers "was anything
+ * taken" and not "which of mine was it". The id is still what `--revoke` accepts.
+ */
+async function reportSends(config: Awaited<ReturnType<typeof loadConfig>>) {
+  const mailboxes = await listSends({ config });
+  if (typeof mailboxes === 'string') return reportNoSession(mailboxes);
+
+  if (mailboxes.length === 0) {
+    console.log('Nothing in flight. Every bundle you sent has been collected, revoked or expired.');
+    return;
+  }
+
+  console.log(`${mailboxes.length} bundle(s) in flight:`);
+  for (const box of mailboxes) {
+    const state = box.claimedAt ? `collected ${box.claimedAt}` : `expires ${box.expiresAt}`;
+    console.log(`  ${box.mailboxId}  ${box.itemCount} atom(s)  sent ${box.createdAt}  ${state}`);
+  }
+
+  if (mailboxes.some(box => box.claimedAt)) {
+    console.log('');
+    console.log('A bundle you never handed to anybody, marked collected, means the code leaked.');
+    console.log('Nothing can un-send it — treat what was in it as disclosed, and rotate what it named.');
+  }
+}
+
+/** `knowl cloud send --revoke`, taking either the code itself or an id copied out of `--list`. */
+async function reportRevoke(config: Awaited<ReturnType<typeof loadConfig>>, target: string) {
+  const revoked = await revokeSend({ config, target });
+  if (typeof revoked === 'string') return reportNoSession(revoked);
+
+  if (!revoked) {
+    // Same uniform answer as a failed peek: already collected, already expired, never existed and
+    // "not yours" are one message, because distinguishing them would confirm a guess for free.
+    console.error('Nothing to revoke. It was already collected, already expired, or never existed.');
+    process.exitCode = 1;
+    return;
+  }
+  console.log('Revoked. The code is dead and whoever holds it now sees nothing.');
+}
+
 /**
  * Names 5.0 removed, kept only so they can say where they went.
  *
@@ -1369,11 +1426,26 @@ cloudCommand
   .option('--query <text>', 'The atoms this retrieves; shown for confirmation before anything is sealed')
   .option('--from <label>', 'How the recipient sees you; defaults to this repo')
   .option('--expires-in <hours>', 'Hours until the bundle dies unread', '24')
+  .option('--words <count>', 'Words in the code: 5 (default) or 6 for a longer one', '5')
+  .option('--list', 'What you have in flight, and whether it has been collected')
+  .option('--revoke <code-or-id>', 'Destroy a bundle before anyone collects it')
   .option('--yes', 'Skip the confirmation')
   .action(async (options) => {
     try {
       const root = await findProjectRoot(process.cwd());
       const config = await loadConfig(root);
+
+      // Both of these answer about bundles already in flight, so they run before anything is
+      // selected, exported or sealed.
+      if (options.list) {
+        await reportSends(config);
+        return;
+      }
+      if (options.revoke) {
+        await reportRevoke(config, options.revoke);
+        return;
+      }
+
       await initDb(root);
       let itemIds: string[] = [];
       let project: { id: string } | null = null;
@@ -1412,8 +1484,16 @@ cloudCommand
         itemIds,
         senderLabel: options.from ?? config.cloud?.repo ?? 'a colleague',
         expiresInHours: Number(options.expiresIn),
+        // Validated rather than coerced: `Number('six')` is NaN, and a code length that fell
+        // through to a default would weaken the one secret in this feature without saying so.
+        words: numericOption(options.words, '--words', { min: 5 }),
       });
 
+      if (result.status === 'refused') {
+        console.error(refusalMessage(result.reason, result.message));
+        process.exitCode = 1;
+        return;
+      }
       if (result.status === 'not-connected') {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
         process.exitCode = 1;
@@ -1454,18 +1534,20 @@ cloudCommand
       const root = await findProjectRoot(process.cwd());
       const config = await loadConfig(root);
 
-      const preview = await previewSend({ config, code });
-      if (preview === 'not-connected') {
+      // One lookup, and the derivation it resolved travels with it. Re-deriving inside the claim
+      // would pay for Argon2id at 64 MiB three more times for the same code.
+      const resolved = await previewSend({ config, code });
+      if (resolved === 'not-connected') {
         console.error('This repository is not connected to a cloud workspace. Run knowl cloud connect.');
         process.exitCode = 1;
         return;
       }
-      if (preview === 'not-logged-in') {
+      if (resolved === 'not-logged-in') {
         console.error('Not signed in. Run knowl cloud login first.');
         process.exitCode = 1;
         return;
       }
-      if (!preview) {
+      if (!resolved) {
         // One message for every reason, matching the server: a peek that distinguished "spent"
         // from "never existed" would confirm a guessed code for free.
         console.error('No bundle waiting on that code. Check what you typed, or ask for a re-send.');
@@ -1473,20 +1555,16 @@ cloudCommand
         return;
       }
 
+      const { preview } = resolved;
       console.log(`From: ${preview.senderLabel} · ${preview.itemCount} atom(s) · expires ${preview.expiresAt}`);
       if (!options.yes && !await confirm('Collect it? This can only be done once.')) {
         console.log('Left where it is. The code still works until it expires.');
         return;
       }
 
-      const result = await receiveKnowledge({ projectRoot: root, config, code });
+      const result = await receiveKnowledge({ projectRoot: root, config, resolved });
       if (result.status === 'refused') {
-        const message = {
-          not_found: 'No bundle waiting on that code.',
-          expired: 'That bundle expired. Ask for a new one.',
-          already_claimed: 'That bundle was already collected. Ask for a new one.',
-        }[result.reason];
-        console.error(message);
+        console.error(refusalMessage(result.reason, result.message));
         process.exitCode = 1;
         return;
       }

--- a/src/cloud/api-client.ts
+++ b/src/cloud/api-client.ts
@@ -98,11 +98,44 @@ export type SendPreview = {
 };
 
 /**
- * Why a claim came back empty. Distinguished rather than collapsed, because the remedies differ:
- * a typo is retryable, an expiry needs a re-send, and "already collected" tells a receiver whose
- * download dropped that the bundle is gone rather than that they mistyped.
+ * Why a send or a claim came back empty. Distinguished rather than collapsed, because the remedies
+ * differ: a typo is retryable, an expiry needs a re-send, and "already collected" tells a receiver
+ * whose download dropped that the bundle is gone rather than that they mistyped.
  */
-export type SendRefusal = 'not_found' | 'expired' | 'already_claimed';
+export type KnownSendRefusal =
+  | 'not_found'
+  | 'expired'
+  | 'already_claimed'
+  /** The mailbox id is taken, which at 2^55 means codegen is broken, not that two people collided. */
+  | 'conflict'
+  /** The sender is at their in-flight quota: wait for claims or expiry rather than minting again. */
+  | 'rate_limited';
+
+/**
+ * Open on purpose, and this is a fix rather than future-proofing.
+ *
+ * The server and this client ship separately, so its `reason` enum grows without asking. It has
+ * already grown twice since 5.1.0 -- `conflict` and `rate_limited` -- and a closed union meant a
+ * sender at their quota was told **"No bundle waiting on that code"**, because the CLI's message
+ * map had no key for what arrived and fell through to the default.
+ *
+ * So an unrecognised reason is carried, not coerced, and the server's own `message` travels with
+ * it. A future addition then degrades to showing the truth instead of a confident wrong answer.
+ */
+export type SendRefusal = KnownSendRefusal | (string & {});
+
+/** A refusal, with whatever the server said about it. */
+export type SendRefused = { refused: SendRefusal; message?: string };
+
+/** One of the caller's own in-flight bundles, as `knowl cloud send --list` shows it. */
+export type SendMailbox = {
+  mailboxId: string;
+  itemCount: number;
+  createdAt: string;
+  expiresAt: string;
+  /** Non-null on a bundle that has been collected -- the tamper-evidence signal. */
+  claimedAt: string | null;
+};
 
 export type CloudApi = {
   startDeviceAuthorization(): Promise<DeviceAuthorization>;
@@ -147,7 +180,7 @@ export type CloudApi = {
     senderLabel: string;
     itemCount: number;
     expiresInHours: number;
-  }): Promise<{ mailboxId: string; expiresAt: string }>;
+  }): Promise<{ mailboxId: string; expiresAt: string } | SendRefused>;
   /** Reads the label without spending the single claim, so a receiver can decline knowingly. */
   peekSend(input: {
     accessToken: string;
@@ -156,7 +189,17 @@ export type CloudApi = {
   claimSend(input: {
     accessToken: string;
     mailboxId: string;
-  }): Promise<{ ciphertext: string; preview: SendPreview } | { refused: SendRefusal }>;
+  }): Promise<{ ciphertext: string; preview: SendPreview } | SendRefused>;
+  /**
+   * The caller's own in-flight bundles, and whether each has been taken.
+   *
+   * The claimed-yet column is the feature, not the listing: a bundle you never handed off showing
+   * `claimedAt` is how a leaked or guessed code announces itself. Own sends only -- these ids are
+   * claim tickets, so the server scopes the query to the principal rather than to a workspace.
+   */
+  listSends(accessToken: string): Promise<SendMailbox[]>;
+  /** Destroys a bundle before anyone collects it. False if there was nothing there to destroy. */
+  revokeSend(input: { accessToken: string; mailboxId: string }): Promise<boolean>;
   /** The profile this repo must match to publish. `reader` is enough to read it. */
   workspaceProfile(input: {
     workspaceId: string;
@@ -195,7 +238,7 @@ export function createCloudApi(options: {
 
   async function request<T>(
     pathname: string,
-    init: { method: 'GET' | 'POST' | 'PATCH'; body?: unknown; accessToken?: string },
+    init: { method: 'GET' | 'POST' | 'PATCH' | 'DELETE'; body?: unknown; accessToken?: string },
   ): Promise<{ status: number; body: T & ApiErrorBody }> {
     const headers: Record<string, string> = { accept: 'application/json' };
     if (init.body !== undefined) headers['content-type'] = 'application/json';
@@ -226,6 +269,19 @@ export function createCloudApi(options: {
 
   function fail(pathname: string, status: number, body: ApiErrorBody): never {
     throw new CloudApiError(status, body.message ?? `${pathname} failed with ${status}`, body.code);
+  }
+
+  /**
+   * A refusal, keeping whatever the server actually said.
+   *
+   * **The reason is not narrowed to a known member**, deliberately. The server's enum grows
+   * independently of this client -- it gained `conflict` and `rate_limited` after 5.1.0 shipped --
+   * and coercing an unrecognised value to `fallback` is what made a sender at their quota read
+   * "No bundle waiting on that code". Carrying the string and the message lets the CLI print a
+   * known reason in its own words and an unknown one in the server's.
+   */
+  function refusalOf(body: { reason?: string; message?: string } | undefined, fallback: SendRefusal): SendRefused {
+    return { refused: body?.reason ?? fallback, message: body?.message };
   }
 
   return {
@@ -334,6 +390,12 @@ export function createCloudApi(options: {
           },
         },
       );
+      // 409 is a mailbox-id collision and 429 is the sender's in-flight quota. Both are refusals a
+      // sender can act on, not transport failures, so they come back as values rather than throws
+      // -- and they carry the server's own wording, which is the half a `reason` cannot express.
+      if (status === 409 || status === 429) {
+        return refusalOf(body as { reason?: string; message?: string }, 'conflict');
+      }
       if (status !== 200 && status !== 201) fail('/send', status, body as { code?: string; message?: string });
       return { mailboxId: body.mailboxId, expiresAt: body.expiresAt };
     },
@@ -352,7 +414,7 @@ export function createCloudApi(options: {
 
     async claimSend(input) {
       const { status, body } = await request<{
-        ciphertext: string; preview: SendPreview; reason?: SendRefusal;
+        ciphertext: string; preview: SendPreview; reason?: string; message?: string;
       }>(
         `/v1/send/${encodeURIComponent(input.mailboxId)}`,
         { method: 'POST', accessToken: input.accessToken },
@@ -360,11 +422,32 @@ export function createCloudApi(options: {
       // The claim discriminates where the peek does not: by now the caller has proven they hold
       // the code, so telling them *why* it failed costs nothing and is the difference between
       // "ask for a re-send" and "check what you typed".
-      if (status === 404 || status === 410) {
-        return { refused: (body?.reason ?? 'not_found') as SendRefusal };
+      if (status === 404 || status === 410 || status === 429) {
+        return refusalOf(body, 'not_found');
       }
       if (status !== 200) fail('/send/:id claim', status, body as { code?: string; message?: string });
       return { ciphertext: body.ciphertext, preview: body.preview };
+    },
+
+    async listSends(accessToken) {
+      const { status, body } = await request<{ mailboxes?: SendMailbox[] }>(
+        '/v1/send',
+        { method: 'GET', accessToken },
+      );
+      if (status !== 200) fail('/send', status, body as { code?: string; message?: string });
+      return body.mailboxes ?? [];
+    },
+
+    async revokeSend(input) {
+      const { status, body } = await request<unknown>(
+        `/v1/send/${encodeURIComponent(input.mailboxId)}`,
+        { method: 'DELETE', accessToken: input.accessToken },
+      );
+      // 404 is not an error here: revoking is idempotent, and a caller walking both derivations
+      // asks for an id that was never there by design.
+      if (status === 404 || status === 410) return false;
+      if (status !== 200) fail('/send/:id revoke', status, body as { code?: string; message?: string });
+      return true;
     },
 
     async workspaceProfile(input) {

--- a/src/cloud/send/argon2.ts
+++ b/src/cloud/send/argon2.ts
@@ -1,0 +1,77 @@
+import crypto from 'node:crypto';
+import { argon2id as nobleArgon2id } from '@noble/hashes/argon2.js';
+
+/**
+ * Argon2id, on whichever runtime this is.
+ *
+ * **Why a memory-hard KDF at all.** The send code is five words, about 2^55, and both the mailbox
+ * id and the sealing key come off it. HKDF-SHA256 -- what v1 used -- is fast by design, so a
+ * database snapshot could be ground against stored mailbox ids in hours-to-days on a GPU rig:
+ * inside a mailbox's own 24-72 hour life. 2^55 is only expensive if each guess is expensive, and
+ * at 64 MiB per guess it is.
+ *
+ * **Why two backends.** `crypto.argon2Sync` landed in Node 24.7 and this package declares
+ * `engines: node >=22`. Bumping that floor would drop Node 22 LTS -- supported until April 2027 --
+ * for every knowl user, over a feature most of them do not use. So the built-in is preferred where
+ * it exists and `@noble/hashes` covers the rest: audited, no dependencies of its own, and verified
+ * byte-identical to Node's before it was chosen. `tests/cloud/send-argon2.test.ts` pins that
+ * equality, because two backends that disagreed by one byte would make a bundle sealed on Node 24
+ * unopenable on Node 22 -- reported as "no bundle waiting on that code", indistinguishable from a
+ * typo.
+ *
+ * This is the one dependency in this corner of the tree, in a repository that treats a package
+ * added for ten lines as a supply-chain surface added for ten lines. The honest accounting is that
+ * it is not for ten lines: it is what lets a memory-hard KDF ship without a major version bump.
+ */
+
+/**
+ * 64 MiB, three passes, no parallelism -- about 0.6s natively and 1.4s through the fallback,
+ * which is the 0.5-1s band this is supposed to sit in.
+ *
+ * `parallelism: 1` deliberately. Lanes help a defender with spare cores and help an attacker with
+ * thousands, and a CLI deriving exactly one key has nothing to parallelise.
+ */
+export const ARGON2_PARAMS = { memory: 65_536, passes: 3, parallelism: 1 } as const;
+
+/**
+ * Node 24.7's addition, reached through a probe rather than a type import.
+ *
+ * `@types/node` is pinned at 22 to match the declared engines floor, which is the right pin: it is
+ * what stops the rest of this codebase from reaching for a Node 24 API unguarded. So the signature
+ * is declared here, narrowly, at the one place that has checked for it at runtime.
+ */
+type Argon2Sync = (algorithm: 'argon2id', options: {
+  message: Uint8Array;
+  nonce: Uint8Array;
+  parallelism: number;
+  tagLength: number;
+  memory: number;
+  passes: number;
+}) => Uint8Array;
+
+const builtin = (crypto as unknown as { argon2Sync?: Argon2Sync }).argon2Sync;
+
+/** Null below Node 24.7. Exported so the equality test can tell "agreed" from "not checked". */
+export const nativeArgon2id: ((secret: string, salt: string, length: number) => Buffer) | null =
+  typeof builtin === 'function'
+    ? (secret, salt, length) => Buffer.from(builtin('argon2id', {
+        message: Buffer.from(secret, 'utf8'),
+        nonce: Buffer.from(salt, 'utf8'),
+        tagLength: length,
+        ...ARGON2_PARAMS,
+      }))
+    : null;
+
+export function fallbackArgon2id(secret: string, salt: string, length: number): Buffer {
+  return Buffer.from(nobleArgon2id(Buffer.from(secret, 'utf8'), Buffer.from(salt, 'utf8'), {
+    t: ARGON2_PARAMS.passes,
+    m: ARGON2_PARAMS.memory,
+    p: ARGON2_PARAMS.parallelism,
+    dkLen: length,
+  }));
+}
+
+/** The same bytes either way. Which one ran is a performance fact, never a correctness one. */
+export function argon2id(secret: string, salt: string, length: number): Buffer {
+  return (nativeArgon2id ?? fallbackArgon2id)(secret, salt, length);
+}

--- a/src/cloud/send/code.ts
+++ b/src/cloud/send/code.ts
@@ -1,5 +1,6 @@
 import { hkdfSync, randomInt } from 'node:crypto';
 import { WORDLIST } from './wordlist.js';
+import { argon2id } from './argon2.js';
 
 /**
  * Words in a code. Five of 2048 is about 2^55.
@@ -12,13 +13,47 @@ import { WORDLIST } from './wordlist.js';
 export const CODE_WORDS = 5;
 
 /**
+ * A sixth word, on request: 2048^6, about 2^66.
+ *
+ * Cheap alongside the v2 derivation and pointless instead of it. What made 2^55 reachable was the
+ * cost per guess, not the exponent -- 11 more bits against a fast KDF buys hours, while 64 MiB per
+ * guess takes the whole codespace out of reach. Offered because a sender who wants both can have
+ * both, and the server never learns how long a code was: the derivation's output width is fixed.
+ */
+export const MAX_CODE_WORDS = 6;
+
+/**
+ * Which derivation produced a mailbox id and a sealing key.
+ *
+ * v1 is HKDF-SHA256 straight off the code, which is what knowl 5.1.0 shipped and what every
+ * bundle already in flight was sealed under. v2 is Argon2id. Both stay, because a 5.1.0 sender
+ * outlives the last v1 bundle by however long it takes that install to be upgraded.
+ */
+export type DerivationVersion = 1 | 2;
+
+/** What a fresh send uses. */
+export const CURRENT_DERIVATION: DerivationVersion = 2;
+
+/**
+ * The order a receiver tries, newest first.
+ *
+ * **The id is the lookup key, so a receiver has to pick a derivation before it can read
+ * anything.** Nothing inside the bundle can tell it which, because the bundle is only reachable
+ * once the id is known -- so the only way to stay compatible is to derive both and ask twice. One
+ * round trip for a v2 bundle, two for a v1 bundle or a mistyped code.
+ */
+export const DERIVATION_VERSIONS: readonly DerivationVersion[] = [2, 1];
+
+/**
  * Fixed, published, and not a secret.
  *
- * HKDF wants a salt and there is nothing to agree on out of band here -- the two humans exchange
- * the code and nothing else. All of the entropy lives in the code, so a constant salt costs
- * nothing; its job is domain separation from any other HKDF use in this codebase.
+ * There is nothing to agree on out of band here -- the two humans exchange the code and nothing
+ * else -- and all of the entropy lives in the code, so a constant salt costs nothing. Its job is
+ * domain separation, and the version in it is what stops a v2 derivation from ever colliding with
+ * a v3 one over the same code.
  */
-const SALT = Buffer.from('knowl-send-v1', 'utf8');
+const SALT_V1 = Buffer.from('knowl-send-v1', 'utf8');
+const SALT_V2 = 'knowl-send:v2';
 
 /**
  * The code, as a human will actually give it back.
@@ -37,27 +72,61 @@ export function normalizeCode(code: string): string {
  * `randomInt` rather than `Math.random`: this is the entire secret. `randomInt` is also rejection-
  * sampled by Node, so the distribution over 2048 is uniform rather than biased by a modulo.
  */
-export function generateCode(): string {
-  return Array.from({ length: CODE_WORDS }, () => WORDLIST[randomInt(WORDLIST.length)]).join('-');
+export function generateCode(words: number = CODE_WORDS): string {
+  if (!Number.isInteger(words) || words < CODE_WORDS || words > MAX_CODE_WORDS) {
+    throw new Error(`A code is ${CODE_WORDS} or ${MAX_CODE_WORDS} words, not ${words}.`);
+  }
+  return Array.from({ length: words }, () => WORDLIST[randomInt(WORDLIST.length)]).join('-');
+}
+
+/** Where the bundle lives, and what unlocks it. */
+export type SendSecrets = { mailboxId: string; key: Buffer };
+
+/**
+ * One memory-hard pass, split by HKDF into the public id and the secret key.
+ *
+ * **Why one Argon2id call and not two.** The issue this implements reads as one derivation per
+ * domain string. An attacker grinding the codespace against stored mailbox ids only ever needs the
+ * *id*, so they pay for exactly one Argon2id per guess either way -- a second call costs the
+ * honest client double and the attacker nothing. The versioned domain strings survive as the HKDF
+ * labels, which is where they do their work.
+ *
+ * The id is public: it travels to the server, is stored, and appears in logs. It still cannot
+ * disclose the key, for the same reason it could not in v1 -- it is a 16-byte HKDF output over a
+ * 256-bit master, and running that backwards is the infeasible step.
+ *
+ * 16 bytes, so the id is 32 lowercase hex. That is not an arbitrary width: the server's contract
+ * pins `^[a-f0-9]{32}$|^[a-f0-9]{64}$`, which is why a v2 derivation needs no server change at
+ * all.
+ */
+function deriveV2(code: string): SendSecrets {
+  const master = argon2id(normalizeCode(code), SALT_V2, 32);
+  return {
+    mailboxId: Buffer.from(hkdfSync('sha256', master, SALT_V2, 'knowl-send:id:v2', 16)).toString('hex'),
+    key: Buffer.from(hkdfSync('sha256', master, SALT_V2, 'knowl-send:key:v2', 32)),
+  };
 }
 
 /**
- * Where the bundle lives, and what unlocks it -- derived from the same code, and independent.
+ * knowl 5.1.0's derivation, kept verbatim.
  *
- * The id is public: it travels to the server, is stored, and appears in logs. The key never
- * leaves this machine. Both come from one secret, so they are two HKDF outputs under distinct
- * `info` labels, which is the standard construction for exactly this and states the independence
- * rather than leaving a reader to deduce it.
- *
- * PR #50 specifies `sha256(code)` for the id, which is also safe -- SHA-256 is one-way, so the id
- * does not disclose the key. The server stores whatever id it is handed, so this is a client-side
- * choice with no contract impact.
+ * Two HKDF-SHA256 outputs under distinct `info` labels -- safe against the id disclosing the key,
+ * and fast, which is the whole problem. Nothing here may change: every byte of it is what a
+ * bundle already sitting in the drop box was addressed and sealed under.
  */
-export function deriveMailboxId(code: string): string {
-  const derived = hkdfSync('sha256', normalizeCode(code), SALT, 'knowl-send:id:v1', 16);
-  return Buffer.from(derived).toString('hex');
+function deriveV1(code: string): SendSecrets {
+  const normalized = normalizeCode(code);
+  return {
+    mailboxId: Buffer.from(hkdfSync('sha256', normalized, SALT_V1, 'knowl-send:id:v1', 16)).toString('hex'),
+    key: Buffer.from(hkdfSync('sha256', normalized, SALT_V1, 'knowl-send:key:v1', 32)),
+  };
 }
 
-export function deriveKey(code: string): Buffer {
-  return Buffer.from(hkdfSync('sha256', normalizeCode(code), SALT, 'knowl-send:key:v1', 32));
+export function deriveSecrets(code: string, version: DerivationVersion): SendSecrets {
+  return version === 2 ? deriveV2(code) : deriveV1(code);
+}
+
+/** Where the bundle lives, for callers that need the address and not the key. */
+export function deriveMailboxId(code: string, version: DerivationVersion): string {
+  return deriveSecrets(code, version).mailboxId;
 }

--- a/src/cloud/send/seal.ts
+++ b/src/cloud/send/seal.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
-import { deriveKey } from './code.js';
+import type { DerivationVersion } from './code.js';
 
 /**
  * Sealing, with `node:crypto` and no dependency.
@@ -9,7 +9,11 @@ import { deriveKey } from './code.js';
  *
  * A library with a nicer API would be one dependency for one encrypt and one decrypt, in a
  * repository that treats a package added for ten lines as a supply-chain surface added for ten
- * lines. `hkdfSync`, `randomBytes` and `aes-256-gcm` are all already here.
+ * lines. `randomBytes` and `aes-256-gcm` are both already here.
+ *
+ * **These functions take the derived key, not the code.** Deriving is Argon2id at 64 MiB since v2,
+ * so a signature that took the code would make every send pay for it twice -- once to address the
+ * mailbox and once to seal it. The caller derives once and passes both halves where they go.
  *
  * **The server can open none of this.** It receives the sealed bytes and an id derived from the
  * same code under a different label; the key never leaves the sender's machine. That is the whole
@@ -21,31 +25,61 @@ import { deriveKey } from './code.js';
 const NONCE_BYTES = 12;
 const TAG_BYTES = 16;
 
-/** `nonce || ciphertext || tag`, which is what goes over the wire, base64'd by the caller. */
-export function seal(payload: Buffer, code: string): Buffer {
+/**
+ * A v2 bundle says so, in a byte the tag covers.
+ *
+ * The version is already known by the time anything is unsealed -- it comes from *which mailbox id
+ * hit*, since the id is the lookup key and its derivation is what changed. So this byte is a
+ * cross-check rather than a discriminator, and it could not have been the discriminator anyway: a
+ * v1 bundle opens with a random nonce whose first byte is 0x02 once in 256.
+ *
+ * It is **additional authenticated data**, not merely a prefix. A prefix a receiver reads and
+ * trusts is a byte an attacker can flip to steer which key schedule gets used; as AAD, flipping it
+ * fails the tag.
+ */
+const VERSION_BYTE = 2;
+
+/**
+ * `nonce || ciphertext || tag` for v1, and `0x02 || nonce || ciphertext || tag` for v2 -- which is
+ * what goes over the wire, base64'd by the caller.
+ */
+export function seal(payload: Buffer, key: Buffer, version: DerivationVersion): Buffer {
   // Fresh per seal. Reuse under one key is the failure GCM does not survive, and while a fresh
   // code per send already gives a fresh key, this does not depend on that staying true.
   const nonce = randomBytes(NONCE_BYTES);
-  const cipher = createCipheriv('aes-256-gcm', deriveKey(code), nonce);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  const prefix = version === 2 ? Buffer.of(VERSION_BYTE) : Buffer.alloc(0);
+  if (version === 2) cipher.setAAD(prefix);
   const ciphertext = Buffer.concat([cipher.update(payload), cipher.final()]);
-  return Buffer.concat([nonce, ciphertext, cipher.getAuthTag()]);
+  return Buffer.concat([prefix, nonce, ciphertext, cipher.getAuthTag()]);
 }
 
 /**
- * Throws on a wrong code, a truncated blob or a flipped bit. Never returns partial plaintext.
+ * Throws on a wrong code, a truncated blob, a flipped bit or a version that does not match what
+ * the mailbox id said. Never returns partial plaintext.
  *
  * The caller is about to hand the result to `importKnowledge`, so "decrypted to something" and
  * "decrypted to the right thing" have to be the same question. GCM's tag is what makes them one.
+ *
+ * `version` comes from the peek that succeeded, not from the bytes -- see `VERSION_BYTE`.
  */
-export function unseal(sealed: Buffer, code: string): Buffer {
-  if (sealed.length < NONCE_BYTES + TAG_BYTES) {
+export function unseal(sealed: Buffer, key: Buffer, version: DerivationVersion): Buffer {
+  const prefixLength = version === 2 ? 1 : 0;
+  if (sealed.length < prefixLength + NONCE_BYTES + TAG_BYTES) {
     throw new Error('That bundle is too short to be a sealed payload.');
   }
-  const nonce = sealed.subarray(0, NONCE_BYTES);
-  const ciphertext = sealed.subarray(NONCE_BYTES, sealed.length - TAG_BYTES);
+  if (version === 2 && sealed[0] !== VERSION_BYTE) {
+    // The mailbox id said v2 and the bundle says otherwise. Reaching this means the stored blob is
+    // not the one that id addresses, so there is nothing safe to try next.
+    throw new Error('That bundle does not carry the derivation its mailbox id promised.');
+  }
+
+  const nonce = sealed.subarray(prefixLength, prefixLength + NONCE_BYTES);
+  const ciphertext = sealed.subarray(prefixLength + NONCE_BYTES, sealed.length - TAG_BYTES);
   const tag = sealed.subarray(sealed.length - TAG_BYTES);
 
-  const decipher = createDecipheriv('aes-256-gcm', deriveKey(code), nonce);
+  const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+  if (version === 2) decipher.setAAD(sealed.subarray(0, 1));
   decipher.setAuthTag(tag);
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }

--- a/src/cloud/send/transfer.ts
+++ b/src/cloud/send/transfer.ts
@@ -5,10 +5,16 @@ import { randomUUID } from 'node:crypto';
 import type { ProjectConfig } from '../../core/types.js';
 import { closeDb, initDb } from '../../store/database.js';
 import { exportKnowledge, importKnowledge } from '../../store/portability.js';
-import { createCloudApi, type CloudApi, type SendPreview, type SendRefusal } from '../api-client.js';
+import {
+  createCloudApi,
+  type CloudApi, type SendMailbox, type SendPreview, type SendRefusal,
+} from '../api-client.js';
 import { cloudPointer } from '../../core/cloud-pointer.js';
 import { ensureAccessToken } from '../token.js';
-import { deriveMailboxId, generateCode } from './code.js';
+import {
+  CODE_WORDS, CURRENT_DERIVATION, DERIVATION_VERSIONS,
+  deriveSecrets, generateCode, type DerivationVersion,
+} from './code.js';
 import { seal, unseal } from './seal.js';
 
 /**
@@ -25,16 +31,69 @@ export type SendResult =
   | { status: 'not-connected' }
   | { status: 'not-logged-in' }
   | { status: 'nothing-selected' }
+  | { status: 'refused'; reason: SendRefusal; message?: string }
   | { status: 'sent'; code: string; itemCount: number; expiresAt: string };
 
 export type ReceiveResult =
   | { status: 'not-connected' }
   | { status: 'not-logged-in' }
-  | { status: 'refused'; reason: SendRefusal }
+  | { status: 'refused'; reason: SendRefusal; message?: string }
   | { status: 'received'; preview: SendPreview; imported: Awaited<ReturnType<typeof importKnowledge>> };
+
+/**
+ * A bundle located, with everything needed to open it and nothing derived twice.
+ *
+ * Argon2id at 64 MiB costs 0.6-1.4s a call, so `knowl cloud receive` re-deriving between the peek
+ * and the claim would pay for it four times over -- peek v2, peek v1, claim v2, claim v1 -- where
+ * one will do. Threaded explicitly rather than memoised in a module-level cache: a process-
+ * lifetime map keyed by code, holding sealing keys, is a worse artefact than a parameter.
+ */
+export type ResolvedSend = {
+  preview: SendPreview;
+  mailboxId: string;
+  key: Buffer;
+  version: DerivationVersion;
+};
+
+/**
+ * What to tell the human, for a reason this build knows — and the server's own words for one it
+ * does not.
+ *
+ * The fallback is the point. knowl-cloud's `reason` enum grows independently of this client, and
+ * before this existed an unrecognised value fell through a lookup to `undefined` and the CLI
+ * printed the `not_found` line: a sender at their in-flight quota was told the bundle they had
+ * just minted did not exist. Showing the server's `message` is worse writing than a line tuned
+ * here and infinitely better than a confident wrong answer.
+ */
+export function refusalMessage(reason: SendRefusal, message?: string): string {
+  const known: Record<string, string> = {
+    not_found: 'No bundle waiting on that code. Check what you typed, or ask for a re-send.',
+    expired: 'That bundle expired. Ask for a new one.',
+    already_claimed: 'That bundle was already collected. Ask for a new one.',
+    conflict: 'That code collided with one already in flight. Run the send again for a fresh code.',
+    rate_limited: 'You have too many bundles in flight. Wait for one to be collected or to expire.',
+  };
+  return known[reason] ?? message ?? `The server refused that: ${reason}.`;
+}
 
 /** A temp path that cannot collide with a concurrent send in the same process or another one. */
 const scratchFile = (suffix: string) => path.join(tmpdir(), `knowl-send-${randomUUID()}.${suffix}`);
+
+/** Everything a cloud verb needs before it can make a call, or the reason it cannot. */
+async function connect(
+  config: ProjectConfig,
+  api?: CloudApi,
+): Promise<{ api: CloudApi; accessToken: string } | 'not-connected' | 'not-logged-in'> {
+  const pointer = cloudPointer(config);
+  if (!pointer) return 'not-connected';
+  const resolved = api ?? createCloudApi({ apiHost: pointer.apiHost });
+  const credential = await ensureAccessToken({
+    apiHost: pointer.apiHost,
+    refresh: refreshToken => resolved.refresh(refreshToken),
+  });
+  if (!credential) return 'not-logged-in';
+  return { api: resolved, accessToken: credential.accessToken };
+}
 
 export async function sendKnowledge(input: {
   projectRoot: string;
@@ -43,30 +102,25 @@ export async function sendKnowledge(input: {
   itemIds: readonly string[];
   senderLabel: string;
   expiresInHours: number;
+  words?: number;
   api?: CloudApi;
 }): Promise<SendResult> {
-  const pointer = cloudPointer(input.config);
-  if (!pointer) return { status: 'not-connected' };
   if (input.itemIds.length === 0) return { status: 'nothing-selected' };
-
-  const api = input.api ?? createCloudApi({ apiHost: pointer.apiHost });
-  const credential = await ensureAccessToken({
-    apiHost: pointer.apiHost,
-    refresh: refreshToken => api.refresh(refreshToken),
-  });
-  if (!credential) return { status: 'not-logged-in' };
+  const session = await connect(input.config, input.api);
+  if (typeof session === 'string') return { status: session };
 
   // The code exists only in this function and in whatever the human pastes into chat. It is never
   // written to disk, never logged, and never sent — the server receives an id derived from it
-  // under a different HKDF label, which cannot be walked back to the key.
-  const code = generateCode();
+  // through a memory-hard KDF under a different label, which cannot be walked back to the key.
+  const code = generateCode(input.words ?? CODE_WORDS);
+  const { mailboxId, key } = deriveSecrets(code, CURRENT_DERIVATION);
   const file = scratchFile('jsonl');
 
   await initDb(input.projectRoot);
   let sealed: Buffer;
   try {
     await exportKnowledge(input.projectId, file, input.projectRoot, input.itemIds);
-    sealed = seal(await readFile(file), code);
+    sealed = seal(await readFile(file), key, CURRENT_DERIVATION);
   } finally {
     await closeDb();
     // The plaintext export is the one artefact worth cleaning up even on failure: it is the
@@ -74,62 +128,74 @@ export async function sendKnowledge(input: {
     await rm(file, { force: true }).catch(() => {});
   }
 
-  const { expiresAt } = await api.createSend({
-    accessToken: credential.accessToken,
-    mailboxId: deriveMailboxId(code),
+  const created = await session.api.createSend({
+    accessToken: session.accessToken,
+    mailboxId,
     ciphertext: sealed.toString('base64'),
     senderLabel: input.senderLabel,
     itemCount: input.itemIds.length,
     expiresInHours: input.expiresInHours,
   });
+  if ('refused' in created) {
+    return { status: 'refused', reason: created.refused, message: created.message };
+  }
 
-  return { status: 'sent', code, itemCount: input.itemIds.length, expiresAt };
+  return { status: 'sent', code, itemCount: input.itemIds.length, expiresAt: created.expiresAt };
 }
 
-/** Reads the label without spending the single claim, so a receiver can decline knowingly. */
+/**
+ * Finds the bundle, and learns which derivation addressed it, without spending the single claim.
+ *
+ * **The id is the lookup key, so the derivation has to be chosen before anything can be read.**
+ * Nothing inside a bundle can say which one, because the bundle is only reachable once the id is
+ * known — so the walk is the compatibility mechanism, not a fallback bolted on beside one. Newest
+ * first: a v2 bundle costs one round trip, a v1 bundle or a mistyped code two.
+ *
+ * A v1 bundle stays claimable for as long as any 5.1.0 install is still sending, which outlives
+ * the 72-hour ceiling on a mailbox by however long that install goes un-upgraded.
+ */
 export async function previewSend(input: {
   config: ProjectConfig;
   code: string;
   api?: CloudApi;
-}): Promise<SendPreview | null | 'not-connected' | 'not-logged-in'> {
-  const pointer = cloudPointer(input.config);
-  if (!pointer) return 'not-connected';
-  const api = input.api ?? createCloudApi({ apiHost: pointer.apiHost });
-  const credential = await ensureAccessToken({
-    apiHost: pointer.apiHost,
-    refresh: refreshToken => api.refresh(refreshToken),
-  });
-  if (!credential) return 'not-logged-in';
-  return api.peekSend({ accessToken: credential.accessToken, mailboxId: deriveMailboxId(input.code) });
+}): Promise<ResolvedSend | null | 'not-connected' | 'not-logged-in'> {
+  const session = await connect(input.config, input.api);
+  if (typeof session === 'string') return session;
+
+  for (const version of DERIVATION_VERSIONS) {
+    const { mailboxId, key } = deriveSecrets(input.code, version);
+    const preview = await session.api.peekSend({ accessToken: session.accessToken, mailboxId });
+    if (preview) return { preview, mailboxId, key, version };
+  }
+  return null;
 }
 
 export async function receiveKnowledge(input: {
   projectRoot: string;
   config: ProjectConfig;
-  code: string;
+  resolved: ResolvedSend;
   api?: CloudApi;
 }): Promise<ReceiveResult> {
-  const pointer = cloudPointer(input.config);
-  if (!pointer) return { status: 'not-connected' };
+  const session = await connect(input.config, input.api);
+  if (typeof session === 'string') return { status: session };
 
-  const api = input.api ?? createCloudApi({ apiHost: pointer.apiHost });
-  const credential = await ensureAccessToken({
-    apiHost: pointer.apiHost,
-    refresh: refreshToken => api.refresh(refreshToken),
+  const claimed = await session.api.claimSend({
+    accessToken: session.accessToken,
+    mailboxId: input.resolved.mailboxId,
   });
-  if (!credential) return { status: 'not-logged-in' };
-
-  const claimed = await api.claimSend({
-    accessToken: credential.accessToken,
-    mailboxId: deriveMailboxId(input.code),
-  });
-  if ('refused' in claimed) return { status: 'refused', reason: claimed.refused };
+  if ('refused' in claimed) {
+    return { status: 'refused', reason: claimed.refused, message: claimed.message };
+  }
 
   // Unsealing throws on a wrong code, a truncated blob or a flipped bit, and that throw happens
   // BEFORE the database is opened. A bundle that cannot be authenticated must never reach
   // `importKnowledge`, because "decrypted to something" and "decrypted to the right thing" have
   // to be the same question when the answer is written into somebody's store.
-  const plaintext = unseal(Buffer.from(claimed.ciphertext, 'base64'), input.code);
+  const plaintext = unseal(
+    Buffer.from(claimed.ciphertext, 'base64'),
+    input.resolved.key,
+    input.resolved.version,
+  );
 
   const file = scratchFile('jsonl');
   await writeFile(file, plaintext);
@@ -141,4 +207,47 @@ export async function receiveKnowledge(input: {
     await closeDb();
     await rm(file, { force: true }).catch(() => {});
   }
+}
+
+/**
+ * The caller's own in-flight bundles.
+ *
+ * Read this as a detection surface first: a bundle nobody was ever given, showing `claimedAt`, is
+ * how a leaked or guessed code announces itself. The ids are opaque to the sender — codes are
+ * never stored, which is deliberate and stays that way — so this answers "was anything taken",
+ * not "which one of mine was it".
+ */
+export async function listSends(input: {
+  config: ProjectConfig;
+  api?: CloudApi;
+}): Promise<SendMailbox[] | 'not-connected' | 'not-logged-in'> {
+  const session = await connect(input.config, input.api);
+  if (typeof session === 'string') return session;
+  return session.api.listSends(session.accessToken);
+}
+
+/**
+ * Destroys a bundle before anyone collects it, addressed by a mailbox id or by the code itself.
+ *
+ * A code goes through the same v2-then-v1 walk a receiver uses, because a sender revoking one they
+ * minted on an older client has a v1 id whether they know it or not. A raw id is tried as given
+ * and nothing is derived — that is the path for an id copied out of `--list`, where no code exists
+ * to derive from.
+ */
+export async function revokeSend(input: {
+  config: ProjectConfig;
+  target: string;
+  api?: CloudApi;
+}): Promise<boolean | 'not-connected' | 'not-logged-in'> {
+  const session = await connect(input.config, input.api);
+  if (typeof session === 'string') return session;
+
+  const candidates = /^[a-f0-9]{32}$|^[a-f0-9]{64}$/.test(input.target.trim().toLowerCase())
+    ? [input.target.trim().toLowerCase()]
+    : DERIVATION_VERSIONS.map(version => deriveSecrets(input.target, version).mailboxId);
+
+  for (const mailboxId of candidates) {
+    if (await session.api.revokeSend({ accessToken: session.accessToken, mailboxId })) return true;
+  }
+  return false;
 }

--- a/tests/cloud/send-argon2.test.ts
+++ b/tests/cloud/send-argon2.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { ARGON2_PARAMS, argon2id, fallbackArgon2id, nativeArgon2id } from '../../src/cloud/send/argon2.js';
+
+/**
+ * The one property a two-backend KDF has to keep.
+ *
+ * `send` derives on the sender's runtime and `receive` derives on the receiver's, and nothing
+ * makes those the same Node version. If the built-in and the fallback disagreed by one byte, a
+ * bundle sealed on Node 24 would be unopenable on Node 22 -- and it would fail as "no bundle
+ * waiting on that code", because a derivation that lands on the wrong mailbox id looks exactly
+ * like a typo. That is the failure this file exists to prevent.
+ */
+describe('the two Argon2id backends', () => {
+  it('agree byte for byte, or a bundle stops crossing Node versions', () => {
+    if (!nativeArgon2id) {
+      // Node < 24.7 has only one backend, so there is nothing to compare. Skipped rather than
+      // silently passing: a green run on such a runtime has NOT checked this.
+      expect(nativeArgon2id).toBeNull();
+      return;
+    }
+    const secret = 'owl-cascade-ridge-plum-tin';
+    const salt = 'knowl-send:v2';
+    expect(Buffer.from(nativeArgon2id(secret, salt, 32)).toString('hex'))
+      .toBe(Buffer.from(fallbackArgon2id(secret, salt, 32)).toString('hex'));
+  });
+
+  it('is reached through whichever one exists', () => {
+    const derived = argon2id('owl-cascade-ridge-plum-tin', 'knowl-send:v2', 32);
+    expect(derived).toHaveLength(32);
+    const expected = nativeArgon2id ?? fallbackArgon2id;
+    expect(derived.equals(expected('owl-cascade-ridge-plum-tin', 'knowl-send:v2', 32))).toBe(true);
+  });
+});
+
+describe('the cost parameters', () => {
+  it('are the ones the whole change is for', () => {
+    // 64 MiB per guess is the number that takes 2^55 out of reach. A later edit that quietly
+    // lowered it would leave every test in this repository green while undoing the issue.
+    expect(ARGON2_PARAMS.memory).toBe(65_536);
+    expect(ARGON2_PARAMS.passes).toBe(3);
+    expect(ARGON2_PARAMS.parallelism).toBe(1);
+  });
+});
+
+describe('the derivation itself', () => {
+  it('separates domains by salt', () => {
+    const secret = 'owl-cascade-ridge-plum-tin';
+    expect(argon2id(secret, 'knowl-send:v2', 32).equals(argon2id(secret, 'knowl-send:v3', 32)))
+      .toBe(false);
+  });
+
+  it('is deterministic, or the recipient cannot find the bundle', () => {
+    const a = argon2id('owl-cascade-ridge-plum-tin', 'knowl-send:v2', 32);
+    const b = argon2id('owl-cascade-ridge-plum-tin', 'knowl-send:v2', 32);
+    expect(a.equals(b)).toBe(true);
+  });
+});

--- a/tests/cloud/send-code.test.ts
+++ b/tests/cloud/send-code.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { WORDLIST } from '../../src/cloud/send/wordlist.js';
-import { CODE_WORDS, deriveKey, deriveMailboxId, generateCode, normalizeCode } from '../../src/cloud/send/code.js';
+import {
+  CODE_WORDS, CURRENT_DERIVATION, DERIVATION_VERSIONS, MAX_CODE_WORDS,
+  deriveMailboxId, deriveSecrets, generateCode, normalizeCode,
+} from '../../src/cloud/send/code.js';
 import { seal, unseal } from '../../src/cloud/send/seal.js';
 
 describe('the send code', () => {
@@ -9,6 +12,18 @@ describe('the send code', () => {
     const words = code.split('-');
     expect(words).toHaveLength(CODE_WORDS);
     for (const word of words) expect(WORDLIST).toContain(word);
+  });
+
+  it('takes a sixth word on request, for the sender who wants 2^66', () => {
+    const words = generateCode(MAX_CODE_WORDS).split('-');
+    expect(words).toHaveLength(MAX_CODE_WORDS);
+    for (const word of words) expect(WORDLIST).toContain(word);
+  });
+
+  it('refuses a length nobody asked for', () => {
+    // Four words is 2^44, which the wordlist would happily produce. A typo in a flag must not
+    // quietly weaken the one secret in this feature.
+    for (const words of [4, 7, 0, -1, 5.5]) expect(() => generateCode(words)).toThrow();
   });
 
   it('does not repeat itself', () => {
@@ -31,28 +46,64 @@ describe('the send code', () => {
 describe('deriving the mailbox id and the key from one code', () => {
   const code = 'owl-cascade-ridge-plum-tin';
 
-  it('is deterministic, or the recipient cannot find the bundle', () => {
-    expect(deriveMailboxId(code)).toBe(deriveMailboxId(code));
-    expect(deriveKey(code).equals(deriveKey(code))).toBe(true);
+  it('sends under v2 and still understands v1', () => {
+    expect(CURRENT_DERIVATION).toBe(2);
+    // Newest first: a v2 bundle costs one round trip and a v1 bundle two. Reversing this would
+    // make every receive pay the fallback.
+    expect([...DERIVATION_VERSIONS]).toEqual([2, 1]);
   });
 
-  it('gives a different id and key for a different code', () => {
-    expect(deriveMailboxId(code)).not.toBe(deriveMailboxId('owl-cascade-ridge-plum-tan'));
+  for (const version of DERIVATION_VERSIONS) {
+    describe(`v${version}`, () => {
+      it('is deterministic, or the recipient cannot find the bundle', () => {
+        const a = deriveSecrets(code, version);
+        const b = deriveSecrets(code, version);
+        expect(a.mailboxId).toBe(b.mailboxId);
+        expect(a.key.equals(b.key)).toBe(true);
+      });
+
+      it('gives a different id and key for a different code', () => {
+        expect(deriveMailboxId(code, version)).not.toBe(deriveMailboxId('owl-cascade-ridge-plum-tan', version));
+      });
+
+      it('derives the id and the key independently', () => {
+        // Both come from one secret, so the id -- which is public, and travels to the server --
+        // must not disclose the key. Distinct HKDF info labels is what buys that. A weak
+        // assertion, but it fails loudly if someone collapses the two labels into one.
+        const { mailboxId, key } = deriveSecrets(code, version);
+        const keyHex = key.toString('hex');
+        expect(mailboxId).not.toBe(keyHex);
+        expect(keyHex.startsWith(mailboxId)).toBe(false);
+        expect(mailboxId.startsWith(keyHex)).toBe(false);
+      });
+
+      it('normalizes before deriving, so a retyped code still finds the bundle', () => {
+        expect(deriveMailboxId('OWL CASCADE RIDGE PLUM TIN', version)).toBe(deriveMailboxId(code, version));
+      });
+
+      it('emits an id the server will accept', () => {
+        // Not cosmetic: knowl-cloud pins `^[a-f0-9]{32}$|^[a-f0-9]{64}$`, and an id of any other
+        // width is rejected at the schema before it reaches a handler. This is the assertion that
+        // says a v2 derivation needs no server change.
+        expect(deriveMailboxId(code, version)).toMatch(/^[a-f0-9]{32}$/);
+      });
+    });
+  }
+
+  it('addresses a different mailbox under v2 than under v1', () => {
+    // The reason a receiver has to try both. If these ever collided, the fallback would silently
+    // hand a v1 key to a v2 bundle.
+    expect(deriveMailboxId(code, 2)).not.toBe(deriveMailboxId(code, 1));
   });
 
-  it('derives the id and the key independently', () => {
-    // Both come from one secret, so the id -- which is public, and travels to the server -- must
-    // not disclose the key. Two HKDF calls with distinct info labels is what buys that. A weak
-    // assertion, but it fails loudly if someone collapses the two labels into one.
-    const id = deriveMailboxId(code);
-    const key = deriveKey(code).toString('hex');
-    expect(id).not.toBe(key);
-    expect(key.startsWith(id)).toBe(false);
-    expect(id.startsWith(key)).toBe(false);
-  });
-
-  it('normalizes before deriving, so a retyped code still finds the bundle', () => {
-    expect(deriveMailboxId('OWL CASCADE RIDGE PLUM TIN')).toBe(deriveMailboxId(code));
+  it('costs enough per guess to be worth the wait', () => {
+    // The whole point of #102, measured rather than asserted about. HKDF-SHA256 -- what v1 does --
+    // returns in microseconds; anything in that range here means the memory-hard pass is gone and
+    // 2^55 is grindable again. The bound is deliberately loose, because CI runners vary far more
+    // than the four orders of magnitude between the two answers.
+    const started = performance.now();
+    deriveSecrets(code, 2);
+    expect(performance.now() - started).toBeGreaterThan(50);
   });
 });
 
@@ -60,33 +111,64 @@ describe('sealing a bundle', () => {
   const code = 'owl-cascade-ridge-plum-tin';
   const payload = Buffer.from('{"format":3,"items":[{"id":"a"}]}\n', 'utf8');
 
-  it('round-trips byte for byte', () => {
-    expect(unseal(seal(payload, code), code).equals(payload)).toBe(true);
+  for (const version of DERIVATION_VERSIONS) {
+    describe(`v${version}`, () => {
+      const { key } = deriveSecrets(code, version);
+
+      it('round-trips byte for byte', () => {
+        expect(unseal(seal(payload, key, version), key, version).equals(payload)).toBe(true);
+      });
+
+      it('produces a different ciphertext every time, for the same input', () => {
+        // A fresh nonce per seal. Identical ciphertexts would leak that two people were handed the
+        // same bundle, to anybody who can read the table.
+        expect(seal(payload, key, version).equals(seal(payload, key, version))).toBe(false);
+      });
+
+      it('refuses a wrong code rather than returning garbage', () => {
+        // GCM's authentication tag doing its job. If this ever returns a Buffer instead of
+        // throwing, the cipher has been swapped for one without integrity and the receiver would
+        // import noise.
+        const wrong = deriveSecrets('owl-cascade-ridge-plum-tan', version).key;
+        expect(() => unseal(seal(payload, key, version), wrong, version)).toThrow();
+      });
+
+      it('refuses a tampered ciphertext', () => {
+        const sealed = seal(payload, key, version);
+        sealed[sealed.length - 1] ^= 0xff;
+        expect(() => unseal(sealed, key, version)).toThrow();
+      });
+
+      it('refuses a truncated blob', () => {
+        expect(() => unseal(Buffer.alloc(4), key, version)).toThrow(/too short/);
+      });
+
+      it('never contains the code or the key in what goes to the server', () => {
+        // The one property the server cannot check for itself, and the whole basis of the claim
+        // that it stores a blob it cannot open.
+        const sealed = seal(payload, key, version).toString('hex');
+        expect(sealed).not.toContain(Buffer.from(code, 'utf8').toString('hex'));
+        expect(sealed).not.toContain(key.toString('hex'));
+      });
+    });
+  }
+
+  it('says which derivation it carries, in a byte the tag covers', () => {
+    const { key } = deriveSecrets(code, 2);
+    const sealed = seal(payload, key, 2);
+    expect(sealed[0]).toBe(2);
+
+    // Flipping it must fail rather than steer the key schedule. This is why the byte is AAD and
+    // not a plain prefix -- as a prefix, a receiver would read the attacker's value and trust it.
+    sealed[0] ^= 0xff;
+    expect(() => unseal(sealed, key, 2)).toThrow();
   });
 
-  it('produces a different ciphertext every time, for the same input', () => {
-    // A fresh nonce per seal. Identical ciphertexts would leak that two people were handed the
-    // same bundle, to anybody who can read the table.
-    expect(seal(payload, code).equals(seal(payload, code))).toBe(false);
-  });
-
-  it('refuses a wrong code rather than returning garbage', () => {
-    // GCM's authentication tag doing its job. If this ever returns a Buffer instead of throwing,
-    // the cipher has been swapped for one without integrity and the receiver would import noise.
-    expect(() => unseal(seal(payload, code), 'owl-cascade-ridge-plum-tan')).toThrow();
-  });
-
-  it('refuses a tampered ciphertext', () => {
-    const sealed = seal(payload, code);
-    sealed[sealed.length - 1] ^= 0xff;
-    expect(() => unseal(sealed, code)).toThrow();
-  });
-
-  it('never contains the code or the key in what goes to the server', () => {
-    // The one property the server cannot check for itself, and the whole basis of the claim that
-    // it stores a blob it cannot open.
-    const sealed = seal(payload, code).toString('hex');
-    expect(sealed).not.toContain(Buffer.from(code, 'utf8').toString('hex'));
-    expect(sealed).not.toContain(deriveKey(code).toString('hex'));
+  it('leaves a v1 bundle exactly as knowl 5.1.0 wrote it', () => {
+    // No prefix byte, because bundles sealed by an already-published client are what the v1 path
+    // exists to open. `nonce(12) || ciphertext || tag(16)` and nothing else.
+    const { key } = deriveSecrets(code, 1);
+    expect(seal(payload, key, 1)).toHaveLength(12 + payload.length + 16);
+    expect(seal(payload, key, 2)).toHaveLength(1 + 12 + payload.length + 16);
   });
 });

--- a/tests/cloud/send-transfer.test.ts
+++ b/tests/cloud/send-transfer.test.ts
@@ -1,0 +1,325 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CloudApi, SendMailbox, SendPreview } from '../../src/cloud/api-client.js';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { clearCredential, writeCredential } from '../../src/cloud/credentials.js';
+import { deriveMailboxId } from '../../src/cloud/send/code.js';
+import {
+  listSends, previewSend, receiveKnowledge, refusalMessage, revokeSend, sendKnowledge,
+} from '../../src/cloud/send/transfer.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+const API_HOST = 'https://api.send.test';
+const HOME = path.resolve('./.knowl-send-home');
+const CODE = 'owl-cascade-ridge-plum-tin';
+
+let counter = 0;
+let SENDER = '';
+let RECEIVER = '';
+let config: ProjectConfig;
+
+const preview: SendPreview = {
+  senderLabel: 'github.com/acme/web',
+  itemCount: 1,
+  createdAt: '2026-08-14T10:00:00.000Z',
+  expiresAt: '2026-08-15T10:00:00.000Z',
+};
+
+/**
+ * A drop box that only answers for the id it was told to hold.
+ *
+ * Which id that is, is the whole subject of this file: it is what the derivation change moved, and
+ * a fake that answered any id would pass whether or not the fallback worked.
+ */
+function fakeApi(over: Partial<CloudApi> = {}): CloudApi {
+  return {
+    refresh: async () => { throw new Error('unused'); },
+    ...over,
+  } as unknown as CloudApi;
+}
+
+function drop(mailboxId: string, calls: string[]): Partial<CloudApi> {
+  return {
+    peekSend: async ({ mailboxId: asked }) => {
+      calls.push(asked);
+      return asked === mailboxId ? preview : null;
+    },
+  };
+}
+
+async function makeRepo(root: string) {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+}
+
+describe('finding a bundle when the derivation changed underneath it', () => {
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+    config = {
+      version: 1,
+      cloud: {
+        apiHost: API_HOST, workspaceId: 'ws-send', workspaceName: 'Acme',
+        repo: 'github.com/acme/web', remote: 'origin',
+      },
+    };
+    await writeCredential(API_HOST, {
+      accessToken: 'at', refreshToken: 'rt', sessionId: 'sess-1',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    await clearCredential(API_HOST).catch(() => {});
+    delete process.env.KNOWL_HOME;
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('asks for the v2 mailbox first, and stops there', async () => {
+    const calls: string[] = [];
+    const resolved = await previewSend({
+      config, code: CODE, api: fakeApi(drop(deriveMailboxId(CODE, 2), calls)),
+    });
+
+    expect(resolved).toMatchObject({ version: 2, mailboxId: deriveMailboxId(CODE, 2) });
+    // One round trip for the common case. A walk that asked v1 first, or asked both regardless,
+    // would make every receive pay for a compatibility path nothing needs.
+    expect(calls).toEqual([deriveMailboxId(CODE, 2)]);
+  });
+
+  it('falls back to v1, so a bundle from a 5.1.0 sender is still collectable', async () => {
+    const calls: string[] = [];
+    const resolved = await previewSend({
+      config, code: CODE, api: fakeApi(drop(deriveMailboxId(CODE, 1), calls)),
+    });
+
+    expect(resolved).toMatchObject({ version: 1, mailboxId: deriveMailboxId(CODE, 1) });
+    expect(calls).toEqual([deriveMailboxId(CODE, 2), deriveMailboxId(CODE, 1)]);
+  });
+
+  it('gives up after both, rather than reporting a miss as an error', async () => {
+    const calls: string[] = [];
+    expect(await previewSend({ config, code: CODE, api: fakeApi(drop('nothing-lives-here', calls)) }))
+      .toBeNull();
+    expect(calls).toHaveLength(2);
+  });
+
+  it('says which of the two preconditions is missing before it derives anything', async () => {
+    expect(await previewSend({ config: { version: 1 }, code: CODE, api: fakeApi() }))
+      .toBe('not-connected');
+    await clearCredential(API_HOST);
+    expect(await previewSend({ config, code: CODE, api: fakeApi() })).toBe('not-logged-in');
+  });
+});
+
+describe('a refusal the client does not recognise', () => {
+  it('reads back what the server said, rather than the wrong known answer', () => {
+    // The bug this replaced: `rate_limited` arrives, the lookup misses, and a sender at their
+    // quota is told the bundle they just minted does not exist.
+    expect(refusalMessage('rate_limited')).toContain('too many bundles in flight');
+    expect(refusalMessage('conflict')).toContain('fresh code');
+
+    // A member added to the server's enum after this build shipped.
+    expect(refusalMessage('quarantined', 'That workspace is under review.'))
+      .toBe('That workspace is under review.');
+  });
+
+  it('still says something when the server sends a reason and no message', () => {
+    expect(refusalMessage('quarantined')).toBe('The server refused that: quarantined.');
+  });
+
+  it('keeps the wording the receiver already relies on', () => {
+    expect(refusalMessage('not_found')).toContain('Check what you typed');
+    expect(refusalMessage('expired')).toContain('expired');
+    expect(refusalMessage('already_claimed')).toContain('already collected');
+  });
+});
+
+describe('the sender looking at what is in flight', () => {
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+    config = {
+      version: 1,
+      cloud: {
+        apiHost: API_HOST, workspaceId: 'ws-send', workspaceName: 'Acme',
+        repo: 'github.com/acme/web', remote: 'origin',
+      },
+    };
+    await writeCredential(API_HOST, {
+      accessToken: 'at', refreshToken: 'rt', sessionId: 'sess-1',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    await clearCredential(API_HOST).catch(() => {});
+    delete process.env.KNOWL_HOME;
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('reports the claimed-yet column, which is the tamper evidence', async () => {
+    const mailboxes: SendMailbox[] = [{
+      mailboxId: 'a'.repeat(32), itemCount: 3,
+      createdAt: preview.createdAt, expiresAt: preview.expiresAt,
+      claimedAt: '2026-08-14T11:00:00.000Z',
+    }];
+    expect(await listSends({ config, api: fakeApi({ listSends: async () => mailboxes }) }))
+      .toEqual(mailboxes);
+  });
+
+  it('revokes a raw id exactly as given, deriving nothing', async () => {
+    // The path for an id copied out of --list, where there is no code to derive from. Treating it
+    // as a code would derive from the id's own text and delete nothing.
+    const asked: string[] = [];
+    const id = 'b'.repeat(32);
+    const revoked = await revokeSend({
+      config, target: id.toUpperCase(),
+      api: fakeApi({ revokeSend: async ({ mailboxId }) => { asked.push(mailboxId); return true; } }),
+    });
+    expect(revoked).toBe(true);
+    expect(asked).toEqual([id]);
+  });
+
+  it('revokes a code through the same walk a receiver uses', async () => {
+    // A sender revoking one they minted on 5.1.0 holds a v1 id whether they know it or not.
+    const asked: string[] = [];
+    const revoked = await revokeSend({
+      config, target: CODE,
+      api: fakeApi({
+        revokeSend: async ({ mailboxId }) => {
+          asked.push(mailboxId);
+          return mailboxId === deriveMailboxId(CODE, 1);
+        },
+      }),
+    });
+    expect(revoked).toBe(true);
+    expect(asked).toEqual([deriveMailboxId(CODE, 2), deriveMailboxId(CODE, 1)]);
+  });
+
+  it('reports nothing revoked rather than throwing, when there was nothing there', async () => {
+    expect(await revokeSend({
+      config, target: 'c'.repeat(32), api: fakeApi({ revokeSend: async () => false }),
+    })).toBe(false);
+  });
+});
+
+describe('a bundle all the way there and back', () => {
+  beforeEach(async () => {
+    await closeDb().catch(() => {});
+    await releaseAll();
+    process.env.KNOWL_HOME = HOME;
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+
+    counter += 1;
+    SENDER = path.resolve(`./.knowl-send-src${counter}`);
+    RECEIVER = path.resolve(`./.knowl-send-dst${counter}`);
+    for (const dir of [SENDER, RECEIVER]) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+      await makeRepo(dir);
+    }
+    config = {
+      version: 1,
+      cloud: {
+        apiHost: API_HOST, workspaceId: 'ws-send', workspaceName: 'Acme',
+        repo: 'github.com/acme/web', remote: 'origin',
+      },
+    };
+    await writeCredential(API_HOST, {
+      accessToken: 'at', refreshToken: 'rt', sessionId: 'sess-1',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    await closeDb().catch(() => {});
+    await releaseAll();
+    await clearCredential(API_HOST).catch(() => {});
+    delete process.env.KNOWL_HOME;
+    for (const dir of [SENDER, RECEIVER, HOME]) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('seals under v2, and the receiver opens what the sender sealed', async () => {
+    // The property no unit test of the crypto can reach: the id the sender registered, the
+    // version the receiver resolved and the key it unsealed with all have to be the same
+    // derivation, threaded through three modules and a fake wire.
+    await initDb(SENDER);
+    const projectId = (await repo.createProject(SENDER, 'sender')).id;
+    const written = await storeKnowledgeItemDeduped(projectId, {
+      category: 'decision',
+      title: 'Argon2id, not raw HKDF',
+      content: 'The cost per guess is what defends a human-typed code.',
+    });
+    await closeDb();
+
+    // The drop box: one row, whatever id the sender hands it.
+    const box = new Map<string, string>();
+    const api = fakeApi({
+      createSend: async ({ mailboxId, ciphertext }) => {
+        box.set(mailboxId, ciphertext);
+        return { mailboxId, expiresAt: preview.expiresAt };
+      },
+      peekSend: async ({ mailboxId }) => (box.has(mailboxId) ? preview : null),
+      claimSend: async ({ mailboxId }) => {
+        const ciphertext = box.get(mailboxId);
+        if (!ciphertext) return { refused: 'not_found' as const };
+        box.delete(mailboxId); // Single claim, like the real one.
+        return { ciphertext, preview };
+      },
+    });
+
+    const sent = await sendKnowledge({
+      projectRoot: SENDER, projectId, config, itemIds: [written.item.id],
+      senderLabel: 'github.com/acme/web', expiresInHours: 24, api,
+    });
+    expect(sent.status).toBe('sent');
+    if (sent.status !== 'sent') return;
+
+    // Registered under the v2 id, and under no other.
+    expect([...box.keys()]).toEqual([deriveMailboxId(sent.code, 2)]);
+
+    const resolved = await previewSend({ config, code: sent.code, api });
+    expect(resolved).toMatchObject({ version: 2 });
+    if (!resolved || typeof resolved === 'string') return;
+
+    const received = await receiveKnowledge({ projectRoot: RECEIVER, config, resolved, api });
+    expect(received.status).toBe('received');
+    if (received.status !== 'received') return;
+    expect(received.imported.inserted).toBe(1);
+
+    // Spent, and the second attempt refuses rather than replaying.
+    expect(await previewSend({ config, code: sent.code, api })).toBeNull();
+  });
+
+  it('refuses a code nobody sent, without touching the store', async () => {
+    const api = fakeApi({ peekSend: async () => null });
+    expect(await previewSend({ config, code: CODE, api })).toBeNull();
+    // No database was opened for a bundle that does not exist.
+    await expect(fs.access(path.join(RECEIVER, '.knowl', 'knowl.db'))).rejects.toThrow();
+  });
+
+  it('carries a refusal up rather than throwing, when the sender is at their quota', async () => {
+    await initDb(SENDER);
+    const projectId = (await repo.createProject(SENDER, 'sender')).id;
+    const written = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'quota', content: 'anything',
+    });
+    await closeDb();
+
+    const result = await sendKnowledge({
+      projectRoot: SENDER, projectId, config, itemIds: [written.item.id],
+      senderLabel: 'x', expiresInHours: 24,
+      api: fakeApi({
+        createSend: async () => ({ refused: 'rate_limited', message: 'Too many in flight.' }),
+      }),
+    });
+    expect(result).toEqual({ status: 'refused', reason: 'rate_limited', message: 'Too many in flight.' });
+  });
+});


### PR DESCRIPTION
Closes #102.

## The gap, and the fix

Five words is about 2^55, and both the mailbox id and the sealing key came off it through
HKDF-SHA256 — fast by design. Against a database snapshot a GPU rig grinds that codespace in
hours-to-days: **inside a mailbox's own 24–72 hour life.** 2^55 is only expensive if each guess is.

Both halves now come off **Argon2id at 64 MiB, t=3, p=1** — about 0.6s natively, the middle of the
0.5–1s the issue asks for.

### One memory-hard pass, not two

The issue reads as one Argon2id call per domain string. This is one:

```
master = Argon2id(code, "knowl-send:v2", m=64MiB, t=3, p=1) → 32 bytes
id     = hex( HKDF(master, "knowl-send:id:v2",  16) )
key    =      HKDF(master, "knowl-send:key:v2", 32)
```

**An attacker grinding against stored mailbox ids only ever needs the id derivation**, so they pay
for one Argon2id per guess either way. A second call costs the honest client double and the
attacker nothing. The versioned domain strings survive as the HKDF labels, which is where they do
their work.

### The server needs no change — verified, not assumed

`MailboxId` in knowl-cloud's contract is `^[a-f0-9]{32}$|^[a-f0-9]{64}$`. v2 emits 16 bytes into
the same 32-hex slot v1 used, and a test asserts that width rather than leaving it to inspection.

### Two backends, because of the engines floor

`crypto.argon2Sync` landed in **Node 24.7** and this package declares `engines: node >=22`. Bumping
that floor drops Node 22 LTS — supported to April 2027 — for every knowl user over a feature most
never touch. So the built-in is used where it exists and `@noble/hashes` covers the rest.

| | time (64 MiB, t=3) | deps | Node 22 |
|---|---|---|---|
| `crypto.argon2Sync` | 603 ms | 0 | ✗ |
| `@noble/hashes` | 1380 ms | 1 (zero-dep, audited) | ✓ |

They are **byte-identical**, and a test pins that on any runtime with both. Two backends
disagreeing by one byte would make a bundle sealed on Node 24 unopenable on Node 22, surfacing as
*"no bundle waiting on that code"* — indistinguishable from a typo.

The one dependency is a real cost in a repo that treats a package added for ten lines as a
supply-chain surface added for ten lines. The honest accounting: it is not for ten lines, it is
what lets a memory-hard KDF ship without a major version bump. No measurable startup regression
(the module costs ~13 ms to load, lost in run-to-run noise on `knowl --version`).

## Staying compatible with v1

**The id is the lookup key, so the derivation has to be chosen before anything can be read** — no
amount of self-description inside the bundle helps, because the bundle is only reachable once the
id is known. So the receiver derives v2 and peeks, then v1 and peeks again. One round trip for a
v2 bundle, two for a v1 bundle or a mistyped code. A 5.1.0 sender keeps working indefinitely.

The version byte in a v2 bundle is therefore a **cross-check, not the discriminator**, and it is
bound as GCM **AAD** rather than merely prefixed — a prefix a receiver reads and trusts is a byte
an attacker can flip to steer the key schedule. It could not have been the discriminator anyway: a
v1 bundle opens with a random nonce whose first byte is `0x02` once in 256.

```
v2:  0x02 || nonce(12) || ciphertext || tag(16)     AAD = 0x02
v1:          nonce(12) || ciphertext || tag(16)     no AAD
```

`seal`/`unseal` take the derived key rather than the code, and `previewSend` returns the resolved
mailbox and version for `receiveKnowledge` to use. Without both, one `knowl cloud receive` would
pay for Argon2id four times over.

## The other three items

- **Unknown `reason` strings** — a live bug, not future-proofing. The server has returned
  `rate_limited` since v0.7.0; against 5.1.0's closed union it fell through to the `not_found`
  line, so **a sender at their quota was told the bundle they had just minted did not exist.**
  Reasons are now carried rather than coerced and the server's `message` travels with them.
  `createSend`'s 409/429 come back as refusals rather than throws.
- **`--list` / `--revoke`** — `GET /v1/send` and `DELETE /v1/send/:id`. The list is a detection
  surface first: a bundle never handed to anybody, marked collected, means the code leaked, and
  that reading is printed rather than left to the reader. `--revoke` takes an id from the list as
  given, or a code through the same v2-then-v1 walk.
- **`--words 6`** — 2^66. Any other length is refused: a typo in a flag must not quietly weaken the
  one secret in this feature.

## Verification

`build`, `test` (**331 files**, incl. 46 new send cases), `typecheck`, `lint`, `docs:check`,
`check:lockfile`, `typecheck:bench`, `test:bench`, `audit:prod`, `git diff --check` — all green.

The test that matters most is the full round trip: the id the sender registers, the version the
receiver resolves and the key it unseals with must be the same derivation across three modules,
and no unit test of the crypto can reach that.

Design doc: `docs/superpowers/specs/2026-08-14-send-argon2id-design.md`, which also records what
was rejected — bumping the engines floor, noble everywhere, scrypt, a version marker inside the
spoken code, and dropping v1 outright.
