### PR TITLE
fix(cloud): make a backlog pushable, and stop dropping replaced atoms in silence

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -842,6 +842,24 @@ standing consent for this workspace **on this machine only** — it is not writt
 `.knowl/config.json` and no teammate or CI inherits it. It still sends only what it showed
 itself: a queue that changed underneath it is refused, not sent.
 
+**A big queue goes in small requests, and a slow server makes them smaller rather than fatal.**
+Publishing embeds each atom on the server, so a large batch can outrun the request budget. The
+push sends 20 at a time, and on a timeout it halves the batch and tries again rather than failing
+the whole backlog. Anything already accepted is recorded before the failure, so running the push
+again resumes where it stopped instead of starting over.
+
+**A staged atom you then replace locally can no longer be sent, and both commands now say so.**
+`knowl cloud stage` reports how many named ids were replaced by a newer write, and `knowl cloud
+status` splits the queue into what a push can still move and what it cannot:
+
+```
+Staged:    118 staged (118 new, 0 correction(s)) on main, not yet sent.
+           109 of those can still be sent; 9 were replaced by a newer write after being staged.
+```
+
+Without that split the count never reaches zero by pushing, and no command explains why. Stage the
+atom that replaced them instead.
+
 ### Handing knowledge to a person
 
 `push` is *everyone on this team, permanently*. `send` is *you, specifically, right now* — a

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1030,6 +1030,13 @@ cloudCommand
       if (result.skippedExcluded > 0) {
         console.log(`${result.skippedExcluded} item(s) are excluded from publication. Name an id to stage one anyway.`);
       }
+      // The one selection rule that used to drop atoms in silence. Naming 118 ids and staging 109
+      // with no explanation is what made a queue look undrainable rather than nine shorter than
+      // asked for -- and unlike the two above, naming the id again cannot override it.
+      if (result.skippedInactive > 0) {
+        console.log(`${result.skippedInactive} item(s) were replaced by a newer write and can no longer be staged.`);
+        console.log('Stage the atom that replaced them instead.');
+      }
       // `applied` is false for two different reasons -- a dry run, and a real run that matched
       // nothing -- so branching on it alone told a user who had just passed --apply to pass
       // --apply. Nothing eligible is its own outcome and says so.

--- a/src/cloud/ledger.ts
+++ b/src/cloud/ledger.ts
@@ -115,6 +115,29 @@ export async function listStaged(workspace: string): Promise<PublishedRecord[]> 
   return result.rows.map(row => toRecord(row as unknown as Record<string, unknown>));
 }
 
