### PR TITLE
chore: release 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.3.0 — 2026-08-15
+
+Two ways a linked workspace stops being a wall. Until now a repo could *see* its siblings'
+knowledge and do nothing else with it: a federated result carried rows you could not open, and work
+that belonged to another repo had to be filed where you were standing or not at all. Both are
+addressed here, and both stop at the same line — a repo's private knowledge stays private, and the
+tools that can act as another repo are the ones that say so.
 
 ### An agent can do another linked repo's work, from here
 
@@ -70,6 +76,14 @@ exactly as before, by the same guard, with the same message.
 A miss now says the linked repos were searched too — and says "readable from here", because a repo
 that is not checked out on this machine was never asked, and must not be reported as one that
 answered no.
+
+### The reference page has a logo you can see
+
+`docs/reference.md` opened with a near-white wordmark on transparent, so on GitHub's light theme
+only the cyan `owl` showed and the page led with a floating half-word. It now ships a light variant
+alongside the dark one and lets `prefers-color-scheme` choose. The dark original also drops from
+329 KB to 118 KB at unchanged dimensions — it is flat two-colour art that was stored as 32-bit
+truecolour.
 
 ## 5.2.1 — 2026-08-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.2.1",
+      "version": "5.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Minor, not patch. Two `feat` commits since `v5.2.1` add a new tool argument and a new read
capability — the shape 3.3.0's notes recorded as a minor, and the shape 5.2.1 explicitly was not
("no new command and no new flag"). Anyone pinned to `~5.2.1` correctly does not get this.

## What ships

**#110 — a `repo` argument.** `repo: "<name>"` runs one call as that linked repo: its store, its
config, its cloud pointer, its ownership rules, stamped as its own. Not a new capability, only a
newly reachable one — `cd ../sibling && knowl store …` always worked, because standing in a repo is
what the ownership guard checks. Honoured only on the six tools that declare it.

**#109 — a linked repo's atom, whole, by id.** `knowl_query { id }` resolves an id a linked repo
*shares*, so a federated result can be read without switching repos. Arrives without
`affectedPaths` or evidence — those resolve against a checkout you are not standing in. Reaches
exactly the rows a query reaches; a private row reports as not found.

**#111** — a light-theme logo, and the dark one down 64% at unchanged resolution.
**#112** — the manual now documents both features, and no longer claims "there is no
cross-repository mutation".

## Verification

Full set on this exact tree: build → **335 files, 3072 passing, 5 skipped** → typecheck → lint →
`docs:check`. All clean.

## Merge note

**Merge commit, not squash** — the house convention, so `chore: release 5.3.0` survives as a
taggable commit for `v5.3.0`.