### PR TITLE
feat(cli): knowl reviewed -- the verb that clears a review flag

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -605,6 +605,24 @@ The check considers `affectedPaths`, source strings, path-like tags, and stale s
 Without `--dry-run`, matching candidates are changed to `needs_review`. It does not rewrite their
 content or decide a replacement.
 
+When a repo is connected to a workspace, `knowl pr` also tells the team, so a flag it raises is
+visible to everyone. The other end of that is:
+
+```bash
+knowl reviewed <itemId>
+knowl reviewed <itemId> --note "still true, the rename did not change the behaviour"
+```
+
+This records that you re-read the item and it still holds: locally it clears the review flag, and
+on a connected repo it discharges the one `knowl pr` raised for the team. It is the only way to
+clear a team review flag — republishing an item says nothing about freshness and leaves the flag
+standing.
+
+It is a command you type rather than something an edit does for you, and deliberately so: it
+vouches for specific text, so it should be the act of someone who just read that text. If the
+team's copy has changed since it was published, the review is refused and says so — what you
+vouched for is not what is there.
+
 Retrieval access logging stores a query fingerprint rather than the raw query. Agents can append
 feedback only after using or rejecting a result:
 
@@ -1864,6 +1882,7 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl gc [--apply] [--stale-days N] [--compress-days N] [--min-bytes N] [--ignore-access] [--tombstone-days N]` | Preview or apply duplicate, archive, compression, and tombstone maintenance |
 | `knowl forget-log [--limit N] [--repo <name>] [--json] [--prune-days N]` | Show why knowledge items were destroyed — policy, reason, and the retrieval evidence it overruled — or prune those records |
 | `knowl pr --since <commit> [--dry-run]` | Find drift candidates and, unless dry-run, mark them for review |
+| `knowl reviewed <itemId> [--note <text>]` | Record that an item was re-read and still holds, clearing its review flag here and on the team's copy |
 | `knowl view [--port <port>]` | Start the local viewer: browse, read, edit, add and archive memory |
 | `knowl serve` | Start the stdio MCP server |
 | `knowl agent-event\|agent-hook\|agent-reminder` | Host-integration commands used by installed lifecycle configuration |

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -63,7 +63,7 @@ import { recommendedTotal, WITHHELD_BY_DEFAULT } from '../core/sharing-defaults.
 import { runConnect } from '../cloud/connect.js';
 import { runPull } from '../cloud/pull.js';
 import { computePushSnapshot, countStageable, pushStaged, stagePublish } from '../cloud/publish.js';
-import { reportDrift } from '../cloud/drift-report.js';
+import { reportDrift, reportReviewed } from '../cloud/drift-report.js';
 import { retractItem } from '../cloud/retract.js';
 import {
   listSends, previewSend, receiveKnowledge, refusalMessage, revokeSend, sendKnowledge,
@@ -3924,6 +3924,67 @@ program
         // Ignore close errors while reporting the root cause.
       }
       console.error(`Error checking PR drift: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+/**
+ * The other end of `knowl pr`: say an atom was read and still holds.
+ *
+ * `reportReviewed` shipped complete, gated and tested with no production caller, and until
+ * `reportDrift` gained one above that was merely untidy. It is not any more -- `knowl pr` now
+ * raises `needsReview` on the workspace, and this is the only verb that clears one. Without it
+ * a team accumulates review flags with nothing able to discharge them.
+ *
+ * A COMMAND rather than an automatic call, and that is the whole design. `reportReviewed` sends
+ * `expectedVersion` because it is a positive claim about specific text, and vouching for text
+ * the caller did not read is the failure that asymmetry exists to prevent. Hanging it off an
+ * edit, or off `updateKnowledgeItem` clearing `last_drift_at`, would vouch on the author's
+ * behalf for words nobody re-read. Somebody has to type this.
+ *
+ * Local first, and unconditionally. Setting `freshness` is what `repository.ts` recognises as a
+ * review, so this clears `last_drift_at` here whether or not a workspace is attached -- a repo
+ * with no cloud still has drift flags to discharge, and a command that only worked when
+ * connected would be a different command.
+ *
+ * The upward half borrows `knowl pr`'s refusal policy exactly: `not-connected`, `not-published`
+ * and `gated` are ordinary states rather than errors, so none of them fails the command or
+ * undoes the local review. `conflict` is the one that is worth saying out loud -- the remote
+ * text moved under the reviewer, so what they vouched for is not what is there.
+ */
+program
+  .command('reviewed')
+  .argument('<itemId>')
+  .description('Record that an item was re-read and still holds, clearing any review flag')
+  .option('--note <text>', 'Why it still holds, for whoever raised the review')
+  .action(async (itemId, options) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      await initDb(root);
+      if (!(await repo.getKnowledgeItem(itemId))) {
+        throw new Error(`No knowledge item "${itemId}". Nothing was reviewed.`);
+      }
+
+      const updated = await repo.updateKnowledgeItem(itemId, { freshness: 'fresh' });
+      console.log(`Reviewed ${itemId}: ${updated?.title ?? ''}`);
+
+      const config = await loadConfig(root);
+      if (config.cloud) {
+        const outcome = await reportReviewed({
+          projectRoot: root, config, itemId,
+          ...(options.note === undefined ? {} : { note: options.note }),
+        }).catch(() => 'not-connected' as const);
+        if (outcome === 'reviewed') console.log('Told the team.');
+        // Everything the reviewer cannot act on stays quiet, exactly as `knowl pr` does. This
+        // one they can: it means the remote content is not what they just vouched for.
+        if (outcome === 'conflict') {
+          console.error('Note: the team\'s copy has changed since it was published, so the review was not recorded. Pull and read it again.');
+        }
+      }
+      await closeDb();
+    } catch (error: any) {
+      await closeDb().catch(() => {});
+      console.error(`Error recording review: ${error.message}`);
       process.exit(1);
     }
   });

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -641,6 +641,67 @@ describe('CLI Integration', () => {
     }
   }, 60_000);
 
