### PR TITLE
perf(cloud): a backlog is one request, and an unedited atom is none

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1380,6 +1380,11 @@ cloudCommand
       }
 
       console.log(`Published ${result.created} new and ${result.updated} updated item(s).`);
+      if (result.skippedUnchanged > 0) {
+        console.log(
+          `  ${result.skippedUnchanged} staged item(s) were already published unchanged and were not re-sent.`,
+        );
+      }
       for (const outcome of result.conflicts) {
         console.log(`  conflict  ${outcome.id} -- the workspace has a newer version. Pull, re-read, and publish again.`);
       }

--- a/src/cloud/ledger.ts
+++ b/src/cloud/ledger.ts
@@ -11,6 +11,9 @@ export type PublishedRecord = {
   retractedAt: string | null;
   /** Explicit since level 10. `pending` is what a push works through. */
   stageState: 'pending' | 'clear';
+  /** The atom's hashes as of the last confirmed push. NULL for a row that predates the columns. */
+  remoteContentHash: string | null;
+  remoteLifecycleHash: string | null;
 };
 
 const asText = (value: unknown): string | null => (value === null || value === undefined ? null : String(value));
@@ -27,6 +30,8 @@ function toRecord(row: Record<string, unknown>): PublishedRecord {
     pushedAt: asText(row.pushed_at),
     retractedAt: asText(row.retracted_at),
     stageState: String(row.stage_state) === 'pending' ? 'pending' : 'clear',
+    remoteContentHash: asText(row.remote_content_hash),
+    remoteLifecycleHash: asText(row.remote_lifecycle_hash),
   };
 }
 
@@ -104,15 +109,77 @@ export async function restageForPublish(
   return staged;
 }
 
