### PR TITLE
docs: name the commands that exist, and stop advertising a removed push gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Seven typed atom types, where a same-subject write retires its predecessor inste
 sitting beside it. That one behavior is the [90-vs-73 difference](#the-idea-memory-that-retires-itself).
 Evidence attached to a file or symbol goes stale *by itself* when the code moves.
 
-`conflicts` · `timeline` · `query --as-of` · `pr check` · `code index`
+`conflicts` · `timeline` · `query --as-of` · `pr --since` · `index-code`
 
 </td>
 <td width="50%" valign="top">
@@ -332,7 +332,7 @@ Vector-primary with a bounded BM25 fallback, reranked by freshness, status, and 
 so the *current* answer wins rather than the merely similar one. The embedding model is
 local and optional — without it you still get keyword retrieval, and nothing leaves the machine.
 
-`query` · `context --token-budget` · `config set-model` · `access report`
+`query` · `context --token-budget` · `config set-model` · `access`
 
 </td>
 </tr>
@@ -395,7 +395,7 @@ knowl state                            # the active memory, as a hierarchy
 knowl conflicts                        # items that contradict each other
 knowl timeline <item-id>               # every version an atom ever had
 knowl context --token-budget 1500      # a fixed-size briefing for an agent
-knowl pr --since origin/main     # knowledge your diff may invalidate
+knowl pr --since origin/main           # knowledge your diff may invalidate
 knowl doctor                           # setup, retrieval, and registration
 ```
 
@@ -436,7 +436,7 @@ knowl doctor                           # setup, retrieval, and registration
   agent/MCP path; a single-repo `knowl query` from the CLI is lexical.)
 - **Runs offline.** The embedding model is local and optional; without it you still get keyword
   retrieval. Retrieval never sends your query anywhere.
-- **Four bundled embedding presets**, including a multilingual one covering 200+ languages, plus
+- **Five bundled embedding presets**, including a multilingual one covering 200+ languages, plus
   `custom` for your own ONNX model. `knowl config set-model <model>`
 - **Exact-identifier support** — filenames, item IDs, and `symbol://` locators still hit even when
   semantic similarity is weak.
@@ -561,7 +561,7 @@ loopback binding is the privacy boundary: do not put it behind a public proxy or
 ### Everything else
 
 <!-- generated:tool-count -->
-**27 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, and 1 when linked into a local workspace)
+**27 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 1 when linked into a local workspace, and 1 when change impact is on)
 <!-- /generated:tool-count -->
 and two resource URIs · the
 **complete CLI**, from `knowl status` to `knowl audit` · a **read-only integrity audit** ·

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -648,11 +648,13 @@ The shipped workspace commands are:
 | --- | --- |
 | `knowl workspace init <name>` | Create a workspace outside its member repositories |
 | `knowl workspace add <name> [--name <repo-name>] [--default-visibility <repo\|workspace>] [--promote-existing] [--force]` | Link the current repository; shares its new writes by default in a `linked` workspace |
+| `knowl workspace set [--role <text>] [--default-visibility <repo\|workspace>] [--kin <group>]` | Change what this repo records about itself; with no flags, prints the current values |
 | `knowl workspace join <manifest> [--name <repo-name>] [--force]` | Adopt a copied manifest and map this checkout |
 | `knowl workspace list` | List workspaces known to this machine |
 | `knowl workspace status [--verbose]` | Show this repository's membership and peer health |
 | `knowl workspace remove <repo-name> [--export-first]` | Unlink the current repository, retiring its name if it still owns atoms |
 | `knowl workspace promote [--category <list> \| --id <id...>] [--apply]` | Share locally owned atoms with linked repos. Bare opens a picker with `decision, constraint, architecture, goal, skill` preticked and confirming applies; `--apply` is only needed on the flag path |
+| `knowl workspace demand [--limit <n>] [--json]` | What the linked repos have queried each other for, most-repeated first — the knowledge this repo owes its peers |
 | `knowl workspace repin-embedding [--yes]` | Move the workspace to this repository's embedding model and list the peers that must reindex |
 
 ### Federation and ownership
@@ -760,6 +762,21 @@ on, and your query text is never sent anywhere. The web console is what queries 
 
 The replica is a replica: deleting it is always safe, and the next pull rebuilds it from scratch.
 
+**An organisation is what carries the plan, not a workspace.** Signing in creates one free
+organisation for you, and every workspace inside it draws on that one allowance — published atoms a
+period, stored atoms, and how many workspaces the organisation may hold. So adding a workspace
+divides the allowance rather than adding to it, and a team that outgrows its plan upgrades the
+organisation once rather than each workspace separately.
+
+Your first organisation is free. Starting a second is a separate subscription — its own plan, its
+own bill, its own allowance — which is what you buy when work needs a wallet of its own, such as a
+different company. You may own as many as you are willing to pay for; there is no limit and no
+second free one.
+
+Members are the exception, and are counted per workspace rather than per organisation. Repositories
+inside a workspace are unlimited on every plan, and queries are never metered because they never
+reach the server.
+
 | Command | Purpose |
 | --- | --- |
 | `knowl cloud login [--api <host>]` | Sign in once, by device code. The credential lives in `~/.knowl`, never in `.knowl/config.json` |
@@ -768,7 +785,9 @@ The replica is a replica: deleting it is always safe, and the next pull rebuilds
 | `knowl cloud connect [--workspace <id>] [--remote <name>] [--repo <name>]` | Point this project at a workspace. Publishes nothing |
 | `knowl cloud pull` | Fetch team knowledge into the local replica |
 | `knowl cloud stage [--id <ids...>] [--category <list>] [--apply]` | Queue knowledge for the team. Bare opens the same picker; naming flags dry-runs until `--apply` |
