### PR TITLE
docs: five comments still say the drift check leaves freshness alone

### DIFF
--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -775,7 +775,9 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // A read-set with nothing collecting it grows for as long as the repository is used.
     await sweepReadSetsBestEffort(plusHoursIso(-READ_SET_RETENTION_HOURS));
     await closeInactiveHostSessionBindings();
-    // Detection only: names what moved and the command to review it, leaving `freshness` alone.
+    // Flips survivors to `needs_review` and stamps `last_drift_at`, then names what moved and
+    // the command to review it. Detection-only until 2026-08-13; see `drift-auto.ts` for why
+    // the narrowed signal made the flip survivable.
     const drift = await runAutoDriftCheckBestEffort(projectId, input.projectRoot);
     // Strictly after drift, and only when drift actually ran. `checked` is false on the run
     // that learns a baseline and on the re-baseline after a rebase -- both skip a window of

--- a/src/store/drift-auto.ts
+++ b/src/store/drift-auto.ts
@@ -4,7 +4,8 @@ import { checkKnowledgeDrift, getCurrentGitCommit, listChangedFilesSince, listRe
 export type AutoDriftResult = {
   /** False on the run that only learns the baseline; nothing was compared. */
   checked: boolean;
-  /** Items whose files changed since the watermark. Detection only — nothing is flipped. */
+  /** Items whose cited files moved since the watermark and survived classification. Each is
+   *  flipped to `needs_review` and stamped with `last_drift_at`; see `apply: true` below. */
   candidateCount: number;
   /** Up to the first few candidate titles, for the session-start warning. */
   candidateTitles: string[];
@@ -117,10 +118,10 @@ const DRIFT_STAMP_CHUNK = 250;
 /**
  * Record that these items' files moved, so a later pass can still tell.
  *
- * This is the one thing detection has to leave behind, and it is why the watermark advancing
- * is survivable. `freshness` stays untouched for the measured reason above; `last_drift_at`
- * is a separate column nothing reads at retrieval time, so recording an observation costs no
- * ranking and no warning volume. Without it the only trace of a window is the one warning
+ * This is what the check leaves behind besides the `needs_review` flip, and it is why the
+ * watermark advancing is survivable. `last_drift_at` is a separate column nothing reads at
+ * retrieval time, so the stamp itself costs no further ranking and no warning volume beyond
+ * what the flip already does. Without it the only trace of a window is the one warning
  * line, and the very next session — which finds `watermark === current` and computes no
  * candidates at all — has no way to know that an item reading `fresh` is a claim about files
  * that changed this morning and that nobody has looked at since.

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -53,9 +53,10 @@ export const knowledgeItems = sqliteTable('knowledge_items', {
   tierSince: text('tier_since'),
   /**
    * When the automatic drift check last saw this item's cited files move, and NULL once
-   * somebody has revisited the item since. Deliberately NOT `freshness`: flipping that would
-   * do the corpus-wide ranking damage `drift-auto.ts` measured and refused, whereas this
-   * column changes nothing an agent reads. Standing promotion is its only consumer.
+   * somebody has revisited the item since. Distinct from `freshness`, which the same check
+   * also flips to `needs_review` since 2026-08-13: this column is read by nothing at
+   * retrieval time, so it costs no ranking of its own. Standing promotion is its only
+   * consumer, and the two are cleared by different events -- see `updateKnowledgeItem`.
    *
    * Store-internal, so it is absent from `KnowledgeItem` and from every export: it records
    * what THIS machine's git history did to the item, which is not a portable property of the

--- a/src/store/tier.ts
+++ b/src/store/tier.ts
@@ -146,10 +146,10 @@ export type ObservedUseResult = {
  * same "one proof of wrongness outweighs any history of usefulness" rule applied above.
  *
  * `last_drift_at` closes the hole stored freshness leaves, and it has to be a stored column
- * rather than the live candidate list. The session-start drift check is detection only — by
- * deliberate design it names what moved without flipping `freshness` — so an item whose files
- * changed this morning still reads `fresh` until somebody runs `knowl pr` by hand, which
- * is the same voluntary act this feature exists to stop depending on. But the live list only
+ * rather than the live candidate list. Since 2026-08-13 the session-start check does flip
+ * survivors to `needs_review`, which the `freshness = 'fresh'` clause above already excludes;
+ * the stamp is not redundant with it, because `updateKnowledgeItem` clears the two on
+ * different conditions. But the live list only
  * covers the one session that happened to straddle the commit: the watermark then advances,
  * the next session computes no candidates at all, and an item refused an hour ago sails
  * through unchanged. Measured on this store, 12 of the 85 items the recurrence gate selects


### PR DESCRIPTION
`runAutoDriftCheck` passes `apply: true` and has since 2026-08-13. Its own docblock says so plainly, and explains the measurement that justified the change. Five comments elsewhere describing the same behaviour were not updated alongside it, and now assert the opposite.

| File | Line | Claim |
|---|---|---|
| `src/store/drift-auto.ts` | 7 | "Detection only — nothing is flipped" |
| `src/store/drift-auto.ts` | 121 | "`freshness` stays untouched for the measured reason above" |
| `src/session/host-lifecycle.ts` | 778 | "leaving `freshness` alone" — at the call site |
| `src/store/schema.ts` | 56 | "Deliberately NOT `freshness`" |
| `src/store/tier.ts` | 150 | "detection only … without flipping `freshness`" |

The first sits 88 lines above the `apply: true` that contradicts it, in the same file. The second cites "the measured reason above" — and the reason above now explains why the flip *does* happen.

## Why this is worth a PR rather than a passing fix

Two knowledge atoms in this project's own store were faithful transcriptions of these comments. A session read them, concluded that automatic drift marking was unimplemented and that `reportDrift` had no caller, and told its user that a shipped feature did not exist. The recovery took a full source audit.

Documentation drift became memory drift. In a repository whose product is memory, that is worth naming.

This is the same class as #142 (`fix(cli): the no-AI notice claimed there is no conflict detection, one line above detecting one`), which is currently `main`'s HEAD.

## Scope

Comments only. No executable line is touched — verified by filtering the diff for non-comment lines and getting an empty result.

## One thing deliberately left undecided

The stamp and the flip now overlap, and the older comments imply a relationship that no longer holds.

`promoteByObservedUse` gates on **both** `freshness = 'fresh'` and `last_drift_at IS NULL`. Meanwhile `updateKnowledgeItem` clears `last_drift_at` on five conditions (`title`, `content`, `affectedPaths`, `sourceCommit`, `freshness`) and never resets `freshness` implicitly — it changes only when explicitly supplied.

So `last_drift_at` clears **more** readily than `needs_review`, which is the reverse of what the old comments suggest. An item whose files moved, and which is then edited for an unrelated reason, has its stamp cleared while still carrying `needs_review`.

I have not asserted which gate is load-bearing. The new wording says only that the two clear on different conditions. Deciding what the promotion rule *should* do is yours — and guessing at it in a comment is precisely how this started.

Happy to follow up with whatever you decide, including removing one of the two clauses if it is now redundant.