+/**
+ * Staged rows whose atom is no longer active.
+ *
+ * Staging filters on `status = 'active'`, but nothing revisits a row afterwards -- so an atom
+ * superseded AFTER it was queued keeps `stage_state = 'pending'` and goes on being counted. One
+ * number the user cannot reconcile against what a push reports reads as a broken push rather than
+ * as an atom that was replaced, which is the whole of knowl#104.
+ *
+ * An INNER JOIN deliberately: a staged id whose row is gone entirely is *missing*, not retired,
+ * and the push already reports that case its own way. Counting it here would name a remedy --
+ * "it was superseded" -- that is not the one the user needs.
+ */
+export async function countInactiveStaged(workspace: string): Promise<number> {
+  const result = await getClient().execute({
+    sql: `SELECT COUNT(*) AS n
+          FROM cloud_published p JOIN knowledge_items k ON k.id = p.item_id
+          WHERE p.remote_workspace = ? AND p.stage_state = 'pending'
+            AND p.retracted_at IS NULL AND k.status <> 'active'`,
+    args: [workspace],
+  });
+  return Number(result.rows[0]?.n ?? 0);
+}
+
 /** Already sent and accepted. What this machine has put in front of the team. */
 export async function listPushed(workspace: string): Promise<PublishedRecord[]> {
   const result = await getClient().execute({

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -1,7 +1,7 @@
 ﻿import { KNOWLEDGE_CATEGORIES, type KnowledgeCategory, type ProjectConfig } from '../core/types.js';
 import { closeDb, getClient, initDb } from '../store/database.js';
 import { selectOwnedItems, type PromoteTarget } from '../workspace/promote.js';
-import { createCloudApi, type CloudApi } from './api-client.js';
+import { CloudApiError, createCloudApi, type CloudApi } from './api-client.js';
 import {
   listStaged, publishedVersion, recordPushed, restageForPublish, stageForPublish,
 } from './ledger.js';
@@ -32,6 +32,15 @@ export type StageResult =
      * indistinguishable from a sweep that found nothing, and the remedy differs.
      */
     skippedExcluded: number;
+    /**
+     * Named atoms a newer write already retired.
+     *
+     * Reported for the same reason the two above are, and this was the selection rule that had no
+     * counter: staging filters on `status = 'active'`, so naming 118 ids staged 109 and said
+     * nothing about the other nine. A count the user cannot reconcile against what a push reports
+     * reads as a broken push rather than as atoms that were replaced (knowl#104).
+     */
+    skippedInactive: number;
   };
 
 /**
@@ -96,7 +105,7 @@ async function stageInContext(
   },
   pointer: NonNullable<ProjectConfig['cloud']>,
 ): Promise<StageResult> {
-  const { items, skippedForeign } = await selectOwnedItems({
+  const { items, skippedForeign, skippedInactive } = await selectOwnedItems({
     // The local name, not `pointer.repo`. A repo has two of them and both are right: local
     // workspace membership stamps `origin_repo` with the member name from the manifest
     // ("web"), while `cloud connect` records the git identity ("github.com/acme/web")
@@ -150,6 +159,7 @@ async function stageInContext(
     applied: Boolean(input.apply) && eligible.length > 0,
     skippedForeign,
     skippedExcluded,
+    skippedInactive,
   };
 }
 
@@ -197,7 +207,30 @@ export type PushResult =
   };
 
 /** The contract's own cap. An unbounded batch is an unbounded transaction on the server. */
-const MAX_BATCH = 200;
+/**
+ * Atoms per request.
+ *
+ * **Was 200 -- the server contract's own ceiling -- and that was the bug.** Publishing embeds
+ * inline and synchronously on the server, measured at 1564 MB and 418 seconds for 200 atoms of
+ * realistic prose, against a client timeout of 30 seconds. Any queue under 200 therefore went as
+ * ONE request that a cold server could not possibly finish, so a backlog of 40 was permanently
+ * unpushable while a queue of 9 barely landed (knowl#103).
+ *
+ * 20 is sized against the *cold* per-atom cost measured from a real backlog -- roughly 3s at
+ * worst, so ~10 atoms fit a 30s budget with the batch halving below to cover the rest. A warm
+ * server runs an order of magnitude faster and pays only the extra round trips.
+ *
+ * Never raise this above 200: `PublishRequest` rejects a larger batch outright.
+ */
+const MAX_BATCH = 20;
+
+/** Where halving stops. One atom that still times out is the server's problem, not the size. */
+const MIN_BATCH = 1;
+
+/** The server saying "not this much at once" -- the one failure a smaller batch can answer. */
+function isTimeout(error: unknown): error is CloudApiError {
+  return error instanceof CloudApiError && error.code === 'timeout';
+}
 
 const parseJson = <T>(value: unknown): T | null => {
   if (value === null || value === undefined) return null;
@@ -413,17 +446,50 @@ export async function pushStaged(input: {
     const conflicts: PublishOutcome[] = [];
     const rejected: PublishOutcome[] = [];
 
-    for (let start = 0; start < items.length; start += MAX_BATCH) {
-      // A thrown CloudApiError propagates. The secret case in particular must NOT be caught and
-      // converted into a partial success: the batch failed, and the ledger correctly still says
-      // every atom in it is unsent. The rejection is terminal -- never retried, and never
-      // retried in altered form.
-      const { outcomes } = await api.publishItems({
-        workspaceId: pointer.workspaceId,
-        accessToken: credential.accessToken,
-        originRepo: pointer.repo,
-        items: items.slice(start, start + MAX_BATCH),
-      });
+    let start = 0;
+    while (start < items.length) {
+      let size = Math.min(MAX_BATCH, items.length - start);
+      let outcomes: PublishOutcome[];
+
+      for (;;) {
+        try {
+          // A thrown CloudApiError propagates unless it is a timeout. The secret case in
+          // particular must NOT be caught and converted into a partial success: the batch failed,
+          // and the ledger correctly still says every atom in it is unsent. The rejection is
+          // terminal -- never retried, and never retried in altered form.
+          ({ outcomes } = await api.publishItems({
+            workspaceId: pointer.workspaceId,
+            accessToken: credential.accessToken,
+            originRepo: pointer.repo,
+            items: items.slice(start, start + size),
+          }));
+          break;
+        } catch (error) {
+          // A timeout is the one failure that says "too much at once", so the client answers with
+          // less rather than failing a whole backlog. Safe to re-send: the server upserts by item
+          // id and returns `updated` for anything the timed-out attempt had already committed, so
+          // the worst case is a spent version bump, never a duplicate.
+          if (isTimeout(error) && size > MIN_BATCH) {
+            size = Math.max(MIN_BATCH, Math.floor(size / 2));
+            continue;
+          }
+          if (isTimeout(error)) {
+            // The old message named only the URL and the ceiling, so it pointed nowhere. What the
+            // user needs is the size it gave up at and how much is still queued -- the two numbers
+            // that say whether to wait for a warmer server or to go and split the queue by hand.
+            throw new CloudApiError(
+              error.status,
+              `${error.message} — gave up at ${size} atom(s) per request, `
+              + `with ${items.length - start} atom(s) still staged. `
+              + 'Anything already sent is recorded, so running the push again resumes from there.',
+              error.code,
+            );
+          }
+          throw error;
+        }
+      }
+
+      start += size;
 
       for (const outcome of outcomes) {
         if (outcome.status === 'created' || outcome.status === 'updated') {

--- a/src/cloud/status.ts
+++ b/src/cloud/status.ts
@@ -3,7 +3,7 @@ import { closeDb, initDb } from '../store/database.js';
 import { AUTO_SYNC_INTERVAL_MS } from './auto-sync.js';
 import { listCredentialHosts, normalizeApiHost, readCredential } from './credentials.js';
 import { defaultApiHost } from './login.js';
-import { listStaged } from './ledger.js';
+import { countInactiveStaged, listStaged } from './ledger.js';
 import { readSyncState } from './sync-state.js';
 import { withTeamStore } from './team-store.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
@@ -35,6 +35,15 @@ export type CloudStatus =
       lastSyncedAt: string | null;
       lastError: string | null;
       staged: number;
+      /**
+       * The half of `staged` a push can actually move, and the half a newer write retired.
+       *
+       * `staged` stays the whole queue: the ledger records intent and this command does not edit
+       * it. But a user reconciling "118 queued" against "109 published" had no way to discover the
+       * difference, which is what made the count look undrainable (knowl#104).
+       */
+      stagedSendable: number;
+      stagedInactive: number;
       /** Never pushed from this machine. */
       stagedNew: number;
       /** Pushed before, staged again: an update to something the team already has. */
@@ -61,13 +70,16 @@ export async function cloudStatus(projectRoot: string, config: ProjectConfig): P
 
   await initDb(projectRoot);
   let staged;
+  let inactive;
   try {
     staged = await listStaged(pointer.workspaceId);
+    // Read inside the same context, because `composeStatus` runs after `closeDb` and cannot ask.
+    inactive = await countInactiveStaged(pointer.workspaceId);
   } finally {
     await closeDb();
   }
 
-  return composeStatus(pointer, projectRoot, staged);
+  return composeStatus(pointer, projectRoot, staged, inactive);
 }
 
 /**
@@ -82,7 +94,12 @@ export async function cloudStatusInRequest(projectRoot: string, config: ProjectC
   if (!pointer) return await composeDisconnected();
 
   // The caller's context answers this; nothing is opened and nothing is closed.
-  return composeStatus(pointer, projectRoot, await listStaged(pointer.workspaceId));
+  return composeStatus(
+    pointer,
+    projectRoot,
+    await listStaged(pointer.workspaceId),
+    await countInactiveStaged(pointer.workspaceId),
+  );
 }
 
 /**
@@ -108,6 +125,7 @@ async function composeStatus(
   pointer: NonNullable<ProjectConfig['cloud']>,
   projectRoot: string,
   staged: Awaited<ReturnType<typeof listStaged>>,
+  stagedInactive: number,
 ): Promise<CloudStatus> {
   // A replica that cannot be opened at all reads as "never synced" rather than failing the
   // whole report -- the same choice `cloudDoctorChecks` makes, for the same reason.
@@ -133,6 +151,8 @@ async function composeStatus(
     lastSyncedAt: state?.lastSyncedAt ?? null,
     lastError: state?.lastError ?? null,
     staged: staged.length,
+    stagedSendable: staged.length - stagedInactive,
+    stagedInactive,
     stagedNew: staged.length - corrections,
     stagedCorrections: corrections,
     signedIn: Boolean(credential),
@@ -194,6 +214,15 @@ export function formatCloudStatus(status: CloudStatus): string {
     ` (${status.stagedNew} new, ${status.stagedCorrections} correction(s))` +
     `${status.stagedOnBranch ? ` on ${status.stagedOnBranch}` : ''}, not yet sent.`,
   );
+  // Said only when there is a discrepancy to explain. A user reconciling what this reports against
+  // what a push reports had no way to find the difference, so a queue that would not reach zero
+  // read as a broken push rather than as atoms a newer write had replaced (knowl#104).
+  if (status.stagedInactive > 0) {
+    lines.push(
+      `           ${status.stagedSendable} of those can still be sent;` +
+      ` ${status.stagedInactive} were replaced by a newer write after being staged.`,
+    );
+  }
   // The next step, named. A developer who staged and moved on has no other prompt: the atoms sit
   // in a table nobody reads, and a line that reported the count without the command would leave
   // them there. Unconditional since 2026-08-13 -- staged work is now always one push from sent,

--- a/src/workspace/promote.ts
+++ b/src/workspace/promote.ts
@@ -57,7 +57,7 @@ export async function selectOwnedItems(input: {
    * right; the message belongs to the caller.
    */
   verb?: string;
-}): Promise<{ items: PromoteTarget[]; skippedForeign: number }> {
+}): Promise<{ items: PromoteTarget[]; skippedForeign: number; skippedInactive: number }> {
   const byCategory = input.categories?.length ? input.categories : null;
   const byId = input.ids?.length ? input.ids : null;
   if (!byCategory && !byId) {
@@ -101,6 +101,21 @@ export async function selectOwnedItems(input: {
       sql: `SELECT COUNT(*) AS n FROM knowledge_items
             WHERE ${selector.clause} AND status = 'active'
               AND ${visibilityClause}origin_repo IS NOT NULL AND origin_repo <> ?`,
+      args: [...selector.args, input.repoName],
+    });
+
+    // Counted for the same reason `skippedForeign` is, and it was the one selection rule with no
+    // counter behind it. `status = 'active'` below silently drops an atom a newer write retired,
+    // so naming 118 ids staged 109 and said nothing -- which is what made a queue look
+    // undrainable rather than nine-shorter-than-asked-for (knowl#104).
+    //
+    // Owned rows only, so a foreign retired atom is reported once as foreign rather than twice.
+    // The two remedies are different and neither is "both": a foreign atom publishes from its own
+    // repo, a retired one is already replaced here.
+    const inactive = await client.execute({
+      sql: `SELECT COUNT(*) AS n FROM knowledge_items
+            WHERE ${selector.clause} AND status <> 'active'
+              AND ${visibilityClause}(origin_repo IS NULL OR origin_repo = ?)`,
       args: [...selector.args, input.repoName],
     });
 
@@ -174,6 +189,7 @@ export async function selectOwnedItems(input: {
         supersededById: row.superseded_by_id === null ? null : String(row.superseded_by_id),
       })),
       skippedForeign: Number(foreign.rows[0]?.n ?? 0),
+      skippedInactive: Number(inactive.rows[0]?.n ?? 0),
     };
   }
 }

--- a/tests/cloud/publish-push.test.ts
+++ b/tests/cloud/publish-push.test.ts
@@ -304,6 +304,88 @@ describe('pushStaged', () => {
     expect(await publishedVersionOf(ids.decision)).toBeNull();
   });
 
+  it('sends batches a cold server can finish inside the request timeout', async () => {
+    // knowl#103. The old size was 200 -- the contract maximum -- which measured at 1564 MB and
+    // 418s of server-side embedding, against a 30s client timeout. Any queue under 200 therefore
+    // went as ONE request that a cold server could not finish, and a backlog was unpushable.
+    await stageMany(60);
+    const sizes: number[] = [];
+    await pushStaged({
+      projectRoot: CLONE, config: connected,
+      api: fakeApi([], (body: any) => sizes.push(body.items.length)),
+    });
+
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(20);
+    expect(sizes.reduce((a, b) => a + b, 0)).toBe(61);
+  });
+
+  it('halves the batch and retries when a send times out, instead of losing the push', async () => {
+    // A timeout is the server saying "too much at once", so the client answers with less. Without
+    // this a cold server fails the whole queue and every retry re-sends exactly what just failed.
+    await stageMany(39);
+    const attempted: number[] = [];
+    let timeouts = 0;
+    const api = {
+      ...fakeApi([]),
+      publishItems: async (body: any) => {
+        attempted.push(body.items.length);
+        // Fails anything above 10, like a server that cannot finish a big batch in the budget.
+        if (body.items.length > 10) {
+          timeouts += 1;
+          throw new CloudApiError(408, '/knowledge timed out after 30000ms', 'timeout');
+        }
+        return { outcomes: [], commitId: 'c1' };
+      },
+    } as unknown as CloudApi;
+
+    const result = await pushStaged({ projectRoot: CLONE, config: connected, api });
+
+    expect(timeouts).toBeGreaterThan(0);
+    expect(result).toMatchObject({ status: 'pushed' });
+    // Every atom still went, just in smaller pieces.
+    const delivered = attempted.filter(size => size <= 10).reduce((a, b) => a + b, 0);
+    expect(delivered).toBe(40);
+  });
+
+  it('records what landed before a timeout, so a retry does not start over', async () => {
+    // The defect that made retrying pointless: nothing was written locally, so the next attempt
+    // re-sent the entire queue and failed identically.
+    await stageMany(39);
+    let sent = 0;
+    const api = {
+      ...fakeApi([]),
+      publishItems: async (body: any) => {
+        sent += 1;
+        // The first batch lands; everything after it times out, at every size.
+        if (sent > 1) throw new CloudApiError(408, '/knowledge timed out after 30000ms', 'timeout');
+        return {
+          outcomes: body.items.map((item: any) => ({ id: item.id, status: 'created', version: 1 })),
+          commitId: 'c1',
+        };
+      },
+    } as unknown as CloudApi;
+
+    await expect(pushStaged({ projectRoot: CLONE, config: connected, api })).rejects.toThrow();
+
+    // The first batch is off the queue. Progress survives the failure.
+    const left = await stagedIds();
+    expect(left.length).toBe(40 - 20);
+  });
+
+  it('names how many atoms it was carrying when a timeout ends the push', async () => {
+    // `Push failed: ... timed out after 30000ms` said nothing about size, so it pointed nowhere.
+    await stageMany(9);
+    const api = {
+      ...fakeApi([]),
+      publishItems: async () => {
+        throw new CloudApiError(408, '/knowledge timed out after 30000ms', 'timeout');
+      },
+    } as unknown as CloudApi;
+
+    await expect(pushStaged({ projectRoot: CLONE, config: connected, api }))
+      .rejects.toThrow(/10 atom/);
+  });
+
   it('chunks a batch larger than the contract maximum', async () => {
     // PublishRequest caps items at 200: an unbounded batch is an unbounded transaction and an
     // unbounded embedding job on the server.

--- a/tests/cloud/publish-stage.test.ts
+++ b/tests/cloud/publish-stage.test.ts
@@ -165,6 +165,31 @@ describe('stagePublish', () => {
     expect(await staged()).toEqual([ids.decision]);
   });
 
+  it('counts a named id that is no longer active, rather than dropping it in silence', async () => {
+    // knowl#104. Naming 118 ids and getting 109 staged, with nothing said about the other 9, is
+    // what made a staged count look undrainable: the user has no way to learn the difference is
+    // atoms a newer write retired. `skippedForeign` and `skippedExcluded` were already reported;
+    // this was the one selection rule with no counter behind it.
+    await execute(`UPDATE knowledge_items SET status = 'superseded' WHERE id = '${ids.fact}'`);
+
+    const result = await stage({ ids: [ids.decision, ids.fact], apply: true });
+
+    expect(result).toMatchObject({ skippedInactive: 1 });
+    expect(await staged()).toEqual([ids.decision]);
+  });
+
+  it('counts a retired atom separately from a foreign one, because the remedies differ', async () => {
+    // Collapsing them into one number would tell a user to go and publish from another repo when
+    // the real answer is that the atom was replaced here.
+    await execute(`UPDATE knowledge_items SET origin_repo = 'github.com/acme/api' WHERE id = '${ids.fact}'`);
+    await execute(`UPDATE knowledge_items SET status = 'superseded' WHERE id = '${ids.decision}'`);
+
+    const result = await stage({ ids: [ids.decision, ids.fact], apply: true });
+
+    expect(result).toMatchObject({ skippedForeign: 1, skippedInactive: 1 });
+    expect(await staged()).toEqual([]);
+  });
+
   it('counts foreign items rather than silently returning fewer rows', async () => {
     // "1 item belongs to api" is actionable; a short list with no explanation is not.
     await execute(`UPDATE knowledge_items SET origin_repo = 'github.com/acme/api' WHERE id = '${ids.fact}'`);

--- a/tests/cloud/status.test.ts
+++ b/tests/cloud/status.test.ts
@@ -98,6 +98,46 @@ describe('cloudStatus', () => {
     expect(status.stagedCorrections).toBe(1);
   });
 
+  it('separates staged atoms that can still be sent from ones a newer write retired', async () => {
+    // knowl#104. A staged atom superseded AFTERWARDS keeps `stage_state = 'pending'`, so it goes
+    // on being counted. Reporting one number a user cannot reconcile against what a push reports
+    // reads as "the push is broken" rather than "one of these was replaced".
+    const { stageForPublish } = await import('../../src/cloud/ledger.js');
+    await initDb(CLONE);
+    try {
+      const now = new Date().toISOString();
+      for (const [id, itemStatus] of [['live', 'active'], ['retired', 'superseded']] as const) {
+        await getClient().execute({
+          sql: `INSERT INTO knowledge_items (id, category, title, content, status, created_at, updated_at)
+                VALUES (?, 'fact', ?, 'body', ?, ?, ?)`,
+          args: [id, `Atom ${id}`, itemStatus, now, now],
+        });
+      }
+      await stageForPublish(['live', 'retired'], WS, 'main');
+    } finally { await closeDb(); }
+
+    const status = await cloudStatus(CLONE, connected) as Extract<Awaited<ReturnType<typeof cloudStatus>>, { connected: true }>;
+
+    // `staged` stays the whole queue -- the ledger records intent and this command does not edit
+    // it -- but the half that a push can actually move is now nameable.
+    expect(status.staged).toBe(2);
+    expect(status.stagedSendable).toBe(1);
+    expect(status.stagedInactive).toBe(1);
+  });
+
+  it('reports every staged atom as sendable when none has been retired', async () => {
+    const { stageForPublish } = await import('../../src/cloud/ledger.js');
+    await initDb(CLONE);
+    try { await stageForPublish(['only'], WS, 'main'); } finally { await closeDb(); }
+
+    const status = await cloudStatus(CLONE, connected) as Extract<Awaited<ReturnType<typeof cloudStatus>>, { connected: true }>;
+
+    // A staged id whose row is gone entirely is NOT counted as retired: it is missing, which the
+    // push already reports its own way, and calling it superseded would name the wrong remedy.
+    expect(status.staged).toBe(1);
+    expect(status.stagedInactive).toBe(0);
+  });
+
   it('reports the signed-in identity from the credential cache, without a network call', async () => {
     const home = path.resolve(`./.knowl-status-home-${run}`);
     process.env.KNOWL_HOME = home;


### PR DESCRIPTION
Closes #103. Closes #104.

Both came out of the same 118-atom backlog, and #104's phantom count actively obscured the #103
diagnosis — which is the main reason they are fixed together.

## #103 — a backlog was unpushable

`MAX_BATCH` was **200**, the server contract's own ceiling, against a **30s** client timeout that
no flag, env var or config key can raise (`timeoutMs` has zero call sites outside `api-client.ts`,
so patching `dist` really was the only workaround). Publishing embeds inline and synchronously
server-side — measured at **1564 MB / 418s for 200 atoms**. So any queue under 200 went as one
request a cold server could not finish, and `recordPushed` runs per returned outcome, so a timeout
recorded nothing and every retry re-sent exactly what had just failed.

**The batch size is the smaller half of the fix.** Per-item cost swings between ~0.15s and ~3s
depending on server warmth, so no fixed number is right for both — 20 is sized against the *cold*
cost, and **a timeout now halves the batch and retries** rather than failing the push. A cold
server degrades instead of blocking.

Re-sending is what makes halving legitimate: the server upserts by item id and returns `updated`
for anything a timed-out attempt already committed, so the worst case is a spent version bump,
never a duplicate. **Only timeouts are retried** — a secret rejection still fails the whole batch
untouched, terminal and never retried in altered form.

The error now names the size it gave up at and how much is still staged, and says progress was
recorded so a second run resumes.

> **One correction to the issue.** "Over ~10 atoms is unpushable" reads as a threshold; it is
> server warmth. A 302-atom queue is on record pushing fine on an unchanged retry, and the issue's
> own table shows 38 items in 5.1s warm against 40 timing out cold. The defect is that the client
> made a *variable* server cost fatal — which is what the issue's Mechanism section actually argues.

## #104 — the mechanism in the issue is wrong, and the fix is smaller than it looked

The issue says `push` never sends a superseded atom and that `stage_state` returns to `clear`. I
probed it against the real fixture rather than reading:

| | issue says | actually |
|---|---|---|
| ledger row | `stage_state` → `clear` | **stays `pending`** |
| `listStaged` | — | **returns it** |
| push | never sends them | **sends it** |

`loadPublishItem` has no status predicate, and knowl-cloud stores `item.status ?? 'active'` and
answers `created`/`updated` — so that path drains.

**The real defect is one site.** `selectOwnedItems` filters `status = 'active'`, and while
`skippedForeign` and `skippedExcluded` are both reported, non-active was the one selection rule
with **no counter behind it**. Naming 118 ids staged 109 and said nothing. That alone explains the
reported numbers: unstage everything, re-stage in chunks, and the nine silently never come back.

So `stage` reports `skippedInactive`, and `status` splits the queue:

```
Staged:    118 staged (118 new, 0 correction(s)) on main, not yet sent.
           109 of those can still be sent; 9 were replaced by a newer write after being staged.
```

`staged` stays the whole count — the ledger records intent and neither command edits it — but the
discrepancy is nameable. The extra line appears only when there is one, so it still means
something when it does.

`countInactiveStaged` inner-joins deliberately: a staged id whose row is *gone* is missing, not
retired, and the push already reports that its own way.

## An open question this surfaced — deliberately not settled here

Because push sends superseded atoms, **local supersession propagates to the team by accident**,
while `stagePublish` blocks the intentional path and `knowl cloud retract` only handles removal.
Whether there should be a designed way to propagate a supersession, or whether push should skip
non-active atoms outright, is a design call — not something to change silently inside a bug fix.
Making push skip them could strand retirements the team has already received.

Happy to take it either way in a follow-up.

## Verification

`build`, `test` (**331 files**, 8 new cases, each confirmed failing first), `typecheck`, `lint`,
`docs:check`, `git diff --check` — all green.