-| `knowl cloud push` | Send staged knowledge. Works from any branch |
+| `knowl cloud unstage <id> [--forever]` | Take an atom back out of the queue. Publishes and unpublishes nothing; `--forever` also stops it being queued again automatically |
+| `knowl cloud push [--yes]` | Send staged knowledge. Works from any branch; `--yes` is required without a terminal to ask |
+| `knowl cloud autopush <on\|off>` | Record standing consent to push automatically, on this machine only — never written to `.knowl/config.json` |
 | `knowl cloud retract <id> --reason <text>` | Remove a published atom for good. Works from any branch |
 | `knowl cloud send [--id <ids...>] [--query <text>] [--expires-in <hours>] [--words <count>]` | Seal a few atoms for one person and print a code. Expires; collected once |
 | `knowl cloud send --list` / `--revoke <code-or-id>` | What you have in flight and whether it was collected; destroy one early |
@@ -1677,14 +1696,14 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | --- | --- |
 | `knowl workspace init <name>` | Create a workspace |
 | `knowl workspace add <name> [--name <repo-name>] [--default-visibility <repo\|workspace>] [--promote-existing] [--force]` | Link the current repository; shares its new writes by default in a `linked` workspace |
-| `knowl workspace join <manifest> [--name <repo-name>]` | Join from a copied manifest |
+| `knowl workspace join <manifest> [--name <repo-name>] [--force]` | Join from a copied manifest |
 | `knowl workspace list` | List machine-local workspaces |
 | `knowl workspace status [--verbose]` | Show membership and resolved peers |
 | `knowl workspace remove <repo-name> [--export-first]` | Unlink the current repository |
 | `knowl workspace promote [--category <list> \| --id <id...>] [--apply]` | Share locally owned knowledge with linked repos. Bare opens a picker; naming flags dry-runs until `--apply` |
 | `knowl workspace demand [--limit <n>] [--json]` | What the linked repos have queried each other for — the readout that says which knowledge this repo owes its peers |
-| `knowl workspace repin-embedding [--force]` | Repoint the workspace at this repository's embedding profile |
-| `knowl workspace set [--default-visibility <repo\|workspace>]` | Change this repo's recorded nature in the workspace manifest |
+| `knowl workspace repin-embedding [--yes]` | Repoint the workspace at this repository's embedding profile |
+| `knowl workspace set [--role <text>] [--default-visibility <repo\|workspace>] [--kin <group>]` | Change this repo's recorded nature in the workspace manifest; bare prints the current values |
 
 ### Memory and retrieval
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -38,7 +38,7 @@ function contextLabel(tokens: number): string {
 /** Region id -> [file, body]. */
 const regions: Record<string, [string, string]> = {
   'tool-count': [README, [
-    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace, and ${WORKSPACE_TOOL_DEFINITIONS.length} when linked into a local workspace)`,
+    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace, ${WORKSPACE_TOOL_DEFINITIONS.length} when linked into a local workspace, and ${IMPACT_TOOL_DEFINITIONS.length} when change impact is on)`,
   ].join('\n')],
 
   'embedding-presets': [REFERENCE, [

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1281,7 +1281,7 @@ cloudCommand
 
 cloudCommand
   .command('push')
-  .description('Send staged knowledge, once its code is on the default branch')
+  .description('Send staged knowledge. Works from any branch')
   .option('-y, --yes', 'Skip the confirmation. Required when there is no terminal to ask')
   .action(async options => {
     try {


### PR DESCRIPTION
A read-through of `README.md` and `docs/reference.md` against the shipped CLI surface. Every item below was verified against `--help` output or the source.

## Commands the README named that do not exist

| README said | Reality |
| --- | --- |
| `pr check` | `pr --since` — no `check` subcommand |
| `code index` | `index-code` — there is no `code` command |
| `access report` | `access` — its only flag is `--json` |

## Counts and tables that had drifted

- **"Four bundled embedding presets" → five.** `arctic-embed-m-v2` was added and the prose was never updated. The generated table in the reference has listed five all along, so the two documents contradicted each other.
- **The generated tool-count omitted the impact tool.** Added `IMPACT_TOOL_DEFINITIONS` to the region in `scripts/generate-docs.ts`, so the line now covers all four gated sets instead of three.
- **"The shipped workspace commands are:"** was missing `workspace set` and `workspace demand` — two of the ten it claims to enumerate.
- **The cloud command table** was missing `cloud unstage` and `cloud autopush`, both of which the surrounding prose already tells you to run.
- **`workspace repin-embedding` takes `--yes`, not `--force`.** The reference gave it both ways in two different tables.
- `workspace join` accepts `--force`, absent from the CLI reference row; `workspace set` also takes `--role` and `--kin`.

## One code fix, where the docs were right and the CLI was wrong

`knowl cloud push` still described itself as *"Send staged knowledge, once its code is on the default branch"*. Publishing stopped consulting the gate on 2026-08-13 (`src/cloud/publish-gate.ts:70`), and the reference has said "works from any branch" ever since — the help string was simply left behind. Anyone running `knowl cloud push --help` was told a constraint that no longer applies.

This is the one change with user-visible behaviour attached, though it is a description string only; no logic moved.

## Also included

The Knowl Cloud section's new paragraphs on how an organisation carries the plan, what a second organisation costs, and which limits are counted per workspace rather than per organisation.

## Verification

`npm run build` · `npm test` (337 files, 3098 passed, 5 skipped) · `npm run typecheck` · `npm run docs:check` · `git diff --check` — all clean.
