### PR TITLE
chore: release 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.4.1 — 2026-08-18
 
 Three fixes to the places where Knowl decides *which* memory it is talking to, and whether an agent
 believes it can talk to Knowl at all. The worktree one is the largest: until now, every agent an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts 5.4.1 from `d6512b3` plus the changelog. Patch, not minor: no new MCP tool, no new CLI command, no schema or migration-level change — three bug fixes and one development script that the tarball does not ship.

**Contents** — #123 (a git worktree reaches the repository's memory), #124 (a listed tool with no schema is not a missing tool, plus the server key `init` writes and `doctor` reads), #125 (card-cost measurement, tooling only).

**Verified at this commit:** `npm run build` clean, `tsc --noEmit` clean, `docs:check` current, **337 test files / 3111 passed / 5 skipped / 0 failed**. `npm pack --dry-run` is 78 files / 906.5 kB and ships neither `scripts/` nor `docs/`.

Release notes extract cleanly — `awk '/^## 5\.4\.1 /{flag=1; next} /^## /{flag=0} flag'` returns the 63-line section, so `cd.yml` will not fall back to `--generate-notes`.

Merge with a **merge commit**, not squash, so the tag can point at `0bcedd2` per house convention (`v5.4.0^{}` is `bf0ed89`, the release commit, not the merge).