### PR TITLE
fix(cloud): receive collects again, and both irreversible prompts became a menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+### `knowl cloud receive` collects again, and the two irreversible prompts became a menu
+
+`knowl cloud receive <code>` could not collect anything. It peeked the mailbox, printed the sender
+and the atom count, and then died:
+
+```
+From: a colleague · 1 atom(s) · expires 2026-08-18T05:22:28.087Z
+Receive failed: confirm is not defined
+```
+
+`knowl cloud send --query …` failed the same way at the same point. Both called a bare global
+`confirm()` — a browser API that does not exist in Node — so both threw a `ReferenceError` on the
+one path either command is ever actually used on. Nothing was lost: the crash landed before the
+claim, so a bundle that failed to collect was still sitting there afterwards. But the only way
+through was `--yes`, which is the flag that skips the question, and answering a question you were
+never asked is not the interaction these two commands wanted.
+
+**Why nothing caught it.** `tsc` was reading `confirm` as legitimate. The project set `target`
+without setting `lib`, and a transitive dependency's `/// <reference lib="dom" />` pulled the whole
+DOM into scope, so every browser global typechecked clean inside a CLI. `lib: ["ES2022"]` is now
+explicit and the bare call is a compile error — verified by putting the original line back and
+watching `npm run typecheck` fail on it, where before it passed. The tests missed it for a second,
+compounding reason: every test drove these commands with `--yes`, which skips the branch entirely,
+so the defect was only ever reachable by a human at a terminal.
+
+**Both prompts are now a two-option menu**, matching the settings picker rather than a y/n:
+
+```
+◆  Collect it? This can only be done once.
+│  ● Decline (the code still works until it expires)
+│  ○ Accept (import the atoms and spend the code)
+```
+
+Decline is listed first and preselected, so the answer a bare Enter gives is the answer that costs
+nothing, and the irreversible option is never under the cursor on arrival. Ctrl-C is a decline.
+Spelling both outcomes out is worth more here than anywhere else in the CLI: one of these spends a
+code that cannot be re-collected, and the other seals atoms to a person on a fuzzy `--query` match.
+
+`--yes` still exists and still skips the menu. What changed is what happens without a terminal:
+rather than treating silence as consent, both commands now say what they would have done and exit
+non-zero, so a script that only meant to peek at a bundle cannot spend it.
+
 ## 5.3.0 — 2026-08-15
 
 Two ways a linked workspace stops being a wall. Until now a repo could *see* its siblings'

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -906,7 +906,15 @@ knowl cloud send --query "retry policy"
 
 knowl cloud receive owl-cascade-ridge-plum-tin
   From: platform · 3 atom(s) · expires 2026-08-14T09:00:00Z
