### PR TITLE
feat(core): keep both ends of a truncated atom body, not just the head

### DIFF
--- a/src/core/token-budget.ts
+++ b/src/core/token-budget.ts
@@ -157,6 +157,49 @@ export function truncateText(value: string, maxChars: number, marker = ''): stri
   return `${value.slice(0, maxChars - marker.length)}${marker}`;
 }
 
+/**
+ * What replaces the elided middle. Fixed rather than counted, following the `truncated` flag's
+ * own reasoning: the caller is deciding "do I need the rest of this", and a byte count answers a
+ * question nobody asked. A fixed marker also keeps the arithmetic below exact.
+ */
+const MIDDLE_ELISION = '\n\n[... elided ...]\n\n';
+
+/**
+ * How much of the surviving budget goes to the opening. The head decides whether the atom is
+ * relevant at all, so it keeps the larger share; the tail is there because that is where the
+ * atom says what it concluded.
+ */
+const HEAD_SHARE = 0.6;
+
+/**
+ * Keep both ends of an over-long body and drop the middle.
+ *
+ * WHY THIS EXISTS, AND WHY IT IS NOT A CEILING CHANGE. Atom bodies in this project are written
+ * with the verdict last -- `CONSEQUENCE`, `THE FIX`, `WHAT NOT TO BUILD`, `THE LIMIT OF THIS
+ * EVIDENCE` -- so a head slice systematically delivers the setup and drops the finding. That
+ * would be recoverable if the flag were acted on, but it mostly is not: measured over the
+ * session archive, 43.3% of delivered items arrive truncated and only 2.2% of them are ever
+ * chased by an id-fetch. The withheld tail is not being declined, it is going unread.
+ *
+ * The corpus measurement that settled `MAX_ITEM_CONTENT_CHARS` at 2,000 also showed that raising
+ * it to 4,000 buys content declined 97.8% of the time at +399 tok/query. This spends nothing:
+ * the budget is identical to the character, and only the choice of WHICH characters changes. It
+ * is therefore orthogonal to that decision rather than a re-litigation of it.
+ *
+ * Exact by construction: `head + marker + tail === maxChars` whenever there is room for the
+ * marker at all, which is what keeps the existing length assertion true.
+ */
+export function truncateMiddle(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  // With no room for the marker there is no middle to speak of, and a caller asking for fewer
+  // characters than the marker wants a prefix, not two fragments of one.
+  if (maxChars <= MIDDLE_ELISION.length) return value.slice(0, Math.max(0, maxChars));
+  const keep = maxChars - MIDDLE_ELISION.length;
+  const head = Math.ceil(keep * HEAD_SHARE);
+  const tail = keep - head;
+  return `${value.slice(0, head)}${MIDDLE_ELISION}${tail === 0 ? '' : value.slice(value.length - tail)}`;
+}
+
 export function estimateTokens(value: string): number {
   return Math.ceil(value.length / 4);
 }
