### PR TITLE
feat(plugin): install as a Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "knowl",
+  "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
+  "version": "5.6.0",
+  "author": {
+    "name": "Knowl"
+  },
+  "homepage": "https://github.com/dat999zx/knowl",
+  "repository": "https://github.com/dat999zx/knowl",
+  "license": "Apache-2.0",
+  "keywords": ["memory", "context", "knowledge", "decisions", "mcp", "persistence"],
+  "mcpServers": {
+    "knowl": {
+      "command": "npx",
+      "args": ["-y", "@dat999zx/knowl", "serve"]
+    }
+  }
+}


### PR DESCRIPTION
One file: `.claude-plugin/plugin.json`. It makes this repo installable as a Claude Code plugin and is the prerequisite for listing Knowl in the official plugin directory (61.9M npm downloads/month, and the only memory plugin currently listed there is `remember` at ~12k installs).

The manifest wires one MCP server, `npx -y @dat999zx/knowl serve`, no credentials, no build step. Version pinned to 5.6.0 to match npm; description is the npm description verbatim.

Validated with `claude plugin validate .`, the same command the directory's CI runs. Passes with one warning (repo CLAUDE.md is not loaded as plugin context, which is what we want, since those are contributor instructions).

Once this is on main I will submit the directory form (submission is form-only for first listings; external PRs to the directory are auto-closed). The directory pins a sha, so future releases update the pin by marketplace PR, which we can send ourselves once the plugin is live.

Deliberately not in v1: shipping the lifecycle hooks through the plugin. That changes hook invocation from the CLI-installed path to npx per event, and the latency call there is yours. Happy to follow up either way.
