### PR TITLE
docs(readme): name the file the reader already has, and put the number on the first screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,58 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+Two changes to what a stored atom is allowed to lose. One is about delivery — a long body arriving
+with its conclusion cut off — and the other about the write path, where a claim could be retired by
+its own negation.
+
+### A truncated body keeps both ends, not just the head
+
+Atom bodies here are written with the verdict last: `CONSEQUENCE`, `THE FIX`, `THE LIMIT OF THIS
+EVIDENCE`. Delivery truncation was a head slice, so it systematically handed over the setup and
+dropped the finding — and the caveat that had to travel with it went with the rest.
+
+That would be recoverable if the `truncated` flag were acted on, and mostly it is not. The withheld
+tail was not being declined; it was going unread, which is exactly the case a head slice makes
+invisible.
+
+An over-long body now keeps a 60/40 head and tail around a marked elision. **This is not a ceiling
+change and does not spend a single extra character** — the budget is identical, and only which
+characters survive it moves. `MAX_ITEM_CONTENT_CHARS` stays at 2,000 for the reasons recorded when
+it was set, and reading an item whole by `id` still returns it whole.
+
+Applied to the three surfaces that hand a stored body to an agent: `knowl_query` results, the
+`knowl://category/{name}` resource, and `knowl_task_start`'s relevant memory. Titles, tags and
+`affectedPaths` deliberately keep the head slice — a path with its middle removed is not a shorter
+path, it is an unusable one.
+
+### A claim can no longer be retired by its own negation
+
+Write-time supersession judges whether two atoms share a subject by testing whether one title's
+significant tokens are contained in the other's. None of `not`, `no`, `never` or `longer` is a stop
+word, so an affirmative title was a strict subset of its own negation and the test fired. "Push gate
+blocks default branch" retired "Push gate no longer blocks default branch", in whichever order the
+two writes happened to arrive, and the survivor then asserted the opposite of what it had retired
+with nothing said about it.
+
+Two titles that differ only by polarity are now left to coexist. The incoming atom is still
+inserted, the predecessor stays active, and the pair is reported through the near-duplicate channel
+that already hands back the exact retire call — so an agent that means to retire the other one says
+so, and an explicit `supersedes` is never second-guessed.
+
+Deliberately narrow. Ambiguous stems (`can`, `won`, `don`) are left out: a missed negation costs
+what it already costs, while a false positive costs a supersession the caller then has to make by
+hand. The numeric case that similar guards elsewhere are built around does not exist here — digits
+survive tokenization, so `768` is simply absent from a title saying `1024` and the two already
+coexist.
+
+**Provenance deliberately does not gate supersession.** A second guard was proposed alongside this
+one — refuse to let an atom with no provenance retire one claiming `observed` — and it was dropped
+on measurement rather than on principle. Replayed against 101 real supersessions it blocked 3, and
+all three were legitimate corrections, including one whose entire point was that the measurement it
+replaced had been defective. Unset provenance is not a weak claim; it is what most writes look like.
+
 ## 5.5.0 — 2026-08-19
 
 Pushing to a workspace got slower the more memory a repository had, and the reason was never the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/hero.svg" alt="Knowl — persistent memory across sessions for Claude Code, Cursor and Codex, over MCP" width="100%" />
 
