### PR TITLE
feat(mcp): a repo argument, so a call can be another repo's work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 - A `WORKSPACE:` notice names linked repos that matched but were not shown, with counts. Re-query with `repos` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
+- When the work you are doing belongs to a LINKED repo, pass `repo: "<name>"` on the call instead of writing it here. The call then applies to that repo exactly as if it had been run there -- what you write is stamped as its own, and retiring its knowledge is allowed, because the repo is correcting itself. Without it a write lands here, attributed here, which is how a finding ends up in the wrong drawer.
 
 ### Safety and freshness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ task, the repo is correcting itself, and which folder the terminal happens to si
 about the knowledge. An additive-only version would have left the destructive half reachable only
 by shelling out, which is the situation this removes.
 
-Two things bound it. The target is **named, not pathed** — resolved through the workspace manifest,
-so a repo has to be linked before it can be acted as. And a linked repo with no checkout on this
-machine is refused rather than written to, because a repo's evidence paths and git state do not
-resolve without a working tree.
+Three things bound it. The target is **named, not pathed** — resolved through the workspace
+manifest, so a repo has to be linked before it can be acted as. A linked repo with no checkout on
+this machine is refused rather than written to, because a repo's evidence paths and git state do
+not resolve without a working tree. And `repo` is honoured **only on the tools that declare it**,
+which the dispatch reads from the published schema rather than from a list kept beside it. Naming
+a repo anywhere else refuses the call and says which tools offer it — notably on `knowl_query`,
+whose `repos` filter over shared rows sits one letter away from a rebind that would have read a
+linked repo's private knowledge as its own.
 
 Omitting `repo` leaves every call exactly as it was.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+### An agent can do another linked repo's work, from here
+
+Pass `repo: "<name>"` to `knowl_store`, `knowl_decide`, `knowl_update`, `knowl_ingest_atoms`,
+`knowl_timeline` or `knowl_evidence_list` and that one call runs as the named repo: against its
+store, stamped as its own, with its config, its cloud pointer and its ownership rules — exactly as
+if it had been run in that repo's directory.
+
+This was never a new capability, only a newly reachable one. `cd ../sibling && knowl store …` has
+always worked, because standing in a repo is what the ownership guard checks: an item there is
+simply *local*, so the guard is satisfied rather than bypassed. What was missing was a way for an
+MCP server — bound to its launch directory for the whole of its life — to do the same thing. The
+workaround was to shell out and run the CLI, which works, and is invisible to every rule this
+codebase otherwise keeps.
+
+So an agent that had spent an hour on one repo's task, with output landing in another, had to file
+what it learned in the wrong place or not at all.
+
+**Full rights, including retiring the target's knowledge.** When you are finishing that repo's
+task, the repo is correcting itself, and which folder the terminal happens to sit in is not a fact
+about the knowledge. An additive-only version would have left the destructive half reachable only
+by shelling out, which is the situation this removes.
+
+Two things bound it. The target is **named, not pathed** — resolved through the workspace manifest,
+so a repo has to be linked before it can be acted as. And a linked repo with no checkout on this
+machine is refused rather than written to, because a repo's evidence paths and git state do not
+resolve without a working tree.
+
+Omitting `repo` leaves every call exactly as it was.
+
 ## 5.2.1 — 2026-08-14
 
 ### A backlog of staged knowledge can be pushed again

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -40,6 +40,7 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 - A `WORKSPACE:` notice names linked repos that matched but were not shown, with counts. Re-query with `repos` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
+- When the work you are doing belongs to a LINKED repo, pass `repo: "<name>"` on the call instead of writing it here. The call then applies to that repo exactly as if it had been run there -- what you write is stamped as its own, and retiring its knowledge is allowed, because the repo is correcting itself. Without it a write lands here, attributed here, which is how a finding ends up in the wrong drawer.
 
 ### Safety and freshness
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1008,10 +1008,16 @@ finishing that repo's task, the repo is correcting itself, and which folder your
 to sit in is not a fact about the knowledge. An additive-only version would have left the
 destructive half reachable only by shelling out, which is the situation this removes.
 
-Two things bound it. The target is **named, not pathed** — resolved through the workspace
-manifest, so a repo has to be linked before it can be acted as. And a linked repo with no checkout
+Three things bound it. The target is **named, not pathed** — resolved through the workspace
+manifest, so a repo has to be linked before it can be acted as. A linked repo with no checkout
 on this machine is refused rather than written to, because a repo's evidence paths and git state
-do not resolve without a working tree.
+do not resolve without a working tree. And `repo` is honoured only on the tools above: the
+dispatch reads the published schema, so a tool that does not describe the argument does not
+accept it, and naming a repo elsewhere refuses the call rather than quietly rebinding it.
+
+That last one matters most on `knowl_query`, which takes `repos` — a *filter* over the shared
+rows of the repos you name. The singular `repo` is a *rebind*, and honouring it there would have
+read a linked repo's private knowledge as though it were your own.
 
 Use it when the work belongs to the other repo — you are finishing its task and have its context
 in hand. It is not for correcting something you merely noticed in passing while working here: you

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -991,6 +991,32 @@ Read-only, on the same line the cloud tool draws. `knowl workspace promote` is a
 shares in one step with no second command to complete, so it stays yours; linking and unlinking
 repos are machine setup and stay yours for the reason `knowl init` does.
 