-/** Staged and not yet sent. This is exactly what a push has to work through. */
+/**
+ * Staged, but byte-for-byte what the server was last given.
+ *
+ * The atom was re-staged -- by an explicit `knowl cloud stage --id`, or by a write that rewrote
+ * it to the same bytes -- and there is nothing to send. Sending it anyway costs a version bump
+ * the server applies unconditionally, and that version then reaches every replica on its next
+ * pull, so one no-op push is a round of sync traffic for the whole team.
+ *
+ * `IS` rather than `=` throughout: SQLite's `=` is unknown when either side is NULL, and a
+ * hash is nullable on both sides. `IS` compares nulls as equal, which is the intended reading --
+ * an atom with no content hash then and no content hash now has not changed.
+ *
+ * `remote_content_hash IS NOT NULL` gates the whole rule, so a row from before these columns
+ * existed never matches and is always sent. Failing toward sending is the recoverable direction:
+ * a redundant push spends a version, a wrongly skipped one strands a correction locally with
+ * nothing to reveal it.
+ *
+ * Both hashes must match. Content alone would treat a retirement -- `status` and `freshness`
+ * live in the lifecycle hash -- as an unchanged atom.
+ *
+ * `LEFT JOIN`, deliberately. A staged id whose atom is gone entirely is *missing*, and the push
+ * reports that case its own way; an inner join would drop it here and turn a reportable problem
+ * into a silent one.
+ */
+const UNCHANGED_SINCE_PUSH = `
+  p.remote_content_hash IS NOT NULL
+  AND p.remote_content_hash IS k.content_hash
+  AND p.remote_lifecycle_hash IS k.lifecycle_hash`;
+
+/**
+ * Staged and not yet sent. This is exactly what a push has to work through.
+ *
+ * Excludes atoms identical to what was already pushed, so `knowl cloud status` and the push
+ * itself agree on one number. `clearUnchangedStaged` settles the same rows in the table; this
+ * filter is what keeps a read honest before that has run.
+ */
 export async function listStaged(workspace: string): Promise<PublishedRecord[]> {
   const result = await getClient().execute({
-    sql: `SELECT * FROM cloud_published
-          WHERE remote_workspace = ? AND stage_state = 'pending' AND retracted_at IS NULL
-          ORDER BY staged_at, item_id`,
+    sql: `SELECT p.* FROM cloud_published p
+          LEFT JOIN knowledge_items k ON k.id = p.item_id
+          WHERE p.remote_workspace = ? AND p.stage_state = 'pending' AND p.retracted_at IS NULL
+            AND NOT (${UNCHANGED_SINCE_PUSH})
+          ORDER BY p.staged_at, p.item_id`,
     args: [workspace],
   });
   return result.rows.map(row => toRecord(row as unknown as Record<string, unknown>));
+}
+
+/**
+ * Settle the rows `listStaged` filters out, so the queue does not accumulate them forever.
+ *
+ * Run at the start of a push rather than from the read, because a read that writes is a surprise
+ * and `knowl cloud status` is a read. The filter and this statement share one predicate so the
+ * two cannot drift apart.
+ *
+ * Returns how many were settled, which is worth reporting: "3 unchanged" is the difference
+ * between a push that did nothing and a push that was not needed.
+ */
+export async function clearUnchangedStaged(workspace: string): Promise<number> {
+  const result = await getClient().execute({
+    sql: `UPDATE cloud_published SET stage_state = 'clear'
+          WHERE remote_workspace = ? AND stage_state = 'pending' AND retracted_at IS NULL
+            AND item_id IN (
+              SELECT p.item_id FROM cloud_published p
+              JOIN knowledge_items k ON k.id = p.item_id
+              WHERE p.remote_workspace = ? AND p.stage_state = 'pending'
+                AND p.retracted_at IS NULL AND ${UNCHANGED_SINCE_PUSH}
+            )`,
+    args: [workspace, workspace],
+  });
+  return Number(result.rowsAffected ?? 0);
 }
 
 /**
@@ -159,11 +226,24 @@ export async function recordPushed(
   itemId: string,
   workspace: string,
   remoteVersion: number,
+  /**
+   * The hashes of the payload that was actually SENT, taken from that payload and never re-read
+   * from the store. A fresh read here would record what the atom says now, and an edit landing
+   * between the send and this write would then look already-published and never be sent -- the
+   * same window `PushSnapshot` exists to close, reopened at the last step.
+   */
+  hashes: { contentHash: string | null; lifecycleHash: string | null },
 ): Promise<void> {
   await getClient().execute({
-    sql: `UPDATE cloud_published SET remote_version = ?, pushed_at = ?, stage_state = 'clear'
+    sql: `UPDATE cloud_published
+          SET remote_version = ?, pushed_at = ?, stage_state = 'clear',
+              remote_content_hash = ?, remote_lifecycle_hash = ?
           WHERE item_id = ? AND remote_workspace = ?`,
-    args: [remoteVersion, new Date().toISOString(), itemId, workspace],
+    args: [
+      remoteVersion, new Date().toISOString(),
+      hashes.contentHash, hashes.lifecycleHash,
+      itemId, workspace,
+    ],
   });
 }
 
@@ -182,7 +262,9 @@ export async function recordPushed(
  */
 export async function recordRetracted(itemId: string, workspace: string): Promise<void> {
   await getClient().execute({
-    sql: `UPDATE cloud_published SET retracted_at = ?, remote_version = NULL
+    sql: `UPDATE cloud_published
+          SET retracted_at = ?, remote_version = NULL,
+              remote_content_hash = NULL, remote_lifecycle_hash = NULL
           WHERE item_id = ? AND remote_workspace = ?`,
     args: [new Date().toISOString(), itemId, workspace],
   });

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -3,6 +3,7 @@ import { closeDb, getClient, initDb } from '../store/database.js';
 import { selectOwnedItems, type PromoteTarget } from '../workspace/promote.js';
 import { CloudApiError, createCloudApi, type CloudApi } from './api-client.js';
 import {
+  clearUnchangedStaged,
   listStaged, publishedVersion, recordPushed, restageForPublish, stageForPublish,
 } from './ledger.js';
 import { filterExcluded } from './exclusions.js';
@@ -204,32 +205,53 @@ export type PushResult =
      * the others the moment retraction is wired.
      */
     rejected: PublishOutcome[];
+    /**
+     * Staged atoms that were settled without being sent, because they were byte-identical to what
+     * the server was last given.
+     *
+     * Reported rather than swallowed: it is the difference between a push that did nothing and a
+     * push that was not needed, and a user watching a queue shrink with no network activity
+     * deserves to be told which.
+     */
+    skippedUnchanged: number;
   };
 
-/** The contract's own cap. An unbounded batch is an unbounded transaction on the server. */
 /**
  * Atoms per request.
  *
- * **Was 200 -- the server contract's own ceiling -- and that was the bug.** Publishing embeds
- * inline and synchronously on the server, measured at 1564 MB and 418 seconds for 200 atoms of
- * realistic prose, against a client timeout of 30 seconds. Any queue under 200 therefore went as
- * ONE request that a cold server could not possibly finish, so a backlog of 40 was permanently
- * unpushable while a queue of 9 barely landed (knowl#103).
+ * **Was 200, then 20, and both numbers were answers to a cost that no longer exists.** Publishing
+ * used to embed inline and synchronously on the server -- 1564 MB and 418 seconds for 200 atoms
+ * -- so 200 was unsendable and 20 was sized against that ~3s-per-atom cold path (knowl#103).
+ * Embedding now runs on a background worker after the commit, and a client that brings its own
+ * vector is never re-embedded at all, so the request no longer waits on a forward pass.
  *
- * 20 is sized against the *cold* per-atom cost measured from a real backlog -- roughly 3s at
- * worst, so ~10 atoms fit a 30s budget with the batch halving below to cover the rest. A warm
- * server runs an order of magnitude faster and pays only the extra round trips.
+ * What is left is round trips and payload, and 100 is sized against the payload. The server's
+ * `BODY_LIMIT` is 2 MB, and a real atom measures ~2 KB of text plus a 384-float vector as ~2 KB
+ * of base64 -- call it 5 KB typical and 12 KB for the largest. 100 therefore lands around 500 KB
+ * and worst-cases near 1.2 MB, both inside the limit, and it puts a routine backlog in ONE
+ * request instead of five.
  *
- * Never raise this above 200: `PublishRequest` rejects a larger batch outright.
+ * Never raise this above 200: `PublishRequest` rejects a larger batch outright. And note the
+ * binding constraint is the body limit, not that ceiling -- 200 fat atoms would 413.
  */
