### PR TITLE
fix(guidance): listed but not callable is not unavailable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
 5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
-6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.
+6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name you need — namespaced it is `mcp__knowl__knowl_query` — and call it. Only when the tools are genuinely absent, stop and tell the user instead of silently bypassing Knowl.
 
 ### Lifecycle modes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
 5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
-6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name you need — namespaced it is `mcp__knowl__knowl_query` — and call it. Only when the tools are genuinely absent, stop and tell the user instead of silently bypassing Knowl.
+6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name your host lists and call it — where names are namespaced from the server key, `knowl_query` appears as `mcp__knowl__knowl_query`. Stop and tell the user only when the tools are genuinely absent, or when every call fails; never silently bypass Knowl.
 
 ### Lifecycle modes
 

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -8,7 +8,7 @@
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
 5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
-6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name you need — namespaced it is `mcp__knowl__knowl_query` — and call it. Only when the tools are genuinely absent, stop and tell the user instead of silently bypassing Knowl.
+6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name your host lists and call it — where names are namespaced from the server key, `knowl_query` appears as `mcp__knowl__knowl_query`. Stop and tell the user only when the tools are genuinely absent, or when every call fails; never silently bypass Knowl.
 
 ### Lifecycle modes
 

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -8,7 +8,7 @@
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
 5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
-6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.
+6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name you need — namespaced it is `mcp__knowl__knowl_query` — and call it. Only when the tools are genuinely absent, stop and tell the user instead of silently bypassing Knowl.
 
 ### Lifecycle modes
 

--- a/src/cli/agents/desktop-adapter.ts
+++ b/src/cli/agents/desktop-adapter.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { mergeJsonMcpConfig, McpEntry } from './files.js';
 import { AgentAdapter, AgentDetection, AgentEnvironment, AgentIntegrationResult } from './types.js';
 import { unsupportedLifecycleResult } from './lifecycle-config.js';