+#### Doing a linked repo's work from here
+
+`knowl_store`, `knowl_decide`, `knowl_update`, `knowl_ingest_atoms`, `knowl_timeline` and
+`knowl_evidence_list` take an optional `repo`. Passing it runs that one call **as** the named
+repo: against its store, stamped as its own, with its config, its cloud pointer and its ownership
+rules — exactly as if the command had been run in its directory.
+
+This has never been a new capability, only a newly reachable one. `cd ../sibling && knowl store …`
+has always worked, because standing in a repo is what the ownership guard checks — an item there
+is simply *local*. An MCP server cannot change directory, so an agent was denied what the human
+running the same commands could already do, and the workaround was to shell out to the CLI.
+
+It is deliberately **full rights**, retiring the target's knowledge included. When you are
+finishing that repo's task, the repo is correcting itself, and which folder your terminal happens
+to sit in is not a fact about the knowledge. An additive-only version would have left the
+destructive half reachable only by shelling out, which is the situation this removes.
+
+Two things bound it. The target is **named, not pathed** — resolved through the workspace
+manifest, so a repo has to be linked before it can be acted as. And a linked repo with no checkout
+on this machine is refused rather than written to, because a repo's evidence paths and git state
+do not resolve without a working tree.
+
+Use it when the work belongs to the other repo — you are finishing its task and have its context
+in hand. It is not for correcting something you merely noticed in passing while working here: you
+have not read that repo's code, and its facts are true of a place you are not standing in.
+
 ### Staying current
 
 Team knowledge arriving is a notification, not a wait. Queries answer from the replica

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,9 +982,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1000,9 +997,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1020,9 +1014,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1038,9 +1029,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1058,9 +1046,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1076,9 +1061,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1096,9 +1078,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1115,9 +1094,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1133,9 +1109,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1159,9 +1132,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1183,9 +1153,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1209,9 +1176,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1233,9 +1197,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1259,9 +1220,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1284,9 +1242,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1308,9 +1263,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1463,6 +1415,7 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
       "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.4",
         "@libsql/hrana-client": "^0.10.0",
@@ -1824,9 +1777,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1841,9 +1791,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1858,9 +1805,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,9 +1819,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,9 +1833,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1909,9 +1847,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1926,9 +1861,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1875,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1960,9 +1889,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1903,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,9 +1917,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1931,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2028,9 +1945,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2229,6 +2143,7 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -2563,6 +2478,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3258,6 +3174,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3317,6 +3234,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3545,6 +3463,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3966,6 +3885,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4660,6 +4580,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4724,6 +4645,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -5506,6 +5428,7 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -5721,6 +5644,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5809,6 +5733,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6061,6 +5986,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -997,6 +1000,9 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1014,6 +1020,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1029,6 +1038,9 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1046,6 +1058,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1061,6 +1076,9 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1078,6 +1096,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1094,6 +1115,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1109,6 +1133,9 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1132,6 +1159,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1153,6 +1183,9 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1176,6 +1209,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1197,6 +1233,9 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1220,6 +1259,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1242,6 +1284,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1263,6 +1308,9 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1415,7 +1463,6 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
       "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.4",
         "@libsql/hrana-client": "^0.10.0",
