### PR TITLE
docs: document cross-repo reads and writes, and correct what they invalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,9 @@ candidates. Park a workstream under a key and pick it up in any session, from an
 **🔗 Workspaces**
 
 Your API repo learned something the frontend repo needs. Link them and a query fans out,
-while each repository keeps its own database and its own ownership boundary. Knowledge a
-repo already holds is shared only when you promote it, and only the owner can retire its
-own atoms.
+while each repository keeps its own database and its own ownership boundary. Open a shared
+peer atom in full by id, or finish that repo's work from here by naming it on the call.
+Knowledge a repo already holds is shared only when you promote it.
 
 `workspace init` · `workspace add` · `workspace promote --apply`
 
@@ -489,9 +489,15 @@ knowl workspace promote --category decision --apply   # or name it outright
 
 Joining a workspace shares what the repo writes **from then on**, and says so when it does; pass
 `--default-visibility repo` to decline. What the repo already knows is shared only when you
-promote it. Peer results are read-only and labeled with the repo that owns them, and only the
-owner can retire its own atoms. A peer that is missing or unreadable is skipped and disclosed,
-never a reason for your local search to fail.
+promote it. Peer results are labeled with the repo that owns them, and a shared one can be opened
+in full by id — without its `affectedPaths` or evidence, which resolve against a checkout you are
+not standing in. A peer that is missing or unreadable is skipped and disclosed, never a reason for
+your local search to fail.
+
+Writing into a sibling is deliberate rather than incidental. An agent names the repo on the call
+and that one call runs **as** that repo — its store, its config, its ownership rules, stamped as
+its own — exactly as `cd`-ing there has always behaved for the CLI. Name nothing and a foreign id
+is refused as before. Either way a repo's private knowledge stays private until it is promoted.
 
 → [Workspaces](docs/reference.md#workspaces)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -31,7 +31,7 @@ which parts of a restore are deliberately not restored.
 | [Retrieval and context](#retrieval-and-context) | [Current retrieval](#current-retrieval) · [What a result carries](#what-a-result-carries) · [Embedding models](#choosing-an-embedding-model) · [Historical queries](#historical-retrieval-and-assertions) · [Context packs](#bounded-context-packs) |
 | [Tasks, sessions, lifecycle](#tasks-sessions-and-agent-lifecycle) | [Work loops](#manual-work-loops) · [Retention and promotion](#session-retention-recovery-and-promotion) · [Handoffs and resume keys](#leaving-work-for-later) · [Transcript search](#searchable-session-transcripts-optional-off-by-default) · [Host behavior](#host-and-subagent-behavior) |
 | [Evidence, code, drift](#evidence-code-intelligence-and-drift) | [Evidence and symbols](#evidence-and-symbols) · [PR drift and feedback](#pull-request-drift-and-retrieval-feedback) |
-| [Workspaces](#workspaces) | [Federation and ownership](#federation-and-ownership) · [Ownership stamping](#ownership) |
+| [Workspaces](#workspaces) | [Federation and ownership](#federation-and-ownership) · [Reading a peer's atom by id](#reading-a-linked-repos-atom-by-id) · [Doing a peer's work](#doing-a-linked-repos-work-from-here) · [Ownership stamping](#ownership) |
 | [Knowl Cloud](#knowl-cloud) | [Identity and connection](#identity-and-connection) · [Publishing and drift](#publishing-works-from-any-branch-reporting-drift-does-not) · [Staying current](#staying-current) |
 | [Learned skills and synthesis](#learned-skills-and-synthesis) | [File-backed skills](#file-backed-skills) · [Deterministic synthesis](#deterministic-synthesis) |
 | [Portability and maintenance](#portability-and-maintenance) | [Export and import](#jsonl-export-and-import) · [Garbage collection](#garbage-collection) · [Snapshots, audit, doctor](#snapshots-audit-and-doctor) |
@@ -666,8 +666,12 @@ Normal `workspace add` refuses to link when `.knowl/config.json` is tracked by G
 mismatches or item ownership.
 
 Only an explicit current query fans out to available peers. A promoted peer result is labeled
-with its `repo` and is read-only from the querying repository. Mutations, historical `asOf`
-queries, recent context, context packs, work loops, synthesis, code indexing, and implicit
+with its `repo` and is read-only from the querying repository — unless the call names that repo,
+which runs it *as* that repo rather than reaching across from this one; see
+[Doing a linked repo's work from here](#doing-a-linked-repos-work-from-here). A shared peer atom
+can also be opened whole by id, without acting as anything: see
+[Reading a linked repo's atom by id](#reading-a-linked-repos-atom-by-id). Mutations, historical
+`asOf` queries, recent context, context packs, work loops, synthesis, code indexing, and implicit
 lifecycle context remain local. Missing, unreadable, or schema-incompatible peers are skipped and
 disclosed in the response rather than causing healthy local retrieval to fail.
 
@@ -692,14 +696,41 @@ costs one check.
 
 Promotion is preview-first and accepts active, private, locally owned atoms selected by category
 or ID. Both `workspace add` and `workspace join` enforce a compatible embedding identity, reject a
-nested checkout, and refuse a Git-tracked `.knowl/config.json` without `--force`. There is no
-cross-repository mutation, demote/unshare command, or workspace-wide historical view.
+nested checkout, and refuse a Git-tracked `.knowl/config.json` without `--force`. Nothing reaches
+across from one repository into another: a foreign id is refused, and the only way to change a
+linked repository's knowledge is to run the call *as* that repository, which makes the atom local
+and the guard satisfied rather than bypassed. There is no demote/unshare command, and no
+workspace-wide historical view.
 
 `workspace remove --export-first` is an acknowledgement that the repository still owns
 knowledge; it does not create an export. A removed name is retired only when the repository
 still owns active atoms, since the name is the ownership key on everything it wrote. A repository
 that owned nothing releases its name for anyone; a repository that owned atoms keeps exclusive
 claim on the name and reclaims it by re-linking, while every other repository is refused.
+
+### Reading a linked repo's atom by id
+
+A federated query returns rows from every linked repository, each labeled with its owner. Asking
+for one of those rows *whole* — `knowl_query { id }` — resolves it too, so reading a federated
+result no longer means switching repositories.
+
+The record crosses; the checkout-relative fields do not. A foreign atom arrives with its content,
+reasoning and alternatives, and **without** `affectedPaths` or evidence, because those name files
+in the owning repository's checkout and resolve against its database and working tree — answered
+here they would be measured against the wrong tree. It carries a `foreign` block naming the owner,
+so an absent `affectedPaths` reads as deliberate rather than as an atom that cites nothing, and so
+the agent knows where the item can be changed.
+
+**It reaches exactly the rows a query reaches, and no others.** A repository's private knowledge
+stays private until `workspace promote` shares it; knowing an id is not a way around that, since
+ids are not secret — they travel in supersession chains and conflict reports. A private row is
+reported as *not found* rather than as a refusal, because "that one is private" would confirm it
+exists.
+
+Reading is all this grants. Updating, superseding or retiring another repository's item is refused
+by the same guard as before, with the same message. A miss says the linked repositories were
+searched too, and says "readable from here": a repository that is not checked out on this machine
+was never asked, and must not be reported as one that answered no.
 
 ### Ownership
 


### PR DESCRIPTION
5.3.0 ships two capabilities the manual never described — and one of them made a standing claim
false.

## The contradiction

`docs/reference.md` → **Federation and ownership** said:

> There is no cross-repository mutation, demote/unshare command, or workspace-wide historical view.

> A promoted peer result is labeled with its `repo` and is **read-only** from the querying repository.

The first is now wrong outright — naming a repo on a call runs it *as* that repo, which is exactly
the mutation path that sentence denied existed. The second holds only until a call names the
target. And the section that *does* document acting as a repo (#110) lives in the agent-facing half
of the document, so the manual contradicted itself depending on which half you read.

## What this corrects it to

The distinction both features turn on: **nothing reaches across from one repo into another.** The
call moves, and standing in the target is what makes its atoms local — the ownership guard
*satisfied*, not bypassed. That is already the sentence the code and the tests use; now the manual
uses it too.

## What it adds

**`### Reading a linked repo's atom by id`** — #109 shipped with no reference section at all. Covers
what crosses (content, reasoning, alternatives), what deliberately does not (`affectedPaths` and
evidence, which resolve against a checkout you are not standing in), and the bound that matters
most: it reaches exactly the rows a query reaches, and a private row reports as *not found* rather
than as a refusal, because "that one is private" confirms it exists.

## README

Follows the rule the project's own docs decision records — *every shipped feature appears in the
Features section*. The workspaces card and its expandable block both said peer results were
read-only and only an owner could retire its atoms: true in the sense that mattered before, and
misleading now. Both now say what writing into a sibling actually requires, which is that you name
it.

Contents table gains both subsections.

## Verification

`docs:check` clean, both new anchors confirmed to resolve. Docs only — no source touched.