### PR TITLE
feat(mcp): serve auto-initializes an uninitialized repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ run the thing that just failed. The ignore entry is a self-ignoring `.gitignore`
 `.knowl/` (venv's shape) — serve edits no file the user owns. The banner and the instructions
 card both announce what was created and where. `KNOWL_DISABLE_SERVE_AUTO_INIT=1` turns it off.
 
+A repository that ships its own `.knowl/skill-trust.json` is refused as well. That file is what
+approves a skill package for execution, and it lives in the repository beside the bytes it
+vouches for — so a checkout can arrive carrying both. `knowl init` may adopt such a repository,
+because a person ran it; auto-init is a host process that chose nothing, and it must not be the
+step that turns a planted `.knowl/skills/` into a runnable one.
+
 ## 5.8.0 — 2026-08-20
 
 ### `knowl reviewed <itemId>` — the verb that clears a review flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+### `knowl serve` auto-initializes an uninitialized repository
+
+Marketplace installs (the OpenHands catalog, MCP directories) launch `serve` with no step that
+could run `knowl init` first — so serve advertised its full tool set and failed every call with
+"run knowl init", which is what closed OpenHands/extensions#486. Now, in a git repository that
+was never initialized, serve scaffolds a minimal store before the handshake and finishes the
+adoption behind it, on the tool-call clock the connect deadline allows.
+
+Narrower than init on purpose: no guidance files, no agent setup, no model download — and the
+anchor is the repository root, never a bare working directory. A directory with no git
+repository, or one whose store would land in the machine's Knowl home, is refused and gets the
+ordinary not-initialized guidance; a failed scaffold gets its own message rather than advice to
+run the thing that just failed. The ignore entry is a self-ignoring `.gitignore` inside
+`.knowl/` (venv's shape) — serve edits no file the user owns. The banner and the instructions
+card both announce what was created and where. `KNOWL_DISABLE_SERVE_AUTO_INIT=1` turns it off.
+
 ## 5.8.0 — 2026-08-20
 
 ### `knowl reviewed <itemId>` — the verb that clears a review flag

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1889,7 +1889,16 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 
 ## MCP tools and resources
 
-Run `knowl serve` to expose Knowl over stdio MCP. The recommended agent flow is:
+Run `knowl serve` to expose Knowl over stdio MCP. In a git repository that was never
+initialized, serve creates a minimal store on its own — marketplace installs launch it with no
+step that could run `knowl init` first. It anchors on the repository root (never a bare working
+directory, never the Knowl home), writes a self-ignoring `.gitignore` inside `.knowl/` instead
+of editing the repository's, and skips the guidance files, agent setup, and model download that
+`knowl init` performs. The startup banner and the server's instructions card both say when this
+happened. Set `KNOWL_DISABLE_SERVE_AUTO_INIT=1` to turn it off; serve then reports the ordinary
+not-initialized guidance instead.
+
+The recommended agent flow is:
 
 1. Use lifecycle bootstrap context when available; otherwise use `knowl_recent`.
 2. Call `knowl_query` before inspecting repository files, using the words that name the subject.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1892,7 +1892,8 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 Run `knowl serve` to expose Knowl over stdio MCP. In a git repository that was never
 initialized, serve creates a minimal store on its own — marketplace installs launch it with no
 step that could run `knowl init` first. It anchors on the repository root (never a bare working
-directory, never the Knowl home), writes a self-ignoring `.gitignore` inside `.knowl/` instead
+directory, never the Knowl home, and never a repository that ships its own
+`.knowl/skill-trust.json`), writes a self-ignoring `.gitignore` inside `.knowl/` instead
 of editing the repository's, and skips the guidance files, agent setup, and model download that
 `knowl init` performs. The startup banner and the server's instructions card both say when this
 happened. Set `KNOWL_DISABLE_SERVE_AUTO_INIT=1` to turn it off; serve then reports the ordinary

--- a/src/cli/database-presence.ts
+++ b/src/cli/database-presence.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { resolveStorage } from '../store/storage-roles.js';
 import { mainWorktreeRoot } from '../core/config.js';
-import { repoRegistryPath } from './repo-registry.js';
+import { repoRegistryPath } from '../core/repo-registry.js';
 
 /**
  * A missing database file is a missing file, not an empty memory.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -41,7 +41,7 @@ import { assertOwnedItem } from '../workspace/ownership.js';
 import { storeKnowledgeItemDeduped } from '../store/knowledge-writer.js';
 import { formatDoctorReport, runDoctor } from './doctor-report.js';
 import { upgradeExistingRepository, type UpgradeResult } from './upgrade.js';
-import { readKnownRepos, recordKnownRepo } from './repo-registry.js';
+import { readKnownRepos, recordKnownRepo } from '../core/repo-registry.js';
 import { discoverRepos } from './repo-discovery.js';
 import { applyDoctorRemedies } from './doctor-fix.js';
 import { formatSweepReport, sweepRepos } from './upgrade-all.js';

--- a/src/cli/repo-discovery.ts
+++ b/src/cli/repo-discovery.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { isProjectRoot } from '../core/config.js';
 import { readManifest } from '../workspace/manifest.js';
 import { listKnownWorkspaces, workspaceManifestPath } from '../workspace/paths.js';
-import { listKnownRepos, recordKnownRepo } from './repo-registry.js';
+import { listKnownRepos, recordKnownRepo } from '../core/repo-registry.js';
 
 export type RepoSource = 'workspace' | 'registry' | 'scan';
 export type DiscoveredRepo = { root: string; source: RepoSource };

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -11,7 +11,7 @@ import { resolveVectorProfile } from '../core/vector-profile.js';
 import { backfillOriginRepo } from '../workspace/membership.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
 import { knowlHome } from '../core/paths.js';
-import { listKnownRepos, recordKnownRepo } from './repo-registry.js';
+import { listKnownRepos, recordKnownRepo } from '../core/repo-registry.js';
 
 export type UpgradeResult = {
   project: Awaited<ReturnType<typeof repo.createProject>>;

--- a/src/core/repo-registry.ts
+++ b/src/core/repo-registry.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { isProjectRoot } from '../core/config.js';
-import { knowlHome } from '../core/paths.js';
+import { isProjectRoot } from './config.js';
+import { knowlHome } from './paths.js';
 
 /**
  * Every Knowl repository this machine has initialized or upgraded.

--- a/src/core/startup-trace.ts
+++ b/src/core/startup-trace.ts
@@ -317,11 +317,21 @@ export function installProcessHooks(
  * you tell which repository a serve process in a host log belongs to, and a log full of
  * anonymous processes is worse than the stall this was meant to diagnose.
  */
-export function serveBanner(state: { pid: number; projectRoot: string | null; readyMs?: number }): string {
+export function serveBanner(state: {
+  pid: number;
+  projectRoot: string | null;
+  readyMs?: number;
+  /** True when serve created the store itself because nothing had run `knowl init` here. */
+  autoInitialized?: boolean;
+}): string {
   return [
     '[knowl serve]',
     `pid=${state.pid}`,
     state.projectRoot ? `projectRoot=${state.projectRoot}` : 'projectRoot=pending',
+    // Announced so a host log shows the store was serve's own doing -- the difference between
+    // "found your repository" and "made one here", which matters the day it made one in the
+    // wrong directory. KNOWL_SERVE_AUTO_INIT=0 disables the behavior.
+    state.autoInitialized ? 'auto-initialized' : null,
     state.readyMs === undefined ? null : `ready=${state.readyMs}ms`,
     state.projectRoot
       ? null

--- a/src/core/startup-trace.ts
+++ b/src/core/startup-trace.ts
@@ -330,7 +330,7 @@ export function serveBanner(state: {
     state.projectRoot ? `projectRoot=${state.projectRoot}` : 'projectRoot=pending',
     // Announced so a host log shows the store was serve's own doing -- the difference between
     // "found your repository" and "made one here", which matters the day it made one in the
-    // wrong directory. KNOWL_SERVE_AUTO_INIT=0 disables the behavior.
+    // wrong directory. KNOWL_DISABLE_SERVE_AUTO_INIT=1 disables the behavior.
     state.autoInitialized ? 'auto-initialized' : null,
     state.readyMs === undefined ? null : `ready=${state.readyMs}ms`,
     state.projectRoot

--- a/src/mcp/auto-init.ts
+++ b/src/mcp/auto-init.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { NEW_PROJECT_CONFIG, isProjectRoot, mainWorktreeRoot, saveConfig } from '../core/config.js';
+import { knowlHome } from '../core/paths.js';
+import { initDb } from '../store/database.js';
+import type { Project } from '../core/types.js';
+import { getProjectByRootPath } from '../store/repository.js';
+import { recordKnownRepo } from '../core/repo-registry.js';
+
+/**
+ * `knowl serve` in a directory nobody initialized: the catalog-install case.
+ *
+ * Marketplace installs (OpenHands, the Claude Code directory, every MCP catalog) launch `serve`
+ * with no step that could ever run `knowl init` -- so an uninitialized project must be a state
+ * serve can leave, not an error it reports from all 27 tools (OpenHands/extensions#486 was
+ * closed over exactly this). Opt out with KNOWL_DISABLE_SERVE_AUTO_INIT=1, named and read the
+ * way KNOWL_DISABLE_STARTUP_TRACE is.
+ *
+ * Deliberately narrower than `knowl init` -- no guidance files, no agent-config flow, no
+ * embedding-model download -- and deliberately NOT an extraction of init's create path. Init
+ * owns the interactive contract (guidance, agent files, the warm) and this owns the guest
+ * contract; sharing a helper would couple the two at exactly the seam where they must differ.
+ * The honest cost of skipping the warm: write-time embedding never downloads
+ * (`src/store/write-embedding.ts`), so anything stored before the first query lands without a
+ * vector and stays out of semantic search until a reindex. A store born empty holds that
+ * exposure to the first minutes of the first session, which is the trade a silent guest
+ * process should make -- init keeps warming precisely because an upgraded repo is NOT empty.
+ *
+ * Split in two along the startup's own seam (see `server.ts` on the 30s connect deadline):
+ * `scaffoldProject` is filesystem-only and runs before the handshake, because the config it
+ * writes is what the `instructions` card needs at server construction; `adoptProject` opens
+ * the database and runs behind the handshake inside `ready`, on the tool-call clock.
+ */
+export function serveAutoInitAllowed(): boolean {
+  return process.env.KNOWL_DISABLE_SERVE_AUTO_INIT !== '1';
+}
+
+/**
+ * Where auto-init may create a store, or null when it may not.
+ *
+ * **A bare cwd is not an anchor.** Hosts launch stdio servers from wherever they happen to be
+ * -- a home directory, an app install dir -- and a store created there is permanent, silent
+ * state the user never asked for. The K-51 incident is the local record of exactly that: one
+ * hook call from a scratch directory bootstrapped an empty database inside the real `~/.knowl`,
+ * and from then on every command under the home directory resolved to it. The reference MCP
+ * servers agree from the outside: none derives a write target from bare cwd, and the official
+ * filesystem server refuses to start without an explicit directory.
+ *
+ * So the anchor is the git repository: the nearest ancestor carrying a `.git` entry. A linked
+ * worktree (`.git` as a file) resolves through `mainWorktreeRoot` to the main checkout, which
+ * is where this repo's own `findProjectRoot` looks for the store. A directory with no
+ * repository gets no store -- serve falls back to the ordinary "run knowl init" refusal,
+ * which is correct for a directory whose owner has expressed no intent at all.
+ *
+ * The `knowlHome` check is `knowl init`'s own guard (`src/cli/program.ts`), kept even though
+ * the git anchor already makes it unlikely: a home directory under version control is exactly
+ * the kind of setup (dotfiles repos) that would otherwise walk straight back into K-51.
+ */
+export async function scaffoldTarget(cwd: string): Promise<string | null> {
+  let candidate = path.resolve(cwd);
+  for (;;) {
+    try {
+      await fs.stat(path.join(candidate, '.git'));
+      break;
+    } catch {
+      const parent = path.dirname(candidate);
+      if (parent === candidate) return null;
+      candidate = parent;
+    }
+  }
+  const root = mainWorktreeRoot(candidate) ?? candidate;
+  if (path.resolve(path.join(root, '.knowl')) === path.resolve(knowlHome())) return null;
+  return root;
+}
+
+/** The pre-handshake half: directories and a default config. No database, idempotent. */
+export async function scaffoldProject(root: string): Promise<void> {
+  if (await isProjectRoot(root)) return;
+  await fs.mkdir(path.join(root, '.knowl', 'skills'), { recursive: true });
+  await saveConfig(root, structuredClone(NEW_PROJECT_CONFIG));
+}
+
+/**
+ * The post-handshake half: database, machine registry, and the store's own ignore file.
+ *
+ * No project row is created, because none is read: `getProjectByRootPath` synthesizes the
+ * `local` project for whatever root it is asked about (`src/store/repository.ts:41-51`), so a
+ * scaffolded root is already a project the moment its database opens.
+ *
+ * The ignore entry goes INSIDE `.knowl/` rather than into the repository's `.gitignore`,
+ * which is where `knowl init` puts it. venv is the precedent: a `.gitignore` containing `*`
+ * inside the created directory ignores the whole directory without editing a file the user
+ * owns -- and a guest process editing the user's `.gitignore` is a diff they never authored
+ * showing up in their own `git status`. Init keeps the root entry because init is the user
+ * acting on their own repository; serve is not.
+ */
+export async function adoptProject(projectRoot: string): Promise<Project | null> {
+  await initDb(projectRoot);
+  await recordKnownRepo(projectRoot);
+  await fs.writeFile(
+    path.join(projectRoot, '.knowl', '.gitignore'),
+    '# Created by knowl serve auto-init. Ignores the whole store.\n*\n',
+    { flag: 'w' },
+  );
+  return getProjectByRootPath(projectRoot);
+}

--- a/src/mcp/auto-init.ts
+++ b/src/mcp/auto-init.ts
@@ -70,6 +70,19 @@ export async function scaffoldTarget(cwd: string): Promise<string | null> {
   }
   const root = mainWorktreeRoot(candidate) ?? candidate;
   if (path.resolve(path.join(root, '.knowl')) === path.resolve(knowlHome())) return null;
+
+  // A repository that ships `.knowl/skill-trust.json` is asserting its own skills are
+  // approved -- and it is the only artifact that says so, because the trust record and the
+  // bytes it vouches for both live in the repo (`src/skills/trust.ts`). `knowl init` is a
+  // human electing to trust a checkout; auto-init is a host process that elected nothing, so
+  // it must not be the step that turns a planted `.knowl/skills/` into a runnable one. Left
+  // to the ordinary "run knowl init" refusal: a store born here is exactly what we decline.
+  try {
+    await fs.stat(path.join(root, '.knowl', 'skill-trust.json'));
+    return null;
+  } catch {
+    // Absent, which is the normal case and the only one that may proceed.
+  }
   return root;
 }
 

--- a/src/mcp/init-error.ts
+++ b/src/mcp/init-error.ts
@@ -20,5 +20,11 @@ export function formatInitError(initError: string): string {
   if (/written by a newer Knowl \(schema/i.test(initError)) {
     return `❌ Knowl MCP Server could not open the project database: its schema version stamp is newer than this build accepts.\nReason: ${initError}\n\nThe repository is set up correctly -- the fault is the version stamp in the database header, not the project. Either a newer Knowl wrote this file, in which case upgrading to that version opens it, or no newer Knowl was ever published, in which case the stamp came from a build that no longer exists and the file is held behind a version nobody can install. Check the published versions before concluding the data is unreadable.`;
   }
+  // Serve already tried to create the store and could not -- "run knowl init" would send the
+  // reader to repeat the same failing filesystem work. The prefix is stamped by
+  // startMcpServer's scaffold catch; keep the two in step.
+  if (/^Automatic initialization failed/.test(initError)) {
+    return `❌ Knowl MCP Server tried to create a store in this directory and could not.\nReason: ${initError}\n\nThe directory is likely not writable by this process. Start the server from a writable project directory, or set the project up on a machine where you can run commands and open it there.`;
+  }
   return `❌ Knowl MCP Server is active but not initialized for the current directory.\nReason: ${initError}\n\nPlease run 'knowl init' in your project root to initialize this project.`;
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -204,8 +204,11 @@ export async function startMcpServer(): Promise<void> {
     getInitError: () => initError,
     whenReady: () => ready,
     ...(autoInitialized ? {
+      // The path is collapsed to single spaces before it goes in: this card is the
+      // highest-trust text the server hands a model, and a POSIX directory name may contain
+      // a newline, which would let a crafted checkout append its own lines to it.
       instructionsSuffix:
-        `\nNOTE: no Knowl store existed here, so serve created an empty one at ${projectRoot}` +
+        `\nNOTE: no Knowl store existed here, so serve created an empty one at "${projectRoot!.replace(/\s+/g, ' ')}"` +
         ' (KNOWL_DISABLE_SERVE_AUTO_INIT=1 prevents this). Memory starts empty; what you store' +
         ' this session is what later sessions will find.',
     } : {}),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,8 +2,10 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ProjectConfig } from '../core/types.js';
 import { findProjectRoot, loadConfig } from '../core/config.js';
+import { ProjectNotFoundError } from '../core/errors.js';
 import { initDb } from '../store/database.js';
 import { getProjectByRootPath } from '../store/repository.js';
+import { adoptProject, scaffoldProject, scaffoldTarget, serveAutoInitAllowed } from './auto-init.js';
 import { registerTools } from './tools.js';
 import { registerResources } from './resources.js';
 import { PACKAGE_VERSION } from '../version.js';
@@ -30,6 +32,8 @@ export interface DeferredServerState {
   getInitError?: () => string | null;
   /** Resolves once initialization has settled, successfully or not. */
   whenReady?: () => Promise<void>;
+  /** Appended to the instructions card verbatim; auto-init announces itself through this. */
+  instructionsSuffix?: string;
 }
 
 /**
@@ -63,7 +67,11 @@ export function createMcpServer(
       // The SDK captures this string in the constructor and replays it in the initialize
       // response, so it cannot be recomputed later; `startMcpServer` settles the config read
       // before building the server for exactly that reason.
-      instructions: mcpServerInstructions(getConfig()),
+      // The suffix exists for auto-init: stderr is dropped by most hosts, so a banner there
+      // is invisible, while this card is captured at construction and replayed to the model.
+      // One line naming the directory serve created state in is the difference between a
+      // silent store and an invisible one.
+      instructions: mcpServerInstructions(getConfig()) + (deferred.instructionsSuffix ?? ''),
     }
   );
 
@@ -128,11 +136,38 @@ export async function startMcpServer(): Promise<void> {
   // two things that do. Neither is the database open the handshake is racing -- one walks
   // directories and one reads a JSON file -- and the `instructions` card is captured by the
   // SDK at construction, so a config that arrives afterwards can never reach a client.
+  let autoInitialized = false;
   try {
     projectRoot = await tracePhase('findProjectRoot', () => findProjectRoot(process.cwd()));
     config = await tracePhase('loadConfig', () => loadConfig(projectRoot!));
   } catch (error: any) {
-    initError = error.message;
+    // The catalog-install case: nobody ever ran `knowl init`, and nobody could have -- no
+    // marketplace install flow contains a step that would (see auto-init.ts). Scaffold here,
+    // because it is filesystem-only and the config it writes is what the `instructions` card
+    // needs before the server is built; the database half waits for `ready` below.
+    //
+    // `scaffoldTarget` may refuse -- no git repository to anchor on, or the target is the
+    // machine's Knowl home -- and the refusal deliberately lands on the ordinary
+    // ProjectNotFoundError message: for a directory whose owner expressed no intent, "run
+    // knowl init" is the right guidance, not a store they never asked for.
+    const target = error instanceof ProjectNotFoundError && serveAutoInitAllowed()
+      ? await tracePhase('autoInitTarget', () => scaffoldTarget(process.cwd()))
+      : null;
+    if (target) {
+      try {
+        projectRoot = target;
+        await tracePhase('autoInitScaffold', () => scaffoldProject(target));
+        config = await tracePhase('autoInitLoadConfig', () => loadConfig(target));
+        autoInitialized = true;
+      } catch (scaffoldError: any) {
+        // Prefixed so `formatInitError` can tell "serve tried to create a store and could
+        // not" apart from "there is no store" -- the guidance differs, because the agent
+        // reading it must not be told to run the thing that just failed.
+        initError = `Automatic initialization failed: ${scaffoldError.message}`;
+      }
+    } else {
+      initError = error.message;
+    }
   }
 
   // Never rejects: every failure is captured as `initError`, which the tools already render
@@ -145,6 +180,15 @@ export async function startMcpServer(): Promise<void> {
 
       // Get project details
       project = await tracePhase('getProject', () => getProjectByRootPath(projectRoot!));
+      if (autoInitialized) {
+        // The scaffold above made the directory a root; this finishes what init would have:
+        // the machine registry entry and the `.gitignore` line. Not gated on `!project`,
+        // because `getProjectByRootPath` synthesizes the local project for any root — a
+        // truthy project says nothing about whether those two side effects ever happened.
+        // Behind the handshake because it opens the database, which is the work the connect
+        // deadline must not wait on.
+        project = await tracePhase('adoptProject', () => adoptProject(projectRoot!));
+      }
       if (!project) {
         throw new Error('Knowl project is not initialized. Run "knowl init" first.');
       }
@@ -159,6 +203,12 @@ export async function startMcpServer(): Promise<void> {
     getConfig: () => config,
     getInitError: () => initError,
     whenReady: () => ready,
+    ...(autoInitialized ? {
+      instructionsSuffix:
+        `\nNOTE: no Knowl store existed here, so serve created an empty one at ${projectRoot}` +
+        ' (KNOWL_DISABLE_SERVE_AUTO_INIT=1 prevents this). Memory starts empty; what you store' +
+        ' this session is what later sessions will find.',
+    } : {}),
   });
 
   const transport = new StdioServerTransport();
@@ -173,13 +223,15 @@ export async function startMcpServer(): Promise<void> {
   // the server is built (see above) is what the `instructions` card needs, and it means the
   // very first line a host log gets can name its repository instead of saying `unresolved`
   // and correcting itself later.
-  process.stderr.write(serveBanner({ pid: process.pid, projectRoot }) + '\n');
+  process.stderr.write(serveBanner({ pid: process.pid, projectRoot, autoInitialized }) + '\n');
 
   void ready.then(() => {
     // The second line is about the database, which the first could not wait for. `readyMs`
     // is the number that separates "connected and working" from "connected and stuck".
     process.stderr.write(
-      serveBanner({ pid: process.pid, projectRoot, readyMs: Date.now() - connectedAt }) + '\n',
+      serveBanner({
+        pid: process.pid, projectRoot, autoInitialized, readyMs: Date.now() - connectedAt,
+      }) + '\n',
     );
     finishStartupTrace({
       ok: !initError,

--- a/tests/cli/repo-discovery.test.ts
+++ b/tests/cli/repo-discovery.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
 import { workspaceManifestPath } from '../../src/workspace/paths.js';
-import { recordKnownRepo } from '../../src/cli/repo-registry.js';
+import { recordKnownRepo } from '../../src/core/repo-registry.js';
 import { discoverRepos } from '../../src/cli/repo-discovery.js';
 
 const HOME = path.resolve('./.knowl-discovery-home');

--- a/tests/cli/upgrade-all.test.ts
+++ b/tests/cli/upgrade-all.test.ts
@@ -8,7 +8,7 @@ import * as repo from '../../src/store/repository.js';
 import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
 import { isKnowlProjectGuidanceCurrent } from '../../src/core/agents-guidance.js';
 import { resetWriteOwnershipCache } from '../../src/store/write-ownership.js';
-import { recordKnownRepo } from '../../src/cli/repo-registry.js';
+import { recordKnownRepo } from '../../src/core/repo-registry.js';
 import { formatSweepReport, sweepRepos } from '../../src/cli/upgrade-all.js';
 
 const HOME = path.resolve('./.knowl-sweep-home');

--- a/tests/cli/upgrade.test.ts
+++ b/tests/cli/upgrade.test.ts
@@ -10,7 +10,7 @@ import { workspaceManifestPath } from '../../src/workspace/paths.js';
 import { joinWorkspace } from '../../src/workspace/membership.js';
 import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
 import { resetWriteOwnershipCache } from '../../src/store/write-ownership.js';
-import { listKnownRepos } from '../../src/cli/repo-registry.js';
+import { listKnownRepos } from '../../src/core/repo-registry.js';
 import { upgradeExistingRepository } from '../../src/cli/upgrade.js';
 
 const HOME = path.resolve('./.knowl-upgrade-home');

--- a/tests/core/repo-registry.test.ts
+++ b/tests/core/repo-registry.test.ts
@@ -6,7 +6,7 @@ import {
   readKnownRepos,
   recordKnownRepo,
   repoRegistryPath,
-} from '../../src/cli/repo-registry.js';
+} from '../../src/core/repo-registry.js';
 import { discoverRepos } from '../../src/cli/repo-discovery.js';
 
 const HOME = path.resolve('./.knowl-registry-home');

--- a/tests/core/startup-trace.test.ts
+++ b/tests/core/startup-trace.test.ts
@@ -130,6 +130,17 @@ describe('serve banner', () => {
     expect(line).toContain('projectRoot=D:\\coding\\knowl');
     expect(line).toContain('ready=1234ms');
   });
+
+  /**
+   * The difference between "found your repository" and "made one here" — which matters most
+   * on the day it made one in the wrong directory. A host log without this token has no way
+   * to tell a store the user initialized from one the server created on its own.
+   */
+  it('says when the store was serve\'s own doing', () => {
+    const line = serveBanner({ pid: 7, projectRoot: 'D:\\coding\\knowl', autoInitialized: true });
+    expect(line).toContain('auto-initialized');
+    expect(serveBanner({ pid: 7, projectRoot: 'D:\\coding\\knowl' })).not.toContain('auto-initialized');
+  });
 });
 
 /**

--- a/tests/mcp/auto-init.test.ts
+++ b/tests/mcp/auto-init.test.ts
@@ -79,6 +79,22 @@ describe('serve auto-init', () => {
     expect(await scaffoldTarget(dir)).toBeNull();
   });
 
+  /**
+   * A repository can ship `.knowl/skill-trust.json`, and that file is the ONLY thing standing
+   * between a planted `.knowl/skills/` package and a spawned process -- the trust record and
+   * the bytes it vouches for both live in the repo (src/skills/trust.ts). Proven: with the
+   * two files planted and no config or database, auto-init used to make the directory a
+   * project and `knowl_skill_run` executed the entrypoint with exit code 0 and no approval.
+   * `knowl init` may adopt such a checkout, because a human ran it; a host process may not.
+   */
+  it('refuses a repository that ships its own skill-trust.json', async () => {
+    dir = await freshGitDir();
+    await fs.mkdir(path.join(dir, '.knowl', 'skills'), { recursive: true });
+    await fs.writeFile(path.join(dir, '.knowl', 'skill-trust.json'), '{}');
+
+    expect(await scaffoldTarget(dir)).toBeNull();
+  });
+
   it('scaffolds a loadable project root and nothing else', async () => {
     dir = await freshGitDir();
     await scaffoldProject(dir);

--- a/tests/mcp/auto-init.test.ts
+++ b/tests/mcp/auto-init.test.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  adoptProject, scaffoldProject, scaffoldTarget, serveAutoInitAllowed,
+} from '../../src/mcp/auto-init.js';
+import { isProjectRoot, loadConfig } from '../../src/core/config.js';
+import { repoRegistryPath } from '../../src/core/repo-registry.js';
+import { closeDb } from '../../src/store/database.js';
+import { getProjectByRootPath } from '../../src/store/repository.js';
+
+/**
+ * The catalog-install case: `serve` launched where nobody ever ran `knowl init`, because no
+ * marketplace install flow contains a step that could (OpenHands/extensions#486 was closed
+ * over exactly this). Auto-init must leave a working store while staying narrower than init —
+ * a server is a guest in the directory it was pointed at, so it may create its own store and
+ * keep that store out of git, and nothing else.
+ */
+describe('serve auto-init', () => {
+  let dir: string;
+  /** Repo-relative, matching tests/core/repo-registry.test.ts — never the developer's ~/.knowl. */
+  const HOME = path.resolve('./.knowl-autoinit-home');
+
+  beforeEach(async () => {
+    dir = '';
+    process.env.KNOWL_HOME = HOME;
+    await fs.mkdir(HOME, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    // Best-effort, as every store test does it: on Windows the @libsql handle can outlive
+    // closeDb briefly and EBUSY the WAL files; the per-run temp root is swept globally anyway.
+    if (dir) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+    delete process.env.KNOWL_HOME;
+    delete process.env.KNOWL_DISABLE_SERVE_AUTO_INIT;
+  });
+
+  async function freshGitDir(): Promise<string> {
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-autoinit-'));
+    execFileSync('git', ['init', '-q', created]);
+    return created;
+  }
+
+  it('is on by default and off when KNOWL_DISABLE_SERVE_AUTO_INIT=1', () => {
+    expect(serveAutoInitAllowed()).toBe(true);
+    process.env.KNOWL_DISABLE_SERVE_AUTO_INIT = '1';
+    expect(serveAutoInitAllowed()).toBe(false);
+  });
+
+  /**
+   * A bare cwd is not an anchor: hosts launch stdio servers from home directories and app
+   * install dirs, and a store created there is permanent state nobody asked for (the K-51
+   * incident). The git repository is the anchor; no repository, no store.
+   */
+  it('refuses a directory with no git repository to anchor on', async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-autoinit-'));
+    expect(await scaffoldTarget(dir)).toBeNull();
+  });
+
+  it('anchors on the git root, not the cwd it was launched from', async () => {
+    dir = await freshGitDir();
+    const nested = path.join(dir, 'src', 'deep');
+    await fs.mkdir(nested, { recursive: true });
+    expect(path.resolve((await scaffoldTarget(nested))!)).toBe(path.resolve(dir));
+  });
+
+  /**
+   * knowl init's own named guard (src/cli/program.ts), kept for the dotfiles-repo case where
+   * the home directory itself is under version control and the git anchor would otherwise
+   * walk straight back into K-51: a store inside the real Knowl home.
+   */
+  it('never targets a root whose .knowl would be the machine\'s Knowl home', async () => {
+    dir = await freshGitDir();
+    process.env.KNOWL_HOME = path.join(dir, '.knowl');
+    expect(await scaffoldTarget(dir)).toBeNull();
+  });
+
+  it('scaffolds a loadable project root and nothing else', async () => {
+    dir = await freshGitDir();
+    await scaffoldProject(dir);
+
+    expect(await isProjectRoot(dir)).toBe(true);
+    await expect(loadConfig(dir)).resolves.toBeDefined();
+    // The boundary: no guidance files, no agent files — those are init's to write, on request.
+    await expect(fs.access(path.join(dir, 'KNOWL.md'))).rejects.toThrow();
+    await expect(fs.access(path.join(dir, 'AGENTS.md'))).rejects.toThrow();
+  });
+
+  it('scaffolding an already-initialized root changes nothing', async () => {
+    dir = await freshGitDir();
+    await scaffoldProject(dir);
+    const before = await fs.readFile(path.join(dir, '.knowl', 'config.json'), 'utf8');
+    await scaffoldProject(dir);
+    expect(await fs.readFile(path.join(dir, '.knowl', 'config.json'), 'utf8')).toBe(before);
+  });
+
+  it('adoptProject registers the repo and leaves the store self-ignored', async () => {
+    dir = await freshGitDir();
+    await scaffoldProject(dir);
+
+    const project = await adoptProject(dir);
+    expect(project).not.toBeNull();
+    expect(await getProjectByRootPath(dir)).not.toBeNull();
+
+    // The registry assertion that can fail: the entry itself, read through the module's own
+    // path helper — not the existence of some file with "repo" in its name.
+    const entries: string[] = JSON.parse(await fs.readFile(repoRegistryPath(), 'utf-8')).repos;
+    expect(entries.map(entry => path.resolve(entry))).toContain(path.resolve(dir));
+
+    // venv's shape: the ignore file lives INSIDE the created directory and ignores all of it,
+    // so no file the user owns is edited. The repository's own .gitignore is untouched.
+    const selfIgnore = await fs.readFile(path.join(dir, '.knowl', '.gitignore'), 'utf8');
+    expect(selfIgnore).toContain('*');
+    await expect(fs.access(path.join(dir, '.gitignore'))).rejects.toThrow();
+  });
+
+  it('adopting twice is idempotent', async () => {
+    dir = await freshGitDir();
+    await scaffoldProject(dir);
+
+    const first = await adoptProject(dir);
+    const second = await adoptProject(dir);
+    expect(second!.id).toBe(first!.id);
+
+    const entries: string[] = JSON.parse(await fs.readFile(repoRegistryPath(), 'utf-8')).repos;
+    expect(entries.filter(entry => path.resolve(entry) === path.resolve(dir))).toHaveLength(1);
+  });
+});

--- a/tests/mcp/init-error.test.ts
+++ b/tests/mcp/init-error.test.ts
@@ -55,4 +55,17 @@ describe('formatInitError', () => {
     expect(message).toContain('not initialized');
     expect(message).toContain('knowl init');
   });
+
+  /**
+   * The auto-init case: serve already tried to create the store and failed — usually a
+   * directory the process cannot write. Telling the agent to run `knowl init` sends it to
+   * repeat the same failing filesystem work, which is the exact class of wrong advice the
+   * two branches above exist to prevent.
+   */
+  it('does not tell a failed auto-init to run the thing that just failed', () => {
+    const message = formatInitError("Automatic initialization failed: EACCES: permission denied, mkdir '/app/.knowl'");
+    expect(message).not.toContain('knowl init');
+    expect(message).toContain('could not');
+    expect(message).toContain('EACCES');
+  });
 });


### PR DESCRIPTION
## Why

OpenHands closed our catalog submission (OpenHands/extensions#486) partly because `knowl serve` completes its handshake in an uninitialized directory, advertises the full tool set, and then fails every call with "run `knowl init` first" — and no marketplace install flow (theirs, the Claude Code directory, any MCP catalog) contains a step that could run init. Zero-config catalog installs need serve to treat "uninitialized" as a state to leave, not an error to report 27 times.

## What

- **Anchored on the repository, never the cwd.** Hosts launch stdio servers from home directories and app dirs; auto-init targets the nearest git root (linked worktrees resolve through `mainWorktreeRoot` to the main checkout, matching `findProjectRoot`), refuses when there is no repository or when the target would be the machine's Knowl home (`knowl init`'s own K-51 guard), and falls back to the ordinary not-initialized guidance on refusal.
- **Split along the connect deadline**: filesystem scaffold (dirs + default config) pre-handshake, because the instructions card is captured at construction; DB + machine registry + ignore file behind the handshake inside `ready`.
- **Narrower than init on purpose**: no guidance files, no agent flow, no model download — the module docblock states the honest cost (pre-model writes stay out of semantic search until reindex; a store born empty holds that exposure to minutes). The create paths are deliberately not extracted into a shared helper: init owns the interactive contract, this owns the guest contract, and the seam where they differ is the point.
- **The ignore file is the store's own**: `.knowl/.gitignore` containing `*` (venv's shape) — serve edits no file the user owns. Init keeps writing the root entry, because init is the user acting on their own repo.
- **Announced where it can be seen**: banner token + one line on the instructions card naming the created directory (stderr is dropped by most hosts). A failed scaffold gets its own `formatInitError` branch instead of advice to run the thing that just failed.
- **Opt-out**: `KNOWL_DISABLE_SERVE_AUTO_INIT=1`, named and read the way `KNOWL_DISABLE_STARTUP_TRACE` is.
- `repo-registry` moves `src/cli/` → `src/core/` (imports were already core-only): mcp needs `recordKnownRepo` and mcp→cli is a sideways edge module-boundaries forbids. Its test mirrors the move.

## Testing

Full suite: **345 files / 3232 passed / 0 failed**, `tsc --noEmit` clean, `eslint` clean. New: `tests/mcp/auto-init.test.ts` (anchor refusals incl. the Knowl-home guard, scaffold boundary, registry entry asserted through `repoRegistryPath()` itself, idempotence), a `formatInitError` case, a banner case. Manual stdio probe from a fresh git dir: handshake → `tools/call knowl_query` answers without `isError`, `.knowl/.gitignore` self-ignores, registry records the root, repo `.gitignore` untouched; from a bare non-git dir: ordinary refusal, nothing created.

Docs: reference.md serve section + CHANGELOG Unreleased entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