@@ -1777,6 +1824,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1791,6 +1841,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,6 +1858,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,6 +1875,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1833,6 +1892,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1847,6 +1909,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1861,6 +1926,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,6 +1943,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1889,6 +1960,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1903,6 +1977,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1917,6 +1994,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1931,6 +2011,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1945,6 +2028,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2143,7 +2229,6 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -2478,7 +2563,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3174,7 +3258,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3234,7 +3317,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3463,7 +3545,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3885,7 +3966,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4580,7 +4660,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4645,7 +4724,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -5428,7 +5506,6 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -5644,7 +5721,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5733,7 +5809,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5986,7 +6061,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -87,7 +87,8 @@ const WORKSPACE = `### Linked repositories
 - Method questions — "how do we generate X", "is there a script for Y" — belong to the whole workspace: query them unscoped before building new tooling; a sibling repo's pipeline answers them more often than this repo's files do.
 - A \`WORKSPACE:\` notice names linked repos that matched but were not shown, with counts. Re-query with \`repos\` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while \`--default-visibility repo\` keeps writes private. \`knowl workspace set\` with no flags prints the current value.
-- Knowledge already written privately stays private until someone runs \`knowl workspace promote\`. Only the owning repo can promote, update, or retire its own items.`;
+- Knowledge already written privately stays private until someone runs \`knowl workspace promote\`. Only the owning repo can promote, update, or retire its own items.
+- When the work you are doing belongs to a LINKED repo, pass \`repo: "<name>"\` on the call instead of writing it here. The call then applies to that repo exactly as if it had been run there -- what you write is stamped as its own, and retiring its knowledge is allowed, because the repo is correcting itself. Without it a write lands here, attributed here, which is how a finding ends up in the wrong drawer.`;
 
 export function renderFullKnowlGuidance(): string {
   const table = [

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -19,6 +19,38 @@ export type ToolDefinition = { name: string; description: string; inputSchema: R
 export const IMPACT_RESOLUTIONS = ['repaired', 'dismissed', 'expired', 'false_positive'];
 
 /**
+ * The `repo` argument: do one call as another linked repo.
+ *
+ * Declared here rather than pasted per tool, and declaring it is what PERMITS it -- dispatch
+ * reads these schemas to decide whether a `repo` argument is honoured at all, so adding the
+ * property to a tool is the entire act of enabling it there. A list kept beside the schemas
+ * would drift from them; this cannot.
+ *
+ * Two variants, because there are two truths. `knowl_timeline` and `knowl_evidence_list` only
+ * read, and promising them "retiring its knowledge" and "what you write is stamped as its own"
+ * described a different tool to the model that has to choose between them.
+ */
+const ACT_AS_REPO_BASE =
+  'Do this as another repo in this workspace, named as the manifest names it. Use when you are ' +
+  'finishing THAT repo\'s work from here: the call applies to its store exactly as if you had run it there';
+
+/** For the tools that write: the full grant, and the case it is not for. */
+export const ACT_AS_REPO_WRITE = {
+  type: 'string', minLength: 1,
+  description: `${ACT_AS_REPO_BASE}, including retiring its knowledge, and what you write is stamped as its own. ` +
+    'Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of ' +
+    'something you noticed in passing while working on this repo.',
+};
+
+/** For the tools that only read: the same rebind, minus a grant they do not have. */
+export const ACT_AS_REPO_READ = {
+  type: 'string', minLength: 1,
+  description: `${ACT_AS_REPO_BASE}, so you read that repo's history rather than this one's. ` +
+    'This tool only reads; nothing about naming a repo here writes to it. Omit it -- the normal ' +
+    'case -- and everything applies here.',
+};
+
+/**
  * Ceilings named inside the schemas below, so they travel with the text that quotes them.
  *
  * The transcript tools already bound every numeric argument and cap their rendered output;
@@ -263,10 +295,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
-              repo: {
-                type: 'string', minLength: 1,
-                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
-              },
+              repo: ACT_AS_REPO_WRITE,
               category: {
                 type: 'string',
                 enum: KNOWLEDGE_CATEGORIES,
@@ -347,10 +376,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
-              repo: {
-                type: 'string', minLength: 1,
-                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
-              },
+              repo: ACT_AS_REPO_WRITE,
               atoms: {
                 type: 'array',
                 // Every other array on this surface is capped -- tags/repos/completed at 20 --
@@ -407,10 +433,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
-              repo: {
-                type: 'string', minLength: 1,
-                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
-              },
+              repo: ACT_AS_REPO_WRITE,
               title: {
                 type: 'string',
                 minLength: 1,
@@ -513,7 +536,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_timeline',
           description: 'Read one item\'s immutable assertion history: what it claimed, when, and what superseded it. Use when memory looks contradictory or you need to know whether a fact changed -- knowl_query answers what it says now, this answers how it got there.',
-          inputSchema: { type: 'object', properties: { repo: { type: 'string', minLength: 1, description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here." }, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID, as returned by knowl_query.' } }, required: ['itemId'] },
+          inputSchema: { type: 'object', properties: { repo: ACT_AS_REPO_READ, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID, as returned by knowl_query.' } }, required: ['itemId'] },
         },
         {
           name: 'knowl_conflicts',
@@ -544,7 +567,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           description: 'List the evidence linked to one knowledge item. Use before relying on an item that is low-confidence, contested, or old enough that its support matters more than its claim.',
           inputSchema: {
             type: 'object',
-            properties: { repo: { type: 'string', minLength: 1, description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here." }, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID.' } },
+            properties: { repo: ACT_AS_REPO_READ, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID.' } },
             required: ['itemId'],
           },
         },
@@ -580,10 +603,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
-              repo: {
-                type: 'string', minLength: 1,
-                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
-              },
+              repo: ACT_AS_REPO_WRITE,
               id: {
                 type: 'string',
                 minLength: 1,

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -263,6 +263,10 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
+              repo: {
+                type: 'string', minLength: 1,
+                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
+              },
               category: {
                 type: 'string',
                 enum: KNOWLEDGE_CATEGORIES,
@@ -343,6 +347,10 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
+              repo: {
+                type: 'string', minLength: 1,
+                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
+              },
               atoms: {
                 type: 'array',
                 // Every other array on this surface is capped -- tags/repos/completed at 20 --
@@ -399,6 +407,10 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
+              repo: {
+                type: 'string', minLength: 1,
+                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
+              },
               title: {
                 type: 'string',
                 minLength: 1,
@@ -501,7 +513,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_timeline',
           description: 'Read one item\'s immutable assertion history: what it claimed, when, and what superseded it. Use when memory looks contradictory or you need to know whether a fact changed -- knowl_query answers what it says now, this answers how it got there.',
-          inputSchema: { type: 'object', properties: { itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID, as returned by knowl_query.' } }, required: ['itemId'] },
+          inputSchema: { type: 'object', properties: { repo: { type: 'string', minLength: 1, description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here." }, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID, as returned by knowl_query.' } }, required: ['itemId'] },
         },
         {
           name: 'knowl_conflicts',
@@ -532,7 +544,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           description: 'List the evidence linked to one knowledge item. Use before relying on an item that is low-confidence, contested, or old enough that its support matters more than its claim.',
           inputSchema: {
             type: 'object',
-            properties: { itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID.' } },
+            properties: { repo: { type: 'string', minLength: 1, description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here." }, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID.' } },
             required: ['itemId'],
           },
         },
@@ -568,6 +580,10 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
           inputSchema: {
             type: 'object',
             properties: {
+              repo: {
+                type: 'string', minLength: 1,
+                description: "Do this as another repo in this workspace, named as the manifest names it. Use when you are finishing THAT repo's work from here: the call applies to its store exactly as if you had run it there, including retiring its knowledge, and what you write is stamped as its own. Omit it -- the normal case -- and everything applies here. Not for a drive-by correction of something you noticed in passing while working on this repo.",
+              },
               id: {
                 type: 'string',
                 minLength: 1,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -233,6 +233,16 @@ const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
     .map(tool => [tool.name, tool.inputSchema]),
 );
 
+/**
+ * The tools that may be run as another linked repo: exactly the ones whose schema says so.
+ *
+ * Derived rather than listed, because a list beside the schemas is a list that drifts from them.
+ * It is used only to name the alternatives in a refusal; the refusal itself reads the schema.
+ */
+const ACT_AS_TOOLS = [...SCHEMA_BY_TOOL.entries()]
+  .filter(([, schema]) => (schema.properties as Record<string, unknown> | undefined)?.repo)
+  .map(([name]) => name);
+
 /** What a shortened result keeps of its body: enough to judge relevance, not to answer from. */
 const QUERY_EXCERPT_CHARS = 240;
 
@@ -1774,10 +1784,32 @@ export function registerTools(
    *
    * The project id is re-resolved inside the swap. The one the server captured at startup names
    * a row in ITS database, which does not exist in the target's.
+   *
+   * **Only where it is declared**, and declaration is read from the published schema rather
+   * than from a list kept beside it, so the two cannot drift. Wrapping the dispatch is what
+   * gives every tool this at once, which is also the hazard: `repo` is read off the raw
+   * arguments before the per-tool schema is consulted, and `validateToolArguments` only rejects
+   * an unknown property where `additionalProperties: false`, which almost none of these
+   * schemas set. Left alone it therefore worked on all thirty tools while being described on
+   * six -- silently rebinding `knowl_gc_apply` at one end and, at the other, `knowl_query`,
+   * whose `repos` FILTER over shared rows sits one letter away from a `repo` REBIND that would
+   * have read the target's private knowledge as its own.
    */
   const callToolAsRepo = async (request: CallToolRequest): Promise<CallToolResult> => {
     const asRepo = (request.params.arguments as Record<string, unknown> | undefined)?.repo;
     if (typeof asRepo !== 'string' || asRepo.length === 0) return callTool(request);
+    const declared = (SCHEMA_BY_TOOL.get(request.params.name)?.properties as Record<string, unknown> | undefined)?.repo;
+    if (!declared) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `${request.params.name} does not take a "repo" argument, and the call was not run. ` +
+            `Acting as a linked repo is offered on ${ACT_AS_TOOLS.join(', ')}. ` +
+            'For everything else, this call applies to the repo the server is running in.',
+        }],
+      };
+    }
     await whenReady();
     const callerRoot = getProjectRoot();
     const workspace = callerRoot ? await resolveWorkspace(callerRoot, getConfig() ?? undefined) : null;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -5,6 +5,8 @@ import { captureChangeWatermark, consumeChangeNotice } from './change-notice.js'
 import { KNOWLEDGE_CATEGORIES, ProjectConfig, KnowledgeCategory, KnowledgeItem, KnowledgeStatus } from '../core/types.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
 import { assertOwnedItem } from '../workspace/ownership.js';
+import { withRepoContext } from '../workspace/act-as.js';
+import { getProjectRoot as ambientProjectRoot } from '../store/database.js';
 import { flattenGroups, queryFederated, type FederatedResult } from '../workspace/federated-query.js';
 import { recordDemandEventBestEffort } from '../workspace/demand-ledger.js';
 import { hasAiConfigured } from '../core/config.js';
@@ -437,7 +439,15 @@ export function registerTools(
 
 
   // 2. Call tool
-  const callTool = async (request: CallToolRequest): Promise<CallToolResult> => {
+  /**
+   * `actingAs` is set only when a call named another repo. Everything it carries is what the
+   * server resolved at startup for ITSELF, recomputed for the target -- so a handler cannot
+   * tell the difference and none of them had to be changed.
+   */
+  const callTool = async (
+    request: CallToolRequest,
+    actingAs?: { projectId: string; projectRoot: string; config: ProjectConfig | null },
+  ): Promise<CallToolResult> => {
     const { name } = request.params;
     // `arguments` is optional in the protocol, and a conformant client omits it for a tool whose
     // properties are all optional. `validateToolArguments` already reads undefined as `{}` -- but
@@ -447,9 +457,9 @@ export function registerTools(
     const args = request.params.arguments ?? {};
     await whenReady();
     const initError = getInitError();
-    const projectId = getProjectId();
-    const projectRoot = getProjectRoot();
-    const config = getConfig();
+    const projectId = actingAs ? actingAs.projectId : getProjectId();
+    const projectRoot = actingAs ? actingAs.projectRoot : getProjectRoot();
+    const config = actingAs ? actingAs.config : getConfig();
 
     if (initError) {
       return {
@@ -1754,13 +1764,53 @@ export function registerTools(
    * the way the hook path is forced to. A failure anywhere in here degrades to "no
    * notice" -- memory news must never be able to fail a tool call.
    */
+  /**
+   * Run one call as another linked repo, when it asked to be.
+   *
+   * A `repo` argument means "do this as that repo would". Wrapping the whole dispatch rather
+   * than each handler is what makes it true of every tool at once: the context swap moves the
+   * database and config root together, so a handler reading the ambient context cannot end up
+   * half-rebound, and no handler needed changing to gain this.
+   *
+   * The project id is re-resolved inside the swap. The one the server captured at startup names
+   * a row in ITS database, which does not exist in the target's.
+   */
+  const callToolAsRepo = async (request: CallToolRequest): Promise<CallToolResult> => {
+    const asRepo = (request.params.arguments as Record<string, unknown> | undefined)?.repo;
+    if (typeof asRepo !== 'string' || asRepo.length === 0) return callTool(request);
+    await whenReady();
+    const callerRoot = getProjectRoot();
+    const workspace = callerRoot ? await resolveWorkspace(callerRoot, getConfig() ?? undefined) : null;
+    try {
+      return await withRepoContext(asRepo, workspace, async () => {
+        const root = ambientProjectRoot();
+        const { getProjectByRootPath } = await import('../store/repository.js');
+        const project = await getProjectByRootPath(root);
+        if (!project) {
+          throw new Error(
+            `Repo "${asRepo}" is checked out at ${root} but has no Knowl project there. ` +
+            'Run `knowl init` in it once before acting as it.',
+          );
+        }
+        const { loadConfig } = await import('../core/config.js');
+        return callTool(request, { projectId: project.id, projectRoot: root, config: await loadConfig(root) });
+      });
+    } catch (error: any) {
+      // Refusals here are about the target rather than about the tool, so they are reported the
+      // same way every other refusal is instead of becoming a protocol-level error.
+      return { isError: true, content: [{ type: 'text', text: String(error?.message ?? error) }] };
+    }
+  };
+
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     // Before `getProjectRoot()`, not just before dispatch: startup fills that variable in
     // behind the handshake, and reading it early would take a watermark against `null`.
     await whenReady();
+    // The caller's root deliberately, even for a call acting as another repo: the change notice
+    // reports what moved in THIS session's store, and a write into a sibling moved nothing here.
     const projectRoot = getProjectRoot();
     const watermark = await captureChangeWatermark(projectRoot);
-    const result = await callTool(request);
+    const result = await callToolAsRepo(request);
     const notice = await consumeChangeNotice(projectRoot, request.params.name, watermark);
     if (!notice) return result;
     return { ...result, content: [...result.content, { type: 'text' as const, text: notice }] };

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -133,6 +133,48 @@ export async function withDbPath<T>(dbPath: string, run: () => Promise<T>): Prom
 }
 
 /**
+ * Run `run` as though the process had started in `projectRoot`.
+ *
+ * `withDbPath` deliberately keeps the CALLER's config root, because the stores it was built for
+ * -- namespace databases -- live outside any `<root>/.knowl/` layout and deriving one from their
+ * path would point at nothing. For another REPO that behaviour is exactly wrong: the config root
+ * is what `resolveWriteDefaults` reads to stamp `origin_repo`, what auto-staging reads to find a
+ * cloud pointer, and what secret patterns are loaded from. A swap that moved only the database
+ * would write into the target repo and stamp it with the caller's name.
+ *
+ * So this swaps both, together. Nothing downstream is told about it and nothing needs to be:
+ * ownership stamping, auto-staging, the cloud pointer and `assertOwnedItem` all read the ambient
+ * context, so each of them follows the target repo by construction rather than by remembering.
+ * That is the same reason `cd` has always worked for the CLI, expressed for a server that cannot
+ * change directory.
+ *
+ * Scoped through `AsyncLocalStorage` like `withDbPath`, and for the same reason: reassigning the
+ * module handle made a swap visible to every concurrent operation in the process, so a write
+ * issued against one database during another's hop executed against the wrong file.
+ */
+export async function withRepoRoot<T>(projectRoot: string, run: () => Promise<T>): Promise<T> {
+  const previous = activeContext();
+  const dbPath = resolveStorage(projectRoot).knowledge;
+  const client = await acquireClient(dbPath, {
+    profileFingerprint: await currentProfileFingerprint(projectRoot),
+  });
+  const context: DbContext = {
+    db: drizzle(client, { schema }),
+    client,
+    projectRoot: path.resolve(projectRoot),
+    configRoot: path.resolve(projectRoot),
+    databasePath: path.resolve(dbPath),
+  };
+  try {
+    return await scopedContext.run(context, run);
+  } finally {
+    // Same rule as `withDbPath`: a database nothing had open before this call is not one the
+    // caller asked to keep pooled.
+    if (!previous) await releaseClient(dbPath);
+  }
+}
+
+/**
  * The one transaction in flight on the shared connection, and the queue of the rest.
  *
  * `BEGIN` belongs to the *connection*, and this process holds exactly one. Two transactions

--- a/src/workspace/act-as.ts
+++ b/src/workspace/act-as.ts
@@ -1,0 +1,81 @@
+import { withRepoRoot } from '../store/database.js';
+import type { ActiveWorkspace } from './resolve.js';
+
+/**
+ * Doing another linked repo's work, from here.
+ *
+ * The CLI has always been able to: `cd` into the sibling and every command applies to it, because
+ * standing somewhere is what the ownership guard checks. `assertOwnedItem` is not bypassed by
+ * that -- it is *satisfied*, since the item really is local to where the process is standing.
+ *
+ * An MCP server cannot `cd`. It is bound to the directory it was launched in for its whole life,
+ * so an agent was denied a capability the human running the same tools already had, and the
+ * workaround was to shell out and run the CLI -- which works, unstamped and undocumented, and is
+ * the worst of both.
+ *
+ * This is that `cd`, made explicit. It is deliberately full-rights: acting as a repo means acting
+ * as it, including retiring its knowledge, because the alternative -- an additive-only rebind --
+ * would leave the destructive half of "finish the other repo's task" still only reachable by
+ * shelling out.
+ *
+ * What keeps it safe is not a narrower grant. It is that the target is named, resolved through
+ * the workspace manifest rather than as a path, and that the swap moves the whole context at once
+ * so nothing downstream can end up half-rebound.
+ */
+
+export class NotInWorkspaceError extends Error {
+  constructor(repoName: string) {
+    super(
+      `Cannot act as "${repoName}": this repo is not in a workspace, so there are no linked repos ` +
+      'to act as. Link them with `knowl workspace add`.',
+    );
+    this.name = 'NotInWorkspaceError';
+  }
+}
+
+export class UnknownRepoError extends Error {
+  constructor(repoName: string, known: string[]) {
+    super(
+      `No repo named "${repoName}" in this workspace. Linked: ${known.map(name => `"${name}"`).join(', ')}. ` +
+      'The target is resolved through the workspace manifest, so a repo has to be linked before ' +
+      'it can be acted as -- a path is never accepted.',
+    );
+    this.name = 'UnknownRepoError';
+  }
+}
+
+export class RepoNotPresentError extends Error {
+  constructor(repoName: string) {
+    super(
+      `Repo "${repoName}" is linked to this workspace but is not checked out on this machine, so ` +
+      'there is no working tree to act in. Clone it, or run this from a machine that has it.',
+    );
+    this.name = 'RepoNotPresentError';
+  }
+}
+
+/**
+ * Run `run` as the named linked repo.
+ *
+ * Acting as yourself is allowed and is a plain no-op, so a caller that passes whatever repo it
+ * happens to be looking at needs no special case of its own.
+ */
+export async function withRepoContext<T>(
+  repoName: string,
+  workspace: ActiveWorkspace | null,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!workspace) throw new NotInWorkspaceError(repoName);
+  if (repoName === workspace.repo) return run();
+
+  const peer = workspace.peers.find(entry => entry.name === repoName);
+  if (!peer) {
+    throw new UnknownRepoError(repoName, [workspace.repo, ...workspace.peers.map(entry => entry.name)]);
+  }
+  // Present is about a working tree, not about a database. Acting as a repo means its evidence
+  // paths and its git state resolve, and neither does without a checkout -- so this refuses
+  // rather than writing knowledge whose `affectedPaths` point at nothing on this machine.
+  if (!peer.present) throw new RepoNotPresentError(repoName);
+
+  return withRepoRoot(peer.root, run);
+}

--- a/tests/mcp/act-as-repo.test.ts
+++ b/tests/mcp/act-as-repo.test.ts
@@ -69,6 +69,19 @@ async function seed(root: string, name: string, title: string, content: string):
   return stored.item.id;
 }
 
+/** A second row in an already-seeded repo, kept private -- what `workspace promote` exists to change. */
+async function seedPrivate(root: string, name: string, title: string, content: string): Promise<string> {
+  await initDb(root);
+  const project = await repo.getProjectByRootPath(root);
+  const stored = await storeKnowledgeItemDeduped(project!.id, { category: 'decision', title, content });
+  await getClient().execute({
+    sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ? WHERE id = ?',
+    args: ['repo', name, stored.item.id],
+  });
+  await closeDb();
+  return stored.item.id;
+}
+
 async function rowIn(root: string, id: string) {
   await initDb(root);
   try {
@@ -92,6 +105,7 @@ describe('acting as a linked repo through the tool surface', { timeout: 180_000 
     await writeManifest(workspaceManifestPath('mas'), createManifest('mas', null));
     await seed(A, 'a', 'Local note', 'Something only this repo knows.');
     ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await seedPrivate(B, 'b', 'Rotation key procedure', 'PRIVATE-SENTINEL: b never shared this.');
     await joinWorkspace({ projectRoot: A, workspaceName: 'mas', repoName: 'a' });
     await joinWorkspace({ projectRoot: B, workspaceName: 'mas', repoName: 'b' });
     resetWriteOwnershipCache();
@@ -178,6 +192,44 @@ describe('acting as a linked repo through the tool surface', { timeout: 180_000 
     await closeDb();
     // Without `repo` this is the `belongs to repo "b"` refusal; with it, it simply reads.
     expect(String(result.content[0].text)).not.toMatch(/belongs to repo/);
+  });
+
+  it('refuses `repo` on a tool that does not declare it, naming the ones that do', async () => {
+    // Declaration IS the contract. `repo` is read off the raw arguments at dispatch, before the
+    // per-tool schema is consulted, and `validateToolArguments` only rejects unknown properties
+    // where `additionalProperties: false` -- which almost no tool sets. So without this check
+    // `repo` silently worked on all thirty tools while being described on six, which is the
+    // gap between "not documented" and "not there".
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_conflicts', { repo: 'b' });
+    await closeDb();
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content[0].text)).toMatch(/knowl_conflicts/);
+    expect(String(result.content[0].text)).toMatch(/knowl_store/);
+  });
+
+  it('does not let `repo` read a linked repo\'s private knowledge through knowl_query', async () => {
+    // `knowl_query` declares `repos` (a FILTER over shared rows) and not `repo` (a REBIND of the
+    // whole call). Honouring the singular here would have made every private row in b readable
+    // from a, because a rebound call is standing in b and everything there is local to it.
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_query', {
+      repo: 'b', query: 'private rotation key procedure',
+    });
+    await closeDb();
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content[0].text)).not.toContain('PRIVATE-SENTINEL');
+  });
+
+  it('a refused `repo` writes nothing, in either repo', async () => {
+    await initDb(A);
+    const before = (await repo.listKnowledgeItems()).length;
+    await callTool(A, await loadConfig(A), 'knowl_conflicts', { repo: 'b' });
+    const after = (await repo.listKnowledgeItems()).length;
+    await closeDb();
+    expect(after).toBe(before);
   });
 
   it('acting as yourself is a no-op rather than an error', async () => {

--- a/tests/mcp/act-as-repo.test.ts
+++ b/tests/mcp/act-as-repo.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { resetWriteOwnershipCache } from '../../src/store/write-ownership.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * `repo` on a tool call: do that repo's work from here.
+ *
+ * The distinction this draws is the one the whole cross-repo design turns on. Acting AS a repo is
+ * full rights, because you are doing its work and it is correcting itself -- which folder the
+ * terminal happens to sit in is not a fact about the knowledge. Noticing something wrong in
+ * passing, while doing THIS repo's work, is the other case and is not this.
+ */
+
+const HOME = path.join(os.tmpdir(), 'knowl-mas-home');
+const A = path.join(os.tmpdir(), 'knowl-mas-a');
+const B = path.join(os.tmpdir(), 'knowl-mas-b');
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+async function callTool(root: string, config: ProjectConfig, name: string, args: Record<string, unknown>) {
+  const server = createMcpServer('local', root, config);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as any);
+  const initialized = new Promise<any>(resolve => { transport.onSend = m => { if (m.id === 'init') resolve(m); }; });
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const response = new Promise<any>(resolve => { transport.onSend = m => { if (m.id === 'call') resolve(m); }; });
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name, arguments: args } });
+  const result = await response;
+  await server.close();
+  return result.result;
+}
+
+async function seed(root: string, name: string, title: string, content: string): Promise<string> {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, name)).id;
+  const stored = await storeKnowledgeItemDeduped(projectId, { category: 'decision', title, content });
+  await getClient().execute({
+    sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ? WHERE id = ?',
+    args: ['workspace', name, stored.item.id],
+  });
+  await closeDb();
+  return stored.item.id;
+}
+
+async function rowIn(root: string, id: string) {
+  await initDb(root);
+  try {
+    const rows = await getClient().execute({
+      sql: 'SELECT status, content, origin_repo FROM knowledge_items WHERE id = ?', args: [id],
+    });
+    return rows.rows[0] ?? null;
+  } finally {
+    await closeDb();
+  }
+}
+
+describe('acting as a linked repo through the tool surface', { timeout: 180_000 }, () => {
+  let ownedByB = '';
+
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('mas'), createManifest('mas', null));
+    await seed(A, 'a', 'Local note', 'Something only this repo knows.');
+    ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'mas', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'mas', repoName: 'b' });
+    resetWriteOwnershipCache();
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('a store from A with repo:"b" lands in B, stamped as B', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_store', {
+      repo: 'b', category: 'fact', title: 'Refresh window', content: 'The refresh window is five minutes.',
+    });
+    await closeDb();
+    expect(result.isError).toBeFalsy();
+
+    const id = /([0-9a-f]{16})/.exec(String(result.content[0].text))?.[1] ?? '';
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+    const inB = await rowIn(B, id);
+    expect(String(inB?.content)).toContain('five minutes');
+    expect(String(inB?.origin_repo)).toBe('b');
+    expect(await rowIn(A, id)).toBeNull();
+  });
+
+  it('the DESTRUCTIVE half works too, which is the point of acting as a repo', async () => {
+    // Retiring b's knowledge from a is refused without `repo` and allowed with it -- not because
+    // a guard was bypassed, but because standing in b makes b's item local, exactly as `cd` does.
+    await initDb(A);
+    const config = await loadConfig(A);
+    const refused = await callTool(A, config, 'knowl_update', { id: ownedByB, content: 'Rewritten from the wrong repo.' });
+    expect(String(refused.content[0].text)).toMatch(/belongs to repo "b"/);
+
+    const allowed = await callTool(A, config, 'knowl_update', {
+      repo: 'b', id: ownedByB, content: 'Auth tokens expire after five minutes.',
+    });
+    await closeDb();
+    expect(allowed.isError).toBeFalsy();
+
+    expect(String((await rowIn(B, ownedByB))?.content)).toContain('five minutes');
+  });
+
+  it('omitting repo is unchanged in every way', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_store', {
+      category: 'fact', title: 'Stays here', content: 'Written without naming a repo.',
+    });
+    await closeDb();
+
+    const id = /([0-9a-f]{16})/.exec(String(result.content[0].text))?.[1] ?? '';
+    expect(String((await rowIn(A, id))?.origin_repo)).toBe('a');
+    expect(await rowIn(B, id)).toBeNull();
+  });
+
+  it('a repo that is not linked is refused, and the refusal names what is', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_store', {
+      repo: 'not-a-member', category: 'fact', title: 'Nope', content: 'Should not be written anywhere.',
+    });
+    await closeDb();
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content[0].text)).toMatch(/No repo named "not-a-member"/);
+    expect(String(result.content[0].text)).toMatch(/"a".*"b"|"b".*"a"/);
+  });
+
+  it('a refused target writes nothing anywhere', async () => {
+    await initDb(A);
+    const before = (await repo.listKnowledgeItems()).length;
+    await callTool(A, await loadConfig(A), 'knowl_store', {
+      repo: 'not-a-member', category: 'fact', title: 'Nope', content: 'Should not be written anywhere.',
+    });
+    const after = (await repo.listKnowledgeItems()).length;
+    await closeDb();
+    expect(after).toBe(before);
+  });
+
+  it('reads the target repo\'s history too, so the whole task can be done from here', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_timeline', { repo: 'b', itemId: ownedByB });
+    await closeDb();
+    // Without `repo` this is the `belongs to repo "b"` refusal; with it, it simply reads.
+    expect(String(result.content[0].text)).not.toMatch(/belongs to repo/);
+  });
+
+  it('acting as yourself is a no-op rather than an error', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_store', {
+      repo: 'a', category: 'fact', title: 'Explicitly here', content: 'Named my own repo.',
+    });
+    await closeDb();
+
+    const id = /([0-9a-f]{16})/.exec(String(result.content[0].text))?.[1] ?? '';
+    expect(String((await rowIn(A, id))?.origin_repo)).toBe('a');
+  });
+});

