### PR TITLE
fix(store): a claim can no longer be retired by its own negation

### DIFF
--- a/src/store/knowledge-writer.ts
+++ b/src/store/knowledge-writer.ts
@@ -36,6 +36,39 @@ const DUPLICATE_STOP_WORDS = new Set([
   'it', 'of', 'on', 'or', 'our', 'the', 'this', 'to', 'use', 'uses', 'using', 'what', 'with',
 ]);
 
+/**
+ * Tokens that flip a claim rather than extend it.
+ *
+ * THE FAILURE THIS EXISTS FOR. `sameSubjectTitle` is a token-SUBSET test, and none of these
+ * words is a stop word, so an affirmative title is a strict subset of its own negation and the
+ * subset test fires. Measured by running the real function, 2026-08-19:
+ *
+ *     "Push gate blocks default branch"  SUPERSEDES  "Push gate no longer blocks default branch"
+ *     "Reranker is the right call"       SUPERSEDES  "Reranker is not the right call"
+ *
+ * The survivor then asserts the opposite of what was retired, silently. The first pair is this
+ * project's own 2026-08-13 push-gate reversal: a title shape that, written twice across the
+ * reversal, retires its own predecessor in whichever order the two writes happen to arrive.
+ *
+ * WHY NOT THE NUMERIC CASE TOO. The published prior art for this guard (muninndb's
+ * `dedup_separation.go`) is built around numbers -- "$99" merging with "$149". That hole does not
+ * exist here and the check would be dead weight: `duplicateTokens` splits on `[^a-z0-9_]+`, so
+ * digits survive as tokens, `768` is absent from a title saying `1024`, the subset test already
+ * fails, and the two atoms already coexist. Verified alongside the two cases above. Only polarity
+ * is unguarded, because only polarity words are short, common, and absent from the stop list.
+ *
+ * DELIBERATELY NARROW. Ambiguous stems are left out -- `can` ("Can the gate block" is a real
+ * title), `won`, `don`. A missed negation costs what today already costs; a false positive here
+ * costs a supersede that should have happened, which the caller then has to make deliberately.
+ * Contraction apostrophes are split by the tokenizer, so `isn't` arrives as `isn` plus a
+ * one-character token that the length filter drops -- hence the bare stems below.
+ */
+const POLARITY_TOKENS = new Set([
+  'not', 'no', 'never', 'none', 'nor', 'without', 'cannot', 'longer', 'unable',
+  'isn', 'aren', 'wasn', 'weren', 'doesn', 'didn', 'hasn', 'haven', 'hadn',
+  'couldn', 'shouldn', 'wouldn',
+]);
+
 export interface StoreKnowledgeInput {
   category: KnowledgeCategory;
   title: string;
@@ -188,6 +221,48 @@ export function sameSubjectTitle(a: { title: string }, b: { title: string }): bo
     if (!larger.has(token)) return false;
   }
   return true;