-**Your CLAUDE.md only grows. Knowl retires a fact the moment it stops being true.**
+**Your CLAUDE.md only grows. Knowl retires facts when they change.**
 
 [![npm](https://img.shields.io/npm/v/%40dat999zx%2Fknowl?color=3987e5&label=npm)](https://www.npmjs.com/package/@dat999zx/knowl)
 [![CI](https://img.shields.io/github/actions/workflow/status/dat999zx/knowl/ci.yml?branch=main&label=CI)](https://github.com/dat999zx/knowl/actions/workflows/ci.yml)
@@ -32,20 +32,15 @@
 
 ---
 
-Every coding agent starts blank, so you keep a file. `CLAUDE.md`, `.cursorrules`, a notes doc in
-the repo. It only ever grows. Six months in it still says you use the database you migrated off
-last spring, because nothing ever told it that decision was over — and now both answers are in
-there and the agent picks one.
+Your agent starts every session blank, so you keep a `CLAUDE.md`. It only grows. Six months in it
+still names the database you migrated off last spring, and now the agent gets both answers.
 
-Knowl is **persistent memory across sessions** for Claude Code, Cursor and Codex, over
-[MCP](https://modelcontextprotocol.io) or the `knowl` CLI. The difference from a file, and from
-every append-only memory store: **a replacement retires its predecessor at write time.** The stale
-value stops being retrievable instead of competing with the new one forever.
+Knowl is persistent memory for Claude Code, Cursor and Codex, over
+[MCP](https://modelcontextprotocol.io) or the CLI. When a fact changes, the old one is retired
+instead of competing with the new one.
 
-Switching that one behaviour off costs **51 points of retrieval accuracy** — 98% top-1 down to
-47% — and **17 points end-to-end**, 90 down to 73, once a model has to read what came back. Same
-corpus, same ranker, one variable.
-[Both measurements ↓](#the-idea-memory-that-retires-itself)
+Turn that off and retrieval drops from 98% to 47%. End to end, 90 to 73.
+[How it was measured ↓](#the-idea-memory-that-retires-itself)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/hero.svg" alt="Knowl — persistent memory across sessions for Claude Code, Cursor and Codex, over MCP" width="100%" />
 
-**Local-first. Typed. And retired the moment it stops being true.**
+**Your CLAUDE.md only grows. Knowl retires a fact the moment it stops being true.**
 
 [![npm](https://img.shields.io/npm/v/%40dat999zx%2Fknowl?color=3987e5&label=npm)](https://www.npmjs.com/package/@dat999zx/knowl)
 [![CI](https://img.shields.io/github/actions/workflow/status/dat999zx/knowl/ci.yml?branch=main&label=CI)](https://github.com/dat999zx/knowl/actions/workflows/ci.yml)
@@ -32,15 +32,19 @@
 
 ---
 
-Coding agents start every session blank, so teams write things down — and those notes only ever
-grow. Six months in, the store still reports the database you migrated off last spring,
-because nothing ever told it that decision was over.
+Every coding agent starts blank, so you keep a file. `CLAUDE.md`, `.cursorrules`, a notes doc in
+the repo. It only ever grows. Six months in it still says you use the database you migrated off
+last spring, because nothing ever told it that decision was over — and now both answers are in
+there and the agent picks one.
 
-Knowl is **persistent memory across sessions** for Claude Code, Cursor and Codex: a
-repository-local store of **typed knowledge atoms** — decisions, constraints, architecture, facts,
-goals, state, and skills — read and written over an [MCP](https://modelcontextprotocol.io) memory
-server or the `knowl` CLI, where **a replacement retires its predecessor at write time** instead of
-sitting beside it.
+Knowl is **persistent memory across sessions** for Claude Code, Cursor and Codex, over
+[MCP](https://modelcontextprotocol.io) or the `knowl` CLI. The difference from a file, and from
+every append-only memory store: **a replacement retires its predecessor at write time.** The stale
+value stops being retrievable instead of competing with the new one forever.
+
+On MemoryAgentBench's FactConsolidation task, that one behaviour is worth **17 points** — 90 with
+supersession on, 73 with it off, same corpus, same retrieval, same reader.
+[See the benchmark ↓](#verified-end-to-end-in-the-benchmarks-own-harness)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Knowl is **persistent memory across sessions** for Claude Code, Cursor and Codex
 every append-only memory store: **a replacement retires its predecessor at write time.** The stale
 value stops being retrievable instead of competing with the new one forever.
 
-On MemoryAgentBench's FactConsolidation task, that one behaviour is worth **17 points** — 90 with
-supersession on, 73 with it off, same corpus, same retrieval, same reader.
-[See the benchmark ↓](#verified-end-to-end-in-the-benchmarks-own-harness)
+Switching that one behaviour off costs **51 points of retrieval accuracy** — 98% top-1 down to
+47% — and **17 points end-to-end**, 90 down to 73, once a model has to read what came back. Same
+corpus, same ranker, one variable.
+[Both measurements ↓](#the-idea-memory-that-retires-itself)
 
 ## Quick start
 


### PR DESCRIPTION
Rewrites the first screen only. No other section is touched.

### Why

The first screen said what Knowl **is** — local-first, typed, a store of typed knowledge atoms read over MCP. Accurate, and it asks a stranger to do the work of mapping that onto a problem they have.

The 26k-star competitor in this category leads with *"replaces CLAUDE.md, .cursorrules and every other static-file memory hack"* — the same product, described as something the reader already resents. That is the gap being closed here.

### What changed

**Tagline.** Three adjectives become the failure and the fix:

> ~~Local-first. Typed. And retired the moment it stops being true.~~
> **Your CLAUDE.md only grows. Knowl retires a fact the moment it stops being true.**

**Lede names the file.** Every coding agent starts blank, you keep a `CLAUDE.md`, it only ever grows, and six months in it still names the database you migrated off — with both answers in there and the agent picking one. The database line was already the strongest sentence on the page; it just sat two sentences deep behind an abstraction.

**The 17-point ablation moves above the fold.** 90 with supersession on, 73 with it off — same corpus, same retrieval, same reader. It was in a section a visitor arriving from a link would never scroll to, and it is the single most persuasive fact on the page. Anyone landing from an external link now sees the claim and the evidence without scrolling.

The typed-atom list is not lost, only demoted — it reads better as detail than as the opening pitch.

### Note for whoever merges

`feature/rollback` also touches this README (badge palette, day-one commands, the viewer-is-now-an-editor rewrite). The hunks do not overlap — that branch leaves the tagline and lede alone — but this change sits about three context lines above its badge recolour, so expect a trivial context conflict if both land close together. No substantive disagreement between them.