### PR TITLE
fix(send): a selected export stays selected, so send stops shipping skills and tombstones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+### A send carries the atoms you chose, and no longer your skills and your forget-log with them
+
+`knowl cloud send --id <one atom>` sealed the selected atom — and also every learned skill package
+in `.knowl/skills`, file contents inlined, and every tombstone in the store.
+
+`exportKnowledge` gained an item selection for `send`, and the selection reached the item records
+and nothing after them. Skill packages and tombstones were appended unconditionally. For
+`knowl export` that is correct, because a backup means everything. For `send` it is not: send hands
+a few atoms to one person, and that person is explicitly someone who may share no workspace with
+the sender.
+
+So a one-atom send to an outside collaborator disclosed the sender's entire learned-skills library,
+file contents and all, plus the full forget-log — which atoms were destroyed, when, and whatever
+free text the deletion reason carried. A tombstone holds no title, so the second is narrower than
+it first looks, but it is still a record of what somebody decided to remove, handed to a person who
+was given none of it.
+
+It went unnoticed because the first real end-to-end send was made from a repository that happened
+to have no tombstones and an empty skills directory, so the bundle was correct by accident. Any
+repository with learned skills would have shipped them all.
+
+A selection now governs the whole stream rather than only the part where it was easy to apply. The
+guard is on "was everything asked for", not on the item list being non-empty, so selecting nothing
+still exports nothing instead of widening to everything. `knowl export` is unchanged and still
+carries both. If a send ever wants skills, that should be a flag somebody asks for rather than a
+default nobody sees.
+
 ### `knowl cloud receive` collects again, and the two irreversible prompts became a menu
 
 `knowl cloud receive <code>` could not collect anything. It peeked the mailbox, printed the sender

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -926,6 +926,11 @@ atoms rather than `--id`. Decline is preselected, so a bare Enter costs nothing.
 menu. Without a terminal to ask, neither command guesses: it prints what it would have done and
 exits non-zero, so a script that only meant to look at a bundle cannot spend it.
 
+**A send carries the atoms you chose and nothing else** — not your learned skills, and not your
+forget-log. A backup means everything, which is what `knowl export` is for; handing a few atoms to
+one person means those atoms. The recipient may share no workspace with you, so the bundle carries
+no record of knowledge you deleted and no copy of a skill you never offered.
+
 **The server cannot read what you send.** Your machine mints a five-word code, derives an
 encryption key and a mailbox id from it under separate labels, and uploads only the id and the
 sealed bytes. The code travels between two humans over whatever channel they already use, and it

--- a/src/store/portability.ts
+++ b/src/store/portability.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto';
+﻿import crypto from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -67,6 +67,11 @@ async function exportOrigin(projectRoot?: string): Promise<ExportOrigin | null> 
  * Absent means everything, so every existing caller is unchanged. An empty array is not the same
  * as absent and produces an empty export, because "send the atoms I selected" and "select nothing"
  * are different requests and only one of them is a mistake worth silently widening.
+ *
+ * `itemIds` governs the WHOLE stream, not just the item records: a selection also withholds skill
+ * packages and tombstones. It did not at first, and the gap was not academic -- a one-atom send
+ * shipped the sender's entire learned-skills library with file contents inlined, plus every
+ * tombstone, to a recipient who may share no workspace with them. See the guard below.
  */
 export async function exportKnowledge(
   projectId: string,
@@ -95,7 +100,18 @@ export async function exportKnowledge(
       records.push({ type: 'knowledge_evidence', link: { knowledgeItemId: item.id, evidenceId: value.id, relationship } });
     }
   }
