### PR TITLE
chore: release 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,18 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.4.0 — 2026-08-15
+
+Mostly a release about knowing what actually happened. Two of these are cases where Knowl told you
+something confidently and wrongly: `cloud send` said it was handing over a few atoms while handing
+over your skills library and your forget-log, and `doctor` said your knowledge had never been
+embedded when an upgrade had just invalidated a perfectly good index. A third said nothing at all —
+`cloud receive` crashed before it could collect. The feature is the same theme from the other side:
+an atom written across repos now records who wrote it, instead of losing that at the moment it was
+created.
+
+If you are upgrading and semantic search has felt worse lately, run `knowl doctor` — it will now
+tell you whether a reindex is what you need.
 
 ### A send carries the atoms you chose, and no longer your skills and your forget-log with them
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Release PR for **5.4.0**. Merge with a **merge commit**, not a squash, so `chore: release 5.4.0` stays taggable.

## Why minor, not patch

`written_by` (#115) is a new column, a new MCP response field, and a migration-level bump (10 → 11). That is the shape [3.3.0](https://github.com/dat999zx/knowl/releases/tag/v3.3.0) was released as a minor for. A patch would push a feature to anyone pinned `~5.3.0`, and npm refuses to republish a version, so it is not a mistake that can be corrected afterwards.

## What ships

| PR | |
|---|---|
| #119 | `cloud send` sealed the atoms you chose **plus** every learned skill package and every tombstone — to a recipient who may share no workspace with you. Closes #117 |
| #118 | `cloud receive` crashed on a bare browser `confirm()` before it could collect. `tsc` could not see it because the project set `target` without `lib` |
| #116 | `doctor` called an index an upgrade had just invalidated one that had *never* been embedded, and told the reader nothing would repair it |
| #115 | `written_by` records the repo whose session authored an atom, when that is not the one that owns it |
| #114 | Replaced a heap assertion that could not observe the regression it existed to prevent |

## Contents

Three files, the usual shape: `CHANGELOG.md`, `package.json`, `package-lock.json`. Version set with `npm version 5.4.0 --no-git-tag-version`.

Verified before pushing:
- `check:lockfile` — lockfile matches package.json at 5.4.0
- `package.json` has no BOM (first byte `0x7b`), which is the Windows trap that breaks the shebang
- the workflow's own `awk` extraction against `## 5.4.0` yields 8,092 bytes — the lead paragraph and all four `###` sections

## After merge

Tag `v5.4.0` (annotated) at the release commit and push it. `cd.yml` publishes to npm on `refs/tags/v*` and then creates the GitHub release from the matching CHANGELOG section.