### PR TITLE
chore: release 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.6.0 — 2026-08-19
 
 A person can now read, correct and add memory by hand — `knowl view` became an editor, and two new
 commands make the store browsable from the terminal. Plus two changes to what a stored atom is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts 5.6.0. CHANGELOG heading dated, version bumped in `package.json` and both lockfile fields.

**Merge this with a merge commit, not a squash.** The tag has to point at the `chore: release` commit, and a squash collapses it — this repo's 4.0.0 notes record that exact trap.

### What ships

`knowl view` becomes an editor: a list beside the graph with All / Unread / Stale, edit, add, archive and restore. **Unread** sorts by never-retrieved, oldest first, which is how you find memory you would never search for. Atom bodies render their markdown instead of printing it as source — measured on a real store, 70% carry inline code. `knowl list` browses what `knowl query` could only search, and `knowl edit <id>` opens one atom in the viewer.

The graph stopped drawing links that carry no information: 1,556 down to 484 on a 675-atom store. A commit with no body is no longer stored as an atom, because its content would be its title.

Also carries #133 and #134, both merged after the 5.5.0 release commit.

### The one thing worth knowing

**This makes `knowl view` a local server that accepts writes.** It binds loopback, mints a fresh token per launch, and refuses any write that does not name the viewer as its origin — `SameSite` alone is not sufficient, because it does not scope by port. That defence was wrong during development and was fixed; six adversarial review passes have gone over the branch since, which is where the CSRF hole, a stored XSS in the markdown link path, and an `md()` loop that froze the tab on eight real atoms were caught.

### Verified

All eight gates green at `b05b17e`: `typecheck`, `lint`, `docs:check`, `check:lockfile` (matches 5.6.0), `build`, and `npm test` — **344 files, 3,210 passed**.

After merge: tag `v5.6.0` at the release commit, push the tag to trigger `cd.yml`, then verify from the registry rather than from a green workflow.