--- a/tests/workspace/act-as-repo.test.ts
+++ b/tests/workspace/act-as-repo.test.ts
@@ -1,0 +1,175 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, getConfigRoot, getProjectRoot, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { resolveWorkspace } from '../../src/workspace/resolve.js';
+import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
+import { resetWriteOwnershipCache } from '../../src/store/write-ownership.js';
+import { UnknownRepoError, withRepoContext } from '../../src/workspace/act-as.js';
+
+/**
+ * Acting as a linked repo.
+ *
+ * The CLI has always been able to do another repo's work: `cd` there and every command applies to
+ * that repo, because standing somewhere is what the ownership guard checks. An MCP server cannot
+ * `cd` -- it is bound to the directory it started in -- so an agent had the capability denied to
+ * it that the human running the same tools already had.
+ *
+ * `withRepoContext` is that `cd`. It swaps the database AND the config root together, which is
+ * the whole design: everything downstream reads the ambient context, so ownership stamping,
+ * auto-staging, the cloud pointer and the ownership guard all follow the target repo without any
+ * of them being told about this.
+ */
+
+const HOME = path.join(os.tmpdir(), 'knowl-actas-home');
+const A = path.join(os.tmpdir(), 'knowl-actas-a');
+const B = path.join(os.tmpdir(), 'knowl-actas-b');
+
+async function seed(root: string, name: string, title: string, content: string): Promise<string> {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, name)).id;
+  const stored = await storeKnowledgeItemDeduped(projectId, { category: 'decision', title, content });
+  await getClient().execute({
+    sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ? WHERE id = ?',
+    args: ['workspace', name, stored.item.id],
+  });
+  await closeDb();
+  return stored.item.id;
+}
+
+describe('withRepoContext', () => {
+  let ownedByB = '';
+
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('aws'), createManifest('aws', null));
+    await seed(A, 'a', 'Local note', 'Something only this repo knows.');
+    ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'aws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'aws', repoName: 'b' });
+    // The seeds above wrote before either repo had joined, so the per-root ownership cache holds
+    // "unlinked" for both. That is a fixture artifact rather than a product one -- a server never
+    // writes into a repo before it joins -- but leaving it would make the stamping assertion
+    // below test the cache instead of the rebind.
+    resetWriteOwnershipCache();
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const inA = async () => {
+    await initDb(A);
+    return resolveWorkspace(A, await loadConfig(A));
+  };
+
+  it('swaps the config root too, not just the database', async () => {
+    // The trap `withDbPath` documents: it keeps the CALLER's config root, which is right for a
+    // namespace store and wrong for a repo. Ownership stamping and the cloud pointer are both
+    // read from the config root, so a swap that moved only the database would write into `b`
+    // and stamp it `a`.
+    const workspace = await inA();
+    const seen = await withRepoContext('b', workspace, async () => ({
+      projectRoot: getProjectRoot(),
+      configRoot: getConfigRoot(),
+    }));
+    await closeDb();
+
+    expect(path.resolve(seen.projectRoot)).toBe(path.resolve(B));
+    expect(path.resolve(seen.configRoot)).toBe(path.resolve(B));
+  });
+
+  it('restores the caller\'s context afterwards', async () => {
+    const workspace = await inA();
+    await withRepoContext('b', workspace, async () => undefined);
+    const after = getProjectRoot();
+    await closeDb();
+
+    expect(path.resolve(after)).toBe(path.resolve(A));
+  });
+
+  it('a write inside the rebind lands in the target repo, stamped as the target', async () => {
+    const workspace = await inA();
+    const written = await withRepoContext('b', workspace, async () => {
+      const project = await repo.getProjectByRootPath(getProjectRoot());
+      const result = await storeKnowledgeItemDeduped(project!.id, {
+        category: 'fact', title: 'Refresh window', content: 'The refresh window is five minutes.',
+      });
+      return result.item.id;
+    });
+    await closeDb();
+
+    // In B's database...
+    await initDb(B);
+    const inTarget = await repo.getKnowledgeItem(written);
+    const stamp = await getClient().execute({ sql: 'SELECT origin_repo FROM knowledge_items WHERE id = ?', args: [written] });
+    await closeDb();
+    expect(inTarget?.title).toBe('Refresh window');
+    // ...and stamped as B's own, which is the point: it is indistinguishable from a write B made.
+    expect(String(stamp.rows[0].origin_repo)).toBe('b');
+
+    // ...and NOT in A's.
+    await initDb(A);
+    const inCaller = await repo.getKnowledgeItem(written);
+    await closeDb();
+    expect(inCaller).toBeNull();
+  });
+
+  it('the ownership guard is satisfied rather than bypassed', async () => {
+    // Standing in `b` makes b's item local, so `assertOwnedItem` passes for the ordinary reason.
+    // Nothing here weakens the guard; the guard is asked a different question.
+    const { assertOwnedItem } = await import('../../src/workspace/ownership.js');
+    const workspace = await inA();
+    await expect(assertOwnedItem(ownedByB, workspace)).rejects.toThrow(/belongs to repo "b"/);
+    await withRepoContext('b', workspace, async () => {
+      const inner = await resolveWorkspace(getProjectRoot(), await loadConfig(getProjectRoot()));
+      await expect(assertOwnedItem(ownedByB, inner)).resolves.toBeUndefined();
+    });
+    await closeDb();
+  });
+
+  it('refuses a repo that is not linked, naming what is', async () => {
+    const workspace = await inA();
+    await expect(withRepoContext('not-a-member', workspace, async () => undefined))
+      .rejects.toThrow(UnknownRepoError);
+    await closeDb();
+  });
+
+  it('refuses outside a workspace, rather than accepting an arbitrary path', async () => {
+    await initDb(A);
+    await expect(withRepoContext('b', null, async () => undefined)).rejects.toThrow(/workspace/i);
+    await closeDb();
+  });
+
+  it('refuses a linked repo that is not checked out on this machine', async () => {
+    const workspace = await inA();
+    const absent = {
+      ...workspace!,
+      peers: workspace!.peers.map(peer => ({ ...peer, present: false })),
+    };
+    await expect(withRepoContext('b', absent, async () => undefined)).rejects.toThrow(/not checked out|not present/i);
+    await closeDb();
+  });
+
+  it('acting as yourself is allowed and is a no-op, so callers need no special case', async () => {
+    const workspace = await inA();
+    const seen = await withRepoContext('a', workspace, async () => getProjectRoot());
+    await closeDb();
+    expect(path.resolve(seen)).toBe(path.resolve(A));
+  });
+});


