### PR TITLE
feat(store): say when part of an atom will not be searchable

### DIFF
--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -117,8 +117,15 @@ export function estimateTokens(text: string): number {
  *
  * Exported for tests. It is a pure string function, and reaching it through `embed()` would
  * make a model download a prerequisite for asserting a slice.
+ *
+ * **`clipped` reports that some of the text was not embedded**, from either cause -- the
+ * 8,000-character pre-clip or the token budget. It exists because the loss was previously
+ * undetectable from outside: the return said what survived and nothing said that anything had
+ * not, so an author who wrote a 12 KB atom got a vector covering the first two-thirds of it and
+ * no way to find out (#132). No caller could reconstruct it either, short of comparing lengths
+ * against a constant this module does not export.
  */
-export function clipToTokenBudget(text: string): { text: string; tokens: number } {
+export function clipToTokenBudget(text: string): { text: string; tokens: number; clipped: boolean } {
   const capped = text.length > MAX_EMBED_CHARS ? text.slice(0, MAX_EMBED_CHARS) : text;
 
   let tokens = 0;
@@ -136,13 +143,14 @@ export function clipToTokenBudget(text: string): { text: string; tokens: number 
         return {
           text: capped.slice(0, Math.max(1, Math.floor(MAX_EMBED_TOKENS * charsPerToken))),
           tokens: MAX_EMBED_TOKENS,
+          clipped: true,
         };
       }
-      return { text: capped.slice(0, match.index), tokens };
+      return { text: capped.slice(0, match.index), tokens, clipped: true };
     }
     tokens += cost;
   }
-  return { text: capped, tokens };
+  return { text: capped, tokens, clipped: capped.length < text.length };
 }
 
 /** What the planner returns: the text to embed and where its vector belongs. */
@@ -387,6 +395,9 @@ export async function createLocalEmbeddingProvider(
     // Null for a model this build has not measured, which switches abstention off rather than
     // borrowing another model's number. See MODEL_RELEVANCE_FLOORS.
     relevanceFloor: relevanceFloorFor(vector.model),
+    // The same function `planEmbeddingBatches` runs on the way in, exposed so a caller holding
+    // the atom can say which one lost text. Pure and cheap -- a regex scan, no model.
+    clipToBudget: clipToTokenBudget,
     embed: async (texts: string[], options?: EmbedOptions) => {
       const vectors: number[][] = [];
       for (const batch of planEmbeddingBatches(texts, options)) {

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -309,7 +309,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
               content: {
                 type: 'string',
                 minLength: 1,
-                description: 'Knowledge content in markdown or plain text.',
+                description: 'The knowledge itself, and why it matters. One finding per atom: aim for about 2,000 characters, and split rather than trim. Bodies dense with file paths, backslashes or fenced code are the ones that fail before reaching the server -- prefer forward slashes, and use `knowl_ingest_atoms` for several findings at once. Content past 8,000 characters is stored but never embedded, so search will not find it.',
               },
               reasoning: {
                 type: 'string',

--- a/src/store/vector-index.ts
+++ b/src/store/vector-index.ts
@@ -34,6 +34,19 @@ export type KnowledgeEmbedder = {
    * already passes an embedding passes this beside it and needs to know nothing more.
    */
   relevanceFloor: number | null;
+  /**
+   * What this embedder would actually turn into a vector, and whether that is all of it.
+   *
+   * Same reasoning as `relevanceFloor` above: the budget belongs to the model that imposes it,
+   * so the thing that does the clipping is the thing that can report it. It is also the only
+   * way the store layer can ask -- `store` may not import `ai`, and the clip is decided there.
+   *
+   * OPTIONAL because the interface has a dozen test doubles and an alternative provider owes
+   * nobody a token budget. A caller that gets `undefined` learns nothing and must not conclude
+   * "nothing was clipped"; every one here treats it as "no report available" and stays quiet,
+   * which is right for a double and moot for the one real implementation.
+   */
+  clipToBudget?(text: string): { text: string; tokens: number; clipped: boolean };
   embed(texts: string[], options?: EmbedOptions): Promise<number[][]>;
   /**
    * A QUERY, not a document.

--- a/src/store/write-embedding.ts
+++ b/src/store/write-embedding.ts
@@ -113,10 +113,36 @@ export async function indexKnowledgeItemsBestEffort(projectId: string, items: Kn
   try {
     const embedder = await resolveEmbedder();
     if (!embedder) return;
+    const texts = items.map(buildKnowledgeEmbeddingText);
+    // Say so when part of an atom will not be searchable. This is the one moment the author is
+    // still present and can act on it -- by the time it is a vector covering the first
+    // two-thirds of a finding, nothing distinguishes it from one covering all of a shorter one.
+    //
+    // Deliberately only on the WRITE path. The reindex in `vector-index.ts` clips the same way,
+    // but it re-embeds the whole corpus and would reprint the same line for every over-long
+    // atom on every run, addressed to whoever happened to be reindexing rather than to whoever
+    // wrote it. A warning nobody can act on is the noise that teaches people to ignore the ones
+    // they can.
+    //
+    // Counted on the embedding text, not on `content`: `buildKnowledgeEmbeddingText` feeds the
+    // model title, content, reasoning and tags together, and it is that combined length the cap
+    // applies to. Quoting `content.length` here would name a number the author could not
+    // reconcile with the limit.
+    texts.forEach((text, index) => {
+      // No report available is not a claim that nothing was clipped -- see `clipToBudget`.
+      const report = embedder.clipToBudget?.(text);
+      if (!report?.clipped) return;
+      const embedded = report.text;
+      console.error(
+        `Note: embedded the first ${embedded.length} of ${text.length} characters of `
+        + `"${items[index].title}". The rest is stored but will not be found by search — `
+        + 'split it into smaller atoms.',
+      );
+    });
     // One text per forward pass. A single write already got that for free; a batch write of
     // several atoms did not, and its vectors then disagreed with the ones a reindex produced
     // for the same text. See `EmbedOptions`.
-    const vectors = await embedder.embed(items.map(buildKnowledgeEmbeddingText), { maxBatch: 1 });
+    const vectors = await embedder.embed(texts, { maxBatch: 1 });
     // One transaction for the batch. Each row written on its own is an implicit commit, and
     // this schema fsyncs the WAL on every one -- 11.57 ms per row against 0.088 ms inside a
     // transaction. A single-item write, which is the common case here, still takes the plain

--- a/tests/ai/embeddings.test.ts
+++ b/tests/ai/embeddings.test.ts
@@ -433,4 +433,41 @@ describe('clipping to the token budget', () => {
   it('leaves a text inside the budget untouched', () => {
     expect(clipToTokenBudget('a short atom').text).toBe('a short atom');
   });
+
+  it('reports whether anything was dropped, from either cause', () => {
+    // The whole point of the flag (#132): the loss was previously undetectable from outside,
+    // so a 12 KB atom embedded its first two-thirds and nothing said so. Both causes have to
+    // report, because an author cannot tell them apart and does not need to.
+    expect(clipToTokenBudget('a short atom').clipped).toBe(false);
+
+    // The character pre-clip, well inside the token budget: 8,000 chars of 'ab ' is ~2,666
+    // tokens, so this one is cut by MAX_EMBED_CHARS on the way in.
+    const byChars = clipToTokenBudget('x'.repeat(9_000));
+    expect(byChars.clipped).toBe(true);
+    expect(byChars.text.length).toBeLessThan(9_000);
+
+    // The token budget, via the mid-segment path digits reach and letters cannot.
+    expect(clipToTokenBudget('1'.repeat(9_000)).clipped).toBe(true);
+
+    // The boundary cut, the third return point.
+    expect(clipToTokenBudget('ab '.repeat(4_000)).clipped).toBe(true);
+  });
+
+  it('does not claim a clip at exactly the character cap', () => {
+    // Off-by-one on the boundary: `text.length > MAX_EMBED_CHARS` is a strict comparison, so a
+    // text of exactly 8,000 characters passes through whole. `>=` would report every one of
+    // them as clipped and send authors splitting atoms that were never cut.
+    //
+    // `word ` and not `ab `: this has to be under the TOKEN budget too or the other cut fires
+    // and the assertion stops being about the character cap. 5 chars costing 1 token puts
+    // 8,000 characters at 1,600 tokens, comfortably under 2,048; `ab ` would be ~2,666 and
+    // clip for the other reason entirely.
+    const exact = 'word '.repeat(1_600);
+    expect(exact.length).toBe(8_000);
+
+    const result = clipToTokenBudget(exact);
+    expect(result.tokens).toBeLessThan(EMBEDDING_LIMITS.maxTokens);
+    expect(result.clipped).toBe(false);
+    expect(result.text).toBe(exact);
+  });
 });


### PR DESCRIPTION
Closes #132.

Two halves, as agreed in the thread: the tool description, and the silent partial embed behind it.

## The framing changed on the evidence

The issue was filed as a size rule from failures measured at 2,949–5,834 bytes. Then one failed at **2,415** while the largest atom either store has ever accepted is **7,305**. Length is not the predictor — escaping density is. A 7 KB block of prose escapes to almost nothing; 2 KB of Windows paths and fenced code is mostly `\` and `\n`.

So @williamttruong's wording, taken as landed, says *one finding per atom* and warns about the content profile rather than just the byte count:

> The knowledge itself, and why it matters. One finding per atom: aim for about 2,000 characters, and split rather than trim. Bodies dense with file paths, backslashes or fenced code are the ones that fail before reaching the server -- prefer forward slashes, and use `knowl_ingest_atoms` for several findings at once. Content past 8,000 characters is stored but never embedded, so search will not find it.

## The half that fails silently

`MAX_EMBED_CHARS` slices at 8,000 and the token budget cuts earlier still. `clipToTokenBudget` returned what survived and nothing said that anything had not — so the author cannot see it, and, as @williamttruong pointed out, **no caller could detect it either** without comparing lengths against a constant the module does not export.

`clipped` now reports it from **either** cause. The write path turns that into a line naming the atom and the real numbers, because "content was clipped" makes someone go and measure it themselves:

```
Note: embedded the first 7729 of 12487 characters of "Payment reconciler ledger comparison".
The rest is stored but will not be found by search — split it into smaller atoms.
```

Note the 7,729 — the **token** budget bit first there, below the character cap. That is exactly why the flag covers both cuts rather than just the 8,000 the issue named.

Counted on the embedding text, not on `content`: `buildKnowledgeEmbeddingText` feeds the model title, content, reasoning and tags together, and that combined length is what the cap applies to. Quoting `content.length` would name a number the author could not reconcile with the limit.

## Two design notes

**It goes through `KnowledgeEmbedder`, not a direct import.** My first cut imported `ai/embeddings.js` from `store/write-embedding.ts` and `tests/architecture/module-boundaries` correctly rejected it — `store` may not import `ai`. The interface is the inversion that already exists for this, and `relevanceFloor` sitting beside it carries the identical argument: the budget belongs to the model that imposes it, so the thing that clips is the thing that can report it.

It is **optional** on the interface. A dozen test doubles implement `KnowledgeEmbedder` and an alternative provider owes nobody a token budget, so `undefined` is documented as *"no report available"* and explicitly not *"nothing was clipped"* — the same absence-versus-verdict distinction this codebase draws for `uncalibrated`.

**Write path only.** The reindex clips identically, but it re-embeds the whole corpus and would reprint for every over-long atom on every run, addressed to whoever is reindexing rather than whoever wrote it. A warning nobody can act on is the noise that teaches people to ignore the ones they can.

## No backfill

**0** active atoms exceed 8,000 characters in either store today (max 5,100 in `knowl`, 7,305 in `knowl-cloud`; 189 and 294 are over 2,000 and fine). This is a guard for the CLI and import paths, not a fix for existing damage — worth stating so nobody goes looking for a migration.

## Verification

`npm run build`, `npm test` (**344 files, 3212 passed**, 5 skipped), `npm run typecheck`, `npm run lint`, `npm run docs:check`, `git diff --check` — all green, build before test.

Two tests added, including an off-by-one guard on the strict `>` at the character cap: a text of exactly 8,000 characters must pass through whole, or every one of them reports as clipped and sends authors splitting atoms that were never cut. Plus the end-to-end run above — warns on the long atom, silent on a short one.