+}
+
+/**
+ * Whether two same-subject titles differ ONLY by polarity -- one negates the other.
+ *
+ * Called after `sameSubjectTitle` has already established containment, so the smaller set is a
+ * subset of the larger and the difference is exactly what the longer title adds. If everything it
+ * adds is a polarity token, the two titles are not "same subject, new information" -- they are
+ * the same subject asserted both ways, and retiring either one leaves the store asserting a
+ * claim its own history contradicts.
+ *
+ * Symmetric on purpose: which of the pair is the incoming write is not the question. Reaching
+ * this from the affirmative side (a re-assertion arriving after a recorded negation) is the more
+ * dangerous direction, because the negation is usually the correction.
+ */
+export function differsOnlyInPolarity(a: { title: string }, b: { title: string }): boolean {
+  const left = duplicateTokens(a.title);
+  const right = duplicateTokens(b.title);
+  const [smaller, larger] = left.size <= right.size ? [left, right] : [right, left];
+
+  let added = 0;
+  for (const token of larger) {
+    if (smaller.has(token)) continue;
+    if (!POLARITY_TOKENS.has(token)) return false;
+    added++;
+  }
+  // Identical token sets add nothing and are not a polarity pair; that case is a plain duplicate
+  // and belongs to the payload comparison above, which can still answer `no-op`.
+  return added > 0;
+}
+
+/**
+ * Whether an item asserts that someone actually grounded the claim.
+ *
+ * The same two values `fuse.ts` treats as a claim, and for the same stated reason: unknown
+ * provenance is not evidence of provenance, so silence sits with `inferred` rather than with
+ * `observed`. Keeping the two modules on one definition matters because they now express the
+ * same judgement in two places -- ranking demotes an unclaimed atom, and this refuses to let one
+ * retire a claimed atom.
+ */
+function claimsFirstHandGrounding(provenance: KnowledgeProvenance | null | undefined): boolean {
+  return provenance === 'observed' || provenance === 'user_stated';
 }
 
 /**
@@ -351,7 +426,29 @@ export function resolveDuplicate(
     };
     if (carriesNothingNew(incoming, held ?? duplicate)) return 'no-op';
   }
-  return sameSubjectTitle(input, duplicate) ? 'supersede' : 'coexist';
+  if (!sameSubjectTitle(input, duplicate)) return 'coexist';
+
+  // Two guards on the supersede branch, both clamping to `coexist` rather than refusing. Neither
+  // can lose a write: the incoming atom is still inserted, the predecessor stays active, and the
+  // caller is told about the pair through the `nearDuplicate` channel that already reports the
+  // exact retire call. An agent that means to retire the other one says so with `supersedes`,
+  // which is checked first and is never second-guessed.
+  //
+  // 1. POLARITY. The titles are the same claim asserted both ways; see `POLARITY_TOKENS`.
+  if (differsOnlyInPolarity(input, duplicate)) return 'coexist';
+
+  // 2. GROUNDING. An atom that does not claim first-hand grounding must not silently retire one
+  //    that does -- "inferred evidence must not overturn an explicit fact". Deliberately
+  //    one-directional and narrow: it fires only where the HELD atom claims `observed` or
+  //    `user_stated` and the incoming one does not, so the 79% of writes that leave provenance
+  //    unset are unaffected unless they are aimed at one of the ~20% that made a claim. That
+  //    asymmetry is also the incentive `fuse.ts` chose on the ranking side: declaring provenance
+  //    is what earns full credit, and here it is what earns the right to retire a grounded claim.
+  if (claimsFirstHandGrounding(duplicate.provenance) && !claimsFirstHandGrounding(input.provenance)) {
+    return 'coexist';
+  }
+
+  return 'supersede';
 }
 
 // Resolve the item (if any) that a new write should mark superseded: the detected

--- a/src/store/knowledge-writer.ts
+++ b/src/store/knowledge-writer.ts
@@ -253,19 +253,6 @@ export function differsOnlyInPolarity(a: { title: string }, b: { title: string }
 }
 
 /**
- * Whether an item asserts that someone actually grounded the claim.
- *
- * The same two values `fuse.ts` treats as a claim, and for the same stated reason: unknown
- * provenance is not evidence of provenance, so silence sits with `inferred` rather than with
- * `observed`. Keeping the two modules on one definition matters because they now express the
- * same judgement in two places -- ranking demotes an unclaimed atom, and this refuses to let one
- * retire a claimed atom.
- */
-function claimsFirstHandGrounding(provenance: KnowledgeProvenance | null | undefined): boolean {
-  return provenance === 'observed' || provenance === 'user_stated';
-}
-
-/**
  * Everything an item carries that a title-and-content comparison cannot see.
  *
  * Named as a type because two places decide "is this copy redundant" -- the write path, when
@@ -428,25 +415,25 @@ export function resolveDuplicate(
   }
   if (!sameSubjectTitle(input, duplicate)) return 'coexist';
 
-  // Two guards on the supersede branch, both clamping to `coexist` rather than refusing. Neither
-  // can lose a write: the incoming atom is still inserted, the predecessor stays active, and the
-  // caller is told about the pair through the `nearDuplicate` channel that already reports the
-  // exact retire call. An agent that means to retire the other one says so with `supersedes`,
-  // which is checked first and is never second-guessed.
+  // One guard on the supersede branch, clamping to `coexist` rather than refusing. It cannot lose
+  // a write: the incoming atom is still inserted, the predecessor stays active, and the caller is
+  // told about the pair through the `nearDuplicate` channel that already reports the exact retire
+  // call. An agent that means to retire the other one says so with `supersedes`, which is checked
+  // first and is never second-guessed.
   //
-  // 1. POLARITY. The titles are the same claim asserted both ways; see `POLARITY_TOKENS`.
+  // The titles are the same claim asserted both ways; see `POLARITY_TOKENS`.
+  //
+  // NOT GUARDED ON PROVENANCE, and that was measured rather than assumed. A second guard was
+  // proposed here -- refuse to let an atom with no provenance retire one claiming `observed` or
+  // `user_stated` -- and replayed against this repo's 101 real supersessions it would have
+  // blocked 3, all three of them legitimate corrections. One of the three is an atom whose entire
+  // point is that the measurement it replaced was defective; blocking it leaves the known-wrong
+  // figure active. Unset provenance is not a weak claim here, it is simply what 73% of all writes
+  // look like, including the most carefully verified ones. `agent-query.ts` does demote an
+  // unclaimed atom, but by a 0.98 multiplier -- a nudge in ranking is not the same judgement as
+  // refusing a supersession, and a pair left coexisting is invisible afterwards: `knowl_conflicts`
+  // reads only `conflictKey`/`conflictExclusive`, set on 3 of 937 active items.
   if (differsOnlyInPolarity(input, duplicate)) return 'coexist';
-
-  // 2. GROUNDING. An atom that does not claim first-hand grounding must not silently retire one
-  //    that does -- "inferred evidence must not overturn an explicit fact". Deliberately
-  //    one-directional and narrow: it fires only where the HELD atom claims `observed` or
-  //    `user_stated` and the incoming one does not, so the 79% of writes that leave provenance
-  //    unset are unaffected unless they are aimed at one of the ~20% that made a claim. That
-  //    asymmetry is also the incentive `fuse.ts` chose on the ranking side: declaring provenance
-  //    is what earns full credit, and here it is what earns the right to retire a grounded claim.
-  if (claimsFirstHandGrounding(duplicate.provenance) && !claimsFirstHandGrounding(input.provenance)) {
-    return 'coexist';
-  }
 
   return 'supersede';
 }

--- a/tests/store/duplicate-polarity-guard.test.ts
+++ b/tests/store/duplicate-polarity-guard.test.ts
@@ -1,0 +1,174 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import {
+  differsOnlyInPolarity,
+  resolveDuplicate,
+  sameSubjectTitle,
+  storeKnowledgeItemDeduped,
+} from '../../src/store/knowledge-writer.js';
+import type { KnowledgeItem } from '../../src/core/types.js';
+
+/**
+ * Both guards on the supersede branch. The cases below are the ones that were measured to
+ * supersede before the guards existed, so each `toBe('coexist')` is a regression pin on a write
+ * that used to be silently lost.
+ */
+
+const held = (over: Partial<KnowledgeItem>): KnowledgeItem => ({
+  id: 'held-1',
+  category: 'fact',
+  title: '',
+  content: '',
+  status: 'active',
+  provenance: null,
+  ...over,
+} as KnowledgeItem);
+
+describe('differsOnlyInPolarity', () => {
+  it('sees a negation added to an otherwise identical title', () => {
+    expect(differsOnlyInPolarity(
+      { title: 'Reranker is the right call' },
+      { title: 'Reranker is not the right call' },
+    )).toBe(true);
+  });
+
+  it('is symmetric -- the affirmative arriving second is the same pair', () => {
+    expect(differsOnlyInPolarity(
+      { title: 'Reranker is not the right call' },
+      { title: 'Reranker is the right call' },
+    )).toBe(true);
+  });
+
+  it('sees the multi-word "no longer" form', () => {
+    expect(differsOnlyInPolarity(
+      { title: 'Push gate blocks default branch' },
+      { title: 'Push gate no longer blocks default branch' },
+    )).toBe(true);
+  });
+
+  it('does not fire when the longer title adds real information', () => {
+    expect(differsOnlyInPolarity(
+      { title: 'Cloud send works' },
+      { title: 'Cloud send works end to end in production' },
+    )).toBe(false);
+  });
+
+  it('does not fire on identical token sets -- that is a plain duplicate, not a polarity pair', () => {
+    expect(differsOnlyInPolarity(
+      { title: 'Cache TTL' },
+      { title: 'Cache TTL' },
+    )).toBe(false);
+  });
+
+  it('leaves ambiguous stems alone: "can" is a real title word, not a negation', () => {
+    expect(differsOnlyInPolarity(
+      { title: 'Gate blocks the branch' },
+      { title: 'Gate can blocks the branch' },
+    )).toBe(false);
+  });
+});
+
+describe('resolveDuplicate polarity guard', () => {
+  const incoming = { category: 'fact' as const, title: 'Reranker is the right call', content: 'Yes.' };
+  const negation = held({ title: 'Reranker is not the right call', content: 'No.' });
+
+  it('the titles are still the same subject -- the guard is a resolution rule, not a subject test', () => {
+    expect(sameSubjectTitle(incoming, negation)).toBe(true);
+  });
+
+  it('clamps to coexist instead of retiring the negation', () => {
+    expect(resolveDuplicate(incoming, negation)).toBe('coexist');
+  });
+
+  it('an explicit supersedes id still wins -- the caller may always be deliberate', () => {
+    expect(resolveDuplicate({ ...incoming, supersedes: negation.id }, negation)).toBe('supersede');
+  });
+
+  it('still supersedes when the longer title adds information rather than polarity', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Cloud send works end to end in production', content: 'Verified.' },
+      held({ title: 'Cloud send works', content: 'Probably.' }),
+    )).toBe('supersede');
+  });
+});
+
+describe('resolveDuplicate grounding guard', () => {
+  const grounded = held({ title: 'Vector dim', content: 'It is 768.', provenance: 'observed' });
+
+  it('an unclaimed write does not retire an observed one', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.' },
+      grounded,
+    )).toBe('coexist');
+  });
+
+  it('a write that claims grounding may retire an observed one', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.', provenance: 'observed' },
+      grounded,
+    )).toBe('supersede');
+  });
+
+  it('user_stated counts as a claim on both sides', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.', provenance: 'user_stated' },
+      held({ title: 'Vector dim', content: 'It is 768.', provenance: 'user_stated' }),
+    )).toBe('supersede');
+  });
+
+  it('is one-directional: an observed write may retire an unclaimed predecessor', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.', provenance: 'observed' },
+      held({ title: 'Vector dim', content: 'It is 768.' }),
+    )).toBe('supersede');
+  });
+
+  it('leaves the unclaimed-to-unclaimed majority path untouched', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.' },
+      held({ title: 'Vector dim', content: 'It is 768.' }),
+    )).toBe('supersede');
+  });
+});
+
+describe('the negation survives a real write', () => {
+  const ROOT = path.resolve('./.knowl-polarity-guard-test');
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'polarity')).id;
+  });
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('the 2026-08-13 push-gate reversal shape leaves both claims active', async () => {
+    const reversal = await storeKnowledgeItemDeduped(projectId, {
+      category: 'decision',
+      title: 'Push gate no longer blocks default branch',
+      content: 'The default-branch and behind-remote blocking gate was removed.',
+    });
+    expect(reversal.action).toBe('inserted');
+
+    const restatement = await storeKnowledgeItemDeduped(projectId, {
+      category: 'decision',
+      title: 'Push gate blocks default branch',
+      content: 'Pushing from the default branch is refused.',
+    });
+    expect(restatement.action).toBe('inserted');
+
+    // The load-bearing assertion: before the guard this read 'superseded', and the store was
+    // left asserting the opposite of a decision it had recorded.
+    const first = await repo.getKnowledgeItem(reversal.item.id);
+    expect(first!.status).toBe('active');
+    expect(first!.supersededById).toBeFalsy();
+    expect((await repo.getKnowledgeItem(restatement.item.id))!.status).toBe('active');
+  });
+});

