### PR TITLE
chore(evidence): drop the two EvidenceType members nothing ever reached

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -145,7 +145,24 @@ export interface KnowledgeCommit {
   createdAt: string;
 }
 
-export type EvidenceType = 'file' | 'symbol' | 'commit' | 'test' | 'command' | 'url' | 'user' | 'agent';
+/**
+ * What a piece of evidence points at.
+ *
+ * `command` and `url` were members until 2026-08-20 and are gone because nothing ever reached
+ * them: `isEvidenceStale` handles `symbol` and `file` and returns false for everything else, and
+ * both stores held zero rows of either across 2,173 evidence rows (#145). They were storable,
+ * syncable, and checked by nothing.
+ *
+ * Removing an exported union member is a breaking type change, which is why it happened while
+ * the count was zero rather than later. `evidence.type` is `TEXT NOT NULL` with no CHECK
+ * constraint, so this is a compile-time narrowing and needs no migration -- a row written by an
+ * older client still reads back, it simply has no type here to be.
+ *
+ * A future verification mechanism should add what it implements rather than reviving these. A
+ * stored free-text `command` that something later executes is a different security posture than
+ * this codebase has today, and the moment to argue that is when something proposes to run one.
+ */
+export type EvidenceType = 'file' | 'symbol' | 'commit' | 'test' | 'user' | 'agent';
 export type EvidenceRelationship = 'supports' | 'contradicts' | 'derived_from';
 
 export interface Evidence {


### PR DESCRIPTION
Item 2 of #145. One line of real change, plus the reasoning that makes it safe to read later.

## What was wrong

`isEvidenceStale` handles `symbol` and `file` and returns `false` for everything else, so `command` and `url` were storable, syncable, accepted free-text locators and arbitrary metadata JSON, and were verified by nothing. **Zero rows of either across 2,173 evidence rows** in both live stores.

## Why now

Removing an exported union member is a breaking type change. That is the argument for doing it at zero rows rather than after something starts writing them — and, as @williamttruong put it when flagging the window, they are exactly what a future implementer reaches for when adding any kind of verification.

## Verified to be a compile-time narrowing and nothing else

- `evidence.type` is `TEXT NOT NULL` with **no CHECK constraint** (`src/store/bootstrap.ts:109`) — no migration, no constraint to update. A row written by an older client still reads back; it simply has no type here to be.
- `src/cloud/sync-contract.ts` does not validate evidence types either, so nothing on the wire enumerates them.
- Every remaining `'command'` in the tree is a `SessionEventType` or a hook config in `src/cli/agents/`; `'url'` had no other occurrence at all.

`npm run typecheck` passes with no other edit, which is its own evidence that nothing reached them.

## No test

The compiler is the check for a type deletion, and an assertion that the union has six members is brittle and tells a future reader less than the comment does. The reasoning lives on the union itself — including the part that matters later: a future verification mechanism should add what it implements rather than reviving these, and the argument about a stored free-text `command` belongs in the review of whatever proposes to execute one.

## Not in this PR: `reportReviewed` (#145 item 3)

Deliberately left alone, and the "wire or delete, either beats the status quo" framing in the issue no longer holds:

- **`reportDrift` gained a production caller** at `src/cli/program.ts:3906`, inside `knowl pr check`. `needsReview` flags are raised in production today.
- **`reportReviewed` is the only thing that clears one** — its docstring: *"The deliberate undo of `needsReview`, and the only one."*

So deleting it would not remove dead code; it would remove the undo for a live flag and leave workspaces accumulating reviews nothing can clear. And wiring it automatically would violate the contract its `expectedVersion` argument exists to enforce — *"vouching for text the caller did not read is the failure this asymmetry exists to prevent"* — so it cannot hang off an edit or off `last_drift_at` clearing. There is no deliberate action to attach it to today (`grep needs_review src/cli/program.ts` returns nothing).

That makes it a product decision about which invocation constitutes vouching, not a patch. Discussed in the issue.

## Verification

`npm run build`, `npm test` (**344 files, 3210 passed**, 5 skipped), `npm run typecheck`, `npm run lint`, `npm run docs:check`, `git diff --check` — all green, build before test.
