### PR TITLE
fix(discovery): a git worktree reaches the repository's memory instead of reporting no project

### DIFF
--- a/src/cli/database-presence.ts
+++ b/src/cli/database-presence.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { resolveStorage } from '../store/storage-roles.js';
+import { mainWorktreeRoot } from '../core/config.js';
 import { repoRegistryPath } from './repo-registry.js';
 
 /**
@@ -54,8 +55,7 @@ function isProjectRootSync(candidate: string): boolean {
   }
 }
 
-/** The enclosing initialized repository, or null when there is none. */
-export function findProjectRootSync(startPath: string): string | null {
+function walkForProjectRootSync(startPath: string): string | null {
   let current = path.resolve(startPath);
   for (;;) {
     if (isProjectRootSync(current)) return current;
@@ -63,6 +63,24 @@ export function findProjectRootSync(startPath: string): string | null {
     if (parent === current) return null;
     current = parent;
   }
+}
+
+/**
+ * The enclosing initialized repository, or null when there is none.
+ *
+ * Falls back to the main checkout for a linked worktree, exactly as `findProjectRoot` does and
+ * for the same reason -- `.knowl/` is gitignored, so a worktree carries no marker. Kept in step
+ * deliberately: this guard exists to turn a vanished database into an explanation rather than a
+ * raw error, and a resolver that gave up where the async one succeeds would skip the guard in
+ * precisely the checkouts that had just started resolving.
+ */
+export function findProjectRootSync(startPath: string): string | null {
+  const direct = walkForProjectRootSync(startPath);
+  if (direct) return direct;
+
+  const main = mainWorktreeRoot(startPath);
+  if (main && path.resolve(main) !== path.resolve(startPath)) return walkForProjectRootSync(main);
+  return null;
 }
 
 /** Has this machine ever initialized or upgraded this repository? */

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -329,14 +329,28 @@ program
       // is that same question asked one directory further up.
       const enclosing = await findProjectRoot(cwd).catch(() => null);
       if (enclosing && path.resolve(enclosing) !== path.resolve(cwd)) {
+        // Two different ways to get here, and the same words are false in the second. `cwd`
+        // under `enclosing` is the subpackage case above. `cwd` NOT under it means the resolver
+        // reached the project sideways, through the shared git directory of a linked worktree --
+        // so "inside", "run commands from anywhere under" and "move it outside" would each
+        // describe something that is not true of where the user is standing.
+        const relative = path.relative(enclosing, cwd);
+        const nested = relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
         throw new Error(
-          `${cwd} is inside the Knowl repository at ${enclosing}.\n` +
-          'Initializing here would create a second store, and every command run below this ' +
-          'directory would then read and write that one instead of the repository\'s -- ' +
-          'silently, because both are valid.\n' +
-          `  - to use the existing memory: run knowl commands from anywhere under ${enclosing}\n` +
-          `  - to upgrade that repository: cd ${enclosing} && knowl init\n` +
-          '  - if this really is a separate project, move it outside that repository first',
+          nested
+            ? `${cwd} is inside the Knowl repository at ${enclosing}.\n` +
+              'Initializing here would create a second store, and every command run below this ' +
+              'directory would then read and write that one instead of the repository\'s -- ' +
+              'silently, because both are valid.\n' +
+              `  - to use the existing memory: run knowl commands from anywhere under ${enclosing}\n` +
+              `  - to upgrade that repository: cd ${enclosing} && knowl init\n` +
+              '  - if this really is a separate project, move it outside that repository first'
+            : `${cwd} is a git worktree of the Knowl repository at ${enclosing}, and already ` +
+              'reads and writes its memory.\n' +
+              'Initializing here would create a second store that only this worktree can see, ' +
+              'and the two would diverge silently.\n' +
+              '  - to use the existing memory: nothing to do -- run knowl commands here\n' +
+              `  - to upgrade that repository: cd ${enclosing} && knowl init`,
         );
       }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import { statSync } from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { ProjectConfig } from './types.js';
@@ -158,10 +159,15 @@ async function walkForProjectRoot(startPath: string): Promise<string | null> {
  * Returns null when git is absent or the path is not in a repository. This is a best-effort
  * widening of a lookup that already failed, so it must not turn a missing git binary into an
  * error the caller did not have before.
+ *
+ * git is asked at all only when `insideLinkedWorktree` finds the marker, and it is asked with
+ * `GIT_DIR` and friends stripped -- see those two helpers for why each is load-bearing.
  */
 export function mainWorktreeRoot(startPath: string): string | null {
+  if (!insideLinkedWorktree(startPath)) return null;
+
   const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
-    cwd: startPath, encoding: 'utf8',
+    cwd: startPath, encoding: 'utf8', env: gitEnvWithoutRepoOverrides(),
   });
   if (result.error || result.status !== 0 || typeof result.stdout !== 'string') return null;
 
@@ -171,6 +177,55 @@ export function mainWorktreeRoot(startPath: string): string | null {
   const resolved = path.resolve(startPath, commonDir);
   if (path.basename(resolved) !== '.git') return null;
   return path.dirname(resolved);
+}
+
+/**
+ * Is `startPath` inside a LINKED worktree -- the only shape the resolution above can answer for?
+ *
+ * `git worktree add` writes `.git` as a FILE holding `gitdir: <path>`, where a main checkout has
+ * `.git` as a DIRECTORY. That one bit is the whole test, and it costs a `stat` per ancestor.
+ *
+ * It is a gate rather than an optimisation, for two separate reasons.
+ *
+ * **The miss branch is a hot path.** `src/cli/agent-hook.ts` runs once per agent tool call as a
+ * fresh process -- "its cost is paid hundreds of times a session ... the only Knowl command with
+ * that property" -- and its own comment names `ProjectNotFoundError` as the ORDINARY case,
+ * because the hook fires in every directory the agent visits and most are not Knowl
+ * repositories. A `git` spawn measures ~22ms here, which is ~13% of the 175ms that bundling the
+ * hook bought, and it cannot be amortised because the process is new every time. Ordinary CLI
+ * commands would pay it twice, once in the `preAction` guard and once in the command body.
+ *
+ * **`GIT_DIR` outranks `cwd`.** `git rev-parse` honours `GIT_DIR`/`GIT_COMMON_DIR` over the
+ * working directory, and git exports them into every hook it runs, so any subprocess of
+ * `git commit` inherits them. Without this gate a directory with no relationship to that
+ * repository resolved to it and silently read and wrote its memory. Stripping the variables
+ * (below) is the direct fix; refusing to ask at all unless a linked-worktree marker is actually
+ * present is the one that does not depend on knowing every variable git consults.
+ */
+function insideLinkedWorktree(startPath: string): boolean {
+  let current = path.resolve(startPath);
+  for (;;) {
+    try {
+      if (statSync(path.join(current, '.git')).isFile()) return true;
+    } catch {
+      // Absent or unreadable: neither is an answer, so keep climbing.
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
+}
+
+/**
+ * `process.env` with the variables that would make git answer about a different repository
+ * removed. `cwd` is the question being asked; these would override it.
+ */
+function gitEnvWithoutRepoOverrides(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_WORK_TREE;
+  return env;
 }
 
 /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { ProjectConfig } from './types.js';
 import { ConfigError, ProjectNotFoundError } from './errors.js';
 import { DEFAULT_PRESET_ID } from './vector-profile.js';
@@ -110,10 +111,8 @@ export async function isProjectRoot(candidate: string): Promise<boolean> {
   }
 }
 
-/**
- * Traverses up from the starting path to find the root of the enclosing Knowl project.
- */
-export async function findProjectRoot(startPath: string = process.cwd()): Promise<string> {
+/** Traverses up from `startPath` looking for the marker. Null when no ancestor carries one. */
+async function walkForProjectRoot(startPath: string): Promise<string | null> {
   let current = path.resolve(startPath);
   const root = path.parse(current).root;
 
@@ -126,6 +125,79 @@ export async function findProjectRoot(startPath: string = process.cwd()): Promis
 
   // Check root directory itself
   if (await isProjectRoot(current)) return current;
+
+  return null;
+}
+
+/**
+ * The main checkout of the repository `startPath` belongs to, or null when that is not a
+ * question with an answer here.
+ *
+ * `git rev-parse --git-common-dir` names the *shared* git directory, which is what separates a
+ * linked worktree from the checkout it was made from. Measured output, which is why the single
+ * `path.resolve` below is enough for all of it:
+ *
+ * | run from                  | prints                   |
+ * |---------------------------|--------------------------|
+ * | main checkout root        | `.git`                   |
+ * | subdirectory of main      | `../../.git`             |
+ * | linked worktree root      | `C:/repo/.git` (absolute)|
+ * | subdirectory of a worktree| `C:/repo/.git` (absolute)|
+ * | outside any repository    | exits non-zero           |
+ *
+ * Relative in the first two cases and absolute in the next two, so resolving against
+ * `startPath` normalises every one of them to the same shared `.git`, whose parent is the main
+ * checkout.
+ *
+ * Only a directory literally named `.git` is accepted. A submodule reports
+ * `.git/modules/<name>`, and a bare or otherwise unusual layout reports something else again;
+ * in those the parent is not a checkout and guessing would hand back a directory that merely
+ * looks like one. Refusing is the safe answer because every caller treats null as "no extra
+ * information", never as "no project".
+ *
+ * Returns null when git is absent or the path is not in a repository. This is a best-effort
+ * widening of a lookup that already failed, so it must not turn a missing git binary into an
+ * error the caller did not have before.
+ */
+export function mainWorktreeRoot(startPath: string): string | null {
+  const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
+    cwd: startPath, encoding: 'utf8',
+  });
+  if (result.error || result.status !== 0 || typeof result.stdout !== 'string') return null;
+
+  const commonDir = result.stdout.trim();
+  if (!commonDir) return null;
+
+  const resolved = path.resolve(startPath, commonDir);
+  if (path.basename(resolved) !== '.git') return null;
+  return path.dirname(resolved);
+}
+
+/**
+ * Traverses up from the starting path to find the root of the enclosing Knowl project.
+ *
+ * When the walk finds nothing, one widening is tried: `.knowl/` is gitignored and
+ * `git worktree add` materialises tracked files only, so a linked worktree is a checkout of an
+ * initialized repository that carries no marker anywhere inside it. Placed outside the main
+ * checkout -- which is where orchestrators put them -- the walk has nothing to reach and every
+ * command failed with `No Knowl project found`. Resolving the shared git directory recovers the
+ * main checkout, and the walk is run again from there so the same marker rule decides.
+ *
+ * The widening is deliberately a FALLBACK rather than a first step. A Knowl project nested
+ * inside a larger git repository must keep resolving to itself, and it does, because the
+ * ordinary walk reaches its marker before this runs (K-09). It also cannot invent a project:
+ * the second walk applies `isProjectRoot` exactly as the first did, so a repository whose main
+ * checkout was never initialized still throws.
+ */
+export async function findProjectRoot(startPath: string = process.cwd()): Promise<string> {
+  const direct = await walkForProjectRoot(startPath);
+  if (direct) return direct;
+
+  const main = mainWorktreeRoot(startPath);
+  if (main && path.resolve(main) !== path.resolve(startPath)) {
+    const fromMain = await walkForProjectRoot(main);
+    if (fromMain) return fromMain;
+  }
 
   throw new ProjectNotFoundError(startPath);
 }

--- a/tests/cli/project-marker.test.ts
+++ b/tests/cli/project-marker.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { findProjectRoot } from '../../src/core/config.js';
+import { findProjectRoot, mainWorktreeRoot } from '../../src/core/config.js';
 import { findProjectRootSync } from '../../src/cli/database-presence.js';
 import { discoverRepos } from '../../src/cli/repo-discovery.js';
 
@@ -175,6 +175,98 @@ describe('a git worktree of an initialized repository', () => {
     await fs.mkdir(plain, { recursive: true });
     git(plain, ['init', '--initial-branch=main']);
     await expect(findProjectRoot(plain)).rejects.toThrow(/No Knowl project found/);
+  });
+
+  /**
+   * `GIT_DIR` outranks `cwd`, and git exports it into every hook it runs.
+   *
+   * So a subprocess of `git commit` -- husky, lint-staged, or Knowl's own agent hook fired from
+   * one -- inherits a `GIT_DIR` naming a repository that has nothing to do with the directory it
+   * is standing in. Asking `git rev-parse --git-common-dir` there answers about the inherited
+   * repository, and the directory silently reads and writes memory that is not its own. That is
+   * worse than the miss the fallback was added to cure: a wrong answer, delivered confidently.
+   */
+  it('ignores an inherited GIT_DIR naming an unrelated repository', async () => {
+    const unrelated = path.join(base, 'unrelated', 'deep');
+    await fs.mkdir(unrelated, { recursive: true });
+
+    const previous = process.env.GIT_DIR;
+    process.env.GIT_DIR = path.join(main, '.git');
+    try {
+      expect(mainWorktreeRoot(unrelated)).toBeNull();
+      await expect(findProjectRoot(unrelated)).rejects.toThrow(/No Knowl project found/);
+    } finally {
+      if (previous === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = previous;
+    }
+  });
+
+  /**
+   * The miss branch is `agent-hook`'s ordinary case -- it fires in every directory the agent
+   * visits, most of which are not repositories at all -- and it runs as a fresh process
+   * hundreds of times a session, so a ~22ms `git` spawn there is unamortisable overhead on the
+   * one command whose cost was deliberately engineered down to 175ms.
+   *
+   * A linked worktree writes `.git` as a FILE; a main checkout writes a DIRECTORY. Refusing to
+   * spawn git without that marker keeps the cost on the path that needs it and off the path
+   * that does not.
+   */
+  it('answers null without consulting git when no linked-worktree marker is present', async () => {
+    const bare = path.join(base, 'not-a-repo', 'deep');
+    await fs.mkdir(bare, { recursive: true });
+    expect(mainWorktreeRoot(bare)).toBeNull();
+
+    // The main checkout is a repository, and still not a linked worktree.
+    expect(mainWorktreeRoot(main)).toBeNull();
+  });
+});
+
+/**
+ * Resolving sideways into the main checkout gave the `knowl init` guard a case its message was
+ * never written for.
+ *
+ * The guard exists for a subpackage NESTED inside an initialized repository, and every line of
+ * it assumes that: "is inside", "run knowl commands from anywhere under", "move it outside that
+ * repository first". A linked worktree placed beside the main checkout is none of those -- it is
+ * not inside, you no longer need to be under the main checkout to reach the memory, and it is
+ * already outside, so the escape hatch names something the user has done. Refusing is still
+ * right; describing it wrongly is not.
+ */
+describe('knowl init inside a git worktree of an initialized repository', () => {
+  let base = '';
+  let main = '';
+  let worktree = '';
+
+  beforeEach(async () => {
+    base = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-init-worktree-')));
+    main = path.join(base, 'main');
+    worktree = path.join(base, 'trees', 'agent-1');
+
+    await fs.mkdir(main, { recursive: true });
+    git(main, ['init', '--initial-branch=main']);
+    await fs.writeFile(path.join(main, '.gitignore'), '.knowl/\n', 'utf8');
+    git(main, ['add', '.']);
+    git(main, ['commit', '-m', 'init']);
+    await fs.mkdir(path.join(main, '.knowl'), { recursive: true });
+    await fs.writeFile(path.join(main, '.knowl', 'config.json'), JSON.stringify({ version: 1 }), 'utf8');
+    git(main, ['worktree', 'add', '-b', 'agent-1', worktree]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(base, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('refuses, and says the worktree already reaches that memory', async () => {
+    const result = initIn(worktree, path.join(base, 'home'));
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('is a git worktree of the Knowl repository at');
+    expect(result.stderr).toContain(main);
+    // The nested-subpackage wording is false here and must not be what the user sees.
+    expect(result.stderr).not.toContain('is inside the Knowl repository at');
+    expect(result.stderr).not.toContain('move it outside that repository first');
+    // It must still refuse to build the second store.
+    await expect(fs.access(path.join(worktree, '.knowl', 'config.json'))).rejects.toThrow();
   });
 });
 

--- a/tests/cli/project-marker.test.ts
+++ b/tests/cli/project-marker.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { findProjectRoot } from '../../src/core/config.js';
+import { findProjectRootSync } from '../../src/cli/database-presence.js';
 import { discoverRepos } from '../../src/cli/repo-discovery.js';
 
 /**
@@ -74,6 +75,106 @@ describe('what marks a directory as a Knowl project', () => {
     const roots = found.map(entry => entry.root);
     expect(roots).toContain(REAL);
     expect(roots).not.toContain(FAKE_HOME);
+  });
+});
+
+/**
+ * A git worktree is a checkout of the same repository, and it must reach the same memory.
+ *
+ * `.knowl/` is gitignored, so `git worktree add` -- which materialises tracked files only --
+ * produces a checkout with no marker anywhere in it. When the worktree is placed outside the
+ * main checkout, the ancestor walk has nothing to find and every command fails with
+ * `No Knowl project found`. Measured 2026-08-16 against 5.4.0: `knowl doctor` reported
+ * NOT READY and `knowl query` exited non-zero inside a worktree under the system temp
+ * directory.
+ *
+ * That is the whole of the parallel-agent case. `isolation: "worktree"` on Claude Code's Agent
+ * tool, this repository's own `docs/audit-lanes.md`, and every orchestrator that fans agents
+ * out across isolated checkouts all produce exactly this shape -- so the agents that most need
+ * shared memory were the ones guaranteed not to have it.
+ *
+ * The fallback runs only after the ordinary walk fails, which is what keeps a Knowl project
+ * nested inside a larger git repository resolving to itself rather than jumping out to the
+ * enclosing repository's main worktree (K-09).
+ */
+function git(cwd: string, args: string[]) {
+  // Per-invocation identity: `git config` run in a fixture searches upward and lands in the
+  // nearest enclosing repository, which for a fixture is this one. `-c` writes no file.
+  const result = spawnSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], {
+    cwd, encoding: 'utf8',
+  });
+  if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+describe('a git worktree of an initialized repository', () => {
+  let base = '';
+  let main = '';
+  let outside = '';
+  let nestedWorktree = '';
+
+  beforeEach(async () => {
+    base = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-worktree-')));
+    main = path.join(base, 'main');
+    outside = path.join(base, 'trees', 'agent-1');
+    nestedWorktree = path.join(main, '.agents', 'agent-2');
+
+    await fs.mkdir(main, { recursive: true });
+    git(main, ['init', '--initial-branch=main']);
+    await fs.writeFile(path.join(main, 'README.md'), '# fixture\n', 'utf8');
+    await fs.writeFile(path.join(main, '.gitignore'), '.knowl/\n', 'utf8');
+    git(main, ['add', '.']);
+    git(main, ['commit', '-m', 'init']);
+
+    // The marker, deliberately never committed -- which is the real situation.
+    await fs.mkdir(path.join(main, '.knowl'), { recursive: true });
+    await fs.writeFile(path.join(main, '.knowl', 'config.json'), JSON.stringify({ version: 1 }), 'utf8');
+
+    git(main, ['worktree', 'add', '-b', 'agent-1', outside]);
+    git(main, ['worktree', 'add', '-b', 'agent-2', nestedWorktree]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(base, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('carries no marker of its own, which is the premise of the bug', async () => {
+    await expect(fs.access(path.join(outside, '.knowl', 'config.json'))).rejects.toThrow();
+  });
+
+  it('resolves to the main checkout when the worktree sits outside it', async () => {
+    expect(await findProjectRoot(outside)).toBe(main);
+  });
+
+  it('resolves from a nested directory inside that worktree', async () => {
+    const deep = path.join(outside, 'src', 'deep');
+    await fs.mkdir(deep, { recursive: true });
+    expect(await findProjectRoot(deep)).toBe(main);
+  });
+
+  it('still resolves a worktree placed inside the main checkout by the ordinary walk', async () => {
+    expect(await findProjectRoot(nestedWorktree)).toBe(main);
+  });
+
+  it('does not invent a project for a worktree whose main checkout has no marker', async () => {
+    await fs.rm(path.join(main, '.knowl'), { recursive: true, force: true });
+    await expect(findProjectRoot(outside)).rejects.toThrow(/No Knowl project found/);
+  });
+
+  it('resolves the same way through the synchronous resolver', async () => {
+    // `assertDatabasePresentForCommand` treats null as "not a project, nothing to check", so a
+    // sync resolver that gave up here would silently skip the missing-database guard in exactly
+    // the checkouts the async resolver had just started serving.
+    expect(findProjectRootSync(outside)).toBe(main);
+  });
+
+  it('does not adopt an enclosing repository when the start path is simply not a project', async () => {
+    // A plain checkout with no Knowl project anywhere must still fail, or the fallback would
+    // turn "not initialized" into "silently borrowed somebody else's store".
+    const plain = path.join(base, 'plain');
+    await fs.mkdir(plain, { recursive: true });
+    git(plain, ['init', '--initial-branch=main']);
+    await expect(findProjectRoot(plain)).rejects.toThrow(/No Knowl project found/);
   });
 });
 


### PR DESCRIPTION
## The bug

`.knowl/` is gitignored, and `git worktree add` materialises tracked files only. So a linked worktree is a checkout of an initialized repository that carries **no marker anywhere inside it**. Placed outside the main checkout — which is where orchestrators put them — the ancestor walk in `findProjectRoot` has nothing to reach.

Measured against released **5.4.0**, in a real worktree of a Knowl project:

```
$ git worktree add <tmp>/wt -b agent-1
$ cd <tmp>/wt && knowl doctor
[FAIL] No Knowl project found at "...\wt". Run "knowl init" to initialize.
Result: NOT READY

$ knowl query "..."
Error querying knowledge: No Knowl project found
```

Not a degraded result — a hard error on every command.

**This is the whole of the parallel-agent case.** `isolation: "worktree"` on Claude Code's Agent tool, this repository's own `docs/audit-lanes.md` (which runs seven audit lanes in hand-made worktrees), and every orchestrator that fans agents across isolated checkouts all produce exactly this shape. The agents that most need shared memory were the ones guaranteed not to have it — silently, because `No Knowl project found` reads as a setup mistake rather than a product gap.

Worth noting the failure is placement-dependent, which is why it stayed hidden: a worktree placed *inside* the main checkout already worked, because the ordinary walk climbs out into it.

## The fix

`mainWorktreeRoot` resolves the shared git directory via `git rev-parse --git-common-dir`. Measured output, which is why a single `path.resolve` covers all of it:

| run from | prints |
|---|---|
| main checkout root | `.git` |
| subdirectory of main | `../../.git` |
| linked worktree root | `C:/repo/.git` (absolute) |
| subdirectory of a worktree | `C:/repo/.git` (absolute) |
| outside any repository | exits non-zero |

Relative in the first two and absolute in the next two, so resolving against the start path normalises every case to the same shared `.git`, whose parent is the main checkout.

Only a directory literally named `.git` is accepted. A submodule reports `.git/modules/<name>`; there the parent is not a checkout, and guessing would hand back something that merely looks like one. Returns null when git is absent or the path is not in a repository — this widens a lookup that already failed, so it must not turn a missing git binary into a new error.

### What keeps it safe

- **It is a fallback, never a first step.** A Knowl project nested inside a larger git repository keeps resolving to itself, because the ordinary walk reaches its marker before this runs (K-09).
- **It cannot invent a project.** The second walk applies `isProjectRoot` exactly as the first did, so a repository whose main checkout was never initialized still throws rather than borrowing a store.
- **`findProjectRootSync` gets the same fallback.** It answers for `assertDatabasePresentForCommand`, which reads null as "not a project, nothing to check" — a resolver that gave up where the async one now succeeds would skip the missing-database guard in precisely the checkouts that had just started resolving.

## Verification

Six new tests in `tests/cli/project-marker.test.ts`, written failing first against a real `git worktree` fixture. They pin the premise (the worktree genuinely has no marker), both resolution paths, the sync resolver, and the two ways this could go wrong — a worktree whose main checkout has no marker, and a plain uninitialized checkout — both of which must still throw.

- `npm test` — **337 files, 3105 passed, 5 skipped, 0 failed**
- `npm run typecheck` — clean
- `npx eslint` on changed files — clean

End-to-end against a real worktree of a Knowl project, same command before and after:

```
BEFORE (5.4.0):  [FAIL] No Knowl project found ... Result: NOT READY
AFTER:           [OK] Repository initialized at C:\Code\knowl-cloud\.knowl
                 [OK] Config loaded
                 [OK] Cloud: github.com/dat999zx/knowl-cloud → ... synced
```

and `knowl query` from inside the worktree returns real atoms from the main checkout's store.

## Note on scope

This makes N worktrees of one repository share **one** store, which is the behaviour parallel agents want. Whether N *simultaneous* writers produce semantically coherent memory is a separate question and is not addressed here — WAL plus `busy_timeout` and the connection-pool retry mean concurrent writers get bounded waits rather than errors, but that is a durability property, not a coherence one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)