--- a/tests/store/duplicate-polarity-guard.test.ts
+++ b/tests/store/duplicate-polarity-guard.test.ts
@@ -95,42 +95,26 @@ describe('resolveDuplicate polarity guard', () => {
   });
 });
 
-describe('resolveDuplicate grounding guard', () => {
-  const grounded = held({ title: 'Vector dim', content: 'It is 768.', provenance: 'observed' });
-
-  it('an unclaimed write does not retire an observed one', () => {
+describe('provenance deliberately does not gate supersession', () => {
+  /**
+   * A guard was proposed that would refuse to let an unclaimed write retire an `observed` one.
+   * Replayed against this repo's 101 real supersessions it blocked 3, and all 3 were legitimate
+   * corrections -- including one whose whole point was that the measurement it replaced was
+   * defective. Unset provenance is what 73% of writes look like, not a weak claim. Pinned here so
+   * the idea is not re-introduced without new evidence.
+   */
+  it('an unclaimed write still retires an observed one', () => {
     expect(resolveDuplicate(
       { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.' },
-      grounded,
+      held({ title: 'Vector dim', content: 'It is 768.', provenance: 'observed' }),
+    )).toBe('supersede');
+  });
+
+  it('and the polarity guard still wins over it, whatever the provenance', () => {
+    expect(resolveDuplicate(
+      { category: 'fact', title: 'Reranker is the right call', content: 'Yes.', provenance: 'observed' },
+      held({ title: 'Reranker is not the right call', content: 'No.', provenance: 'observed' }),
     )).toBe('coexist');
-  });
-
-  it('a write that claims grounding may retire an observed one', () => {
-    expect(resolveDuplicate(
-      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.', provenance: 'observed' },
-      grounded,
-    )).toBe('supersede');
-  });
-
-  it('user_stated counts as a claim on both sides', () => {
-    expect(resolveDuplicate(
-      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.', provenance: 'user_stated' },
-      held({ title: 'Vector dim', content: 'It is 768.', provenance: 'user_stated' }),
-    )).toBe('supersede');
-  });
-
-  it('is one-directional: an observed write may retire an unclaimed predecessor', () => {
-    expect(resolveDuplicate(
-      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.', provenance: 'observed' },
-      held({ title: 'Vector dim', content: 'It is 768.' }),
-    )).toBe('supersede');
-  });
-
-  it('leaves the unclaimed-to-unclaimed majority path untouched', () => {
-    expect(resolveDuplicate(
-      { category: 'fact', title: 'Vector dim setting', content: 'It is 1024.' },
-      held({ title: 'Vector dim', content: 'It is 768.' }),
-    )).toBe('supersede');
   });
 });
 


### PR DESCRIPTION
## The defect

`resolveDuplicate` supersedes whenever `sameSubjectTitle` holds, and that is a token-**subset** test. None of `not`, `no`, `never`, `longer` is in `DUPLICATE_STOP_WORDS`, so an affirmative title is a strict subset of its own negation and the subset test fires.

Found by running the exported function, not by reading it:

```
coexist    | new="Vector dim is 768"               vs held="Vector dim is 1024"
SUPERSEDE  | new="Reranker is the right call"      vs held="Reranker is not the right call"
SUPERSEDE  | new="Reranker is not the right call"  vs held="Reranker is the right call"
coexist    | new="Retrieval latency p50 is 208ms"  vs held="Retrieval latency p50 is 428ms"
SUPERSEDE  | new="Push gate blocks default branch" vs held="Push gate no longer blocks default branch"
SUPERSEDE  | new="Cloud send works"                vs held="Cloud send works end to end in production"
```

The survivor then asserts the opposite of what was retired, silently. **Row 5 is not hypothetical** — it is this project's own 2026-08-13 push-gate reversal. A title shape written twice across that reversal retires its own predecessor, in whichever order the two writes happen to arrive.

## The fix

Two guards on the supersede branch, both clamping to `coexist` rather than refusing. **Neither can lose a write:** the incoming atom is still inserted, the predecessor stays active, and the pair is reported through the `nearDuplicate` channel that already hands the caller the exact retire call. An explicit `supersedes` is checked first and is never second-guessed.

1. **Polarity** — if everything the longer title adds is a polarity token, the two titles are the same claim asserted both ways, not "same subject, new information".

2. **Grounding** — an atom that does not claim first-hand provenance no longer retires one that does ("inferred evidence must not overturn an explicit fact"). One-directional and narrow: it fires only where the *held* atom claims `observed`/`user_stated` and the incoming one does not, so the ~79% of writes that leave provenance unset are unaffected unless aimed at one of the ~20% that made a claim. That asymmetry is the same incentive `fuse.ts` already chose on the ranking side — declaring provenance is what earns full credit, and here it earns the right to retire a grounded claim.

## What I deliberately did NOT port

The published prior art for this guard (muninndb's `dedup_separation.go`) is built around **numbers** — "$99" merging with "$149". **That hole does not exist here.** `duplicateTokens` splits on `[^a-z0-9_]+`, so digits survive as tokens, `768` is absent from a title saying `1024`, the subset test already fails, and the two atoms already coexist — rows 1 and 4 above. Porting its regex bank would have been dead weight while leaving the real hole open. Only polarity words are short, common, and absent from the stop list.

Ambiguous stems are also left out — `can` ("Can the gate block…" is a real title), plus `won` and `don`. A missed negation costs what today already costs; a false positive costs a supersede the caller then makes deliberately.

## Verification

- **16 new tests.** Disabling the polarity guard fails exactly the two load-bearing ones — including the end-to-end case, which reads `superseded` without the guard and `active` with it. That is the regression pin.
- `tsc --noEmit` clean.
- Full suite **3017 passed**. 21 files fail, and **the identical 21 fail on a pristine `upstream/main` worktree** — Windows CLI-subprocess tests plus `tests/store/retention.test.ts`. Baseline, untouched by this change; happy to attach both JSON runs.

Not for self-merge — over to you.