+  it('should clear a review flag with knowl reviewed', async () => {
+    // The other end of `knowl pr`. That command raises `needs_review` and, on a connected repo,
+    // tells the team; this is the only thing that discharges either. The local half has to work
+    // with no cloud attached, which is what this asserts -- a repo that never connected still
+    // accumulates drift flags, and a command that only worked when connected would be a
+    // different command.
+    const reviewDir = path.join(os.tmpdir(), 'knowl-cli-reviewed-test');
+    await fs.rm(reviewDir, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(reviewDir, { recursive: true });
+
+    try {
+      execSync(`node "${CLI_PATH}" init --yes`, { cwd: reviewDir, encoding: 'utf-8' });
+      execSync(
+        `node "${CLI_PATH}" decide "Refund window" "Refunds are accepted for 30 days." -r "Reviewing restores freshness."`,
+        { cwd: reviewDir, encoding: 'utf-8' },
+      );
+
+      const client = createClient({ url: `file:${path.join(reviewDir, '.knowl', 'knowl.db')}` });
+      try {
+        const itemId = String((await client.execute({
+          sql: 'SELECT id FROM knowledge_items WHERE title = ?',
+          args: ['Refund window'],
+        })).rows[0].id);
+
+        // The state `knowl pr` leaves behind: flagged, and stamped with when the check saw it.
+        await client.execute({
+          sql: 'UPDATE knowledge_items SET freshness = ?, last_drift_at = ? WHERE id = ?',
+          args: ['needs_review', '2026-08-20T00:00:00.000Z', itemId],
+        });
+
+        const output = execSync(`node "${CLI_PATH}" reviewed ${itemId} --note "still true"`, {
+          cwd: reviewDir,
+          encoding: 'utf-8',
+        });
+        expect(output).toContain('Refund window');
+
+        const updated = await client.execute({
+          sql: 'SELECT freshness, last_drift_at FROM knowledge_items WHERE id = ?',
+          args: [itemId],
+        });
+        expect(updated.rows[0].freshness).toBe('fresh');
+        // Setting freshness is what `repository.ts` recognises as a review, and clearing this is
+        // what unblocks standing promotion. If `reviewed` ever stops going through
+        // `updateKnowledgeItem`, the flag would clear while this stamp silently persisted.
+        expect(updated.rows[0].last_drift_at).toBeNull();
+      } finally {
+        client.close();
+      }
+
+      // A typo must not report success on an item that does not exist.
+      const missing = spawnSync(process.execPath, [CLI_PATH, 'reviewed', 'no-such-item'], {
+        cwd: reviewDir,
+        encoding: 'utf-8',
+      });
+      expect(missing.status).not.toBe(0);
+      expect(missing.stderr).toContain('no-such-item');
+    } finally {
+      await fs.rm(reviewDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 60_000);
+
   it('should report agent readiness with doctor', async () => {
     const doctorDir = path.join(os.tmpdir(), 'knowl-cli-doctor-test');
     await fs.rm(doctorDir, { recursive: true, force: true }).catch(() => {});


### PR DESCRIPTION
Closes the last item of #145 — the one the issue framed as "wire it or delete it".

## Deleting was the worse half by the time this was reached

The issue was written when `src/cloud/drift-report.ts` was reachable only from its own test, which made both exports look equally dead. That changed:

- **`reportDrift` has a production caller** at `src/cli/program.ts:3906`, inside `knowl pr`, gated on `config.cloud && !dryRun`. `needsReview` flags are raised on the workspace today.
- **`reportReviewed` is the only thing that clears one.** Its docstring: *"The deliberate undo of `needsReview`, and the only one -- a republish that says nothing about freshness leaves an open flag standing."*

So deleting it would not have removed dead code. It would have removed the undo for a live flag and left workspaces accumulating reviews nothing could close.

## Why it is a command and not a hook

`reportReviewed` sends `expectedVersion` because it is a positive claim about specific text — *"vouching for text the caller did not read is the failure this asymmetry exists to prevent."*

That rules out every automatic wiring. Hanging it off an edit, or off `updateKnowledgeItem` clearing `last_drift_at`, would vouch on the author's behalf for words nobody re-read — which is precisely the thing the argument exists to stop. Somebody has to type it.

This is the same reasoning already recorded at `reportDrift`'s call site for why *that* one belongs to the deliberate pass a human runs rather than to session start. Consistent treatment of the pair.

```bash
knowl reviewed <itemId>
knowl reviewed <itemId> --note "still true, the rename did not change the behaviour"
```

**Top-level, not `knowl pr reviewed`.** `pr` takes `--since` directly, so giving it subcommands would change its shape for an unrelated reason. This sits beside `supersede <itemId>` — the same kind of verb on the same kind of argument.

**Local first, and unconditionally.** Setting `freshness` is what `repository.ts` recognises as a review, so the flag and `last_drift_at` clear whether or not a workspace is attached. A repo that never connected still accumulates drift flags from `knowl pr`, and a command that only worked when connected would be a different command.

**The upward half borrows `knowl pr`'s refusal policy exactly.** `not-connected`, `not-published` and `gated` are ordinary states — silent, non-fatal, and they never undo the local review. `conflict` is the one worth saying out loud, because it means the remote text moved under the reviewer and what they vouched for is not what is there.

## Verification

`npm run build`, `npm test` (**344 files, 3216 passed**, 5 skipped), `npm run typecheck`, `npm run lint`, `npm run docs:check`, `git diff --check` — all green, build before test.

One end-to-end test in the existing CLI harness: flag the item the way `knowl pr` leaves it, run the command, assert `freshness` is back to `fresh` **and** `last_drift_at` is null — the second is what catches a future version that clears the flag without going through `updateKnowledgeItem`, which would leave the stamp silently blocking standing promotion. Plus an unknown id exiting non-zero, so a typo cannot report success.

## Worth knowing: `docs:check` fails open

It shells out to `--help`, so it reads `dist/`. It **passed** on this new command before I rebuilt, then correctly failed with `documents no command named "knowl reviewed"` after. Same stale-build trap the test suite has, and the same fix — build first. Flagging it because a green `docs:check` on an undocumented command is a quiet way to ship one.
