### PR TITLE
fix(cli): the no-AI notice claimed there is no conflict detection, one line above detecting one

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2401,7 +2401,11 @@ program
           console.log(`ℹ️ Decision was identified as a duplicate and skipped.`);
         }
       } else {
-        console.log(`⚠️ No AI provider configured or API keys found. Falling back to direct insertion without conflict detection.`);
+        // Says what is actually unavailable. Same-subject reconciliation is deterministic and
+        // still runs here -- the AI pipeline adds contradiction detection ACROSS subjects. The
+        // old wording claimed there was no conflict detection at all, immediately above a line
+        // reporting a superseded predecessor.
+        console.log(`ℹ️ No AI provider configured. Same-subject writes still reconcile; cross-subject contradiction detection is off.`);
         const decision = await recordDecisionDirect(project.id, atom, `Record decision: ${title}`, config);
         console.log(decision.action === 'duplicate'
           ? `ℹ️ Already recorded verbatim, nothing written. ID: ${decision.item.id}`


### PR DESCRIPTION
`knowl decide` with no AI provider printed:

```
⚠️ No AI provider configured or API keys found. Falling back to direct insertion without conflict detection.
✅ Recorded decision successfully! ID: e3614f5719...
🔄 Superseded older decision: cbb8c5d0e4...
```

Both cannot be true. It's the warning that's wrong.

Same-subject reconciliation is deterministic and runs regardless — rules 1–5 in `docs/reference.md`, keyed on significant-token overlap of the title. What an AI provider adds is contradiction detection **across** subjects, where the new atom doesn't name the same thing it invalidates.

Now:

```
ℹ️ No AI provider configured. Same-subject writes still reconcile; cross-subject contradiction detection is off.
✅ Recorded decision successfully! ID: d1bb99a41e...
🔄 Superseded older decision: 8581609edf...
```

**Why it matters beyond wording.** This line is the loudest thing in `docs/assets/demo.gif` — it appears twice in a seven-line recording that exists to demonstrate conflict resolution. And it cost an evening in one session: a single failing case (a *claim* used as a title, which misses the two-token floor) was read as "supersession needs an API key", and that misreading reached the README before being caught.

Dropped from ⚠️ to ℹ️ since nothing is degraded on the common path.

No test asserted the old string. Suite green: 344 files, 3210 passed, 5 skipped.