### PR TITLE
feat(workspace): record who wrote an atom, when that is not who owns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,28 @@ only one of them is something the user just did:
 Severity is unchanged: a majority uncovered still fails, a tail still warns, and the remedy is
 `knowl reindex --vectors` either way.
 
+### An atom written across repos records who wrote it
+
+5.3.0 let an agent do a linked repo's work by naming it on the call. The write lands in that
+repo, stamped as its own — which is right, because it governs that repo, and that repo promotes
+and retires it. But nothing recorded that another repo's session authored it, so the fact simply
+disappeared at the moment it was created.
+
+`written_by` records it. Subject and author are two different questions, and `origin_repo` only
+ever answered the first.
+
+**Null keeps meaning "the owner wrote it"**, which is the ordinary case and the reason the column
+is not stamped on every write. Putting a repo's own name on every one of its own atoms would make
+the column say nothing on the overwhelming majority of rows, and force a reader to compare it
+against `origin_repo` to discover that. It is set only when the two genuinely differ.
+
+Existing knowledge is deliberately **not** backfilled, and here writing nothing is the correct
+answer rather than a concession: every row that predates the column was written before a repo
+could act as another, so its owner is exactly who wrote it — which is what null already says.
+
+Migration level 11, one nullable column. The compatibility floor does not move: an older Knowl
+ignores the column, and a newer one reading null gets the truth rather than a hole.
+
 ## 5.3.0 — 2026-08-15
 
 Two ways a linked workspace stops being a wall. Until now a repo could *see* its siblings'

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -738,6 +738,16 @@ was never asked, and must not be reported as one that answered no.
 promotable. Joining additionally backfills the rows that already existed, which are by definition
 the joining repository's own.
 