### PR DESCRIPTION
## What

`repo: "<name>"` on a tool call runs that one call **as** the named linked repo — against its store, stamped as its own, with its config, its cloud pointer and its ownership rules. Exactly as if the command had been run in that repo's directory.

Declared on `knowl_store`, `knowl_decide`, `knowl_update`, `knowl_ingest_atoms`, `knowl_timeline` and `knowl_evidence_list`. Omitting it leaves every call exactly as it was.

## Why

This is **not a new capability**. `cd ../sibling && knowl store …` has always worked, because standing in a repo is what the ownership guard checks — an item there is simply *local*, so `assertOwnedItem` is **satisfied, not bypassed**. What was missing was a way for an MCP server, bound to its launch directory for the whole of its life, to do the same. The workaround was shelling out to the CLI: it works, and it is invisible to every rule this codebase otherwise keeps.

The cost showed up as knowledge filed in the wrong place. A session that spends an hour on one repo's task, with its output landing in another, had to write what it learned where it was standing or not at all.

## The design, in one line

**Move the whole context, not part of it.**

`withDbPath` deliberately keeps the *caller's* config root — correctly, because the stores it was built for are namespace databases outside any `<root>/.knowl/` layout, where deriving a root from the path would point at nothing. For another **repo** that is exactly wrong: the config root is what `resolveWriteDefaults` reads to stamp `origin_repo`, what auto-staging reads to find a cloud pointer, and where secret patterns come from. A swap that moved only the database would write into the target and stamp it with the caller's name.