+import { KNOWL_MCP_SERVER_KEY } from '../../core/knowl-guidance.js';
 
 function desktopConfigPath(environment: AgentEnvironment) {
   if (environment.platform === 'win32') return path.join(environment.appDataDir, 'Claude', 'claude_desktop_config.json');
@@ -17,7 +18,7 @@ function entry(environment: AgentEnvironment): McpEntry {
 async function configured(pathname: string, expected: McpEntry) {
   try {
     const config = JSON.parse(await fs.readFile(pathname, 'utf8')) as Record<string, any>;
-    const value = config.mcpServers?.knowl;
+    const value = config.mcpServers?.[KNOWL_MCP_SERVER_KEY];
     return value?.command === expected.command && JSON.stringify(value.args) === JSON.stringify(expected.args);
   } catch (error: any) {
     if (error.code === 'ENOENT') return false;

--- a/src/cli/agents/files.ts
+++ b/src/cli/agents/files.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { parse, stringify } from 'smol-toml';
+import { KNOWL_MCP_SERVER_KEY } from '../../core/knowl-guidance.js';
 
 export interface McpEntry {
   command: string;
@@ -41,9 +42,9 @@ export async function mergeJsonMcpConfig(configPath: string, entry: McpEntry): P
   const servers = config.mcpServers && typeof config.mcpServers === 'object' && !Array.isArray(config.mcpServers)
     ? config.mcpServers as Record<string, unknown>
     : {};
-  if (equalEntry(servers.knowl, entry)) return 'unchanged';
-  const status: MergeStatus = servers.knowl === undefined ? 'configured' : 'updated';
-  config.mcpServers = { ...servers, knowl: entry };
+  if (equalEntry(servers[KNOWL_MCP_SERVER_KEY], entry)) return 'unchanged';
+  const status: MergeStatus = servers[KNOWL_MCP_SERVER_KEY] === undefined ? 'configured' : 'updated';
+  config.mcpServers = { ...servers, [KNOWL_MCP_SERVER_KEY]: entry };
   await writeWithBackup(configPath, `${JSON.stringify(config, null, 2)}\n`, existing);
   return status;
 }
@@ -54,9 +55,9 @@ export async function mergeCodexTomlConfig(configPath: string, entry: McpEntry):
   const servers = config.mcp_servers && typeof config.mcp_servers === 'object' && !Array.isArray(config.mcp_servers)
     ? config.mcp_servers as Record<string, unknown>
     : {};
-  if (equalEntry(servers.knowl, entry)) return 'unchanged';
-  const status: MergeStatus = servers.knowl === undefined ? 'configured' : 'updated';
-  config.mcp_servers = { ...servers, knowl: entry };
+  if (equalEntry(servers[KNOWL_MCP_SERVER_KEY], entry)) return 'unchanged';
+  const status: MergeStatus = servers[KNOWL_MCP_SERVER_KEY] === undefined ? 'configured' : 'updated';
+  config.mcp_servers = { ...servers, [KNOWL_MCP_SERVER_KEY]: entry };
   await writeWithBackup(configPath, stringify(config), existing);
   return status;
 }

--- a/src/cli/agents/project-adapters.ts
+++ b/src/cli/agents/project-adapters.ts
@@ -10,6 +10,7 @@ import {
   NativeInstructionHost,
   verifyKnowlHostInstructions,
 } from './instruction-files.js';
+import { KNOWL_MCP_SERVER_KEY } from '../../core/knowl-guidance.js';
 
 function commandEntry(environment: AgentEnvironment): McpEntry {
   return { command: environment.platform === 'win32' ? 'knowl.cmd' : 'knowl', args: ['serve'] };
@@ -45,7 +46,7 @@ export function createCodexAdapter(environment: AgentEnvironment): AgentAdapter 
       const pathname = configPath(root);
       const source = await readConfig(pathname);
       const parsed = source ? parse(source) as Record<string, any> : {};
-      return { installed: await environment.commandExists('codex'), configured: equalEntry(parsed.mcp_servers?.knowl, commandEntry(environment)), scope: 'project', configPath: pathname };
+      return { installed: await environment.commandExists('codex'), configured: equalEntry(parsed.mcp_servers?.[KNOWL_MCP_SERVER_KEY], commandEntry(environment)), scope: 'project', configPath: pathname };
     },
     async configure(root): Promise<AgentIntegrationResult> {
       const pathname = configPath(root);
@@ -81,7 +82,7 @@ function createJsonProjectAdapter(
       const pathname = configPath(root);
       const source = await readConfig(pathname);
       const parsed = source ? JSON.parse(source) as Record<string, any> : {};
-      return { installed: await environment.commandExists(command), configured: equalEntry(parsed.mcpServers?.knowl, commandEntry(environment)), scope: 'project', configPath: pathname };
+      return { installed: await environment.commandExists(command), configured: equalEntry(parsed.mcpServers?.[KNOWL_MCP_SERVER_KEY], commandEntry(environment)), scope: 'project', configPath: pathname };
     },
     async configure(root): Promise<AgentIntegrationResult> {
       const pathname = configPath(root);

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -228,17 +228,6 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         const detection = await adapter.detect(root);
         if (!detection.configured) continue;
         configuredAgentCount += 1;
-        // These two checks stay WARN, but they no longer say "MCP remains available" -- that
-        // wording claimed the tool surface is a sufficient fallback, and it is only sufficient
-        // on a host that loads tool *descriptions*. A host may list the tools by name and defer
-        // their schemas until asked, and there the routing prose is not in context at all: the
-        // host instruction file and the server card are the only carriers left. So the fallback
-        // is narrower than the old message promised, and naming what actually survives -- the
-        // recording, not the routing -- is the honest form.
-        //
-        // Severity is deliberately unchanged. Deferral is a client-side presentation choice made
-        // after `initialize` and `tools/list`, so the server cannot detect it, and an
-        // unconditional FAIL would report NOT READY on every host where nothing is wrong.
         if (adapter.verifyInstructions) {
           const verified = await adapter.verifyInstructions(root);
           checks.push({
@@ -263,6 +252,21 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
             fix: verified ? undefined : `run \`knowl init ${adapter.name}\``,
             remedy: verified ? undefined : { kind: 'host-init', host: adapter.name },
           });
+        // The two messages below no longer say "MCP remains available". That wording claimed the
+        // tool surface is a sufficient fallback, and it is only sufficient on a host that loads
+        // tool *descriptions*. A host may list the tools by name and defer their schemas until
+        // asked, and there the routing prose is not in context at all: the host instruction file
+        // and the server card are the only carriers left. So the fallback is narrower than the
+        // old message promised, and naming what actually survives -- the recording, not the
+        // routing -- is the honest form.
+        //
+        // Severity is deliberately unchanged. Deferral is a client-side presentation choice made
+        // after `initialize` and `tools/list`, so the server cannot detect it, and an
+        // unconditional FAIL would report NOT READY on every host where nothing is wrong.
+        //
+        // NOTE: the `degraded` branch is currently unreachable from here. No adapter's
+        // `lifecycleCapability` returns it -- the only producer is `init-flow.ts`, which does not
+        // feed this call. It is worded correctly for when one does.
         } else if (capability === 'degraded') {
           checks.push({
             status: 'WARN',

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -228,6 +228,17 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         const detection = await adapter.detect(root);
         if (!detection.configured) continue;
         configuredAgentCount += 1;
+        // These two checks stay WARN, but they no longer say "MCP remains available" -- that
+        // wording claimed the tool surface is a sufficient fallback, and it is only sufficient
+        // on a host that loads tool *descriptions*. A host may list the tools by name and defer
+        // their schemas until asked, and there the routing prose is not in context at all: the
+        // host instruction file and the server card are the only carriers left. So the fallback
+        // is narrower than the old message promised, and naming what actually survives -- the
+        // recording, not the routing -- is the honest form.
+        //
+        // Severity is deliberately unchanged. Deferral is a client-side presentation choice made
+        // after `initialize` and `tools/list`, so the server cannot detect it, and an
+        // unconditional FAIL would report NOT READY on every host where nothing is wrong.
         if (adapter.verifyInstructions) {
           const verified = await adapter.verifyInstructions(root);
           checks.push({
@@ -255,12 +266,12 @@ export async function runDoctor(startPath: string = process.cwd()): Promise<Doct
         } else if (capability === 'degraded') {
           checks.push({
             status: 'WARN',
-            message: `${adapter.name} lifecycle hooks degraded; MCP remains available`,
+            message: `${adapter.name} lifecycle hooks degraded; MCP still records knowledge, but capture is manual`,
             fix: `run \`knowl init ${adapter.name}\``,
             remedy: { kind: 'host-init', host: adapter.name },
           });
         } else {
-          checks.push({ status: 'OK', message: `${adapter.name} lifecycle hooks unsupported; MCP remains available` });
+          checks.push({ status: 'OK', message: `${adapter.name} lifecycle hooks unsupported; MCP still records knowledge, use the manual work loop` });
         }
       } catch (error: any) {
         // No remedy: the check itself failed, so what is wrong with the host is unknown and

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -8,10 +8,19 @@ export const KNOWL_GUIDANCE_END_MARKER = '<!-- /KNOWL_PROJECT_MEMORY -->';
  * The key `knowl init` writes into every host's MCP config, and the prefix that follows from it.
  *
  * Hosts that namespace MCP tools build the callable name from the *registration key*, so the
- * prefix is not a guess: `knowl init` writes `mcpServers.knowl` / `mcp_servers.knowl` and a
- * namespacing host therefore exposes `mcp__knowl__knowl_query`. Guidance that prints the bare
- * name prints something that does not resolve, which matters most on a host that lists tools
- * without loading their schemas -- there the agent has to select a tool by its exact name.
+ * middle segment is not a guess: `knowl init` writes `mcpServers.knowl` / `mcp_servers.knowl`,
+ * and every reader of those files derives the key from this constant too, so the name printed
+ * here cannot drift from the name written and then detected. That matters most on a host that
+ * lists tools without loading their schemas -- there the agent selects a tool by exact name.
+ *
+ * The `mcp__` / `__` wrapper around it is NOT universal. It is Claude Code's convention, and it
+ * is where the observed failure happened, but this guidance is written once and installed for
+ * every host: `installKnowlProjectGuidance` writes the same managed text into `KNOWL.md` and
+ * `AGENTS.md` whichever host was selected, and `GEMINI.md` includes it by reference. Nothing in
+ * `src/session/hosts/` carries per-host tool-name knowledge, so there is nowhere to resolve a
+ * different convention from -- and `cli/agents/host-hook.ts` already splits on the LAST `__`
+ * precisely because it has met other shapes. So the prose names this form as an example of the
+ * convention rather than asserting it is the name every host will show.
  *
  * Defined here rather than in `cli/agents/files.ts` so guidance does not import from the CLI
  * layer, and shared with the writers so the printed name cannot drift from the written one.
@@ -79,7 +88,7 @@ const REQUIRED_WORKFLOW = `### Required workflow
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
 5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
-6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name you need — namespaced it is \`${KNOWL_NAMESPACED_TOOL_PREFIX}knowl_query\` — and call it. Only when the tools are genuinely absent, stop and tell the user instead of silently bypassing Knowl.`;
+6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name your host lists and call it — where names are namespaced from the server key, \`knowl_query\` appears as \`${KNOWL_NAMESPACED_TOOL_PREFIX}knowl_query\`. Stop and tell the user only when the tools are genuinely absent, or when every call fails; never silently bypass Knowl.`;
 
 const LIFECYCLE_MODES = `### Lifecycle modes
 
@@ -159,7 +168,7 @@ const TRANSCRIPT_ROUTE_LINE =
 function renderCompactKnowlGuidance(modeLine: string, options: { transcripts?: boolean } = {}): string {
   return [
     'KNOWL WORKFLOW - for project work.',
-    'Start: use a relevant active lifecycle hit; else call knowl_query with the words that name the subject before repository files or commands. A knowl_task_start hit counts in manual mode. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are unavailable, stop and tell the user.',
+    'Start: use a relevant active lifecycle hit; else call knowl_query with the words that name the subject before repository files or commands. A knowl_task_start hit counts in manual mode. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are absent, stop and tell the user.',
     modeLine,
     'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
     'Route by what you need; the tool list names them:',

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -4,6 +4,21 @@ import { isTranscriptSearchEnabled } from './config.js';
 export const KNOWL_GUIDANCE_START_MARKER = '<!-- KNOWL_PROJECT_MEMORY -->';
 export const KNOWL_GUIDANCE_END_MARKER = '<!-- /KNOWL_PROJECT_MEMORY -->';
 
+/**
+ * The key `knowl init` writes into every host's MCP config, and the prefix that follows from it.
+ *
+ * Hosts that namespace MCP tools build the callable name from the *registration key*, so the
+ * prefix is not a guess: `knowl init` writes `mcpServers.knowl` / `mcp_servers.knowl` and a
+ * namespacing host therefore exposes `mcp__knowl__knowl_query`. Guidance that prints the bare
+ * name prints something that does not resolve, which matters most on a host that lists tools
+ * without loading their schemas -- there the agent has to select a tool by its exact name.
+ *
+ * Defined here rather than in `cli/agents/files.ts` so guidance does not import from the CLI
+ * layer, and shared with the writers so the printed name cannot drift from the written one.
+ */
+export const KNOWL_MCP_SERVER_KEY = 'knowl';
+export const KNOWL_NAMESPACED_TOOL_PREFIX = `mcp__${KNOWL_MCP_SERVER_KEY}__`;
+
 export const KNOWL_MCP_TOOL_GROUPS = [
   {
     label: 'Focused retrieval',
@@ -64,7 +79,7 @@ const REQUIRED_WORKFLOW = `### Required workflow
 3. Use a relevant active hit immediately. Inspect files only after a miss, conflict, stale/low-confidence memory, or explicit verification request.
 4. Query again before switching to a distinct subtask or project area, and before choosing how to build something new — existing tooling and pipelines are project knowledge, and in a linked workspace they often live in a sibling repo, so leave method queries unscoped.
 5. Store or update durable knowledge during work and before the final answer — verified findings, stated intent (goals, plans, direction the user voiced) stored as goals with user_stated provenance even while unsettled, and resolved diagnoses stored as skills when the cause will recur (an environment quirk, a config trap — not a typo). The test: could a fresh session recover this from memory alone? Never store raw transcripts, secrets, or transient debugging noise.
-6. If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.`;
+6. Listed but not callable is not unavailable. A host may namespace the tools and withhold their schemas until asked, so load the schema for the name you need — namespaced it is \`${KNOWL_NAMESPACED_TOOL_PREFIX}knowl_query\` — and call it. Only when the tools are genuinely absent, stop and tell the user instead of silently bypassing Knowl.`;
 
 const LIFECYCLE_MODES = `### Lifecycle modes
 

--- a/tests/cli/agent-adapters.test.ts
+++ b/tests/cli/agent-adapters.test.ts
@@ -133,6 +133,35 @@ describe('agent adapters', () => {
     expect((await readJson(desktopPath)).mcpServers.knowl.command).toBe('knowl.cmd');
   });
 
+  /**
+   * Whatever key `configure` writes, `detect` and `verify` have to look for the same one.
+   *
+   * The writers were moved onto `KNOWL_MCP_SERVER_KEY` while three readers kept the literal --
+   * `project-adapters.ts` twice and `desktop-adapter.ts` once. Mutating the constant proved the
+   * split: every adapter reported `configure -> configured` and then `verify -> false`,
+   * `detect.configured -> false`. `knowl init` would write a config `knowl doctor` can never
+   * see, and `doctor --fix` would re-run init forever without converging.
+   *
+   * The tests above pin the on-disk key as the literal `knowl`, which is right -- it is a
+   * compatibility contract with configs users already have. This one pins the *join*, so the
+   * two halves cannot be renamed apart.
+   */
+  it('detects and verifies every adapter it just configured', async () => {
+    const adapters = [
+      createCodexAdapter(environment),
+      createClaudeCodeAdapter(environment),
+      createCursorAdapter(environment),
+      createGeminiAdapter(environment),
+      createClaudeDesktopAdapter(environment),
+    ];
+
+    for (const adapter of adapters) {
+      await adapter.configure(PROJECT);
+      expect(`${adapter.name}: ${(await adapter.detect(PROJECT)).configured}`).toBe(`${adapter.name}: true`);
+      expect(`${adapter.name}: ${await adapter.verify(PROJECT)}`).toBe(`${adapter.name}: true`);
+    }
+  });
+
   it('deduplicates agent names and rejects unsupported names', () => {
     expect(parseAgentNames(['codex', 'claude', 'codex'])).toEqual(['codex', 'claude']);
     expect(() => parseAgentNames(['unknown'])).toThrow('Unsupported agent "unknown"');

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -33,7 +33,7 @@ const EXPECTED_TOOLS = [
 
 const EXPECTED_CLAUDE_CARD = [
   'KNOWL WORKFLOW - for project work.',
-  'Start: use a relevant active lifecycle hit; else call knowl_query with the words that name the subject before repository files or commands. A knowl_task_start hit counts in manual mode. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are unavailable, stop and tell the user.',
+  'Start: use a relevant active lifecycle hit; else call knowl_query with the words that name the subject before repository files or commands. A knowl_task_start hit counts in manual mode. Re-query on a new area. Inspect files only after miss/conflict/stale/low-confidence or explicit verification. If tools are absent, stop and tell the user.',
   'Mode: Claude hooks own lifecycle. Never call knowl_task_start, knowl_task_checkpoint, knowl_task_finish, or knowl_session_finish while active.',
   'Manual fallback: knowl task run for one bounded command; resumable work uses knowl_task_start once, knowl_task_checkpoint at milestones or blockers with its taskId, and knowl_task_finish once after verification.',
   'Route by what you need; the tool list names them:',
@@ -131,8 +131,8 @@ describe('canonical Knowl agent guidance', () => {
     // (see 'does not grow when a tool is added'), so a new tool inside an existing group should
     // leave both numbers untouched. If adding a tool changes them, something re-introduced the
     // inventory the card stopped carrying.
-    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_833);
-    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_884);
+    expect(KNOWL_CLAUDE_OPERATIONAL_CARD).toHaveLength(1_828);
+    expect(KNOWL_MCP_SERVER_INSTRUCTIONS).toHaveLength(1_879);
     for (const card of [KNOWL_CLAUDE_OPERATIONAL_CARD, KNOWL_MCP_SERVER_INSTRUCTIONS]) {
       expect(card.length).toBeLessThan(2_000);
       expect(card.slice(0, 512)).toContain('knowl_query');
@@ -246,21 +246,29 @@ describe('canonical Knowl agent guidance', () => {
    * derived from one exported constant and asserted against what the writers actually emit.
    */
   it('derives the namespaced tool prefix from the key the config writers register', async () => {
-    expect(KNOWL_NAMESPACED_TOOL_PREFIX).toBe(`mcp__${KNOWL_MCP_SERVER_KEY}__`);
-
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-mcp-key-'));
     const entry = { command: 'knowl', args: ['serve'] };
 
-    const jsonPath = path.join(directory, '.mcp.json');
-    await mergeJsonMcpConfig(jsonPath, entry);
-    const json = JSON.parse(await fs.readFile(jsonPath, 'utf8'));
-    expect(Object.keys(json.mcpServers)).toEqual([KNOWL_MCP_SERVER_KEY]);
+    try {
+      const jsonPath = path.join(directory, '.mcp.json');
+      await mergeJsonMcpConfig(jsonPath, entry);
+      const json = JSON.parse(await fs.readFile(jsonPath, 'utf8'));
+      expect(Object.keys(json.mcpServers)).toEqual([KNOWL_MCP_SERVER_KEY]);
 
-    const tomlPath = path.join(directory, 'config.toml');
-    await mergeCodexTomlConfig(tomlPath, entry);
-    expect(await fs.readFile(tomlPath, 'utf8')).toContain(`[mcp_servers.${KNOWL_MCP_SERVER_KEY}]`);
+      const tomlPath = path.join(directory, 'config.toml');
+      await mergeCodexTomlConfig(tomlPath, entry);
+      expect(await fs.readFile(tomlPath, 'utf8')).toContain(`[mcp_servers.${KNOWL_MCP_SERVER_KEY}]`);
 
-    await fs.rm(directory, { recursive: true, force: true });
+      // Deliberately NOT `expect(PREFIX).toBe(\`mcp__${KNOWL_MCP_SERVER_KEY}__\`)`. That restates
+      // the definition, so it cannot fail -- proven by mutation: renaming the constant left this
+      // whole file passing while the guidance rendered a name nothing registers. Read the key
+      // back off the config that was actually written, and assert the guidance prints THAT.
+      const written = Object.keys(json.mcpServers)[0];
+      expect(renderFullKnowlGuidance()).toContain(`mcp__${written}__knowl_query`);
+      expect(KNOWL_NAMESPACED_TOOL_PREFIX).toBe(`mcp__${written}__`);
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
   });
 
   it('changes only the lifecycle mode line between compact renderings', () => {

--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import {
   KNOWL_CLAUDE_CONTINUATION_REMINDER,
@@ -8,12 +9,15 @@ import {
   KNOWL_CLAUDE_PROMPT_REMINDER,
   KNOWL_HOST_NEUTRAL_MODE_LINE,
   KNOWL_MCP_SERVER_INSTRUCTIONS,
+  KNOWL_MCP_SERVER_KEY,
   KNOWL_MCP_TOOL_GROUPS,
   KNOWL_MCP_TOOL_NAMES,
+  KNOWL_NAMESPACED_TOOL_PREFIX,
   KNOWL_SUBAGENT_BOOTSTRAP_CARD,
   renderFullKnowlGuidance,
   renderManagedKnowlGuidanceSection,
 } from '../../src/core/knowl-guidance.js';
+import { mergeCodexTomlConfig, mergeJsonMcpConfig } from '../../src/cli/agents/files.js';
 
 const EXPECTED_TOOLS = [
   'knowl_query',
@@ -205,6 +209,58 @@ describe('canonical Knowl agent guidance', () => {
     // The subagent card stays intent-free — a subagent receives a bounded task, not a user
     // conversation — but it does debug, so diagnoses are in its storable class too.
     expect(KNOWL_SUBAGENT_BOOTSTRAP_CARD).toMatch(recurrence);
+  });
+
+  /**
+   * Listed-but-not-callable has to be distinguishable from unavailable.
+   *
+   * Grounded in a live failure, not taste: a Claude Code session (2026-08-16) listed all of
+   * knowl's tools by name under "schemas are NOT loaded -- calling them directly will fail",
+   * and reaching `knowl_query` first cost a schema-load round-trip that rule 6 did not describe.
+   * Rule 6 read "if Knowl MCP tools are unavailable, stop and tell the user", which an agent
+   * looking at a list of uncallable tools can reasonably read as its own case -- and the
+   * instructed response to that case is to stop using Knowl.
+   *
+   * The subagent card already had this line, because a subagent is dispatched into exactly that
+   * shape. It is the same failure in the main session and it wants the same sentence.
+   */
+  it('tells an agent that listed-but-not-callable tools are loadable, not unavailable', () => {
+    const guidance = renderFullKnowlGuidance();
+    expect(guidance).toMatch(/listed but not callable is not unavailable/i);
+    expect(guidance).toMatch(/load the schema/i);
+    // The bare name does not resolve on a namespacing host, so the rule prints the form that does.
+    expect(guidance).toContain(`${KNOWL_NAMESPACED_TOOL_PREFIX}knowl_query`);
+    // Unchanged: the genuine-absence half of the rule still has to survive the rewrite.
+    expect(guidance).toMatch(/stop and tell the user/i);
+    // The subagent card is the surface this was generalised from; it must not regress.
+    expect(KNOWL_SUBAGENT_BOOTSTRAP_CARD).toMatch(/listed but not callable/i);
+  });
+
+  /**
+   * The printed name must be built from the written one.
+   *
+   * This is a known defect class in this project: a surface that PRINTS an identifier drifts
+   * from the identifier that actually resolves, because nothing joins the two halves. It has
+   * already happened twice with CLI command names. A namespaced tool name is the same shape --
+   * derived from the MCP registration key, which lives in the config writers -- so the prefix is
+   * derived from one exported constant and asserted against what the writers actually emit.
+   */
+  it('derives the namespaced tool prefix from the key the config writers register', async () => {
+    expect(KNOWL_NAMESPACED_TOOL_PREFIX).toBe(`mcp__${KNOWL_MCP_SERVER_KEY}__`);
+
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-mcp-key-'));
+    const entry = { command: 'knowl', args: ['serve'] };
+
+    const jsonPath = path.join(directory, '.mcp.json');
+    await mergeJsonMcpConfig(jsonPath, entry);
+    const json = JSON.parse(await fs.readFile(jsonPath, 'utf8'));
+    expect(Object.keys(json.mcpServers)).toEqual([KNOWL_MCP_SERVER_KEY]);
+
+    const tomlPath = path.join(directory, 'config.toml');
+    await mergeCodexTomlConfig(tomlPath, entry);
+    expect(await fs.readFile(tomlPath, 'utf8')).toContain(`[mcp_servers.${KNOWL_MCP_SERVER_KEY}]`);
+
+    await fs.rm(directory, { recursive: true, force: true });
   });
 
   it('changes only the lifecycle mode line between compact renderings', () => {


### PR DESCRIPTION
## What happened

A Claude Code session (2026-08-16) listed **every** knowl tool by name under:

> The following deferred tools are now available via ToolSearch. Their schemas are NOT loaded — calling them directly will fail with `InputValidationError`.

Reaching `knowl_query` first therefore cost a schema-load round-trip that our guidance never describes. The host is doing progressive disclosure *to* us, and we get no say in the subset or the ordering.

The sharp part is rule 6, which read:

> If Knowl MCP tools are unavailable, stop and tell the user instead of silently bypassing Knowl.

An agent staring at a list of uncallable tools can reasonably read that as its own case — and the instructed response to that case is **to stop using Knowl**.

## What this changes

**1. Rule 6 distinguishes deferred from absent** (`renderFullKnowlGuidance`). `KNOWL_SUBAGENT_BOOTSTRAP_CARD` already carries this line, because a subagent is dispatched into exactly that shape and a probe found it. Same failure in the main session, same sentence. The genuine-absence half is kept intact.

**2. It prints the name that resolves.** A namespacing host builds the callable name from the registration key, and `knowl init` writes `mcpServers.knowl` — so the namespaced form is `mcp__knowl__knowl_query`, which is what an agent has to select by *exact name* when schemas are withheld. The key is now one exported constant (`KNOWL_MCP_SERVER_KEY`) shared by the guidance and both config writers, with a test asserting the printed prefix against what the writers actually emit.

That join is the part worth having. A surface that *prints* an identifier drifting from the identifier that *resolves* has already bitten this repo twice with CLI command names (`knowl workspace connect`, `knowl cloud login`), both times because nothing connected the two halves.

**3. Doctor stops claiming "MCP remains available."** The degraded and unsupported lifecycle-hook messages promised the tool surface is a sufficient fallback. It is only sufficient on a host that loads tool *descriptions*; where schemas are deferred the routing prose is not in context at all, and the host instruction file plus the server card are the only carriers left. The messages now name what actually survives — the recording, not the routing.

## Two things I deliberately did not do

**Nothing lands in the compact cards.** The transcript-enabled card sits at **1,990 / 2,000**, and this sentence does not fit. The full guidance is a file written once per repo, not a cost paid per session, so it is the right home. Whether the card should buy the room by compressing an existing line is a real question, but it spends a contested budget and touches prose with an eval harness behind it — that is your call, not a drive-by.

**Doctor severity is unchanged.** Flipping hooks-stale from WARN to FAIL was my first instinct and I think it is wrong: deferral is a client-side presentation choice made *after* `initialize` and `tools/list`, so the server cannot detect it, and an unconditional FAIL would report NOT READY on every host where nothing is actually wrong. If you want the severity rule revisited, that is a separate decision with real blast radius — `ready` gates on it.

## Verification

- `tsc --noEmit` — clean
- `eslint .` — clean
- `npm run docs:check` — current (`KNOWL.md` / `AGENTS.md` regenerated)
- `npx vitest run` — **337 test files, 3,100 tests, 0 failures**

Diff is 6 files, +94/−11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
