### PR TITLE
fix(doctor): distinguish an index an upgrade invalidated from one never built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,35 @@ code that cannot be re-collected, and the other seals atoms to a person on a fuz
 rather than treating silence as consent, both commands now say what they would have done and exit
 non-zero, so a script that only meant to peek at a bundle cannot spend it.
 
+### Doctor says when an upgrade invalidated the vector index, instead of calling it never embedded
+
+`fingerprintProfile` hashes the embedding recipe and the batching policy alongside the model, so a
+recipe change invalidates its own rows rather than leaving them matching a space they are no longer
+in. Retrieval filters on that same fingerprint. Both halves are right, and together they mean a
+release can take a fully embedded store to zero reachable vectors at once, without the user doing
+anything at all.
+
+Doctor counted those rows as unembedded — correct, since search cannot read them — and then
+described them with the wrong sentence: *"only 23 of 747 active item(s) are embedded … Nothing
+embeds these retroactively."* Every one of the 724 was embedded, and a reindex is exactly what
+repairs them. The reader was told the opposite of both facts, and the natural conclusion — a broken
+embedder, or a model that never downloaded — sends them looking in the wrong place.
+
+Measured on a real machine upgrading across 5.0.0: **1,100 of 1,639 vectors, three repositories'
+entire indexes, went invisible on the version bump** and semantic search silently fell back to
+keyword for three days.
+
+The check now separates the two conditions, because two different things can be wrong at once and
+only one of them is something the user just did:
+
+- rows embedded under an **earlier recipe** — named as such, with the note that re-embedding
+  restores every one, and without the "nothing embeds these retroactively" line that is untrue of
+  them
+- rows that were **never embedded at all** — the original wording, unchanged
+
+Severity is unchanged: a majority uncovered still fails, a tail still warns, and the remedy is
+`knowl reindex --vectors` either way.
+
 ## 5.3.0 — 2026-08-15
 
 Two ways a linked workspace stops being a wall. Until now a repo could *see* its siblings'

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,9 +982,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1000,9 +997,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1020,9 +1014,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1038,9 +1029,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1058,9 +1046,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1076,9 +1061,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1096,9 +1078,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1115,9 +1094,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1133,9 +1109,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1159,9 +1132,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1183,9 +1153,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1209,9 +1176,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1233,9 +1197,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1259,9 +1220,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1284,9 +1242,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1308,9 +1263,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1463,6 +1415,7 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
       "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.4",
         "@libsql/hrana-client": "^0.10.0",
@@ -1824,9 +1777,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1841,9 +1791,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1858,9 +1805,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,9 +1819,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,9 +1833,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1909,9 +1847,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1926,9 +1861,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1875,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1960,9 +1889,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1903,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,9 +1917,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,9 +1931,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2028,9 +1945,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2229,6 +2143,7 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -2563,6 +2478,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3258,6 +3174,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3317,6 +3234,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3545,6 +3463,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3966,6 +3885,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4660,6 +4580,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4724,6 +4645,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -5506,6 +5428,7 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -5721,6 +5644,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5809,6 +5733,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6061,6 +5986,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -997,6 +1000,9 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1014,6 +1020,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1029,6 +1038,9 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1046,6 +1058,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1061,6 +1076,9 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1078,6 +1096,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1094,6 +1115,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1109,6 +1133,9 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1132,6 +1159,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1153,6 +1183,9 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1176,6 +1209,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1197,6 +1233,9 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1220,6 +1259,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1242,6 +1284,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1263,6 +1308,9 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1415,7 +1463,6 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
       "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.4",
         "@libsql/hrana-client": "^0.10.0",
