### PR TITLE
chore: release 5.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,18 +1,29 @@
 {
   "name": "knowl",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "author": {
     "name": "Knowl"
   },
   "homepage": "https://github.com/dat999zx/knowl",
   "repository": "https://github.com/dat999zx/knowl",
   "license": "Apache-2.0",
-  "keywords": ["memory", "context", "knowledge", "decisions", "mcp", "persistence"],
+  "keywords": [
+    "memory",
+    "context",
+    "knowledge",
+    "decisions",
+    "mcp",
+    "persistence"
+  ],
   "mcpServers": {
     "knowl": {
       "command": "npx",
-      "args": ["-y", "@dat999zx/knowl", "serve"]
+      "args": [
+        "-y",
+        "@dat999zx/knowl",
+        "serve"
+      ]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,23 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.8.0 — 2026-08-20
+
+### `knowl reviewed <itemId>` — the verb that clears a review flag
+
+`knowl pr` raises `needs_review` and, on a connected repo, tells the team. Nothing discharged
+either, so a workspace could only accumulate reviews with no way to close one. A republish says
+nothing about freshness and leaves an open flag standing.
+
+It is a command a person types, deliberately, rather than something an edit does on their behalf:
+the remote half sends `expectedVersion`, which is a positive claim about specific text, and
+vouching for text the caller did not read is exactly the failure that check exists to prevent.
+
+Local first and unconditional — the flag and `last_drift_at` clear whether or not a workspace is
+attached, since a repo that never connected still accumulates drift flags. The upward half
+borrows `knowl pr`'s refusal policy: `not-connected`, `not-published` and `gated` are ordinary
+states and stay silent. `conflict` is the one worth saying out loud, because the remote text moved
+under the reviewer and what they vouched for is no longer what is there.
 
 ### Retrieval publishes the raw cosine, the one number a caller can judge with
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts **5.8.0** over six commits: #148, #149, #152, #154, #155, #156.

## Why minor

The recorded criterion is whether the release adds a command, flag, MCP tool, table or migration level. Two do:

- **#155** adds a new top-level command, `knowl reviewed <itemId>`.
- **#148** adds a new `cosine` field to the query response and the MCP tool surface, published beside `score` rather than changing what `score` means, so anything keyed on the old field keeps working.

Nothing needs a migration and nothing changes a schema. The one removal — **#152**, two `EvidenceType` members — was of values nothing ever produced or read, reachable only by hand-writing the string, so it does not force a major.

## Contents

- `knowl reviewed` — the verb that discharges a `needs_review` flag (#155)
- Retrieval publishes the raw cosine (#148)
- `knowl store` says when part of an atom will not be searchable (#149)
- `knowl view` reads as a graph rather than as confetti, with names that resolve on zoom and a flatter ground (#154)
- Removed: two unreachable `EvidenceType` members (#152)
- Regenerated viewer screenshots, shot against a seeded store built by a committed script (#156)

Three of these merged without a changelog entry and were backfilled in #156 and here — the same gap that made 5.5.1 reconstruct its notes from diffs.

## Verification

`build`, `typecheck`, `docs:check` and `check:versions` clean; `package-lock.json` and `.claude-plugin/plugin.json` both synced to 5.8.0. **344 test files, 3216 passed, 5 skipped.**

## Merge note

**Merge commit, not squash** — the house convention is that the tag points at the `chore: release` commit carrying the CHANGELOG and version bump, so that commit has to stay taggable.
