### PR TITLE
chore: release 5.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.10.0 — 2026-08-23
 
 The viewer stops being a snapshot. `knowl view` now watches the store while it is open and draws
 what happens: a retrieval lights the atoms it answered with, a write arrives on a cleared stage, a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.9.0",
+      "version": "5.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts **5.10.0** from `09b6bab`.

**Minor, not patch:** #163 adds a feature (`knowl view` draws live store activity) and changes existing behaviour (retired atoms render as ash; retiring an atom by id now reaches the change log and stages to a connected cloud workspace). Nothing breaking.

Four files, the same shape as every release commit here: `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `CHANGELOG.md`. `npm run check:versions` confirms all three version files agree at 5.10.0 — the check exists because 3.0.1 once shipped advertising one number and installing another.

The CHANGELOG heading is `## 5.10.0 — 2026-08-23`, which is what `cd.yml` awk-extracts for the GitHub release notes; verified the extraction returns the section.

**Merge with a merge commit, not a squash**, so `chore: release 5.10.0` stays taggable — the tag has to point at the release commit itself.

Verified on merged `main` before this branch was cut: build clean, `tsc --noEmit` clean, **3,318 tests / 350 files**, and both CI and CodeQL green on `09b6bab`.