+  ◆  Collect it? This can only be done once.
+  │  ● Decline (the code still works until it expires)
+  │  ○ Accept (import the atoms and spend the code)
 ```
+
+Both ends ask before the irreversible half — `receive` always, `send` when `--query` chose the
+atoms rather than `--id`. Decline is preselected, so a bare Enter costs nothing. `--yes` skips the
+menu. Without a terminal to ask, neither command guesses: it prints what it would have done and
+exits non-zero, so a script that only meant to look at a bundle cannot spend it.
 
 **The server cannot read what you send.** Your machine mints a five-word code, derives an
 encryption key and a mailbox id from it under separate labels, and uploads only the id and the

--- a/src/cli/confirm-prompt.ts
+++ b/src/cli/confirm-prompt.ts
@@ -1,0 +1,45 @@
+/**
+ * Ask, as a two-option menu, before something that cannot be taken back.
+ *
+ * A menu rather than a y/n confirm because these two commands are where a wrong answer costs the
+ * most, and a menu is the one shape that cannot be answered by reflex: both outcomes are spelled
+ * out and named, and the hint says what each one actually does. It matches the settings picker in
+ * `config/ui.ts`, which is where a reader has already met this interaction.
+ *
+ * The three answers are distinct because the caller's remedy differs. `no-tty` is not a "no": the
+ * question was never asked, so the caller must say how to answer it without a terminal (`--yes`)
+ * and exit non-zero rather than treat silence as consent. `declined` is a decided no and exits
+ * clean. Collapsing the two would either block CI or let it proceed unasked, and both have shipped
+ * in this file before.
+ *
+ * `isTTY` is injectable for the same reason it is on `pickWorkspace`: the interactive branch is the
+ * only place these commands actually run, so it has to be reachable from a test. The version this
+ * replaces called a bare global `confirm()` -- a browser API that is undefined in Node -- at both
+ * call sites, and every test drove them with `--yes`, which skips the branch entirely.
+ *
+ * The prompt library is imported lazily, matching `cloud-picker.ts`: it is reachable only from
+ * interactive paths and must not be paid for by `knowl serve`.
+ */
+export async function askConfirm(
+  message: string,
+  io: { isTTY?: boolean; acceptHint?: string; declineHint?: string } = {},
+): Promise<'confirmed' | 'declined' | 'no-tty'> {
+  const isTTY = io.isTTY ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!isTTY) return 'no-tty';
+
+  const clack = await import('@clack/prompts');
+  const chosen = await clack.select({
+    message,
+    options: [
+      { value: 'declined', label: 'Decline', hint: io.declineHint },
+      { value: 'confirmed', label: 'Accept', hint: io.acceptHint },
+    ],
+    // Decline is both first and preselected, so the answer a bare Enter gives is the answer that
+    // costs nothing. The irreversible option is never the one under the cursor on arrival.
+    initialValue: 'declined',
+  });
+
+  // Cancelling (Ctrl-C at the menu) is a decline. It is the one answer a user gives by reflex when
+  // they did not mean to be here at all, so it must never fall through to the irreversible half.
+  return clack.isCancel(chosen) || chosen !== 'confirmed' ? 'declined' : 'confirmed';
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -56,6 +56,7 @@ import { unstagePublish } from '../cloud/ledger.js';
 import { writeAutoPushConsent } from '../cloud/consent.js';
 import { maybeAutoPush } from './auto-push.js';
 import { pickWorkspace } from './cloud-picker.js';
+import { askConfirm } from './confirm-prompt.js';
 import { formatProfileMismatch } from './profile-mismatch.js';
 import { pickCategories } from './sharing-picker.js';
 import { recommendedTotal, WITHHELD_BY_DEFAULT } from '../core/sharing-defaults.js';
@@ -1479,9 +1480,22 @@ cloudCommand
         process.exitCode = 1;
         return;
       }
-      if (options.query && !options.yes && !await confirm(`Send these ${itemIds.length}?`)) {
-        console.log('Nothing sent.');
-        return;
+      if (options.query && !options.yes) {
+        const answer = await askConfirm(`Send these ${itemIds.length} atom(s)?`, {
+          acceptHint: 'seal them; undoing it means a revoke',
+          declineHint: 'nothing is sealed or sent',
+        });
+        if (answer === 'no-tty') {
+          // Sealing is irreversible without a revoke, and a fuzzy query is exactly the selection
+          // nobody should confirm on the reader's behalf.
+          console.error(`${itemIds.length} atom(s) would be sealed. Re-run with --yes to confirm.`);
+          process.exitCode = 1;
+          return;
+        }
+        if (answer === 'declined') {
+          console.log('Nothing sent.');
+          return;
+        }
       }
 
       const result = await sendKnowledge({
@@ -1564,9 +1578,22 @@ cloudCommand
 
       const { preview } = resolved;
       console.log(`From: ${preview.senderLabel} · ${preview.itemCount} atom(s) · expires ${preview.expiresAt}`);
-      if (!options.yes && !await confirm('Collect it? This can only be done once.')) {
-        console.log('Left where it is. The code still works until it expires.');
-        return;
+      if (!options.yes) {
+        const answer = await askConfirm('Collect it? This can only be done once.', {
+          acceptHint: 'import the atoms and spend the code',
+          declineHint: 'the code still works until it expires',
+        });
+        if (answer === 'no-tty') {
+          // The peek above is free and repeatable; the claim is the one-shot. Left unasked, this
+          // would spend somebody's bundle in a script that only meant to look at it.
+          console.error('Collecting spends the code. Re-run with --yes to confirm.');
+          process.exitCode = 1;
+          return;
+        }
+        if (answer === 'declined') {
+          console.log('Left where it is. The code still works until it expires.');
+          return;
+        }
       }
 
       const result = await receiveKnowledge({ projectRoot: root, config, resolved });

--- a/tests/cli/confirm-prompt.test.ts
+++ b/tests/cli/confirm-prompt.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('askConfirm', () => {
+  afterEach(() => { vi.resetModules(); vi.restoreAllMocks(); });
+
+  it('reports no-tty without prompting, so silence is never read as consent', async () => {
+    vi.doMock('@clack/prompts', () => ({
+      select: async () => { throw new Error('must not prompt without a TTY'); },
+      isCancel: () => false,
+    }));
+
+    const { askConfirm } = await import('../../src/cli/confirm-prompt.js');
+    expect(await askConfirm('Collect it?', { isTTY: false })).toBe('no-tty');
+  });
+
+  it('confirms when Accept is chosen', async () => {
+    vi.doMock('@clack/prompts', () => ({
+      select: async () => 'confirmed',
+      isCancel: () => false,
+    }));
+
+    const { askConfirm } = await import('../../src/cli/confirm-prompt.js');
+    expect(await askConfirm('Collect it?', { isTTY: true })).toBe('confirmed');
+  });
+
+  it('declines when Decline is chosen', async () => {
+    vi.doMock('@clack/prompts', () => ({
+      select: async () => 'declined',
+      isCancel: () => false,
+    }));
+
+    const { askConfirm } = await import('../../src/cli/confirm-prompt.js');
+    expect(await askConfirm('Collect it?', { isTTY: true })).toBe('declined');
+  });
+
+  it('treats a cancel as declined, not as an accept', async () => {
+    // Ctrl-C at the menu is the reflex answer of somebody who did not mean to be here. clack
+    // returns a symbol rather than one of the option values, and anything that is not an explicit
+    // Accept has to land on the safe side.
+    const CANCEL = Symbol('cancel');
+    vi.doMock('@clack/prompts', () => ({
+      select: async () => CANCEL,
+      isCancel: (value: unknown) => value === CANCEL,
+    }));
+
+    const { askConfirm } = await import('../../src/cli/confirm-prompt.js');
+    expect(await askConfirm('Collect it?', { isTTY: true })).toBe('declined');
+  });
+
+  it('offers Accept and Decline, with Decline preselected so a bare Enter spends nothing', async () => {
+    let input: { message?: string; options?: unknown[]; initialValue?: string } = {};
+    vi.doMock('@clack/prompts', () => ({
+      select: async (received: { message: string; options: unknown[]; initialValue?: string }) => {
+        input = received;
+        return 'declined';
+      },
+      isCancel: () => false,
+    }));
+
+    const { askConfirm } = await import('../../src/cli/confirm-prompt.js');
+    await askConfirm('Collect it? This can only be done once.', {
+      isTTY: true,
+      acceptHint: 'import the atoms and spend the code',
+      declineHint: 'the code still works until it expires',
+    });
+
+    expect(input.message).toBe('Collect it? This can only be done once.');
+    expect(input.initialValue).toBe('declined');
+    expect(input.options).toEqual([
+      { value: 'declined', label: 'Decline', hint: 'the code still works until it expires' },
+      { value: 'confirmed', label: 'Accept', hint: 'import the atoms and spend the code' },
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,


### PR DESCRIPTION
## The bug

`knowl cloud receive <code>` could not collect anything. It peeked the mailbox, printed the sender and the atom count, and then died:

```
From: William - Lemon Squeezy store readiness · 1 atom(s) · expires 2026-08-18T05:22:28.087Z
Receive failed: confirm is not defined
```

`knowl cloud send --query …` failed the same way at the same point. Both called a bare global `confirm()` — a browser API that does not exist in Node — so both threw a `ReferenceError` on the one path either command is ever actually used on.

Nothing was lost: the crash landed before the claim, so a bundle that failed to collect was still sitting there afterwards. But the only way through was `--yes`, which is the flag whose whole job is to skip the question.

Found by running it against a live bundle, not by reading.

## Why nothing caught it

**The type checker was reading `confirm` as legitimate.** The project set `target` without setting `lib`, and a transitive dependency's `/// <reference lib="dom" />` pulled the whole DOM into scope — so every browser global typechecks clean inside a CLI.