`withRepoRoot` moves both together. Because everything downstream reads the ambient context, **nothing had to be told about this**: ownership stamping, auto-staging, the cloud pointer and the ownership guard each follow the target by construction rather than by remembering to. That is also why the wrap sits at the dispatch level rather than in each handler — a handler cannot end up half-rebound, and not one of them changed.

## Notes for review

- **Follows the recorded constraint on reaching another database inside a request.** `AsyncLocalStorage`-scoped like `withDbPath`, never `initDbPath`/`closeDb` — those own the process-wide context, and a helper reachable from a request that touches them leaves every *later* call in that server with no database at all.
- **The project id is re-resolved inside the swap.** The one captured at startup names a row in the server's own database that does not exist in the target's.
- **Full rights, deliberately.** Acting as a repo means acting as it, retiring its knowledge included. An additive-only rebind would leave the destructive half of "finish the other repo's task" reachable only by shelling out — the situation this removes. What bounds it is not a narrower grant: the target is **named, not pathed**, resolved through the workspace manifest, so a repo must be linked before it can be acted as.
- **An absent checkout is refused rather than written to.** A repo's evidence paths and git state do not resolve without a working tree, so knowledge written into one would cite files that are not on this machine.
- **The change notice still reads the caller's root.** It reports what moved in this session's store, and a write into a sibling moved nothing here.
- **`repo` is declared on six tools, not thirty.** An undescribed argument is one the model never uses; a described one on a tool it makes no sense for is noise on every listing.

## Identified and deliberately not in this diff

Acting as another repo currently **erases who did the work** — the write is stamped `origin_repo: <target>` with nothing recording that another repo's session authored it. The right fix is a nullable `written_by` beside `origin_repo` (subject and author are two different facts that `origin_repo` conflates), plus carrying it on the cloud wire, since `PublishItem` dropping a field the local schema holds is the failure shape this repo already records for `evidence`, `assertions` and `tier`. Left out because no consumer reads it yet and it is a schema change with a migration level of its own. Happy to follow up.

## Verification

Full suite on the branch: **333 files, 3053 passing, 0 failing.** Lint, typecheck, build and `docs:check` clean. Baseline on `upstream/main` @ `006b4eb` measured first.

15 new tests across `tests/workspace/act-as-repo.test.ts` (context swap, restoration, stamping, guard-satisfied-not-bypassed, four refusals) and `tests/mcp/act-as-repo.test.ts` (end-to-end through a real server, including that a refused target writes nothing anywhere).