-const MAX_BATCH = 20;
+const MAX_BATCH = 100;
 
 /** Where halving stops. One atom that still times out is the server's problem, not the size. */
 const MIN_BATCH = 1;
 
-/** The server saying "not this much at once" -- the one failure a smaller batch can answer. */
-function isTimeout(error: unknown): error is CloudApiError {
-  return error instanceof CloudApiError && error.code === 'timeout';
+/**
+ * The server saying "not this much at once" -- the failures a smaller batch can answer.
+ *
+ * Two of them, and they arrive from opposite ends. A timeout is the request taking too long; a
+ * 413 is the body being too large before it is read at all. Both mean the same thing to a client
+ * holding a queue -- send fewer -- and both are safe to retry smaller, because the server upserts
+ * by item id and a 413 committed nothing at all.
+ *
+ * Nothing else is retried. A secret rejection in particular is terminal and must fail the batch
+ * untouched, never retried and never retried in altered form.
+ */
+function isTooMuchAtOnce(error: unknown): error is CloudApiError {
+  return error instanceof CloudApiError && (error.code === 'timeout' || error.status === 413);
 }
 
 const parseJson = <T>(value: unknown): T | null => {
@@ -351,10 +373,18 @@ export async function pushStaged(input: {
 
   await initDb(input.projectRoot);
   try {
+    // Before the queue is read, so an atom re-staged into identical bytes is settled rather than
+    // sent. `listStaged` filters the same rows anyway; this is what stops them accumulating in
+    // the table forever, and it runs here rather than from the read because `knowl cloud status`
+    // is also a reader and a read must not write.
+    const skippedUnchanged = await clearUnchangedStaged(pointer.workspaceId);
+
     const staged = await listStaged(pointer.workspaceId);
 
     if (staged.length === 0) {
-      return { status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [] };
+      return {
+        status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [], skippedUnchanged,
+      };
     }
 
     // The role rides on every sync response, so refusing a reader here costs nothing and saves a
@@ -438,8 +468,18 @@ export async function pushStaged(input: {
       return { status: 'needs-embedding', count: unembedded.length, remedy: 'knowl reindex --vectors' };
     }
     if (items.length === 0) {
-      return { status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [] };
+      return {
+        status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [], skippedUnchanged,
+      };
     }
+
+    // Keyed off the payloads being sent, never a fresh read. `recordPushed` stores these, and a
+    // re-read there would record what the atom says *now* -- so an edit landing between the send
+    // and the confirmation would look already-published and never be sent again.
+    const sentHashes = new Map(items.map(item => [item.id, {
+      contentHash: item.contentHash ?? null,
+      lifecycleHash: item.lifecycleHash ?? null,
+    }]));
 
     let created = 0;
     let updated = 0;
@@ -469,11 +509,11 @@ export async function pushStaged(input: {
           // less rather than failing a whole backlog. Safe to re-send: the server upserts by item
           // id and returns `updated` for anything the timed-out attempt had already committed, so
           // the worst case is a spent version bump, never a duplicate.
-          if (isTimeout(error) && size > MIN_BATCH) {
+          if (isTooMuchAtOnce(error) && size > MIN_BATCH) {
             size = Math.max(MIN_BATCH, Math.floor(size / 2));
             continue;
           }
-          if (isTimeout(error)) {
+          if (isTooMuchAtOnce(error)) {
             // The old message named only the URL and the ceiling, so it pointed nowhere. What the
             // user needs is the size it gave up at and how much is still queued -- the two numbers
             // that say whether to wait for a warmer server or to go and split the queue by hand.
@@ -493,7 +533,12 @@ export async function pushStaged(input: {
 
       for (const outcome of outcomes) {
         if (outcome.status === 'created' || outcome.status === 'updated') {
-          await recordPushed(outcome.id, pointer.workspaceId, outcome.version);
+          await recordPushed(
+            outcome.id,
+            pointer.workspaceId,
+            outcome.version,
+            sentHashes.get(outcome.id) ?? { contentHash: null, lifecycleHash: null },
+          );
           if (outcome.status === 'created') created += 1; else updated += 1;
           continue;
         }
@@ -505,7 +550,7 @@ export async function pushStaged(input: {
       }
     }
 
-    return { status: 'pushed', created, updated, conflicts, rejected };
+    return { status: 'pushed', created, updated, conflicts, rejected, skippedUnchanged };
   } finally {
     await closeDb();
   }

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -368,6 +368,8 @@ const SCHEMA_STATEMENTS = [
     pushed_at TEXT,
     retracted_at TEXT,
     stage_state TEXT NOT NULL DEFAULT 'clear',
+    remote_content_hash TEXT,
+    remote_lifecycle_hash TEXT,
     PRIMARY KEY (item_id, remote_workspace)
   );`,
 
@@ -755,6 +757,35 @@ async function ensureLedgerStageState(client: Client): Promise<void> {
     "ALTER TABLE cloud_published ADD COLUMN stage_state TEXT NOT NULL DEFAULT 'clear';",
   );
   await backfillLedgerStageState(client);
+}
+
+/**
+ * Remember WHAT was pushed, not only that something was.
+ *
+ * The ledger recorded `remote_version` and no content, so nothing on this machine could tell a
+ * re-staged atom whose text actually changed from one that was merely rewritten to the same
+ * bytes. The second is sent anyway, the server bumps `version` unconditionally, and that spent
+ * version reaches every replica on its next pull -- a whole round of sync traffic for an atom
+ * nobody edited.
+ *
+ * Both hashes, because either can move without the other. Content alone would send a retirement
+ * -- `status` and `freshness` live in the lifecycle hash -- as an unchanged atom and silently
+ * strand it locally, which is a far worse defect than the one this fixes.
+ *
+ * Left NULL for every existing row, and the skip predicate requires NOT NULL, so a row written
+ * before this column simply never skips. Backfilling from `knowledge_items` would be the wrong
+ * direction: it would claim the server holds whatever this machine holds now, which is exactly
+ * what nobody knows.
+ */
+async function ensurePublishedContentHashes(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'cloud_published'))) return;
+  const columns = await tableColumns(client, 'cloud_published');
+  if (!columns.includes('remote_content_hash')) {
+    await client.execute('ALTER TABLE cloud_published ADD COLUMN remote_content_hash TEXT;');
+  }
+  if (!columns.includes('remote_lifecycle_hash')) {
+    await client.execute('ALTER TABLE cloud_published ADD COLUMN remote_lifecycle_hash TEXT;');
+  }
 }
 
 async function ensureFreshnessColumns(client: Client): Promise<void> {
@@ -1161,6 +1192,7 @@ export async function bootstrapSchema(
     await ensureQualityColumns(client);
     await ensureForgetLogColumns(client);
     await ensureLedgerStageState(client);
+    await ensurePublishedContentHashes(client);
     await ensureConflictColumns(client);
     await ensureOwnershipColumns(client);
     await ensureMemorySessionColumns(client);

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -156,7 +156,25 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * `KNOWL_SCHEMA_VERSION` deliberately does not move: an older build ignores the column, and a
  * newer one reading NULL gets the truth rather than a hole.
  */
-export const KNOWL_MIGRATION_LEVEL = 11;
+/*
+ * Level 12 adds `cloud_published.remote_content_hash` and `.remote_lifecycle_hash`: the atom's
+ * hashes as of the last confirmed push, so a re-staged atom that nobody actually edited is
+ * settled instead of sent.
+ *
+ * Two nullable columns and NO backfill, and the absence is load-bearing rather than lazy. The
+ * skip predicate requires `remote_content_hash IS NOT NULL`, so every existing row simply never
+ * skips and behaves exactly as it does today. Backfilling from `knowledge_items` would assert
+ * that the server holds whatever this machine holds right now -- which is precisely what no
+ * local row knows, and getting it wrong strands a correction locally with nothing to reveal it.
+ *
+ * The bump is load-bearing for the same reason as level 10: `CREATE TABLE IF NOT EXISTS` is a
+ * no-op on a store that already has `cloud_published`, so without it an existing database would
+ * never gain the columns while `listStaged` joins on them.
+ *
+ * `KNOWL_SCHEMA_VERSION` does not move: an older build ignores both columns and pushes exactly
+ * as it did before.
+ */
+export const KNOWL_MIGRATION_LEVEL = 12;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/tests/cloud/auto-stage-seam.test.ts
+++ b/tests/cloud/auto-stage-seam.test.ts
@@ -81,7 +81,7 @@ describe('the auto-stage seam', () => {
 
   it('an update to a published atom stages a correction and keeps its version', async () => {
     const stored = await storeKnowledgeItemDeduped(projectId, atom('published'));
-    await recordPushed(stored.item.id, WS, 4);
+    await recordPushed(stored.item.id, WS, 4, { contentHash: null, lifecycleHash: null });
     expect(await staged()).toEqual([]);
 
     await updateKnowledgeItemWithCommit(projectId, stored.item.id, { content: 'Corrected wording entirely.' });

--- a/tests/cloud/auto-stage.test.ts
+++ b/tests/cloud/auto-stage.test.ts
@@ -70,7 +70,7 @@ describe('maybeAutoStage', () => {
 
   it('re-stages a published atom as a correction, preserving its version', async () => {
     await stageForPublish(['a'], WS, 'main');
-    await recordPushed('a', WS, 5);
+    await recordPushed('a', WS, 5, { contentHash: null, lifecycleHash: null });
 
     await maybeAutoStage({ projectRoot: ROOT, config: connected(), itemId: 'a', alreadyPublished: true });
 

--- a/tests/cloud/drift-report.test.ts
+++ b/tests/cloud/drift-report.test.ts
@@ -79,7 +79,7 @@ describe('reporting upward', () => {
     await initDb(CLONE);
     await getClient().execute('DELETE FROM cloud_published');
     await stageForPublish([published], WS, 'main');
-    await recordPushed(published, WS, 1);
+    await recordPushed(published, WS, 1, { contentHash: null, lifecycleHash: null });
     await closeDb();
 
     await writeCredential(API_HOST, {

--- a/tests/cloud/ledger-invariant.test.ts
+++ b/tests/cloud/ledger-invariant.test.ts
@@ -41,7 +41,7 @@ describe('remote_version is written by push and cleared only by retract', () => 
     await stageForPublish(['a'], WS, 'main');
     expect(await storedVersion('a')).toBeNull();
 
-    await recordPushed('a', WS, 4);
+    await recordPushed('a', WS, 4, { contentHash: null, lifecycleHash: null });
     expect(Number(await storedVersion('a'))).toBe(4);
 
     // Edit -> re-stage -> change your mind -> edit again -> re-stage.
@@ -60,7 +60,7 @@ describe('remote_version is written by push and cleared only by retract', () => 
 
   it('is cleared by retraction, and only by retraction', async () => {
     await stageForPublish(['a'], WS, 'main');
-    await recordPushed('a', WS, 4);
+    await recordPushed('a', WS, 4, { contentHash: null, lifecycleHash: null });
 
     await recordRetracted('a', WS);
     expect(await storedVersion('a')).toBeNull();
@@ -68,7 +68,7 @@ describe('remote_version is written by push and cleared only by retract', () => 
 
   it('a sweep never blanks the version of a pushed atom', async () => {
     await stageForPublish(['a'], WS, 'main');
-    await recordPushed('a', WS, 11);
+    await recordPushed('a', WS, 11, { contentHash: null, lifecycleHash: null });
 
     await stageForPublish(['a'], WS, 'main');
     expect(Number(await storedVersion('a'))).toBe(11);

--- a/tests/cloud/ledger.test.ts
+++ b/tests/cloud/ledger.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeDb, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import {
+  clearUnchangedStaged,
   listPushed, listStaged, publishedVersion, recordPushed, restageForPublish, stageForPublish,
 } from '../../src/cloud/ledger.js';
 
@@ -46,7 +47,7 @@ describe('publication ledger', () => {
 
   it('staging twice does not duplicate or re-stage a pushed item', async () => {
     await stageForPublish(['a1'], WS, 'main');
-    await recordPushed('a1', WS, 3);
+    await recordPushed('a1', WS, 3, { contentHash: null, lifecycleHash: null });
     await stageForPublish(['a1'], WS, 'main');
 
     expect(await listStaged(WS)).toEqual([]);
@@ -59,7 +60,7 @@ describe('publication ledger', () => {
     // `remote_version`, because dropping it would make the republish arrive with no
     // `expectedVersion`, which the server treats as a conflict by design.
     await stageForPublish(['a1'], WS, 'main');
-    await recordPushed('a1', WS, 3);
+    await recordPushed('a1', WS, 3, { contentHash: null, lifecycleHash: null });
 
     await restageForPublish(['a1'], WS, 'main');
 
@@ -72,14 +73,14 @@ describe('publication ledger', () => {
     // an older client cannot acquire overwrite rights by not knowing the field exists. This
     // column is the only place that number lives on this machine.
     await stageForPublish(['a1'], WS, 'main');
-    await recordPushed('a1', WS, 7);
+    await recordPushed('a1', WS, 7, { contentHash: null, lifecycleHash: null });
 
     expect(await publishedVersion('a1', WS)).toBe(7);
   });
 
   it('keeps workspaces apart, so one team\'s version cannot answer for another\'s', async () => {
     await stageForPublish(['a1'], WS, 'main');
-    await recordPushed('a1', WS, 7);
+    await recordPushed('a1', WS, 7, { contentHash: null, lifecycleHash: null });
 
     expect(await publishedVersion('a1', 'other-workspace')).toBeNull();
   });
@@ -88,7 +89,7 @@ describe('publication ledger', () => {
     const { unstagePublish } = await import('../../src/cloud/ledger.js');
 
     await stageForPublish(['a'], WS, 'main');
-    await recordPushed('a', WS, 7);
+    await recordPushed('a', WS, 7, { contentHash: null, lifecycleHash: null });
     await restageForPublish(['a'], WS, 'main');
     expect(await listStaged(WS)).toHaveLength(1);
 
@@ -108,7 +109,7 @@ describe('publication ledger', () => {
     const { getClient } = await import('../../src/store/database.js');
 
     await stageForPublish(['a'], WS, 'main');
-    await recordPushed('a', WS, 1);
+    await recordPushed('a', WS, 1, { contentHash: null, lifecycleHash: null });
     await restageForPublish(['a'], WS, 'main');
 
     const rows = await getClient().execute({
@@ -126,11 +127,77 @@ describe('publication ledger', () => {
     await unstagePublish('never-pushed', WS);
 
     await stageForPublish(['already-pushed'], WS, 'main');
-    await recordPushed('already-pushed', WS, 2);
+    await recordPushed('already-pushed', WS, 2, { contentHash: null, lifecycleHash: null });
 
     await stageForPublish(['never-pushed', 'already-pushed'], WS, 'main');
 
     const staged = (await listStaged(WS)).map(row => row.itemId);
     expect(staged).toEqual(['never-pushed']);
+  });
+
+  /**
+   * The skip is the whole point of recording hashes, and it has two ways to be wrong that a
+   * single happy-path assertion would miss: skipping a lifecycle-only change strands a
+   * retirement locally, and skipping a row whose hashes were never recorded would silently drop
+   * every atom published before the columns existed.
+   */
+  describe('unchanged atoms are not re-sent', () => {
+    const putItem = async (id: string, contentHash: string | null, lifecycleHash: string | null) => {
+      const { getClient } = await import('../../src/store/database.js');
+      await getClient().execute({
+        sql: `INSERT INTO knowledge_items (id, category, title, content, content_hash, lifecycle_hash, created_at, updated_at)
+              VALUES (?, 'fact', 't', 'c', ?, ?, '2026-01-01', '2026-01-01')
+              ON CONFLICT(id) DO UPDATE SET content_hash = excluded.content_hash,
+                                            lifecycle_hash = excluded.lifecycle_hash`,
+        args: [id, contentHash, lifecycleHash],
+      });
+    };
+
+    it('skips an atom whose content and lifecycle both match what was pushed', async () => {
+      await putItem('same', 'c1', 'l1');
+      await stageForPublish(['same'], WS, null);
+      await recordPushed('same', WS, 1, { contentHash: 'c1', lifecycleHash: 'l1' });
+      await restageForPublish(['same'], WS, null);
+
+      expect((await listStaged(WS)).map(r => r.itemId)).toEqual([]);
+      expect(await clearUnchangedStaged(WS)).toBe(1);
+      expect((await listStaged(WS)).map(r => r.itemId)).toEqual([]);
+    });
+
+    it('sends an atom whose lifecycle moved even though its content did not', async () => {
+      await putItem('retired', 'c1', 'l1');
+      await stageForPublish(['retired'], WS, null);
+      await recordPushed('retired', WS, 1, { contentHash: 'c1', lifecycleHash: 'l1' });
+      await putItem('retired', 'c1', 'l2');
+      await restageForPublish(['retired'], WS, null);
+
+      expect((await listStaged(WS)).map(r => r.itemId)).toEqual(['retired']);
+      expect(await clearUnchangedStaged(WS)).toBe(0);
+    });
+
+    it('sends an atom whose content moved', async () => {
+      await putItem('edited', 'c1', 'l1');
+      await stageForPublish(['edited'], WS, null);
+      await recordPushed('edited', WS, 1, { contentHash: 'c1', lifecycleHash: 'l1' });
+      await putItem('edited', 'c2', 'l1');
+      await restageForPublish(['edited'], WS, null);
+
+      expect((await listStaged(WS)).map(r => r.itemId)).toEqual(['edited']);
+    });
+
+    it('sends a row that predates the hash columns, where both sides are null', async () => {
+      await putItem('legacy', null, null);
+      await stageForPublish(['legacy'], WS, null);
+      await recordPushed('legacy', WS, 1, { contentHash: null, lifecycleHash: null });
+      await restageForPublish(['legacy'], WS, null);
+
+      expect((await listStaged(WS)).map(r => r.itemId)).toEqual(['legacy']);
+      expect(await clearUnchangedStaged(WS)).toBe(0);
+    });
+
+    it('keeps a staged id whose atom is missing entirely, so the push can still report it', async () => {
+      await stageForPublish(['ghost'], WS, null);
+      expect((await listStaged(WS)).map(r => r.itemId)).toEqual(['ghost']);
+    });
   });
 });

--- a/tests/cloud/publish-push.test.ts
+++ b/tests/cloud/publish-push.test.ts
@@ -104,6 +104,23 @@ const publishedVersionOf = async (id: string): Promise<number | null> => {
   finally { await closeDb(); }
 };
 
+/**
+ * Rewrite an atom's body, the way a correction does.
+ *
+ * `content_hash` is what the ledger compares against, so a test that means "this atom changed"
+ * has to move it. Republishing byte-identical content is now skipped outright, which is what
+ * `does not re-send an atom that is byte-identical to what was pushed` covers.
+ */
+async function editAtom(id: string, body: string): Promise<void> {
+  await initDb(CLONE);
+  try {
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET content = ?, content_hash = ? WHERE id = ?',
+      args: [body, `hash-${body}`, id],
+    });
+  } finally { await closeDb(); }
+}
+
 /** Real rows, not bare ledger ids: the push sends atom bodies, so the items have to exist. */
 async function stageMany(count: number): Promise<void> {
   await initDb(CLONE);
@@ -243,6 +260,9 @@ describe('pushStaged', () => {
       projectRoot: CLONE, config: connected,
       api: fakeApi([{ id: ids.decision, status: 'created', version: 1 }]),
     });
+    // Edited before re-staging. An unchanged republish is now settled without a send, so an
+    // atom that never moved would reach no request at all and this test would assert on nothing.
+    await editAtom(ids.decision, 'a corrected decision');
     await stagePublish({ projectRoot: CLONE, config: connected, ids: [ids.decision], apply: true });
 
     let body: any;
@@ -305,18 +325,21 @@ describe('pushStaged', () => {
   });
 
   it('sends batches a cold server can finish inside the request timeout', async () => {
-    // knowl#103. The old size was 200 -- the contract maximum -- which measured at 1564 MB and
-    // 418s of server-side embedding, against a 30s client timeout. Any queue under 200 therefore
-    // went as ONE request that a cold server could not finish, and a backlog was unpushable.
-    await stageMany(60);
+    // knowl#103. 200 -- the contract maximum -- measured at 1564 MB and 418s of server-side
+    // embedding against a 30s client timeout, so any queue under 200 went as ONE request a cold
+    // server could not finish. 20 answered that. Embedding now runs on a background worker after
+    // the commit and a client-supplied vector is never recomputed, so the binding constraint is
+    // no longer time but the server's 2 MB `BODY_LIMIT` -- which 100 atoms of ~5 KB fit with
+    // room, and which is why the ceiling is asserted rather than the old number.
+    await stageMany(150);
     const sizes: number[] = [];
     await pushStaged({
       projectRoot: CLONE, config: connected,
       api: fakeApi([], (body: any) => sizes.push(body.items.length)),
     });
 
-    expect(Math.max(...sizes)).toBeLessThanOrEqual(20);
-    expect(sizes.reduce((a, b) => a + b, 0)).toBe(61);
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(100);
+    expect(sizes.reduce((a, b) => a + b, 0)).toBe(151);
   });
 
   it('halves the batch and retries when a send times out, instead of losing the push', async () => {
@@ -350,7 +373,7 @@ describe('pushStaged', () => {
   it('records what landed before a timeout, so a retry does not start over', async () => {
     // The defect that made retrying pointless: nothing was written locally, so the next attempt
     // re-sent the entire queue and failed identically.
-    await stageMany(39);
+    await stageMany(150);
     let sent = 0;
     const api = {
       ...fakeApi([]),
@@ -369,7 +392,61 @@ describe('pushStaged', () => {
 
     // The first batch is off the queue. Progress survives the failure.
     const left = await stagedIds();
-    expect(left.length).toBe(40 - 20);
+    expect(left.length).toBe(151 - 100);
+  });
+
+  it('does not re-send an atom that is byte-identical to what was pushed', async () => {
+    // The server bumps `version` on any accepted update whether or not the content moved, and
+    // that spent version reaches every replica on its next pull -- so a no-op republish costs the
+    // whole team a round of sync traffic for an atom nobody edited.
+    await pushStaged({
+      projectRoot: CLONE, config: connected,
+      api: fakeApi([{ id: ids.decision, status: 'created', version: 1 }]),
+    });
+    await stagePublish({ projectRoot: CLONE, config: connected, ids: [ids.decision], apply: true });
+
+    let called = 0;
+    const result = await pushStaged({
+      projectRoot: CLONE, config: connected,
+      api: fakeApi([], () => { called += 1; }),
+    });
+
+    expect(called).toBe(0);
+    expect(result).toMatchObject({ status: 'pushed', created: 0, updated: 0, skippedUnchanged: 1 });
+    // Settled, not merely hidden: a filtered row would come back on the next status read.
+    expect(await stagedIds()).not.toContain(ids.decision);
+  });
+
+  it('halves the batch on a 413, because a body too large says "send fewer" the same way', async () => {
+    // A timeout is the request taking too long and a 413 is the body being too big before it is
+    // read at all. Both mean send fewer, and raising MAX_BATCH to 100 makes the second reachable
+    // on unusually fat atoms -- a 413 that failed the push outright would be a worse regression
+    // than the round trips the raise saves.
+    await stageMany(150);
+    const attempted: number[] = [];
+    let oversized = 0;
+    const api = {
+      ...fakeApi([]),
+      publishItems: async (body: any) => {
+        attempted.push(body.items.length);
+        if (body.items.length > 50) {
+          oversized += 1;
+          throw new CloudApiError(413, '/knowledge failed with 413', 'payload_too_large');
+        }
+        return {
+          outcomes: body.items.map((item: any) => ({ id: item.id, status: 'created', version: 1 })),
+          commitId: 'c1',
+        };
+      },
+    } as unknown as CloudApi;
+
+    const result = await pushStaged({ projectRoot: CLONE, config: connected, api });
+
+    expect(oversized).toBeGreaterThan(0);
+    expect(Math.max(...attempted)).toBe(100);
+    expect(Math.min(...attempted)).toBeLessThanOrEqual(50);
+    expect(result).toMatchObject({ status: 'pushed', created: 151 });
+    expect(await stagedIds()).toEqual([]);
   });
 
   it('names how many atoms it was carrying when a timeout ends the push', async () => {

--- a/tests/cloud/retract.test.ts
+++ b/tests/cloud/retract.test.ts
@@ -80,7 +80,7 @@ describe('retracting a published atom', () => {
     await initDb(CLONE);
     await getClient().execute('DELETE FROM cloud_published');
     await stageForPublish([published], WS, 'main');
-    await recordPushed(published, WS, 3);
+    await recordPushed(published, WS, 3, { contentHash: null, lifecycleHash: null });
     await closeDb();
 
     await writeCredential(API_HOST, {

--- a/tests/cloud/status.test.ts
+++ b/tests/cloud/status.test.ts
@@ -87,7 +87,7 @@ describe('cloudStatus', () => {
     try {
       await stageForPublish(['fresh'], WS, 'main');
       await stageForPublish(['known'], WS, 'main');
-      await recordPushed('known', WS, 3);
+      await recordPushed('known', WS, 3, { contentHash: null, lifecycleHash: null });
       await restageForPublish(['known'], WS, 'main');
     } finally { await closeDb(); }
 

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -68,6 +68,11 @@ const SCHEMA_PINS: Record<number, string> = {
   // and every pre-existing row was written before a repo could act as another.
   // `KNOWL_SCHEMA_VERSION` again does not move.
   11: '2f2aa4d61c1fd3600266ec572a964aa0',
+  // 12 adds `cloud_published.remote_content_hash` and `.remote_lifecycle_hash`, so a re-staged
+  // atom nobody edited is settled rather than re-sent. Two nullable columns, no backfill --
+  // the skip predicate requires a non-null hash, so every pre-existing row keeps being sent.
+  // Additive, so `KNOWL_SCHEMA_VERSION` again does not move.
+  12: '8655428a61126c78a4117b827a103703',
 };
 
 let root: string;


### PR DESCRIPTION
## What

Two costs, both measured against the live server rather than reasoned about.

**`MAX_BATCH` 20 → 100.** 20 was sized against ~3s per atom of inline server-side embedding, which no longer happens — embedding moved to a background worker after the commit, and a client that brings its own vector is never re-embedded. The binding constraint is now the server's 2 MB `BODY_LIMIT`, **not** the contract's 200-item cap.

Sized against a real store: 659 atoms averaging ~2 KB of text, 384-dim vectors at ~2 KB of base64 — so ~5 KB typical and ~12 KB worst. 100 lands near 500 KB and worst-cases at 1.2 MB. A routine backlog stops being five requests and becomes one, and `/health` measures a stable **300ms** warm per request through the edge with an empty handler, so those four saved requests are real time.

**`isTimeout` → `isTooMuchAtOnce`.** The raise is what makes a 413 reachable. A timeout is the request taking too long, a 413 is the body being too large before it is read at all, and both mean *send fewer*. Both are safe to retry smaller — the server upserts by item id, and a 413 committed nothing. Nothing else is retried; a secret rejection stays terminal.

**The ledger remembers what it sent.** `cloud_published` gains `remote_content_hash` and `remote_lifecycle_hash`. `listStaged` drops rows where both still match, `clearUnchangedStaged` settles them at push start so the queue does not accumulate them, and `pushStaged` reports `skippedUnchanged`.

Without this, a no-op republish spends a version bump the server applies unconditionally — and that version reaches every replica on its next pull. One wasted push is a round of sync traffic for the whole team.

## Both hashes, and that is the load-bearing half

`status` and `freshness` live in the lifecycle hash. Comparing content alone would read a **retirement** as an unchanged atom and strand it locally — a worse defect than the redundant push it removes. There is a test for exactly that, plus one for a lifecycle-only change and one for the legacy null-hash row.

## Migration

Level **12**, pin `8655428a61126c78a4117b827a103703`. Two nullable columns, no backfill — the skip predicate requires a non-null hash, so every pre-existing row keeps being sent exactly as today. Backfilling from `knowledge_items` would assert the server holds whatever this machine holds now, which is precisely what no local row knows.

`KNOWL_SCHEMA_VERSION` does not move: an older build ignores both columns and pushes as before.

## Tests

**3118 passed, 0 failed.** Three existing push tests changed because the behaviour genuinely changed — the batch-size assertions were rescaled to 100, and the republish test now edits the atom first, since republishing byte-identical content is the thing this PR stops doing. New coverage for the skip predicate and for 413 halving.