@@ -1777,6 +1824,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1791,6 +1841,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,6 +1858,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,6 +1875,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1833,6 +1892,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1847,6 +1909,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1861,6 +1926,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,6 +1943,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1889,6 +1960,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1903,6 +1977,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1917,6 +1994,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1931,6 +2011,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1945,6 +2028,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2143,7 +2229,6 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -2478,7 +2563,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3174,7 +3258,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3234,7 +3317,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3463,7 +3545,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3885,7 +3966,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4580,7 +4660,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4645,7 +4724,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -5428,7 +5506,6 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -5644,7 +5721,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5733,7 +5809,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5986,7 +6061,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -303,13 +303,21 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
           (SELECT COUNT(*) FROM knowledge_items WHERE status = 'active') AS active,
           (SELECT COUNT(*) FROM knowledge_items i
              JOIN knowledge_embeddings e ON e.knowledge_item_id = i.id
-           WHERE i.status = 'active' AND e.profile_fingerprint = ${fingerprint}) AS embedded
+           WHERE i.status = 'active' AND e.profile_fingerprint = ${fingerprint}) AS embedded,
+          -- Embedded, but under a different recipe -- as unreachable as never having been
+          -- embedded, since retrieval filters on this same column, and yet a different thing
+          -- to report. IS NOT rather than != so a row predating the column counts here
+          -- instead of vanishing from both totals on a NULL comparison.
+          (SELECT COUNT(*) FROM knowledge_items i
+             JOIN knowledge_embeddings e ON e.knowledge_item_id = i.id
+           WHERE i.status = 'active' AND e.profile_fingerprint IS NOT ${fingerprint}) AS stale
       `);
       checks.push(vectorCoverageCheck({
         enabled: true,
         model: `${vector.provider}/${vector.model}`,
         activeItems: Number(counts[0]?.active ?? 0),
         embeddedItems: Number(counts[0]?.embedded ?? 0),
+        staleItems: Number(counts[0]?.stale ?? 0),
         writeEmbeddingDisabled: process.env.KNOWL_DISABLE_WRITE_EMBEDDING === '1',
       }));
     } else {

--- a/src/cli/vector-coverage.ts
+++ b/src/cli/vector-coverage.ts
@@ -20,6 +20,15 @@ export function vectorCoverageCheck(input: {
   embeddedItems: number;
   /** KNOWL_DISABLE_WRITE_EMBEDDING=1 — the gap is then chosen, not accidental. */
   writeEmbeddingDisabled?: boolean;
+  /**
+   * Active items that DO carry an embedding, produced under a different profile fingerprint.
+   *
+   * A subset of the gap, never additional to it: these are counted as unembedded because
+   * retrieval filters on the fingerprint, so they are as invisible as a row that was never
+   * written. What they are not is *absent*, and the difference decides both what to tell the
+   * reader and whether "nothing embeds these retroactively" is true of them.
+   */
+  staleItems?: number;
 }): VectorCoverageCheck {
   if (!input.enabled) {
     return { status: 'OK', message: 'Vector search disabled; BM25 retrieval remains active' };
@@ -66,9 +75,44 @@ export function vectorCoverageCheck(input: {
    * results -- so a partial index misleads in a way an absent one cannot, because there is no
    * symptom to notice.
    */
-  if (missing * 2 > input.activeItems) {
+  const status = missing * 2 > input.activeItems ? 'FAIL' : 'WARN';
+
+  /*
+   * A gap an UPGRADE opened reads nothing like a gap a missing model left, and until now both
+   * got the never-embedded sentence.
+   *
+   * `fingerprintProfile` hashes the embedding recipe and the batching policy alongside provider,
+   * model, dtype and pooling -- deliberately, so that a recipe change invalidates its own rows
+   * instead of leaving them "matching a space they are no longer in". Retrieval filters on that
+   * same fingerprint. Both halves are right, and together they mean a release can take a fully
+   * embedded store to zero reachable vectors at once, without the user doing anything.
+   *
+   * Measured on a real machine, 2026-08-15, upgrading across 5.0.0: 1,100 of 1,639 vectors --
+   * three repositories' entire indexes -- went invisible on the version bump. Every one of them
+   * was reported as an item that "are embedded" only 23 of 747 times over, and the remedy line
+   * said `Nothing embeds these retroactively`, which is the single thing that is NOT true of a
+   * stale row: a reindex is exactly what repairs it.
+   *
+   * So say which it is. The counts are separated rather than summed because two different things
+   * can be wrong at once, and only one of them is something the user just did.
+   */
+  if ((input.staleItems ?? 0) > 0) {
+    const stale = Math.min(input.staleItems ?? 0, missing);
+    const never = missing - stale;
+    const neverClause = never > 0
+      ? ` A further ${never} were never embedded at all.`
+      : '';
     return {
-      status: 'FAIL',
+      status,
+      message: `Vector search is enabled with ${input.model} and ${stale} of ${input.activeItems} active item(s) are embedded under an earlier embedding recipe, which retrieval cannot read -- so they are invisible to semantic search even though their vectors exist. This is what an upgrade that changes the embedding recipe does, and re-embedding them restores every one.${neverClause}`,
+      fix: 'run `knowl reindex --vectors`',
+      remedy: { kind: 'reindex-vectors' },
+    };
+  }
+
+  if (status === 'FAIL') {
+    return {
+      status,
       message: `Vector search is enabled with ${input.model} but only ${input.embeddedItems} of ${input.activeItems} active item(s) are embedded, so semantic search reaches a minority of this project's knowledge and its results are not representative of what is stored. Nothing embeds these retroactively.`,
       fix: 'run `knowl reindex --vectors`',
       remedy: { kind: 'reindex-vectors' },
