### PR TITLE
chore: release 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## 5.2.1 — 2026-08-14
+
+### A backlog of staged knowledge can be pushed again
+
+`knowl cloud push` sent the whole queue in one request. Publishing embeds every atom on the server
+as it arrives, so a large batch could not finish inside the request budget — and because nothing
+was recorded when it failed, every retry re-sent exactly what had just failed. A backlog of forty
+atoms was stuck permanently, while nine went through.
+
+The push now sends twenty at a time, and **on a timeout it halves the batch and tries again**
+rather than failing outright. That second part is what matters: how long an atom takes on the
+server varies by an order of magnitude depending on whether it is warm, so no fixed size is right
+for both. A slow server now degrades into smaller requests instead of blocking.
+
+Anything already accepted is recorded before the failure, so running the push again resumes where
+it stopped. When a push does give up, it says how many atoms it was carrying and how many are
+still queued, instead of naming only the timeout.
+
+### Staging says when an atom was already replaced
+
+`knowl cloud status` could report a number that pushing never drove to zero. Staging skips atoms
+that a newer write has retired — correctly — but said nothing, so naming 118 ids staged 109 with
+no way to discover what happened to the other nine. Reconciling "118 queued" against "109
+published" read as a broken push rather than as replaced knowledge.
+
+`knowl cloud stage` now reports how many named atoms were replaced, and `status` splits the queue:
+
+```
+Staged:    118 staged (118 new, 0 correction(s)) on main, not yet sent.
+           109 of those can still be sent; 9 were replaced by a newer write after being staged.
+```
+
 ## 5.2.0 — 2026-08-14
 
 ### Guessing a send code is now expensive, not merely improbable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts 5.2.1. One substantive commit since `v5.2.0`: #107, closing #103 and #104.

**Patch, not minor.** Two bug fixes and no new surface — no new command, no new flag. The two new
`cloudStatus` fields (`stagedSendable`, `stagedInactive`) are additive on an internal shape, and
`MAX_BATCH` 200 → 20 changes how a push is carried, not what it does.

## What ships

- **A staged backlog is pushable again.** The whole queue went in one request against a 30s
  timeout, while the server embeds inline (1564 MB / 418s for 200 atoms) — so 40 atoms were stuck
  permanently while 9 went through, and a failure recorded nothing so retries re-sent the same
  thing. Now 20 per request, **halving and retrying on a timeout**, with progress recorded before
  any failure.
- **Staging says when an atom was already replaced.** `stage` reports `skippedInactive`, and
  `status` splits the queue into what a push can still move and what it cannot — so a count that
  never reached zero is now explained instead of looking like a broken push.

## Release mechanics

**Merge with a merge commit, not a squash** — the tag points at the single-parent `chore: release`
commit (`c7c546b`), and a squash would collapse it.

Verified on the release commit: `build`, `test` (331 files), `typecheck`, `docs:check`,
`check:lockfile`, `typecheck:bench`, `audit:prod`.