+`written_by` records the repository whose session authored an atom, when that is not the one that
+owns it — the case that arises from naming a repo on a call. Ownership is unaffected: the atom is
+the target's, and the target promotes and retires it. `NULL` means the owner wrote it, which is
+the ordinary case, so the column is set only when author and owner genuinely differ; stamping a
+repository's own name on its own atoms would make the field say nothing on almost every row. Rows
+predating the column are `NULL` for the same reason rather than as a gap — they were written
+before a repository could act as another, so their owner is exactly who wrote them. It is not part
+of the lifecycle fingerprint: authorship is fixed at write time and never diverges, so including
+it would make every cross-repository atom look changed to a peer holding the same one.
+
 ## Knowl Cloud
 
 A hosted workspace shares knowledge across a team. It is entirely opt-in: a repository that never

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -93,6 +93,19 @@ export interface KnowledgeItem {
   lifecycleHash?: string | null;
   /** Owning repo in a workspace; null outside one. The only lifecycle key. */
   originRepo?: string | null;
+  /**
+   * The repo whose session authored this atom, when that is not the repo that owns it.
+   *
+   * Subject and author are two different facts, and `originRepo` answers only the first. Acting
+   * as a linked repo writes an atom that is genuinely the target's -- it governs that repo, is
+   * promoted and retired by it, and travels with its knowledge -- but the work happened
+   * somewhere else, and without this nothing recorded where.
+   *
+   * Null is the ordinary case and means "the owner wrote it", not "unknown". Storing the owner's
+   * own name here for every local write would make the column noise and cost a read to discover
+   * it says nothing, so it is set only when the two genuinely differ.
+   */
+  writtenBy?: string | null;
   /** 'repo' | 'workspace'. Logical scope, independent of which file holds the row. */
   visibility?: string | null;
   freshness: KnowledgeFreshness;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -747,6 +747,10 @@ export function registerTools(
             ...(!foreign && item.affectedPaths?.length ? { affectedPaths: item.affectedPaths } : {}),
             ...(item.conflictKey ? { conflictKey: item.conflictKey } : {}),
             ...(item.supersededById ? { supersededById: item.supersededById } : {}),
+            // Present only when the author is not the owner, which is what makes it worth
+            // reading: an atom carrying it was written by another repo's session finishing this
+            // repo's work, and that is context for judging it. Absent means the owner wrote it.
+            ...(item.writtenBy ? { writtenBy: item.writtenBy } : {}),
             createdAt: item.createdAt,
             updatedAt: item.updatedAt,
             // Said, not implied. An absent `affectedPaths` is indistinguishable from an atom

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -52,6 +52,7 @@ const SCHEMA_STATEMENTS = [
     tier TEXT NOT NULL DEFAULT 'asserted',
     tier_since TEXT,
     last_drift_at TEXT,
+    written_by TEXT,
     provenance TEXT,
     conflict_key TEXT, conflict_scope TEXT, conflict_exclusive INTEGER NOT NULL DEFAULT 0,
     superseded_by_id TEXT,
@@ -775,6 +776,12 @@ async function ensureFreshnessColumns(client: Client): Promise<void> {
     // Left NULL rather than backfilled: an existing row has no recorded drift observation,
     // and inventing one would refuse promotion for items nothing has actually contradicted.
     await client.execute('ALTER TABLE knowledge_items ADD COLUMN last_drift_at TEXT;');
+  }
+  if (!columns.includes('written_by')) {
+    // Left NULL, and NULL already means the right thing: "the owner wrote it". Every row that
+    // predates this column was written before any repo could act as another, so the owner is
+    // exactly who wrote it -- the honest backfill is the one that writes nothing.
+    await client.execute('ALTER TABLE knowledge_items ADD COLUMN written_by TEXT;');
   }
   if (!columns.includes('freshness')) {
     await client.execute(`ALTER TABLE knowledge_items ADD COLUMN freshness TEXT NOT NULL DEFAULT '${DEFAULT_FRESHNESS}';`);

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -28,7 +28,7 @@ import {
 } from '../core/types.js';
 import { DatabaseError, KnowledgeConflictError } from '../core/errors.js';
 import { DEFAULT_FRESHNESS, hashKnowledgeContent, hashKnowledgeLifecycle, normalizeAffectedPaths } from './freshness.js';
-import { resolveWriteDefaults } from './write-ownership.js';
+import { currentAuthorRepo, resolveWriteDefaults } from './write-ownership.js';
 import { assertConfidenceInRange, KnowledgeValidationError, validateKnowledgeWrite } from '../core/knowledge-validation.js';
 
 export const LOCAL_PROJECT_ID = 'local';
@@ -158,11 +158,19 @@ export async function createKnowledgeItem(
   // Visibility rides the same resolution: both come from this repo's manifest entry, and a
   // second lookup per write is the 2.7.0 regression 2.7.1 fixed.
   const { repo: originRepo, visibility } = await resolveWriteDefaults();
+  // Recorded only when the author is not the owner. Writing the owner's own name on every local
+  // write would make the column say nothing on the overwhelming majority of rows, and a reader
+  // would have to compare it against `originRepo` to discover that. NULL already carries "the
+  // owner wrote it" -- including for every row written before the column existed, when no repo
+  // could act as another and so the owner necessarily did.
+  const author = currentAuthorRepo();
+  const writtenBy = author && author !== originRepo ? author : null;
   const freshness = item.freshness || DEFAULT_FRESHNESS;
 
   const newItem = {
     id,
     originRepo,
+    writtenBy,
     category: item.category,
     status: 'active' as KnowledgeStatus,
     title: item.title,

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -138,7 +138,25 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * re-send atoms already published. `ensureLedgerStageState` backfills it, and the backfill
  * direction is deliberately fail-safe: see its docblock.
  */
-export const KNOWL_MIGRATION_LEVEL = 10;
+/*
+ * Level 11 adds `knowledge_items.written_by`: the repo whose session authored an atom, when
+ * that is not the repo that owns it.
+ *
+ * One nullable column and no backfill, on the same reasoning as level 5 -- and here the absence
+ * of a backfill is not a compromise but the correct value. NULL means "the owner wrote it", and
+ * every row predating this column was written before any repo could act as another, so the
+ * owner IS who wrote it.
+ *
+ * The bump is still load-bearing rather than ceremonial. `ALTER TABLE ... ADD COLUMN` only runs
+ * for a store that reaches the migration body, so without it an existing database stamped at
+ * level 10 would skip the column forever while this build's mapper reads it -- the failure this
+ * gate exists to prevent, and one that would surface as a write error rather than a missing
+ * feature.
+ *
+ * `KNOWL_SCHEMA_VERSION` deliberately does not move: an older build ignores the column, and a
+ * newer one reading NULL gets the truth rather than a hole.
+ */
+export const KNOWL_MIGRATION_LEVEL = 11;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -27,6 +27,17 @@ export const knowledgeItems = sqliteTable('knowledge_items', {
   lifecycleHash: text('lifecycle_hash'),
   /** Owning repo in a workspace; NULL outside one. The only lifecycle key. */
   originRepo: text('origin_repo'),
+  /**
+   * The repo whose session authored this atom, when that is not `originRepo`.
+   *
+   * Deliberately NOT part of `lifecycleHash`. Authorship is a fact about how the row came to
+   * exist and never changes after the write; the lifecycle fingerprint tracks what an import or
+   * a sync has to reconcile, and including a field that cannot diverge would make every atom
+   * written across repos look changed to a peer that has the same one.
+   *
+   * NULL means the owner wrote it, which is the ordinary case -- see `KnowledgeItem.writtenBy`.
+   */
+  writtenBy: text('written_by'),
   /** 'repo' | 'workspace'. Logical scope, persisted independently of which file holds the row. */
   visibility: text('visibility').notNull().default('repo'),
   freshness: text('freshness').notNull().default('fresh'), // 'fresh', 'stale', 'needs_review'

--- a/src/store/write-ownership.ts
+++ b/src/store/write-ownership.ts
@@ -1,4 +1,30 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { getConfigRoot } from './database.js';
+
+/**
+ * The repo whose session is running the current call, while it acts as a different repo.
+ *
+ * `resolveWriteDefaults` answers "who owns what I am writing", and once a call has been rebound
+ * to a linked repo that answer is the TARGET -- correctly, since the atom really is the
+ * target's. What it can no longer answer is who did the work, because the ambient context it
+ * reads has already been replaced. So the caller's name rides beside the swap rather than being
+ * derived from it.
+ *
+ * `AsyncLocalStorage` for the same reason the database swap uses it: a module-level variable
+ * would leak the caller's identity into every concurrent operation in the process, and an MCP
+ * server serves calls from one repo while another is mid-hop.
+ */
+const authorScope = new AsyncLocalStorage<string>();
+
+/** Run `run` recording `callerRepo` as the author of anything it writes. */
+export function runAsAuthor<T>(callerRepo: string, run: () => Promise<T>): Promise<T> {
+  return authorScope.run(callerRepo, run);
+}
+
+/** The acting repo, or null when a call is simply running where it stands. */
+export function currentAuthorRepo(): string | null {
+  return authorScope.getStore() ?? null;
+}
 
 /**
  * Which repo owns knowledge written right now, or null outside a workspace.

--- a/src/workspace/act-as.ts
+++ b/src/workspace/act-as.ts
@@ -1,4 +1,5 @@
 import { withRepoRoot } from '../store/database.js';
+import { runAsAuthor } from '../store/write-ownership.js';
 import type { ActiveWorkspace } from './resolve.js';
 
 /**
@@ -77,5 +78,14 @@ export async function withRepoContext<T>(
   // rather than writing knowledge whose `affectedPaths` point at nothing on this machine.
   if (!peer.present) throw new RepoNotPresentError(repoName);
 
-  return withRepoRoot(peer.root, run);
+  // The caller's name rides alongside the context swap, because the swap is what destroys the
+  // ability to derive it: everything downstream reads the ambient context, and after the hop
+  // that context IS the target. Acting as a repo makes the atom the target's, which is right --
+  // it governs that repo and is promoted and retired by it. It should not also erase the fact
+  // that another repo's session did the work.
+  //
+  // Outside the swap on purpose. `withRepoRoot` is reachable from other callers with other
+  // reasons to point at another database, and only THIS one -- a named repo doing another
+  // repo's work -- has an author to record.
+  return runAsAuthor(workspace.repo, () => withRepoRoot(peer.root, run));
 }

--- a/tests/mcp/query-fetch-by-id.test.ts
+++ b/tests/mcp/query-fetch-by-id.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { closeDb, initDb } from '../../src/store/database.js';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import * as repo from '../../src/store/repository.js';
 import { createMcpServer } from '../../src/mcp/server.js';
@@ -85,6 +85,38 @@ describe('knowl_query fetch-by-id', () => {
     expect(full.reasoning).toContain('REASONING-SENTINEL');
     expect(full.alternatives).toContain('a nightly batch');
     expect(full).toHaveProperty('createdAt');
+  });
+
+  /**
+   * `written_by` is written by the store and read by nothing else, so the one link that makes it
+   * a feature rather than a column is this surface. Its failure mode is silence: a mapper that
+   * dropped the field, or a select that never asked for it, yields a response that looks exactly
+   * like the ordinary case where the owner wrote the atom. Both branches are pinned here for
+   * that reason -- an assertion that the field appears is only worth as much as one that it does
+   * not appear when it should not.
+   */
+  it('omits writtenBy for an ordinary atom, since absent already means the owner wrote it', async () => {
+    const [full] = parse(await call('knowl_query', { id: bigId }));
+    expect(full).not.toHaveProperty('writtenBy');
+  });
+
+  it('surfaces writtenBy when another repo authored the atom', async () => {
+    // Its own item rather than a stamp on the shared one, so the pair above and below cannot be
+    // made to pass or fail by the order they run in.
+    //
+    // Set on the row rather than through `withRepoContext`, deliberately: what is under test is
+    // the read path from column to response, and driving it through the write path would let a
+    // broken mapper pass on a value the writer had put there anyway.
+    const authored = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Written from a sibling', content: 'Authored elsewhere, owned here.',
+    });
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET written_by = ? WHERE id = ?',
+      args: ['github.com/acme/service-a', authored.id],
+    });
+
+    const [full] = parse(await call('knowl_query', { id: authored.id }));
+    expect(full.writtenBy).toBe('github.com/acme/service-a');
   });
 
   it('refuses an unknown id with isError, not an empty array that reads as a miss', async () => {

--- a/tests/store/migration-level-10.test.ts
+++ b/tests/store/migration-level-10.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { createClient, type Client } from '@libsql/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { bootstrapSchema } from '../../src/store/bootstrap.js';
-import { readMigrationLevel } from '../../src/store/schema-version.js';
+import { KNOWL_MIGRATION_LEVEL, readMigrationLevel } from '../../src/store/schema-version.js';
 
 let root: string;
 let client: Client;
@@ -69,7 +69,10 @@ describe('a level-9 store upgrading to level 10', () => {
       "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'cloud_excluded'",
     );
     expect(tables.rows).toHaveLength(1);
-    expect(await readMigrationLevel(client)).toBe(10);
+    // The CURRENT level, not the literal 10. What this asserts is that one bootstrap stamps the
+    // gate forward, and pinning the number made an unrelated later level fail a test about this
+    // one -- the brittleness `impact-schema.test.ts` already avoids by asserting `>= 4`.
+    expect(await readMigrationLevel(client)).toBe(KNOWL_MIGRATION_LEVEL);
   });
 
   it('maps the old three-column predicate onto explicit states', async () => {

--- a/tests/store/migration-level-11.test.ts
+++ b/tests/store/migration-level-11.test.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createClient, type Client } from '@libsql/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { bootstrapSchema } from '../../src/store/bootstrap.js';
+import { KNOWL_MIGRATION_LEVEL, readMigrationLevel, readSchemaVersion } from '../../src/store/schema-version.js';
+
+let root: string;
+let client: Client;
+
+/**
+ * A store as a level-10 build left it: `knowledge_items` without `written_by`.
+ *
+ * Built by bootstrapping the current schema and removing what level 11 added, rather than by
+ * pasting level 10's DDL -- a copy would drift from `bootstrap.ts` silently and start testing a
+ * schema no build ever wrote. Same construction as the level-10 test, for the same reason.
+ */
+async function makeLevel10Store(c: Client): Promise<void> {
+  await bootstrapSchema(c);
+  await c.execute('ALTER TABLE knowledge_items DROP COLUMN written_by');
+  // Only the gate is rewound. `user_version` stays where a current build left it, which is what
+  // makes this a migration test rather than a compatibility one.
+  await c.execute('PRAGMA application_id = 10');
+}
+
+const columnsOf = async (c: Client): Promise<string[]> => {
+  const rows = await c.execute('PRAGMA table_info(knowledge_items)');
+  return rows.rows.map(row => String(row.name));
+};
+
+describe('a level-10 store upgrading to level 11', () => {
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-mig11-'));
+    client = createClient({ url: `file:${path.join(root, 'knowl.db')}` });
+    await makeLevel10Store(client);
+  });
+
+  afterEach(async () => {
+    try { client.close(); } catch { /* already closed */ }
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('gets the column and the stamp from one bootstrap', async () => {
+    expect(await readMigrationLevel(client)).toBe(10);
+    expect(await columnsOf(client)).not.toContain('written_by');
+
+    await bootstrapSchema(client);
+
+    expect(await columnsOf(client)).toContain('written_by');
+    expect(await readMigrationLevel(client)).toBe(KNOWL_MIGRATION_LEVEL);
+  });
+
+  it('leaves existing rows NULL, which is the true answer rather than a gap', async () => {
+    // Every row predating this column was written before a repo could act as another, so the
+    // owner is exactly who wrote it -- and NULL is precisely how this column says that. A
+    // backfill writing `origin_repo` into `written_by` would be inventing a distinction that
+    // never existed and would make every legacy row read as cross-repo authored.
+    await client.execute({
+      sql: `INSERT INTO knowledge_items (id, category, status, title, content, origin_repo, created_at, updated_at)
+            VALUES ('legacy-000', 'fact', 'active', 'Older than the column', 'Body.', 'a', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+    });
+
+    await bootstrapSchema(client);
+
+    const row = await client.execute("SELECT origin_repo, written_by FROM knowledge_items WHERE id = 'legacy-000'");
+    expect(String(row.rows[0].origin_repo)).toBe('a');
+    expect(row.rows[0].written_by).toBeNull();
+  });
+
+  it('does not move the compatibility floor, so an older build can still open it', async () => {
+    // Additive and nullable: an older build ignores the column, and a newer one reading NULL
+    // gets the truth rather than a hole. That is the whole case for not touching user_version.
+    const before = await readSchemaVersion(client);
+    await bootstrapSchema(client);
+    expect(await readSchemaVersion(client)).toBe(before);
+  });
+
+  it('is idempotent: a second bootstrap neither re-adds nor throws', async () => {
+    await bootstrapSchema(client);
+    await client.execute({
+      sql: `INSERT INTO knowledge_items (id, category, status, title, content, origin_repo, written_by, created_at, updated_at)
+            VALUES ('after-000', 'fact', 'active', 'Written across', 'Body.', 'b', 'a', '2026-02-01T00:00:00.000Z', '2026-02-01T00:00:00.000Z')`,
+    });
+
+    await bootstrapSchema(client);
+
+    const row = await client.execute("SELECT written_by FROM knowledge_items WHERE id = 'after-000'");
+    expect(String(row.rows[0].written_by)).toBe('a');
+    expect((await columnsOf(client)).filter(name => name === 'written_by')).toHaveLength(1);
+  });
+});

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -62,6 +62,12 @@ const SCHEMA_PINS: Record<number, string> = {
   // does not move: an older build can still read a database with an extra column and an extra
   // table it does not know about.
   10: '0fb5091ab39e438ed70777b8d7c4b8c9',
+  // 11 adds `knowledge_items.written_by`: who authored an atom, when that is not who owns it.
+  // One nullable column and no backfill, as level 5 was -- and here writing nothing is the
+  // correct backfill rather than a concession, because NULL already means "the owner wrote it"
+  // and every pre-existing row was written before a repo could act as another.
+  // `KNOWL_SCHEMA_VERSION` again does not move.
+  11: '2f2aa4d61c1fd3600266ec572a964aa0',
 };
 
 let root: string;

--- a/tests/workspace/act-as-repo.test.ts
+++ b/tests/workspace/act-as-repo.test.ts
@@ -166,6 +166,83 @@ describe('withRepoContext', () => {
     await closeDb();
   });
 
+  it('records who did the work, without changing who owns it', async () => {
+    // Ownership and authorship are two different facts. The atom is genuinely b's -- b promotes
+    // it, b retires it -- but a's session wrote it, and before `written_by` nothing said so.
+    const workspace = await inA();
+    const written = await withRepoContext('b', workspace, async () => {
+      const project = await repo.getProjectByRootPath(getProjectRoot());
+      const result = await storeKnowledgeItemDeduped(project!.id, {
+        category: 'fact', title: 'Written from a', content: 'Authored by a, owned by b.',
+      });
+      return result.item.id;
+    });
+    await closeDb();
+
+    await initDb(B);
+    const row = await getClient().execute({
+      sql: 'SELECT origin_repo, written_by FROM knowledge_items WHERE id = ?', args: [written],
+    });
+    await closeDb();
+
+    expect(String(row.rows[0].origin_repo)).toBe('b');
+    expect(String(row.rows[0].written_by)).toBe('a');
+  });
+
+  it('leaves written_by NULL for an ordinary local write, because null already means the owner', async () => {
+    // Stamping every row with its own owner's name would make the column say nothing on the
+    // overwhelming majority of rows, and force a reader to compare it against origin_repo to
+    // find that out.
+    await initDb(A);
+    const project = await repo.getProjectByRootPath(A);
+    const result = await storeKnowledgeItemDeduped(project!.id, {
+      category: 'fact', title: 'Written at home', content: 'No repo was named.',
+    });
+    const row = await getClient().execute({
+      sql: 'SELECT origin_repo, written_by FROM knowledge_items WHERE id = ?', args: [result.item.id],
+    });
+    await closeDb();
+
+    expect(String(row.rows[0].origin_repo)).toBe('a');
+    expect(row.rows[0].written_by).toBeNull();
+  });
+
+  it('leaves written_by NULL when a repo names itself, since nothing crossed', async () => {
+    const workspace = await inA();
+    const written = await withRepoContext('a', workspace, async () => {
+      const project = await repo.getProjectByRootPath(getProjectRoot());
+      const result = await storeKnowledgeItemDeduped(project!.id, {
+        category: 'fact', title: 'Named my own repo', content: 'Author and owner are the same.',
+      });
+      return result.item.id;
+    });
+    const row = await getClient().execute({
+      sql: 'SELECT written_by FROM knowledge_items WHERE id = ?', args: [written],
+    });
+    await closeDb();
+
+    expect(row.rows[0].written_by).toBeNull();
+  });
+
+  it('does not leak the author into a write made after the rebind returns', async () => {
+    // The scope is async-local rather than a module variable precisely so this cannot happen:
+    // an MCP server serves one repo's call while another is mid-hop.
+    const workspace = await inA();
+    await withRepoContext('b', workspace, async () => undefined);
+
+    await initDb(A);
+    const project = await repo.getProjectByRootPath(A);
+    const after = await storeKnowledgeItemDeduped(project!.id, {
+      category: 'fact', title: 'After the hop', content: 'Written back at home.',
+    });
+    const row = await getClient().execute({
+      sql: 'SELECT written_by FROM knowledge_items WHERE id = ?', args: [after.item.id],
+    });
+    await closeDb();
+
+    expect(row.rows[0].written_by).toBeNull();
+  });
+
   it('acting as yourself is allowed and is a no-op, so callers need no special case', async () => {
     const workspace = await inA();
     const seen = await withRepoContext('a', workspace, async () => getProjectRoot());


### PR DESCRIPTION
Closes the attribution gap #110 flagged in its own "identified and deliberately not in this diff".

## The gap

5.3.0 let an agent do a linked repo's work by naming it on the call. The write lands in that repo
stamped as its own — correctly: it governs that repo, and that repo promotes and retires it. But
nothing recorded that **another repo's session authored it**, so the fact disappeared at the moment
it was created. Subject and author are two different questions, and `origin_repo` only ever
answered the first.

## How the author survives the swap

The caller's name rides *alongside* the context swap rather than being derived from it — because
the swap is precisely what destroys the ability to derive it. Everything downstream reads the
ambient context, and after the hop that context **is** the target.

`AsyncLocalStorage`, for the same reason the database swap uses it: a module-level variable would
leak the author into every concurrent operation, and an MCP server serves one repo's call while
another is mid-hop. A test pins that a write made *after* the rebind returns is unattributed.

Scoped in `withRepoContext`, not in `withRepoRoot` — the latter is reachable from other callers
with other reasons to point at another database, and only a named repo doing another repo's work
has an author to record.

## Why NULL is the default, and the correct backfill

`NULL` keeps meaning **"the owner wrote it"**. Stamping a repo's own name on its own atoms would
make the column say nothing on the overwhelming majority of rows, and force a reader to compare it
against `origin_repo` to discover that. So it is written only when the two genuinely differ —
including when a repo names *itself*, which crosses nothing.

Existing rows are **not** backfilled, and here writing nothing is the correct value rather than a
concession: every row predating the column was written before a repo could act as another, so its
owner is exactly who wrote it. A backfill copying `origin_repo` across would invent a distinction
that never existed and make every legacy row read as cross-repo authored.

## Not in the lifecycle fingerprint

Authorship is fixed at write time and cannot diverge; including it would make every cross-repo atom
look *changed* to a peer holding the same one. Excluded by construction rather than by memory —
`hashKnowledgeLifecycle` takes an explicit field list.

## Migration

Level **11**. One nullable column, no backfill, `KNOWL_SCHEMA_VERSION` unmoved: an older build
ignores the column, a newer one reading `NULL` gets the truth rather than a hole.

`tests/store/migration-level-11.test.ts` covers the upgrade path, `NULL` legacy rows, the unmoved
floor, and idempotency — built by bootstrapping the current schema and removing what level 11
added, so it cannot drift from `bootstrap.ts` the way a pasted copy would.

Also unpins `migration-level-10.test.ts` from the literal `10`. It meant *"one bootstrap stamps the
gate forward"*, and asserting the number made an unrelated later level fail a test about an earlier
one — the brittleness `impact-schema.test.ts` already avoids by asserting `>= 4`.

## Deliberately NOT on the cloud wire yet

`loadPublishItem` builds the payload explicitly, so publishing is unchanged today. Sending the
field needs knowl-cloud to accept it first, and shipping a client that sends a field the server
rejects would break pushes outright. Worth noting knowl-cloud already attributes on the verified
principal (`author_user_id`), which is the stronger signal — this column answers a different
question: which *working context* produced the atom.

## Verification

Full suite **336 files, 3080 passing, 5 skipped**; build, typecheck, lint and `docs:check` clean.
Four new attribution tests plus four migration tests.