### PR TITLE
docs(reference): title the subject, not the claim

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -73,10 +73,11 @@ It also prepares the local embedding model on a best-effort basis. If the model 
 setup still completes; the CLI lexical query remains available, and MCP can run BM25-only after
 vectors are disabled.
 
-Record a decision:
+Record a decision. **Title the subject, not the claim** — the reconciliation rules below
+explain why `"Database choice"` supersedes cleanly later and `"Use SQLite"` does not:
 
 ```bash
-knowl decide "Use SQLite" "Use SQLite for local project memory." \
+knowl decide "Database choice" "Use SQLite for local project memory." \
   --reasoning "Keeps storage repository-local and simple to operate." \
   --alternatives PostgreSQL MongoDB \
   --tags database local-first
@@ -172,6 +173,11 @@ and raw-output size limits still apply. Accepted writes then follow these reconc
 2. Knowl examines up to the top three active BM25 candidates in the same category.
    A normalized title subset with at least two significant shared tokens and at least `0.35`
    significant-token overlap identifies the same subject and retires the predecessor.
+   **That two-token floor is why a title should name the subject rather than assert the claim.**
+   `"Database choice"` and `"Cache backend"` carry two significant tokens and reconcile;
+   `"Redis"` and `"Use SQLite"` carry one (`use` is a stopword), so a later decision on the same
+   subject is left active beside the first. Rule 4 reports it and prints the `knowl supersede`
+   command, so nothing is lost silently — but the title decides whether it is automatic.
 3. If no detected candidate qualifies for supersession, an explicitly named active
    `supersedes` item is retired. A qualifying detected same-subject candidate currently takes
    priority when it differs from that explicit ID.


### PR DESCRIPTION
The reference's own `knowl decide` example used `"Use SQLite"` as the title — which is exactly the shape that will not reconcile later.

Rule 2 requires **at least two significant shared tokens**. `use` is a stopword, so `"Use SQLite"` carries one. Copy the example, record the reversal six months later, and you get both decisions left active with no obvious reason.

Verified on published 5.5.0 across fresh projects:

| title | second write on same subject |
|---|---|
| `"Database choice"`, `"Cache layer"`, `"Search engine"` | 🔄 Superseded older decision |
| `"Use SQLite"`, `"Use Redis"`, `"Redis"` | ⚠️ Left active beside … |

The discriminator is the title's significant-token count — not the AI provider, not the content, and not whether the second write negates the first.

Two changes: the example becomes `"Database choice"`, and rule 2 states the consequence of its own two-token floor instead of leaving it to be derived from the threshold.

Rule 4 already reports the unreconciled item and prints the `knowl supersede` command, so nothing was ever lost silently. But the title decides whether reconciliation is automatic, and that wasn't written down anywhere.