@@ -76,7 +120,7 @@ export function vectorCoverageCheck(input: {
   }
 
   return {
-    status: 'WARN',
+    status,
     message: `Vector search is enabled with ${input.model} but ${missing} of ${input.activeItems} active item(s) have no embedding, so they are invisible to semantic search. Items written before the embedding model was first downloaded are not embedded retroactively.`,
     fix: 'run `knowl reindex --vectors`',
     remedy: { kind: 'reindex-vectors' },

--- a/tests/cli/doctor-report.test.ts
+++ b/tests/cli/doctor-report.test.ts
@@ -88,7 +88,10 @@ describe('doctor vector coverage', () => {
     // FAIL rather than WARN because the whole store is uncovered, not because a fingerprint
     // is null: what this test pins is that the row is COUNTED as missing at all.
     expect(check.status).toBe('FAIL');
-    expect(check.message).toContain('0 of 1');
+    // A row that exists but cannot be read is reported as exactly that. `IS NOT` is what puts
+    // a NULL fingerprint on this side of the split rather than dropping it from both totals.
+    expect(check.message).toMatch(/earlier embedding recipe/i);
+    expect(check.message).toContain('1 of 1');
     expect(check.fix).toContain('knowl reindex --vectors');
   });
 
@@ -105,7 +108,26 @@ describe('doctor vector coverage', () => {
     const check = coverageCheck((await runDoctor(root)).checks);
 
     expect(check.status).toBe('FAIL');
+    expect(check.message).toMatch(/earlier embedding recipe/i);
+    expect(check.message).toContain('1 of 1');
+    // The sentence that was wrong for this row specifically: a reindex is precisely what
+    // embeds it, so telling the reader nothing does is the opposite of the remedy offered.
+    expect(check.message).not.toMatch(/retroactively/i);
+  });
+
+  it('says NEVER embedded, not stale, when no embedding row exists at all', async () => {
+    // The other side of the split, pinned so the two cannot collapse back into one message.
+    // Nothing was written here, so there is no earlier recipe to blame and the reindex is a
+    // backfill rather than a repair.
+    await setup(ARCTIC);
+    await closeDb();
+
+    const check = coverageCheck((await runDoctor(root)).checks);
+
+    expect(check.status).toBe('FAIL');
     expect(check.message).toContain('0 of 1');
+    expect(check.message).toMatch(/retroactively/i);
+    expect(check.message).not.toMatch(/recipe/i);
   });
 
   it('gates the verdict, so an unembedded store cannot report READY', async () => {

--- a/tests/cli/vector-coverage.test.ts
+++ b/tests/cli/vector-coverage.test.ts
@@ -86,4 +86,68 @@ describe('vector coverage check', () => {
     expect(vectorCoverageCheck({ enabled: true, model: 'local/m', activeItems: 0, embeddedItems: 0 }).status)
       .toBe('OK');
   });
+
+  /**
+   * The gap an UPGRADE opened, which is a different condition from the gap a missing model left.
+   *
+   * `fingerprintProfile` hashes the embedding recipe and the batching policy alongside the model,
+   * deliberately, so a recipe change invalidates its own rows. Retrieval filters on that same
+   * fingerprint. The consequence is that a release can take a fully-embedded store to zero
+   * reachable vectors at once, through no action of the user's -- and the old wording described
+   * that as items that "are embedded", counted them as never-embedded, and told the reader
+   * "nothing embeds these retroactively", which is the one thing that is not true of them.
+   */
+  describe('when a previous embedding recipe left rows behind', () => {
+    it('says the rows exist under an older profile rather than implying they were never made', () => {
+      const check = vectorCoverageCheck({
+        enabled: true, model: 'local/m', activeItems: 747, embeddedItems: 23, staleItems: 724,
+      });
+      expect(check.status).toBe('FAIL');
+      expect(check.message).toContain('724');
+      expect(check.message).toMatch(/earlier embedding recipe|previous embedding recipe/i);
+      expect(check.message).toMatch(/upgrade/i);
+    });
+
+    it('does NOT say nothing embeds them retroactively, because a reindex is exactly what does', () => {
+      const check = vectorCoverageCheck({
+        enabled: true, model: 'local/m', activeItems: 747, embeddedItems: 23, staleItems: 724,
+      });
+      expect(check.message).not.toMatch(/retroactively/i);
+      expect(check.fix).toMatch(/reindex/);
+    });
+
+    it('separates rows left by an upgrade from rows that were never embedded at all', () => {
+      // 100 active, 10 current, 60 stale -- so 30 were never embedded. Reporting one number
+      // would hide that two different things went wrong and only one of them is an upgrade.
+      const check = vectorCoverageCheck({
+        enabled: true, model: 'local/m', activeItems: 100, embeddedItems: 10, staleItems: 60,
+      });
+      expect(check.message).toContain('60');
+      expect(check.message).toContain('30');
+    });
+
+    it('still fails loudly when an upgrade darkened the whole store', () => {
+      const check = vectorCoverageCheck({
+        enabled: true, model: 'local/m', activeItems: 48, embeddedItems: 0, staleItems: 48,
+      });
+      expect(check.status).toBe('FAIL');
+      expect(check.remedy).toEqual({ kind: 'reindex-vectors' });
+    });
+
+    it('a stale tail is a warning, matching how a never-embedded tail is treated', () => {
+      const check = vectorCoverageCheck({
+        enabled: true, model: 'local/m', activeItems: 100, embeddedItems: 97, staleItems: 3,
+      });
+      expect(check.status).toBe('WARN');
+      expect(check.message).toMatch(/earlier embedding recipe|previous embedding recipe/i);
+    });
+
+    it('keeps the never-embedded wording when nothing is stale, so the old case is unchanged', () => {
+      const check = vectorCoverageCheck({
+        enabled: true, model: 'local/m', activeItems: 10, embeddedItems: 4, staleItems: 0,
+      });
+      expect(check.message).toMatch(/retroactively/i);
+      expect(check.message).not.toMatch(/recipe/i);
+    });
+  });
 });


### PR DESCRIPTION
## The bug, found by upgrading a real machine

`knowl upgrade --all` after 5.2.1 → 5.3.0 reported four of five repositories NOT READY:

```
[FAIL] Vector search is enabled with local/Snowflake/... but only 23 of 747 active
       item(s) are embedded ... Nothing embeds these retroactively.
```

**All 747 were embedded.** Both halves of that sentence are inverted for the rows it is about, and the conclusion the wording invites — a broken embedder, or a model that never downloaded — sends the reader somewhere the fault is not. I went looking for a missing model and found 2.6 GB of them, present and correct.

## What was actually happening, and it is not a defect

`fingerprintProfile` hashes `EMBED_RECIPE_VERSION` and `EMBEDDING_BATCH_POLICY` alongside provider, model, dtype and pooling. That is deliberate and the docblock argues it well: the recipe decides what text reaches the model at all, so a recipe change without a fingerprint change would leave every stored row *"matching a space it is no longer in."* Retrieval filters on the same fingerprint.

Both halves are right. Together they mean **a release can take a fully embedded store to zero reachable vectors at once, with the user having done nothing.** Commit `8f80ff5` (v5.0.0) added those two inputs, which is the correct moment for it.

Measured on this machine:

| fingerprint | vectors | written |
|---|---|---|
| `d3f842a5…` (pre-5.0 formula) | **1,100** | Aug 4–13 |
| `f0814d56…` (current, arctic) | 26 | Aug 14+ |
| `eeb8ae73…` (current, granite) | 509 | Aug 13+ |

Three repositories' entire indexes went invisible on the version bump. Semantic search silently fell back to keyword for three days, with no symptom other than results being quietly worse. The one repo that was fine is the one whose atoms were all written after the cutover.

## The fix

Report the two conditions apart, because they have different causes, different explanations, and only one of them is something the user just did:

- **embedded under an earlier recipe** — named as such, with the note that re-embedding restores every one, and *without* the "nothing embeds these retroactively" line, which is the single thing that is not true of them
- **never embedded at all** — the original wording, unchanged

Counts are separated rather than summed, since both can be true at once (10 current, 60 stale, 30 never embedded is three facts, not one).

Severity is untouched: a majority uncovered still FAILs, a tail still WARNs, the remedy is `knowl reindex --vectors` either way. This changes what the reader is told, not what the check decides.

## Notes for review

- **`IS NOT` rather than `!=`** in the new count. A row written before the column existed carries NULL, and `!=` would drop it from *both* totals rather than putting it on the side it belongs to — the K-60 shape the null-fingerprint test already pins. That test now reads as what it always meant.
- **Pinned at the call site, not only at the pure function.** The comment three lines above the one I changed records why: a check written to turn a silent gap into a visible one once could not see the gap it was written for, because the call site and the check disagreed. `staleItems` is asserted through the real query in `doctor-report.test.ts`.
- **The two existing coverage tests changed their expected wording** — deliberately, since they describe exactly the condition being re-worded. What they pin is unchanged: the row is still *counted as missing*, the status is still FAIL, the remedy is still the reindex. A new test pins the other side of the split so the two messages cannot collapse back into one.

## Worth considering separately, not in this diff

The sweep **defers** the reindex (`deferred reindex-vectors`) and prints that as a neutral line. Given a fingerprint change can dark an entire index, it may be worth either auto-reindexing when the stale count is the majority, or naming the consequence in the summary line rather than only in the FAIL detail. Left alone here because reindexing is expensive and the deferral looks like a deliberate cost decision — your call.

## Verification

Full suite: **335 files, 3079 passing, 0 failing.** Lint, typecheck, build, `docs:check` clean.