`lib: ["ES2022"]` is now explicit, and `src/` still typechecks without DOM. Verified the guard works rather than assuming it: put the original line back, ran `npm run typecheck`, got

```
src/cli/program.ts(1579,31): error TS2304: Cannot find name 'confirm'.
```

on the exact line that passed before this change. CI already runs `typecheck`, so this closes the class, not just the instance.

**The tests missed it for a second, compounding reason**, and it is the one worth fixing properly: every test drove these commands with `--yes`, which skips the branch entirely. The defect was only ever reachable by a human at a terminal.

So the fix is not an inline repair. `askConfirm` is a module with an injectable `isTTY`, matching `cloud-picker.ts` and `sharing-picker.ts` — the shape this repo already uses to make an interactive prompt reachable from a test.

## Three answers, not a boolean

`confirmed | declined | no-tty`, because the caller's remedy differs. `no-tty` is not a "no": the question was never asked, so both commands now print what they would have done and exit non-zero instead of treating silence as consent. A script that only meant to peek at a bundle cannot spend it.

## Both prompts are a menu now

Matching the settings picker rather than a y/n:

```
◆  Collect it? This can only be done once.
│  ● Decline (the code still works until it expires)
│  ○ Accept (import the atoms and spend the code)
```

Decline is listed first **and** preselected, so the answer a bare Enter gives is the answer that costs nothing, and the irreversible option is never under the cursor on arrival. Ctrl-C is a decline.

Spelling both outcomes out earns its place here more than anywhere else in the CLI: one of these spends a code that cannot be re-collected, and the other seals atoms to a person on a fuzzy `--query` match.

`--yes` still exists and still skips the menu.

## Scope

`cloud push` keeps its own inline `clack.confirm`. It works, and migrating it is a separate change.

## Verification

| gate | result |
| --- | --- |
| `npm test` | 336 files, **3077 passed**, 5 skipped, 0 failed |
| `npm run typecheck` | clean, and now fails on the reintroduced bug |
| `npm run lint` | clean |
| `npm run docs:check` | clean, with `dist` built |

5 new tests in `tests/cli/confirm-prompt.test.ts` covering no-tty, accept, decline, cancel-is-not-consent, and the preselected-Decline option list.