@@ -175,7 +218,10 @@ export function compactKnowledgeItem(item: KnowledgeItem, extras: CompactProvena
     id: item.id,
     category: item.category as KnowledgeCategory,
     title: truncateText(item.title, MAX_TITLE_CHARS),
-    content: truncateText(item.content, MAX_ITEM_CONTENT_CHARS),
+    // Middle-elided, not head-sliced: see `truncateMiddle`. Titles, tags and paths above stay
+    // head-truncated on purpose -- a path with its middle removed is not a shorter path, it is
+    // an unusable one, and those fields have no conclusion to preserve.
+    content: truncateMiddle(item.content, MAX_ITEM_CONTENT_CHARS),
     freshness: item.freshness as KnowledgeFreshness,
     confidence: item.confidence,
     // A flag, not a length: the caller is deciding "is this the whole fact or the start of

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -4,7 +4,7 @@ import { KnowledgeCategory } from '../core/types.js';
 import { getRecentContext } from '../store/recent-context.js';
 import { formatRecentContextToMarkdown, formatHierarchyToMarkdown } from '../core/format.js';
 import { getHierarchicalKnowledge, queryKnowledgeBase } from '../store/queries.js';
-import { DEFAULT_CONTEXT_MAX_CHARS, DEFAULT_RESULT_LIMIT, MAX_ITEM_CONTENT_CHARS, MAX_PREVIEW_CHARS, MAX_TITLE_CHARS, truncateText } from '../core/token-budget.js';
+import { DEFAULT_CONTEXT_MAX_CHARS, DEFAULT_RESULT_LIMIT, MAX_ITEM_CONTENT_CHARS, MAX_PREVIEW_CHARS, MAX_TITLE_CHARS, truncateMiddle, truncateText } from '../core/token-budget.js';
 import { fenceUntrusted, inlineUntrusted, UNTRUSTED_NOTICE_BRIEF } from '../core/untrusted.js';
 import { formatInitError } from './init-error.js';
 import { sanitizeToolErrorMessage } from './tool-schema.js';
@@ -109,7 +109,7 @@ export function registerResources(
           for (const item of items.slice(0, DEFAULT_RESULT_LIMIT)) {
             md += `## ${inlineUntrusted(truncateText(item.title, MAX_TITLE_CHARS))} (ID: ${item.id})\n\n`;
             // A body keeps its shape, inside a container it cannot close.
-            md += `${fenceUntrusted(truncateText(item.content, MAX_ITEM_CONTENT_CHARS))}\n\n`;
+            md += `${fenceUntrusted(truncateMiddle(item.content, MAX_ITEM_CONTENT_CHARS))}\n\n`;
             if (item.reasoning) md += `**Reasoning:** ${inlineUntrusted(truncateText(item.reasoning, MAX_PREVIEW_CHARS))}\n\n`;
             if (item.alternatives && item.alternatives.length > 0) {
               md += `**Alternatives:** ${inlineUntrusted(truncateText(item.alternatives.join(', '), MAX_PREVIEW_CHARS))}\n\n`;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -16,7 +16,7 @@ import { getHierarchicalKnowledge, queryKnowledgeBase } from '../store/queries.j
 import { formatHierarchyToMarkdown, formatRecentContextToMarkdown } from '../core/format.js';
 import { inlineUntrusted } from '../core/untrusted.js';
 import { compactMcpJson, compactItemResponse, compactAssertionResponse, boundedEvidence } from './response-format.js';
-import { DEFAULT_RESULT_LIMIT, MAX_ITEM_CONTENT_CHARS, MAX_PREVIEW_CHARS, truncateText, uncalibratedScore, type UncalibratedScore } from '../core/token-budget.js';
+import { DEFAULT_RESULT_LIMIT, MAX_ITEM_CONTENT_CHARS, MAX_PREVIEW_CHARS, truncateMiddle, truncateText, uncalibratedScore, type UncalibratedScore } from '../core/token-budget.js';
 import { getRecentContext } from '../store/recent-context.js';
 import { storeKnowledgeItemDeduped, storeKnowledgeAtomsDeduped } from '../store/knowledge-writer.js';
 import { recordDecisionDirect, updateKnowledgeItemWithCommit } from '../store/knowledge-actions.js';
@@ -1358,7 +1358,7 @@ export function registerTools(
         const { title, query } = args as any;
         const result = await startWorkLoop(projectId!, title, query);
         return {
-          content: [{ type: 'text', text: compactMcpJson({ ...result, relevantMemory: result.relevantMemory.map(item => ({ ...item, content: truncateText(item.content, MAX_ITEM_CONTENT_CHARS) })) }) }],
+          content: [{ type: 'text', text: compactMcpJson({ ...result, relevantMemory: result.relevantMemory.map(item => ({ ...item, content: truncateMiddle(item.content, MAX_ITEM_CONTENT_CHARS) })) }) }],
         };
       }
 

--- a/tests/core/truncate-middle.test.ts
+++ b/tests/core/truncate-middle.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_ITEM_CONTENT_CHARS,
+  compactKnowledgeItem,
+  truncateMiddle,
+} from '../../src/core/token-budget.js';
+import type { KnowledgeItem } from '../../src/core/types.js';
+
+const ELISION = '[... elided ...]';
+
+describe('truncateMiddle', () => {
+  it('leaves anything within budget byte-identical', () => {
+    expect(truncateMiddle('short', 100)).toBe('short');
+    expect(truncateMiddle('x'.repeat(50), 50)).toBe('x'.repeat(50));
+  });
+
+  it('spends exactly the budget, so the existing length contract holds', () => {
+    for (const max of [40, 100, 999, 2000, 2001]) {
+      expect(truncateMiddle('x'.repeat(10_000), max)).toHaveLength(max);
+    }
+  });
+
+  it('keeps both ends -- the head to judge relevance, the tail for the verdict', () => {
+    const body = `OPENING${'-'.repeat(5000)}CONCLUSION`;
+    const cut = truncateMiddle(body, 200);
+    expect(cut.startsWith('OPENING')).toBe(true);
+    expect(cut.endsWith('CONCLUSION')).toBe(true);
+    expect(cut).toContain(ELISION);
+  });
+
+  it('weights the head more heavily than the tail', () => {
+    const cut = truncateMiddle('x'.repeat(10_000), 1000);
+    const [head, tail] = cut.split(ELISION);
+    expect(head.length).toBeGreaterThan(tail.length);
+  });
+
+  /**
+   * The real shape this exists for: an atom whose last paragraph is the caveat that must travel
+   * with the finding. Head-slicing delivers the setup and drops it.
+   */
+  it('preserves a trailing caveat that a head slice would have dropped', () => {
+    const body = [
+      'MEASURED 2026-08-16 by parsing tool results in the session archive.',
+      'x'.repeat(4000),
+      'THE LIMIT OF THIS EVIDENCE, which must travel with it: this is revealed preference.',
+    ].join('\n\n');
+
+    expect(truncateMiddle(body, MAX_ITEM_CONTENT_CHARS)).toContain('THE LIMIT OF THIS EVIDENCE');
+    expect(body.slice(0, MAX_ITEM_CONTENT_CHARS)).not.toContain('THE LIMIT OF THIS EVIDENCE');
+  });
+
+  it('degrades to a prefix when there is no room for the marker', () => {
+    const tiny = truncateMiddle('abcdefghij', 4);
+    expect(tiny).toBe('abcd');
+    expect(truncateMiddle('abcdefghij', 0)).toBe('');
+  });
+
+  it('survives a negative budget without throwing or over-spending', () => {
+    expect(truncateMiddle('abcdefghij', -5)).toBe('');
+  });
+});
+
+describe('compactKnowledgeItem uses it for content only', () => {
+  const item = {
+    id: 'k1',
+    category: 'fact',
+    title: 'T',
+    content: '',
+    freshness: 'fresh',
+    confidence: 1,
+  } as KnowledgeItem;
+
+  it('elides the middle of an over-long body and still flags it', () => {
+    const body = `HEAD${'-'.repeat(MAX_ITEM_CONTENT_CHARS * 2)}TAIL`;
+    const compact = compactKnowledgeItem({ ...item, content: body });
+
+    expect(compact.content).toHaveLength(MAX_ITEM_CONTENT_CHARS);
+    expect(compact.content.startsWith('HEAD')).toBe(true);
+    expect(compact.content.endsWith('TAIL')).toBe(true);
+    expect(compact).toHaveProperty('truncated', true);
+  });
+
+  it('leaves a body that fits completely alone, flag included', () => {
+    const body = 'x'.repeat(MAX_ITEM_CONTENT_CHARS);
+    const compact = compactKnowledgeItem({ ...item, content: body });
+    expect(compact.content).toBe(body);
+    expect(compact).not.toHaveProperty('truncated');
+  });
+
+  /**
+   * A path with its middle removed is not a shorter path, it is an unusable one, and neither
+   * titles nor paths have a conclusion at the end worth preserving.
+   */
+  it('does not middle-elide paths', () => {
+    const compact = compactKnowledgeItem({
+      ...item,
+      affectedPaths: [`src/${'deep/'.repeat(80)}file.ts`],
+    } as KnowledgeItem);
+    expect(compact.affectedPaths?.[0]).not.toContain(ELISION);
+    expect(compact.affectedPaths?.[0].startsWith('src/deep/')).toBe(true);
+  });
+});


### PR DESCRIPTION
## The problem

Atom bodies in this project put the verdict last — `CONSEQUENCE`, `THE FIX`, `WHAT NOT TO BUILD`, `THE LIMIT OF THIS EVIDENCE`. `truncateText` is a head slice, so it systematically delivers the setup and drops the finding.

That would be recoverable if the `truncated` flag were acted on. Measured over the session archive, it mostly is not: **43.3% of delivered items arrive truncated, and only 2.2% of them are ever chased by an id-fetch.** The withheld tail isn't being declined — it's going unread.

That same measurement recorded its own limit, and it is exactly this: it *"cannot distinguish 'the tail was not needed' from 'the agent answered from a partial fact and never discovered it was wrong'."* A head slice is what makes the second case invisible. (Fittingly, the atom recording that finding is itself long enough to be truncated, and `THE LIMIT OF THIS EVIDENCE` is in the part that gets cut.)

## The fix

`truncateMiddle` — 60/40 head/tail around a fixed marker. The head keeps the larger share because it decides whether the atom is relevant at all; the tail exists because that is where the atom says what it concluded.

**This is not a ceiling change, and that is the point.** The corpus sweep that settled `MAX_ITEM_CONTENT_CHARS` at 2,000 showed that raising it to 4,000 buys content declined 97.8% of the time at +399 tok/query. This spends **nothing** — the budget is identical to the character, and only *which* characters survive changes. It's orthogonal to that decision rather than a re-litigation of it.

Exact by construction (`head + marker + tail === maxChars` whenever there's room for the marker), so `token-budget.test.ts`'s existing length assertion holds unchanged.

## Scope

Applied to the three surfaces that hand a stored body to an agent:

- `compactKnowledgeItem` — every `knowl_query` result
- `knowl://category/{name}` — truncate-then-contain order preserved, so the fence length is still picked over the text that actually ships
- `task_start`'s `relevantMemory`

Titles, tags and `affectedPaths` deliberately keep the head slice: a path with its middle removed is not a shorter path, it's an unusable one, and none of those fields has a conclusion at the end worth preserving.

A byte count in the marker was considered and rejected, following the `truncated` flag's own stated reasoning — the caller is deciding "do I need the rest of this", and a length answers a question nobody asked. It also keeps the arithmetic exact.

## Verification

- **13 new tests**, including a pin that a trailing caveat survives where a head slice provably drops it, and one asserting paths are *not* middle-elided.
- Existing `token-budget.test.ts` passes unchanged.
- `npm run typecheck` clean.
- Suite excluding `tests/cli`: **2581 passed, 1 failed** — `tests/store/retention.test.ts`, which fails identically on a pristine `upstream/main` worktree. (`tests/cli/**` has 20 pre-existing failures on this machine, also identical at baseline.)

## Not included

The branch name mentions atom markers (`<knowl_atom id rev>` wrappers for dedup and mid-session invalidation). I've left that out — it only pays off alongside a consumer that reads the markers back, and it touches the MCP response surface whose block count is pinned by three tests. Better as its own PR.

Not for self-merge — over to you.