-  if (projectRoot) {
+  // Both of the blocks below are gated on `wanted === null` -- "everything was asked for" --
+  // and NOT on the item list being non-empty. A selection is a selection at every level of the
+  // stream, not only at the one where it was easy to apply.
+  //
+  // The distinction is the whole of `knowl cloud send`. Export means a backup, where a skill
+  // library and a forget-log belong. Send hands a person a handful of atoms and its recipient
+  // may share no workspace with the sender, so shipping them there disclosed the repo's entire
+  // learned-skills library -- file contents inlined -- plus which atoms had been destroyed, when,
+  // and whatever free text their deletion reason held. A per-item send has no use for either: the
+  // recipient cannot act on a tombstone for an item they were never given. If a send ever does
+  // want skills, that is a flag someone asks for, not a default nobody sees.
+  if (wanted === null && projectRoot) {
     const skillsDir = `${projectRoot}/.knowl/skills`;
     for (const entry of await fs.readdir(skillsDir, { withFileTypes: true }).catch(() => [] as any[])) {
       if (entry.isDirectory()) records.push({ type: 'skill_package', name: entry.name, files: await skillFiles(projectRoot, `${skillsDir}/${entry.name}`) });
@@ -103,7 +119,7 @@ export async function exportKnowledge(
   }
   // Tombstones ride after the items so an older importer, which ignores unknown record
   // types, still reads a valid stream.
-  const tombstones = await listTombstones();
+  const tombstones = wanted === null ? await listTombstones() : [];
   for (const tombstone of tombstones) records.push({ type: 'tombstone', tombstone });
   const body = `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
   const manifest = crypto.createHash('sha256').update(body).digest('hex');

--- a/tests/cloud/send-transfer.test.ts
+++ b/tests/cloud/send-transfer.test.ts
@@ -6,6 +6,7 @@ import { closeDb, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import * as repo from '../../src/store/repository.js';
 import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { listTombstones } from '../../src/store/tombstones.js';
 import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
 import { clearCredential, writeCredential } from '../../src/cloud/credentials.js';
 import { deriveMailboxId } from '../../src/cloud/send/code.js';
@@ -296,6 +297,76 @@ describe('a bundle all the way there and back', () => {
 
     // Spent, and the second attempt refuses rather than replaying.
     expect(await previewSend({ config, code: sent.code, api })).toBeNull();
+  });
+
+  it('hands over the chosen atom, and not the sender\'s skills or forget-log', async () => {
+    // Asserted on what the RECEIVER ends up holding rather than on the sealed bytes, because
+    // that is the disclosure: a skill directory installed on their disk and a tombstone replayed
+    // into their store are the things the sender never meant to give them.
+    //
+    // The fixture carries both on purpose. The first real end-to-end send was made from a
+    // repository that happened to have neither, which is the only reason the bundle looked
+    // correct and the leak shipped in 5.3.0.
+    await fs.mkdir(path.join(SENDER, '.knowl', 'skills', 'deploy-runbook'), { recursive: true });
+    await fs.writeFile(
+      path.join(SENDER, '.knowl', 'skills', 'deploy-runbook', 'SKILL.md'),
+      '# Deploy runbook\n\nSECRET-SKILL-SENTINEL\n', 'utf8',
+    );
+
+    await initDb(SENDER);
+    const projectId = (await repo.createProject(SENDER, 'sender')).id;
+    const chosen = await storeKnowledgeItemDeduped(projectId, {
+      category: 'decision', title: 'The atom they asked for', content: 'Selected deliberately.',
+    });
+    const buried = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Destroyed on purpose', content: 'Not theirs to see.',
+    });
+    await repo.deleteKnowledgeItem(buried.item.id);
+    await closeDb();
+
+    const box = new Map<string, string>();
+    const api = fakeApi({
+      createSend: async ({ mailboxId, ciphertext }) => {
+        box.set(mailboxId, ciphertext);
+        return { mailboxId, expiresAt: preview.expiresAt };
+      },
+      peekSend: async ({ mailboxId }) => (box.has(mailboxId) ? preview : null),
+      claimSend: async ({ mailboxId }) => {
+        const ciphertext = box.get(mailboxId);
+        if (!ciphertext) return { refused: 'not_found' as const };
+        box.delete(mailboxId);
+        return { ciphertext, preview };
+      },
+    });
+
+    const sent = await sendKnowledge({
+      projectRoot: SENDER, projectId, config, itemIds: [chosen.item.id],
+      senderLabel: 'github.com/acme/web', expiresInHours: 24, api,
+    });
+    expect(sent.status).toBe('sent');
+    if (sent.status !== 'sent') return;
+
+    const resolved = await previewSend({ config, code: sent.code, api });
+    if (!resolved || typeof resolved === 'string') throw new Error('the bundle did not resolve');
+    const received = await receiveKnowledge({ projectRoot: RECEIVER, config, resolved, api });
+    expect(received.status).toBe('received');
+    if (received.status !== 'received') return;
+
+    // The atom they were given arrived.
+    expect(received.imported.inserted).toBe(1);
+
+    // The skill did not land on their disk.
+    const installed = await fs.readdir(path.join(RECEIVER, '.knowl', 'skills')).catch(() => []);
+    expect(installed).not.toContain('deploy-runbook');
+
+    // And the forget-log did not follow it into their store. Read from the receiver's own
+    // database, since a tombstone that arrived would have been replayed into exactly this table.
+    // By id: a tombstone is `{id, deletedAt, reason}` and carries no title, so what a leaked
+    // forget-log gives away is which atoms were destroyed and when.
+    await initDb(RECEIVER);
+    const tombstones = await listTombstones();
+    await closeDb();
+    expect(tombstones.map(entry => entry.id)).not.toContain(buried.item.id);
   });
 
   it('refuses a code nobody sent, without touching the store', async () => {

--- a/tests/store/portability.test.ts
+++ b/tests/store/portability.test.ts
@@ -78,6 +78,98 @@ describe('portability', () => {
     expect(tombstones.map(record => record.tombstone.id)).toContain(doomed.id);
   });
 
+  /**
+   * A selected export must stay selected, all the way down the record stream.
+   *
+   * `exportKnowledge` grew `itemIds` for `knowl cloud send`, which hands a person a handful of
+   * atoms and whose recipient may share no workspace with the sender. The filter reached the
+   * items and nothing else: skill packages and tombstones were appended unconditionally, so a
+   * one-atom send also disclosed the repo's entire learned-skills library -- file contents
+   * inlined -- and its whole forget-log. The forget-log is the sharper half: a tombstone exists
+   * because somebody decided to destroy something, and its title travels inside it.
+   *
+   * It survived the first real end-to-end send only because that repo happened to have no
+   * tombstones and an empty `.knowl/skills`. So the fixture below deliberately has both.
+   */
+  describe('a targeted export', () => {
+    const SEND = path.resolve('.knowl-portability-send');
+
+    beforeAll(async () => {
+      await fs.rm(SEND, { recursive: true, force: true });
+      await fs.mkdir(path.join(SEND, '.knowl', 'skills', 'deploy-runbook'), { recursive: true });
+      await fs.writeFile(
+        path.join(SEND, '.knowl', 'skills', 'deploy-runbook', 'SKILL.md'),
+        '# Deploy runbook\n\nSECRET-SKILL-SENTINEL: internal steps.\n',
+        'utf8',
+      );
+    });
+    afterAll(async () => { await fs.rm(SEND, { recursive: true, force: true }).catch(() => {}); });
+
+    const recordsOf = async (file: string) => (await fs.readFile(file, 'utf8'))
+      .split('\n').filter(Boolean).map(line => JSON.parse(line));
+
+    it('emits only the selected item, and neither skills nor tombstones', async () => {
+      const sent = await createKnowledgeItem('local', {
+        category: 'fact', title: 'The one atom', content: 'This is what was selected.',
+      });
+      const withheld = await createKnowledgeItem('local', {
+        category: 'fact', title: 'Not for sending', content: 'Stays home.',
+      });
+      const buried = await createKnowledgeItem('local', {
+        category: 'fact', title: 'Deliberately destroyed', content: 'Gone on purpose.',
+      });
+      await deleteKnowledgeItem(buried.id);
+
+      const target = path.join(SEND, 'targeted.jsonl');
+      const result = await portability.exportKnowledge('local', target, SEND, [sent.id]);
+      const records = await recordsOf(target);
+
+      expect(records.filter(r => r.type === 'item').map(r => r.item.id)).toEqual([sent.id]);
+      expect(records.filter(r => r.type === 'skill_package')).toEqual([]);
+      expect(records.filter(r => r.type === 'tombstone')).toEqual([]);
+      // The counted result is what `cloud send` reports to the sender, so it has to agree with
+      // the bytes rather than describe a stream nobody sent.
+      expect(result.tombstones).toBe(0);
+
+      // Said against the raw bytes too: the record-type filters above would pass on a record
+      // that leaked the same values under a type this test did not think to name. The deleted
+      // atom is checked by ID rather than by title, because a tombstone row is
+      // `{id, deletedAt, reason}` and carries no title -- what a leaked forget-log discloses is
+      // which atoms were destroyed and when, plus whatever free text the reason holds.
+      const raw = await fs.readFile(target, 'utf8');
+      expect(raw).not.toContain('SECRET-SKILL-SENTINEL');
+      expect(raw).not.toContain(buried.id);
+      expect(raw).not.toContain(withheld.id);
+    });
+
+    it('still ships both when nothing was selected, because that request means everything', async () => {
+      // The counterweight. The cheap way to pass the test above is to stop exporting skills and
+      // tombstones at all, which would silently break `knowl export` -- a backup, where both
+      // belong. Absent `itemIds` and an empty one are different requests.
+      const target = path.join(SEND, 'whole.jsonl');
+      const result = await portability.exportKnowledge('local', target, SEND);
+      const records = await recordsOf(target);
+
+      expect(records.filter(r => r.type === 'skill_package').map(r => r.name)).toContain('deploy-runbook');
+      expect(records.filter(r => r.type === 'tombstone').length).toBeGreaterThanOrEqual(1);
+      expect(result.tombstones).toBeGreaterThanOrEqual(1);
+    });
+
+    it('selecting nothing exports nothing, rather than widening to everything', async () => {
+      // An empty array is a selection, not an absence -- the docblock on `exportKnowledge` says
+      // so, and the guard added for this bug tests `wanted === null` precisely so an empty
+      // selection cannot fall through to the "everything" branch.
+      const target = path.join(SEND, 'empty-selection.jsonl');
+      const result = await portability.exportKnowledge('local', target, SEND, []);
+      const records = await recordsOf(target);
+
+      expect(records.filter(r => r.type === 'item')).toEqual([]);
+      expect(records.filter(r => r.type === 'skill_package')).toEqual([]);
+      expect(records.filter(r => r.type === 'tombstone')).toEqual([]);
+      expect(result.tombstones).toBe(0);
+    });
+  });
+
   it('applies new items even when another item diverged', async () => {
     // The defect this replaces: one divergent item discarded the whole import, so
     // unrelated new knowledge could never land on a machine that had done any work.


### PR DESCRIPTION
Closes #117.

## The bug

`knowl cloud send --id <one atom>` sealed the selected atom — and also every learned skill package in `.knowl/skills` with its file contents inlined, and every tombstone in the store.

`exportKnowledge` grew an item selection for `send`, and the selection reached the item records and nothing after them. `wanted` was consulted in exactly one place, [portability.ts:84](../blob/fix/send-ships-everything/src/store/portability.ts#L84). Two later blocks ignored it, and `transfer.ts:122` always passes `projectRoot`, so the send path always took both.

For `knowl export` that is correct — a backup means everything. For `send` it is not: send hands a few atoms to one person, and the recipient is explicitly someone who **may share no workspace with the sender**.

## What was actually disclosed

- **Every learned skill package, file contents inlined.** This is the larger half.
- **The full forget-log** — which atoms were destroyed, when, and whatever free text the deletion reason held.

One correction to the issue as filed: a tombstone row is `{id, deletedAt, reason}` and carries **no title**, so the forget-log half is narrower than "titles and metadata" suggests. It is still a record of what somebody decided to remove, handed to a person who was given none of it.

It survived the first real end-to-end send only because that repository happened to have no tombstones and an empty skills directory, so the bundle was correct by accident. Any repository with learned skills would have shipped them all.

## The fix

Both blocks are now gated on `wanted === null` — *"everything was asked for"* — and **not** on the item list being non-empty. That matters: `itemIds` already documents an empty array as a selection rather than an absence, and this keeps that true one level further down, so selecting nothing still exports nothing instead of widening to everything.

`knowl export` is unchanged and still carries both.

## Tests, at both levels

The two failure modes differ, so both are pinned:

- **Unit** (`tests/store/portability.test.ts`) — a targeted export emits exactly one `item` record and no `skill_package` or `tombstone`, asserted against the **raw bytes** as well as the parsed records, since a record-type filter would pass on a leak under a type the test did not think to name. Plus a counterweight that a full export still ships both, so the cheap way to pass is not to stop exporting them.
- **End to end** (`tests/cloud/send-transfer.test.ts`) — through `sendKnowledge` → `previewSend` → `receiveKnowledge`, asserting the **receiver** ends up without the skill directory on disk and without the tombstone in their store. That is the disclosure as a user meets it.

Both fixtures carry a skill package and a tombstone deliberately — their absence is exactly what hid this.

**Verified non-vacuous:** reverting the guard fails both. The end-to-end one fails on `expect(installed).not.toContain('deploy-runbook')`.

## Verification

`npm run build`, `tsc --noEmit`, `docs:check` all clean. Full suite **337 files, 3098 passed, 5 skipped, 0 failed**. `eslint` clean on the three changed files.

## Note for the release

This should land before 5.4.0. #118 repaired the interactive `cloud send --query` / `receive` prompts that were crashing, which makes the send path *more* used on the next release than it was on 5.3.0 — shipping the fix that makes the leaky path usable without fixing the leak is the wrong order.