### PR TITLE
The README says "persistent memory across sessions" where the answer engines can hear it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/hero.svg" alt="Knowl — governed project memory for AI coding agents" width="100%" />
+<img src="docs/assets/hero.svg" alt="Knowl — persistent memory across sessions for Claude Code, Cursor and Codex, over MCP" width="100%" />
 
 **Local-first. Typed. And retired the moment it stops being true.**
 
@@ -36,10 +36,11 @@ Coding agents start every session blank, so teams write things down — and thos
 grow. Six months in, the store still reports the database you migrated off last spring,
 because nothing ever told it that decision was over.
 
-Knowl is a repository-local store of **typed knowledge atoms** — decisions, constraints,
-architecture, facts, goals, state, and skills — read and written over
-[MCP](https://modelcontextprotocol.io) or the `knowl` CLI, where **a replacement retires its
-predecessor at write time** instead of sitting beside it.
+Knowl is **persistent memory across sessions** for Claude Code, Cursor and Codex: a
+repository-local store of **typed knowledge atoms** — decisions, constraints, architecture, facts,
+goals, state, and skills — read and written over an [MCP](https://modelcontextprotocol.io) memory
+server or the `knowl` CLI, where **a replacement retires its predecessor at write time** instead of
+sitting beside it.
 
 ## Quick start
 


### PR DESCRIPTION
Two sentences change — the hero alt text and the opening definition. The reason is a measurement, and it comes with screenshots' worth of receipts.

## What was measured

Running an answer-engine baseline for knowl.cloud (2026-08-16, clean Claude account, web search on), the question this repo answers — *"how do I give my coding agent memory that persists across sessions?"* — was asked twice in separate chats. Both times Claude searched, composing nearly the same query for itself:

```
Claude Code persistent memory across sessions CLAUDE.md memory tool
Claude Code memory CLAUDE.md persistent across sessions
```

**4 of 9 results were GitHub repos**: `claude-code-memory`, `claude-howto`, `claude-remember`, `claude-mem` — plus mem0.ai's integration page and two MCP registry entries (`qdrant memory`, `mcp memory keeper` on glama.ai). Claude's prose answer then recommended the category by name — *"MCP memory servers … the closest thing to a portable, cross-tool memory layer"* — citing those tools as the examples.

`knowl` did not appear. Every repo that won carries the query's vocabulary in its name or description (*"Persistent memory system for Claude Code"*, *"Persistent Context Across Sessions for Every Agent"*). Before this PR, the README's 621 lines contained **zero** occurrences of "persistent memory" or "across sessions" — the opening described "a repository-local store of typed knowledge atoms", which is accurate and retrieves nothing.

The obvious objection — "the engine is just echoing the asker's words" — was tested. A casually-worded version (*"my AI coding assistant forgets everything when I start a new chat"*) triggers **no search at all**; Claude answers from its weights. The technical phrasing is the only one where retrieval happens, so it is the phrasing worth being findable under.

## The change

- Hero alt: `Knowl — persistent memory across sessions for Claude Code, Cursor and Codex, over MCP`
- Opening: now begins *"Knowl is **persistent memory across sessions** for Claude Code, Cursor and Codex: a repository-local store of typed knowledge atoms…"* and names the transport *"an MCP memory server"* — the exact category label Claude's answer used.

Everything after line 40 is untouched. The supersession pitch, the benchmark chips, the quick start — all as they were.

## Two things only you can change (repo settings, not files)

1. **Homepage is empty.** The repo doesn't link knowl.cloud (or anything) at all. Suggested: `https://knowl.cloud`
2. **Description** is `Knowledge Operating System for AI agents` — an abstraction, where every repo that outranked us is literal. Suggested:
   > Persistent memory across sessions for Claude Code, Cursor and Codex — a typed, repo-local MCP memory server where a new fact retires the one it replaces

The topics are already right (`persistent-memory`, `agent-memory`, `claude`, `mcp`) — it's the name-adjacent text that's losing.

Full measurement doc lives in the cloud repo: `docs/research/aeo-baseline-2026-08-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)