### PR TITLE
feat: the maximal-recall posture — recall chain, event-driven capture, turn-scoped silence

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -440,7 +440,8 @@ spent in the guidance card.
 "search": {
   "transcripts": {
     "enabled": false,   // nothing is created, no MCP tools are registered
-    "share": false      // let linked workspace repos read this index
+    "share": false,     // let linked workspace repos read this index
+    "fallback": false   // a missed knowl_query runs transcript search itself
   }
 }
 ```
@@ -480,6 +481,48 @@ because they are laid out differently: Claude Code names a directory after the p
 (`~/.claude/projects/<encoded-root>/`), while Codex partitions by date
 (`~/.codex/sessions/YYYY/MM/DD/`) and records the project inside each file as
 `session_meta.payload.cwd`. Every Codex candidate is therefore opened, with a bounded header read.
+
+### The recall and capture posture — `knowl posture`
+
+How much memory should do on its own is a stance, not a matrix, so the stance has one command.
+Every key it touches exists on its own in `knowl config` and stays the contract; `posture` is
+the convenience over them.
+
+```bash
+knowl posture            # show the current values of the posture keys
+knowl posture maximal    # the all-knowing stance
+knowl posture frugal     # reset the same keys -- knowl exactly as it ships
+```
+
+`maximal` sets, and `frugal` resets:
+
+- **`search.transcripts.enabled` + `search.transcripts.fallback`** — the recall chain. With
+  `fallback` on, a `knowl_query` that missed runs transcript search itself instead of
+  suggesting the second tool in prose, and a miss in **both** stores returns
+  `RECALL CHAIN — VERIFIED NEGATIVE` with coverage lines: "that never happened" becomes a
+  claim checked against the atoms *and* the archive, not a guess over one of them. An AND
+  with `enabled`, by the same rule as `share`.
+- **`capture.nudge: enforce`** — the end-of-conversation silence nudge, delivered by
+  withholding one stop.
+- **`capture.events: enforce`** — event-shaped lessons. A destructive command (a broad
+  process kill, a git command that discards work, a recursive force-delete, a `DROP TABLE`)
+  or a prompt that reads as the user correcting the agent becomes a *pending lesson* that
+  only a subsequent durable write settles. In `enforce` the agent is nudged mid-turn while
+  it still knows what else the command matched, and an unstored lesson withholds one stop —
+  at most three per conversation, with "no such event actually happened" always a legal
+  answer. `shadow` records what it would have said and says nothing; the correction detector
+  runs in the host hook and forwards only a derived boolean, never the prompt text.
+- **`capture.scope: turn`** — the silence question asked per turn, through the free mid-turn
+  channel rather than a blocked stop, when a turn does substantial work and stores nothing.
+  Its defining property: a `knowl_query` does not quiet it, only a durable write does — the
+  memory-active session is precisely the one every other reminder goes silent for.
+- **`impact.enabled` + `impact.gate: shadow`** — change-impact detection on, with the write
+  gate in shadow: even the maximal stance does not arm a blocking gate ahead of its measured
+  precision bar.
+
+Query results also annotate staleness whatever the posture says: a row whose `affectedPaths`
+were modified after the row was stored carries `pathsChanged` ("n of m affectedPaths modified
+since this was stored — verify"), absent when clean. The field says *verify*, never *wrong*.
 
 ### `knowl transcripts` — turning sessions into candidates
 

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { validateKnowledgeWrite } from '../../core/knowledge-validation.js';
+import { detectCorrectionSignal } from '../../core/lesson-signals.js';
 import { SessionEventType } from '../../core/types.js';
 import type {
   HookHost, NormalizedHookEventName, NormalizedHostHook,
@@ -303,7 +304,18 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
     };
   }
   if (event === 'session-start' || event === 'turn-start') {
-    return { host: normalizedHost, event, ...ids, projectRoot, title: event === 'turn-start' ? 'Agent turn' : 'Agent session', payload: {} };
+    // The prompt text itself never enters the payload -- it would be persisted into
+    // `memory_session_events`, and raw user text is exactly what knowl promises never to
+    // store. Only the derived bit travels: the classification runs here, where the raw event
+    // still exists, and downstream sees a boolean it can act on but not a sentence it could
+    // leak. Hosts that send no prompt on this event simply never set it.
+    const correctionSignal = event === 'turn-start'
+      && typeof raw.prompt === 'string' && detectCorrectionSignal(raw.prompt);
+    return {
+      host: normalizedHost, event, ...ids, projectRoot,
+      title: event === 'turn-start' ? 'Agent turn' : 'Agent session',
+      payload: correctionSignal ? { correctionSignal: true } : {},
+    };
   }
   if (event === 'agent-start' || event === 'agent-stop') {
     if (!agent.agentId) throw new IncompleteHostHookPayloadError('Subagent hook payload requires agent_id.');

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -13,6 +13,7 @@ export type ConfigKey =
   | 'search.vector.cacheDir'
   | 'search.transcripts.enabled'
   | 'search.transcripts.share'
+  | 'search.transcripts.fallback'
   | 'ai.provider'
   | 'ai.model'
   | 'ai.temperature'
@@ -25,6 +26,8 @@ export type ConfigKey =
   | 'impact.enabled'
   | 'impact.gate'
   | 'capture.nudge'
+  | 'capture.events'
+  | 'capture.scope'
   | 'cloud.autoStage'
   | 'updateCheck.enabled';
 
@@ -94,6 +97,7 @@ const IMPACT_GATE_MODES = ['off', 'shadow', 'enforce'] as const;
 // than shared: they mean different things (one refuses a write, one withholds a stop), and a
 // shared list is how a fourth mode added for one of them silently becomes settable on the other.
 const CAPTURE_NUDGE_MODES = ['off', 'shadow', 'enforce'] as const;
+const CAPTURE_SCOPES = ['conversation', 'turn'] as const;
 
 export const CONFIG_FIELDS: ConfigField[] = [
   // The preset leads the Search list: it is the one setting most people should touch,
@@ -154,6 +158,12 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: booleanValue, defaultValue: false,
     label: 'Share transcripts with workspace',
     description: 'Let linked workspace repos search this repo\'s transcripts, read-only. Has no effect unless transcript search is on.',
+  },
+  {
+    key: 'search.transcripts.fallback', category: 'Search', type: 'boolean',
+    parse: booleanValue, defaultValue: false,
+    label: 'Transcript fallback on query miss',
+    description: 'A knowl_query that missed runs transcript search itself and reports a verified negative when both stores miss, instead of suggesting the second tool in prose. Has no effect unless transcript search is on.',
   },
   {
     key: 'security.rejectSecrets', category: 'Security', type: 'boolean',
@@ -247,6 +257,20 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(CAPTURE_NUDGE_MODES), defaultValue: 'off',
     label: 'Empty-session nudge',
     description: 'When a conversation has run for several turns and stored nothing durable: shadow records the nudge it would have sent, enforce withholds the stop once and asks the agent to store what it learned. Measurement runs either way.',
+  },
+  {
+    // `defaultValue: 'off'` here and nowhere else, exactly as `capture.nudge` above: written
+    // into DEFAULT_CONFIG it would arm event inspection in every repository on the machine.
+    key: 'capture.events', category: 'Capture', type: 'enum', values: CAPTURE_NUDGE_MODES,
+    parse: enumValue(CAPTURE_NUDGE_MODES), defaultValue: 'off',
+    label: 'Event lessons',
+    description: 'Watch for destructive commands and user corrections, and hold each as a pending lesson until a durable write settles it: shadow records what it would have said, enforce nudges mid-turn and withholds a stop over unstored lessons, at most three times per conversation.',
+  },
+  {
+    key: 'capture.scope', category: 'Capture', type: 'enum', values: CAPTURE_SCOPES,
+    parse: enumValue(CAPTURE_SCOPES), defaultValue: 'conversation',
+    label: 'Capture scope',
+    description: 'Granularity of the stored-nothing question. conversation is the one-shot end-of-session verdict; turn additionally prompts once, through the free mid-turn channel, when a turn does substantial work and stores nothing -- and a query does not quiet it, only a write does.',
   },
   {
     // Absent from DEFAULT_CONFIG on purpose, like the three above: merged in, it would write

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2813,6 +2813,66 @@ configCommand.on('command:*', () => {
   process.exitCode = 1;
 });
 
+/**
+ * The recall/capture posture, as one word instead of six keys.
+ *
+ * Every key it touches exists on its own and stays the contract; this is the convenience for
+ * the user whose answer to "how much should memory do" is a stance rather than a matrix.
+ * `maximal` is the all-knowing posture: the recall chain runs the transcript fallback inside a
+ * missed query, capture asks per turn and per event and may withhold a stop, impact detection
+ * runs with the gate in shadow. `frugal` resets the same keys to their defaults -- which is
+ * knowl exactly as it ships.
+ */
+const POSTURE_KEYS = [
+  'search.transcripts.enabled', 'search.transcripts.fallback',
+  'capture.nudge', 'capture.events', 'capture.scope',
+  'impact.enabled', 'impact.gate',
+] as const;
+const MAXIMAL_POSTURE: Array<{ key: (typeof POSTURE_KEYS)[number]; raw: string }> = [
+  { key: 'search.transcripts.enabled', raw: 'true' },
+  { key: 'search.transcripts.fallback', raw: 'true' },
+  { key: 'capture.nudge', raw: 'enforce' },
+  { key: 'capture.events', raw: 'enforce' },
+  { key: 'capture.scope', raw: 'turn' },
+  { key: 'impact.enabled', raw: 'true' },
+  // Shadow, not enforce, even here: the write gate refuses tool calls, and its own contract
+  // requires the measured precision bar before anything is permitted to block.
+  { key: 'impact.gate', raw: 'shadow' },
+];
+
+program
+  .command('posture')
+  .argument('[stance]', "'maximal', 'frugal', or omit to show the current values")
+  .description('Set the recall and capture posture: maximal (all-knowing) or frugal (the defaults)')
+  .action(async (stance?: string) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      if (stance && stance !== 'maximal' && stance !== 'frugal') {
+        throw new Error(`Unknown posture "${stance}". Use 'maximal', 'frugal', or no argument to show the current values.`);
+      }
+      const before = await loadConfig(root);
+      if (stance === 'maximal') {
+        await setConfigValues(root, MAXIMAL_POSTURE);
+      } else if (stance === 'frugal') {
+        for (const key of POSTURE_KEYS) await resetConfigValue(root, key);
+      }
+      const after = await loadConfig(root);
+      console.log(stance ? `Posture: ${stance}` : 'Posture keys:');
+      for (const key of POSTURE_KEYS) {
+        console.log(`  ${key} = ${JSON.stringify(await getEffectiveConfigValue(root, key))}`);
+      }
+      if (stance === 'maximal' && before.search?.transcripts?.enabled !== true) {
+        console.log('Transcript search was off. Run `knowl reindex --transcripts` to make past sessions searchable -- the recall chain is only as deep as its index.');
+      }
+      // Turning transcripts off has teardown consequences the transition helper owns.
+      const teardown = describeTranscriptTeardown(await applyTranscriptConfigTransition(root, before, after));
+      if (teardown) console.log(teardown);
+    } catch (error: any) {
+      console.error(`❌ Posture error: ${error.message}`);
+      process.exitCode = 1;
+    }
+  });
+
 // --- 8. REINDEX COMMAND ---
 program
   .command('reindex')

--- a/src/core/lesson-signals.ts
+++ b/src/core/lesson-signals.ts
@@ -1,0 +1,183 @@
+/**
+ * Event-shaped capture signals: a destructive command that just ran, and a prompt that reads
+ * as the user correcting the agent.
+ *
+ * These exist because nothing else inspects the event. Every storage cue in the guidance is a
+ * taxonomy of nouns, and the two kinds of knowledge these detect -- "I damaged the
+ * environment" and "the user had to correct me" -- map to none of them, which is exactly why
+ * they get apologised for in chat and never stored. The cue approach has been patched twice
+ * before (stated intent, recurring diagnoses; see `knowl-guidance.ts`), each time by adding
+ * the noun whose absence had already cost a measured miss. A detector on the event itself is
+ * the first fix that does not need the *next* miss to learn the next noun.
+ *
+ * Pure functions over text, in `core` so both the CLI hook layer and the store can reach
+ * them. Tuned for PRECISION over recall throughout: every pattern here can spend a turn of
+ * somebody's session, and a gate that cries wolf is a gate that gets switched off. The narrow
+ * forms of each operation -- kill by PID, delete with a WHERE, rm -rf on a build dir -- are
+ * exempted by design, so doing it the right way never trips anything.
+ */
+
+export type DestructiveCommandHit = {
+  id: 'process-kill-broad' | 'git-discard' | 'git-rewrite-remote' | 'recursive-delete' | 'container-destroy' | 'db-destructive';
+  label: string;
+};
+
+/**
+ * Quoted spans collapse to a placeholder before any verb is matched, because the measured
+ * false positives were all mentions rather than commands: a `pkill` inside an agent prompt's
+ * quoted argument, `git reset --hard` inside a PR body, a correction phrase inside a pasted
+ * bug report. The placeholder carries no separators, so a newline inside a quoted body cannot
+ * fabricate a segment that starts with a verb.
+ */
+const maskQuoted = (text: string): string => text
+  .replace(/```[\s\S]*?```/g, ' __fence__ ')
+  .replace(/"(?:[^"\\]|\\.)*"/g, ' __q__ ')
+  .replace(/'(?:[^'\\]|\\.)*'/g, ' __q__ ');
+
+/**
+ * A verb only counts at command position: the start of a segment, where segments are cut at
+ * the separators a shell actually honours. Found the hard way (and re-found by review): a
+ * bare word-boundary match reads any command that TALKS about killing as a kill, and a
+ * whole-string read-only exemption reads `ls && rm -rf src` as an `ls`.
+ */
+const SEGMENT_SEPARATOR = /\r?\n|;|&&|\|\||\||\(|\b(?:then|do|else)\b/gi;
+
+/** Wrappers that put the real command one token later. Stripped repeatedly: `sudo timeout 5 pkill`. */
+const COMMAND_WRAPPER = /^(?:sudo|command|npx|timeout\s+\d+[a-z]*|env(?:\s+\w+=\S+)*)\s+/i;
+
+/** A segment that only reads or prints must not arm anything -- investigating a incident mentions its command. */
+const READ_ONLY_HEAD = /^(?:grep|rg|ag|ack|findstr|sls|select-string|cat|type|head|tail|less|more|echo|printf|ls|dir|which|where|write-host|get-\w+|git\s+(?:log|show|diff|grep|status|blame))\b/i;
+
+/** Programs whose arguments are prose or patches, never executed SQL. */
+const SQL_EXEMPT_HEAD = /^(?:claude|codex|cursor|aider|gemini|gh|git|echo|printf)\b/i;
+
+/** Build artefacts and scratch space: blowing these away is routine, not a lesson. */
+const SAFE_RM_TARGET = /(node_modules|[\\/](?:dist|build|out|target|coverage|\.next|\.turbo|\.cache|\.vite|\.tmp[^\\/\s]*)(?:[\\/]|\s|$)|[\\/]te?mp[\\/]|scratchpad|\.knowl-[\w-]*test)/i;
+
+/** `-n` / `--dry-run` means nothing happened, so nothing was learned. Segment-scoped. */
+const DRY_RUN = /(?:^|\s)(?:--dry-run|-[a-z]*n)\b/i;
+
+const rmFlagsRecursiveForce = (segment: string): boolean => {
+  if (!/^rm\s/i.test(segment)) return false;
+  const flags = segment.match(/(?:^|\s)-[a-zA-Z]+/g)?.join('') ?? '';
+  return /r/i.test(flags) && /f/i.test(flags);
+};
+
+function segments(command: string): Array<{ masked: string; original: string }> {
+  const masked = maskQuoted(command);
+  const maskedSegs = masked.split(SEGMENT_SEPARATOR).map(s => s.trim()).filter(Boolean);
+  const originalSegs = command.split(SEGMENT_SEPARATOR).map(s => s.trim()).filter(Boolean);
+  // Pairing by index only holds when quoting hid no separators; when it did, the original
+  // split is wrong by construction, so the masked segment stands in for both sides. The SQL
+  // class loses quoted statement bodies in that case, which is the precision-preserving
+  // direction to lose in.
+  const paired = maskedSegs.map((seg, i) => ({
+    masked: seg,
+    original: maskedSegs.length === originalSegs.length ? originalSegs[i] : seg,
+  }));
+  return paired.map(pair => {
+    let masked = pair.masked;
+    let original = pair.original;
+    for (let strip = 0; strip < 3; strip += 1) {
+      const next = masked.replace(COMMAND_WRAPPER, '');
+      if (next === masked) break;
+      original = original.replace(COMMAND_WRAPPER, '');
+      masked = next;
+    }
+    return { masked, original };
+  });
+}
+
+/**
+ * Which class of irreversible command this is, or null. One verdict per command -- the first
+ * matching segment names it, which is enough for a nudge that fires once per class anyway.
+ */
+export function classifyDestructiveCommand(command: string): DestructiveCommandHit | null {
+  const text = String(command ?? '');
+  if (!text.trim()) return null;
+
+  for (const { masked, original } of segments(text)) {
+    if (READ_ONLY_HEAD.test(masked)) continue;
+
+    // Stop-Process without -Id is a name or pipeline match: it takes every process that fits
+    // the predicate, which is exactly the shape that has already destroyed a live session.
+    if ((/^stop-process\b/i.test(masked) && !/-id\b/i.test(original))
+      || (/^taskkill\b/i.test(masked) && /\/(?:im|fi)\b/i.test(original))
+      || /^(?:pkill|killall)\b/i.test(masked)
+      || /^pm2\s+(?:kill|delete)\b/i.test(masked)) {
+      return { id: 'process-kill-broad', label: 'a process kill with a broad selector (name, image, filter or pipeline)' };
+    }
+
+    if (/^git\s+reset\s+(?:--hard|--merge)\b/i.test(masked)
+      || (/^git\s+clean\s+-[a-z]*[fdx]/i.test(masked) && !DRY_RUN.test(original))
+      || /^git\s+(?:checkout|restore)\s+(?:--\s+)?\.(?:\s|$)/i.test(masked)
+      || /^git\s+stash\s+(?:drop|clear)\b/i.test(masked)
+      || (/^git\s+worktree\s+remove\b/i.test(masked) && /(?:--force\b|\s-f\b)/i.test(original))) {
+      return { id: 'git-discard', label: 'a git command that discards uncommitted work' };
+    }
+
+    if ((/^git\s+push\b/i.test(masked) && /(?:--force(?!-with-lease)\b|\s-f\b)/i.test(original))
+      || /^git\s+branch\s+(?:\S+\s+)*-D\b/.test(masked)
+      || (/^git\s+(?:rebase|filter-branch)\b/i.test(masked) && /--(?:root|force-rebase|all)\b/i.test(original))) {
+      return { id: 'git-rewrite-remote', label: 'a git command that rewrites shared history or force-deletes a branch' };
+    }
+
+    if ((rmFlagsRecursiveForce(masked)
+      || (/^remove-item\b/i.test(masked) && /-recurse\b/i.test(original) && /-force\b/i.test(original))
+      || (/^rmdir\b/i.test(masked) && /\/s\b/i.test(original))
+      || (/^del\b/i.test(masked) && /\/s\b/i.test(original)))
+      && !SAFE_RM_TARGET.test(text)) {
+      return { id: 'recursive-delete', label: 'a recursive force-delete outside build or scratch directories' };
+    }
+
+    if ((/^docker\s+(?:rm|rmi)\b/i.test(masked) && /(?:\s-f\b|--force\b)/i.test(original))
+      || /^docker\s+(?:system|volume|container|image)\s+prune\b/i.test(masked)) {
+      return { id: 'container-destroy', label: 'a container or image force-removal' };
+    }
+
+    if (!SQL_EXEMPT_HEAD.test(masked)) {
+      if (/^dropdb\b/i.test(masked)
+        || /\bdrop\s+(?:table|database|schema|index|column)\b/i.test(original)
+        || /\btruncate\s+(?:table\s+)?\w/i.test(original)
+        || (/\bdelete\s+from\s+\w+/i.test(original) && !/\bwhere\b/i.test(original))
+        || (/\bupdate\s+\w+\s+set\b/i.test(original) && !/\bwhere\b/i.test(original))) {
+        return { id: 'db-destructive', label: 'a destructive database statement' };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether a prompt reads as the user correcting the agent -- the highest-precision "store
+ * this" signal that exists, and the one nothing was watching. A correction is, by definition,
+ * durable knowledge the agent was supposed to be holding and was not.
+ *
+ * Three guards, each one a measured false positive:
+ * - quoted and fenced spans are masked first, so a pasted bug report, a review brief, or a
+ *   test-fixture string cannot arm it by quoting somebody else's correction;
+ * - only the opening of the prompt is scanned -- a correction leads, an aside trails;
+ * - the "should have" form requires a verb of memory or care, so "you should have write
+ *   access now" stays what it is.
+ */
+const CORRECTION_WINDOW = 240;
+
+const CORRECTION_PATTERNS = [
+  /\byou\s+should(?:'?ve|\s+have)\s+(?:saved|stored|remembered|checked|asked|known|written|kept|read|verified|queried)\b/i,
+  /\bwhy\s+(?:didn'?t|did\s+not|don'?t|doesn'?t|won'?t)\s+you\b/i,
+  /\b(?:i|we)\s+(?:already\s+)?told\s+you\b/i,
+  /\bwe\s+already\s+(?:decided|agreed|discussed|went\s+over)\b/i,
+  /\b(?:that|this)\s+was\s+(?:careless|sloppy|reckless|dangerous)\b/i,
+  /\byou\s+(?:broke|killed|destroyed|deleted|wiped|nuked|lost)\s+(?:my|the|our)\b/i,
+  /\byou\s+keep\s+(?:forgetting|ignoring|missing|breaking|repeating|losing)\b/i,
+  /\bnever\s+(?:do|run|use)\s+(?:that|this|it)\s+again\b/i,
+  /\bfor\s+the\s+(?:last|second|third|hundredth|nth)\s+time\b/i,
+  /\bstop\s+(?:doing|running|using)\s+(?:that|this)\b/i,
+];
+
+export function detectCorrectionSignal(prompt: string): boolean {
+  const text = String(prompt ?? '');
+  if (!text.trim()) return false;
+  const window = maskQuoted(text).slice(0, CORRECTION_WINDOW);
+  return CORRECTION_PATTERNS.some(pattern => pattern.test(window));
+}

--- a/src/core/lesson-signals.ts
+++ b/src/core/lesson-signals.ts
@@ -17,10 +17,26 @@
  * exempted by design, so doing it the right way never trips anything.
  */
 
-export type DestructiveCommandHit = {
-  id: 'process-kill-broad' | 'git-discard' | 'git-rewrite-remote' | 'recursive-delete' | 'container-destroy' | 'db-destructive';
-  label: string;
+export type DestructiveCommandId =
+  'process-kill-broad' | 'git-discard' | 'git-rewrite-remote' | 'recursive-delete' | 'container-destroy' | 'db-destructive';
+
+export type DestructiveCommandHit = { id: DestructiveCommandId; label: string };
+
+/**
+ * One place the classes are named. The stop gate renders lessons from a stored `class` column
+ * long after the hit object is gone, so a second list over there drifts from this one -- it
+ * already had.
+ */
+export const DESTRUCTIVE_LABELS: Readonly<Record<DestructiveCommandId, string>> = {
+  'process-kill-broad': 'a process kill with a broad selector (name, image, filter or pipeline)',
+  'git-discard': 'a git command that discards uncommitted work',
+  'git-rewrite-remote': 'a git command that rewrites shared history or force-deletes a branch',
+  'recursive-delete': 'a recursive force-delete outside build or scratch directories',
+  'container-destroy': 'a container or image force-removal',
+  'db-destructive': 'a destructive database statement',
 };
+
+const hit = (id: DestructiveCommandId): DestructiveCommandHit => ({ id, label: DESTRUCTIVE_LABELS[id] });
 
 /**
  * Quoted spans collapse to a placeholder before any verb is matched, because the measured
@@ -51,8 +67,17 @@ const READ_ONLY_HEAD = /^(?:grep|rg|ag|ack|findstr|sls|select-string|cat|type|he
 /** Programs whose arguments are prose or patches, never executed SQL. */
 const SQL_EXEMPT_HEAD = /^(?:claude|codex|cursor|aider|gemini|gh|git|echo|printf)\b/i;
 
-/** Build artefacts and scratch space: blowing these away is routine, not a lesson. */
-const SAFE_RM_TARGET = /(node_modules|[\\/](?:dist|build|out|target|coverage|\.next|\.turbo|\.cache|\.vite|\.tmp[^\\/\s]*)(?:[\\/]|\s|$)|[\\/]te?mp[\\/]|scratchpad|\.knowl-[\w-]*test)/i;
+/**
+ * Build artefacts and scratch space: blowing these away is routine, not a lesson.
+ *
+ * Both boundaries are load-bearing and both were wrong once. A leading separator is
+ * OPTIONAL: `rm -rf dist` is how the clean is actually written, and requiring `/dist` made
+ * the most common safe delete there is fire. A trailing one is REQUIRED, so `/var/dist-data`
+ * is not read as the build directory. Tested per SEGMENT, never against the whole command --
+ * the whole-string form is the same defect as a whole-string read-only exemption, and it let
+ * `rm -rf dist && rm -rf ~/live` off entirely.
+ */
+const SAFE_RM_TARGET = /(?:^|[\s\\/])(?:node_modules|dist|build|out|target|coverage|\.next|\.turbo|\.cache|\.vite|\.tmp[^\\/\s]*|te?mp|scratchpad|\.knowl-[\w-]*test)(?:[\\/]|\s|$)/i;
 
 /** `-n` / `--dry-run` means nothing happened, so nothing was learned. Segment-scoped. */
 const DRY_RUN = /(?:^|\s)(?:--dry-run|-[a-z]*n)\b/i;
@@ -105,7 +130,7 @@ export function classifyDestructiveCommand(command: string): DestructiveCommandH
       || (/^taskkill\b/i.test(masked) && /\/(?:im|fi)\b/i.test(original))
       || /^(?:pkill|killall)\b/i.test(masked)
       || /^pm2\s+(?:kill|delete)\b/i.test(masked)) {
-      return { id: 'process-kill-broad', label: 'a process kill with a broad selector (name, image, filter or pipeline)' };
+      return hit('process-kill-broad');
     }
 
     if (/^git\s+reset\s+(?:--hard|--merge)\b/i.test(masked)
@@ -113,26 +138,26 @@ export function classifyDestructiveCommand(command: string): DestructiveCommandH
       || /^git\s+(?:checkout|restore)\s+(?:--\s+)?\.(?:\s|$)/i.test(masked)
       || /^git\s+stash\s+(?:drop|clear)\b/i.test(masked)
       || (/^git\s+worktree\s+remove\b/i.test(masked) && /(?:--force\b|\s-f\b)/i.test(original))) {
-      return { id: 'git-discard', label: 'a git command that discards uncommitted work' };
+      return hit('git-discard');
     }
 
     if ((/^git\s+push\b/i.test(masked) && /(?:--force(?!-with-lease)\b|\s-f\b)/i.test(original))
       || /^git\s+branch\s+(?:\S+\s+)*-D\b/.test(masked)
       || (/^git\s+(?:rebase|filter-branch)\b/i.test(masked) && /--(?:root|force-rebase|all)\b/i.test(original))) {
-      return { id: 'git-rewrite-remote', label: 'a git command that rewrites shared history or force-deletes a branch' };
+      return hit('git-rewrite-remote');
     }
 
     if ((rmFlagsRecursiveForce(masked)
       || (/^remove-item\b/i.test(masked) && /-recurse\b/i.test(original) && /-force\b/i.test(original))
       || (/^rmdir\b/i.test(masked) && /\/s\b/i.test(original))
       || (/^del\b/i.test(masked) && /\/s\b/i.test(original)))
-      && !SAFE_RM_TARGET.test(text)) {
-      return { id: 'recursive-delete', label: 'a recursive force-delete outside build or scratch directories' };
+      && !SAFE_RM_TARGET.test(original)) {
+      return hit('recursive-delete');
     }
 
     if ((/^docker\s+(?:rm|rmi)\b/i.test(masked) && /(?:\s-f\b|--force\b)/i.test(original))
       || /^docker\s+(?:system|volume|container|image)\s+prune\b/i.test(masked)) {
-      return { id: 'container-destroy', label: 'a container or image force-removal' };
+      return hit('container-destroy');
     }
 
     if (!SQL_EXEMPT_HEAD.test(masked)) {
@@ -141,7 +166,7 @@ export function classifyDestructiveCommand(command: string): DestructiveCommandH
         || /\btruncate\s+(?:table\s+)?\w/i.test(original)
         || (/\bdelete\s+from\s+\w+/i.test(original) && !/\bwhere\b/i.test(original))
         || (/\bupdate\s+\w+\s+set\b/i.test(original) && !/\bwhere\b/i.test(original))) {
-        return { id: 'db-destructive', label: 'a destructive database statement' };
+        return hit('db-destructive');
       }
     }
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -421,6 +421,18 @@ export interface ProjectConfig {
      * say otherwise -- the same ladder `impact.gate` climbs.
      */
     nudge?: 'off' | 'shadow' | 'enforce';
+    /**
+     * Event-shaped lessons: a destructive command that just ran, or a prompt that reads as
+     * the user correcting the agent, each recorded as a pending item that only a subsequent
+     * durable write settles. The class of knowledge the silence nudge above structurally
+     * cannot see -- its verdict is per conversation, so a session that stored plenty of
+     * unrelated atoms reads as healthy while the one event that mattered goes unwritten.
+     *
+     * Same ladder as `nudge`, and shadow is where it is expected to sit first: the detectors
+     * are precision-tuned regexes, and the measurement of how often they fire is what any
+     * decision to enforce has to be made on.
+     */
+    events?: 'off' | 'shadow' | 'enforce';
   };
   /**
    * This repo's half of workspace membership. The other half is the workspace manifest

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -316,6 +316,15 @@ export interface ProjectConfig {
       enabled?: boolean;
       /** Let linked workspace repos open this index read-only. Requires `enabled`. */
       share?: boolean;
+      /**
+       * Run transcript search automatically inside a `knowl_query` that missed, instead of
+       * suggesting it in prose. Requires `enabled`, by the same AND rule as `share`.
+       *
+       * The suggestion path already existed and its failure mode is measured: the agent reads
+       * the miss, skips the second tool, and answers "no record" over an archive it never
+       * consulted. With this on, a negative is a claim verified against both stores.
+       */
+      fallback?: boolean;
     };
   };
   memory?: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -433,6 +433,17 @@ export interface ProjectConfig {
      * decision to enforce has to be made on.
      */
     events?: 'off' | 'shadow' | 'enforce';
+    /**
+     * At what granularity the silence question is asked. `conversation` (the default) is the
+     * one-shot end-of-conversation verdict above. `turn` additionally watches each turn as it
+     * runs: a turn that crosses a substantive-work threshold with no durable write gets one
+     * capture prompt through the free mid-turn channel -- never a blocked stop -- at the
+     * moment the unstored knowledge actually exists. The property that distinguishes it from
+     * the drift reminder: querying memory does not reset it, only storing does, so the
+     * memory-active session -- precisely the one every other reminder goes quiet for -- is
+     * still asked.
+     */
+    scope?: 'conversation' | 'turn';
   };
   /**
    * This repo's half of workspace membership. The other half is the workspace manifest

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -975,6 +975,13 @@ export function registerTools(
         // path resolves against a checkout that is not this one, and a path that escapes the
         // root reveals nothing about the file it names. A missing file counts as changed --
         // deletion is the strongest form of "moved".
+        //
+        // The grace window covers the one systematic false positive: "edit the file, then
+        // immediately store the atom citing it" is the ordinary write pattern, and a buffered
+        // write's mtime can land a moment AFTER the store's own clock reading (observed on
+        // macOS and Windows under node 22). A file that truly changed after the atom is
+        // seconds to weeks later, not milliseconds, so the window costs nothing real.
+        const PATHS_CHANGED_GRACE_MS = 2_000;
         const pathsChangedNotes = new Map<string, string>();
         if (projectRoot) {
           await Promise.all(resolvedItems.map(async item => {
@@ -987,7 +994,7 @@ export function registerTools(
               if (!contained) { changed += 1; return; }
               try {
                 const stat = await fs.stat(path.resolve(projectRoot, contained));
-                if (stat.mtimeMs > storedAt) changed += 1;
+                if (stat.mtimeMs > storedAt + PATHS_CHANGED_GRACE_MS) changed += 1;
               } catch {
                 changed += 1;
               }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -35,7 +37,7 @@ import { applyFeedbackToTierBestEffort } from '../store/tier.js';
 import { finishMemorySession, listActiveMemorySessions } from '../store/session-repository.js';
 import { isImpactEnabled } from '../store/impact-config.js';
 import { openFindingsForSession, resolveFinding, type ImpactFinding, type ImpactTier } from '../session/impact.js';
-import { activeReadSetForSession } from '../store/read-set.js';
+import { activeReadSetForSession, containedRepoPath } from '../store/read-set.js';
 import { formatPendingHandoffContext, recordDeliberateHandoff } from '../session/session-handoff.js';
 import { createResumePoint, formatResumeBrief, listResumePoints, readResumePoint } from '../session/resume-points.js';
 import { resumeInstruction } from '../session/resume-keys.js';
@@ -960,6 +962,42 @@ export function registerTools(
         // foreign item would be judged against the wrong checkout -- reporting "stale" for a
         // file that is simply somewhere else. Omitting it beats answering wrongly.
         const isForeign = (item: any) => Boolean(active) && item.repo && item.repo !== active!.repo;
+        // Whether the files a row cites have moved since the row was stored, answered per row
+        // and said only when true. The stale-atom failure this closes is on the READ side:
+        // impact detection tells the session that did the writing, but the session that
+        // retrieves the atom three weeks later gets a confident-sounding answer over files
+        // that changed underneath it, with nothing on the row saying so.
+        //
+        // mtime against `updatedAt`, deliberately -- no git and no hashing on a path that runs
+        // several times a turn. A touch with no edit flags a clean atom, which is the cheap
+        // direction to be wrong in: the field says "verify", never "wrong". Local rows only
+        // and containment-checked, both for the reason the evidence code gives: a foreign
+        // path resolves against a checkout that is not this one, and a path that escapes the
+        // root reveals nothing about the file it names. A missing file counts as changed --
+        // deletion is the strongest form of "moved".
+        const pathsChangedNotes = new Map<string, string>();
+        if (projectRoot) {
+          await Promise.all(resolvedItems.map(async item => {
+            if (isForeign(item) || !item.affectedPaths?.length) return;
+            const storedAt = Date.parse(item.updatedAt ?? '');
+            if (!Number.isFinite(storedAt)) return;
+            let changed = 0;
+            await Promise.all(item.affectedPaths.map(async raw => {
+              const contained = containedRepoPath(raw);
+              if (!contained) { changed += 1; return; }
+              try {
+                const stat = await fs.stat(path.resolve(projectRoot, contained));
+                if (stat.mtimeMs > storedAt) changed += 1;
+              } catch {
+                changed += 1;
+              }
+            }));
+            if (changed > 0) {
+              pathsChangedNotes.set(item.id,
+                `${changed} of ${item.affectedPaths.length} affectedPaths modified since this was stored -- verify against the files before trusting.`);
+            }
+          })).catch(() => {});
+        }
         const compact = (item: any) => {
           const score = scoreOf(item);
           const cosine = cosineOf(item);
@@ -976,6 +1014,8 @@ export function registerTools(
             // to be linked are fork siblings, where the same path exists in both and means
             // different things. Same reasoning as the evidence omission directly above.
             ...(affectedPaths && !isForeign(item) ? { affectedPaths } : {}),
+            // Absent when clean, so a row that says nothing still means what it always meant.
+            ...(pathsChangedNotes.has(item.id) ? { pathsChanged: pathsChangedNotes.get(item.id) } : {}),
             ...(explain && item.explanation ? { explanation: item.explanation } : {}),
           };
         };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -41,9 +41,9 @@ import { createResumePoint, formatResumeBrief, listResumePoints, readResumePoint
 import { resumeInstruction } from '../session/resume-keys.js';
 import { finalizeMemorySession } from '../store/session-finalizer.js';
 import { configuredNamespaces, namespaceDescriptor, queryLayeredKnowledge, withNamespaceDatabase } from '../store/namespaces.js';
-import { isTranscriptSearchEnabled } from '../transcripts/config.js';
+import { isTranscriptFallbackEnabled, isTranscriptSearchEnabled } from '../transcripts/config.js';
 import { hasIndexableArchive } from '../transcripts/paths.js';
-import { handleSessionList, handleTranscriptRead, handleTranscriptSearch } from '../transcripts/mcp-handlers.js';
+import { handleSessionList, handleTranscriptRead, handleTranscriptSearch, NO_TRANSCRIPT_MATCHES_PREFIX } from '../transcripts/mcp-handlers.js';
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
 import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
 import { teamUpdateNotice } from '../cloud/team-update.js';
@@ -64,6 +64,13 @@ export const CLOUD_DISCONNECTED_MESSAGE =
  */
 /** Matches `MAX_RESPONSE_CHARS` in the transcript handlers, deliberately. */
 const MAX_RESPONSE_CHARS = 12_000;
+/**
+ * Bounds for the transcript search a missed query runs on its own behalf. Tighter than the
+ * standalone tool's, because this rides another tool's response: three hits answer "does the
+ * archive know this", and a caller who wants the rest has the real tool named in the block.
+ */
+const TRANSCRIPT_FALLBACK_LIMIT = 3;
+const TRANSCRIPT_FALLBACK_CHARS = 4_000;
 const MAX_SKILLS_LISTED = 30;
 const MAX_SKILL_PURPOSE_CHARS = 200;
 const MAX_TRIGGERS_LISTED = 5;
@@ -1106,6 +1113,48 @@ export function registerTools(
             text: 'NO CONFIDENT MATCH: every result above scored below the relevance floor, so this store probably does not hold the answer. They are returned rather than withheld because the floor is a fixed threshold on a corpus-dependent scale and is wrong often enough to matter — read `cosine` and judge, not `score`: `cosine` is the absolute similarity the floor itself is measured against, while `score` only orders this page. If none of them answers the question, treat this as a miss and go to the files.'
               + transcriptRoute,
           });
+        }
+        // The second link of the recall chain, run rather than suggested. The abstention notice
+        // above names transcript search in prose, and the measured failure mode is that the
+        // suggestion is not taken: the agent reads the miss, skips the second tool, and answers
+        // "that never happened" over an archive it never consulted. With
+        // `search.transcripts.fallback` on, the search this response would have asked for has
+        // already run by the time the response arrives, and a negative is a claim verified
+        // against both stores instead of a guess over one.
+        //
+        // The empty-result case is deliberately included: it takes no abstention block today --
+        // `some(abstained)` over nothing is false -- so a store with no lexical match at all was
+        // the one shape of miss that got no route anywhere.
+        //
+        // Fail open throughout, and appended after the verdict blocks so a fallback that breaks
+        // can only cost its own addendum, never the answer it rides on.
+        const queryMissed = resolvedItems.length === 0
+          || resolvedItems.some(item => (item.explanation as { abstained?: boolean } | undefined)?.abstained);
+        if (queryMissed && config && projectRoot && isTranscriptFallbackEnabled(config)
+          && typeof query === 'string' && query.trim()) {
+          try {
+            const fallback = await handleTranscriptSearch({
+              config,
+              projectRoot,
+              query,
+              repos: Array.isArray(repos) ? repos.map(String) : undefined,
+              limit: TRANSCRIPT_FALLBACK_LIMIT,
+            });
+            const negative = fallback.startsWith(NO_TRANSCRIPT_MATCHES_PREFIX);
+            const bounded = fallback.length > TRANSCRIPT_FALLBACK_CHARS
+              ? `${fallback.slice(0, TRANSCRIPT_FALLBACK_CHARS)}\n[fallback bounded -- run knowl_transcript_search for the rest]`
+              : fallback;
+            blocks.push({
+              type: 'text',
+              text: negative
+                ? 'RECALL CHAIN — VERIFIED NEGATIVE: the knowledge store missed and the transcript archive holds no match for these words either (coverage below). If the user believes this happened, it predates the archive or used different words — try knowl_transcript_search with other words before concluding, and state the negative truthfully rather than guessing.\n'
+                  + bounded
+                : 'RECALL CHAIN: the knowledge store missed, so the transcript archive was searched automatically with the same words:\n'
+                  + bounded,
+            });
+          } catch {
+            // The query result stands on its own; a broken fallback appends nothing.
+          }
         }
         // Last of the notices, because it is the only one that asks the agent to do something
         // rather than to interpret what it just got.

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -989,9 +989,15 @@ export function registerTools(
             const storedAt = Date.parse(item.updatedAt ?? '');
             if (!Number.isFinite(storedAt)) return;
             let changed = 0;
+            let checked = 0;
             await Promise.all(item.affectedPaths.map(async raw => {
+              // A path that will not resolve against THIS checkout -- absolute, drive-lettered,
+              // `./`-prefixed, escaping the root -- is skipped, not counted. A missing FILE is
+              // evidence the atom's ground moved; an unreadable PATH is only absence of
+              // evidence, and counting it as changed marked every such row stale forever.
               const contained = containedRepoPath(raw);
-              if (!contained) { changed += 1; return; }
+              if (!contained) return;
+              checked += 1;
               try {
                 const stat = await fs.stat(path.resolve(projectRoot, contained));
                 if (stat.mtimeMs > storedAt + PATHS_CHANGED_GRACE_MS) changed += 1;
@@ -1001,7 +1007,7 @@ export function registerTools(
             }));
             if (changed > 0) {
               pathsChangedNotes.set(item.id,
-                `${changed} of ${item.affectedPaths.length} affectedPaths modified since this was stored -- verify against the files before trusting.`);
+                `${changed} of ${checked} affectedPaths modified since this was stored -- verify against the files before trusting.`);
             }
           })).catch(() => {});
         }

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -7,7 +7,7 @@ import { hostProfile } from './hosts/index.js';
 import { indexFile, listCodeSymbols } from '../code/symbol-index.js';
 import { loadConfig } from '../core/config.js';
 import { isImpactEnabled } from '../store/impact-config.js';
-import { captureEventsMode, captureNudgeMode } from '../store/capture-config.js';
+import { captureEventsMode, captureNudgeMode, captureScope } from '../store/capture-config.js';
 import { classifyDestructiveCommand } from '../core/lesson-signals.js';
 import {
   claimLessonBlock,
@@ -22,13 +22,19 @@ import {
 } from '../store/pending-lessons.js';
 import {
   claimSilenceNudge,
+  claimTurnCapturePrompt,
   conversationKey,
   isDurableWriteTool,
   readCaptureOutcome,
   recordDurableWrite,
   recordSessionTurn,
+  recordTurnToolEvent,
   renderSilenceNudge,
+  renderTurnCapturePrompt,
+  resetTurnCapture,
+  shouldPromptTurnCapture,
   shouldNudgeForSilence,
+  turnCaptureKey,
 } from '../store/capture-outcome.js';
 import { detectCertainImpactBestEffort, markFindingsDelivered, openFindingsForSession } from './impact.js';
 import {
@@ -948,6 +954,11 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     const withCorrection = (context: string | undefined): string | undefined =>
       correctionLine ? (context ? `${correctionLine}\n\n${context}` : correctionLine) : context;
 
+    // A new turn under a reused turn key must start its capture counters from zero. Cheap
+    // enough not to gate on config: one DELETE matching zero rows when the scope was never
+    // 'turn', at a turn boundary rather than on the tool path.
+    await resetTurnCapture(turnCaptureKey(bindingKey(input, 'turn')));
+
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
     if (!sessionBinding && hostProfile(input.host).sharesSessionBinding) {
       const started = await bootstrapWithHandoff(projectId, input, 'session', true);
@@ -999,6 +1010,8 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
 
   if (input.event === 'agent-stop') {
     const agentKey = bindingKey(input, 'turn');
+    // A subagent's turn key carries its agent id, so its counters are its own to clean up.
+    await resetTurnCapture(turnCaptureKey(agentKey));
     const closed = await closeHostSessionBinding(agentKey);
     // Emits no host output: SubagentStop may block a subagent from stopping and
     // this never does.
@@ -1032,6 +1045,19 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         // the thing it is not.
         await resolveLessonsBefore(conversationKey(input), new Date().toISOString());
       }
+      // One config read serves both capture features below; each is off for anyone who has
+      // not turned it on, and a missing config is simply "everything off".
+      const captureConfig = await loadConfig(input.projectRoot).catch(() => null);
+      // Turn-scoped capture counters (capture.scope = 'turn'). Counted for checkpoint events
+      // too, because hosts may report tool activity under that event -- but never for a
+      // failure, which produced nothing worth storing. The updated row comes back from the
+      // same write, so the slot logic below pays no second query.
+      const turnOutcome = input.status !== 'failed' && captureScope(captureConfig ?? undefined) === 'turn'
+        ? await recordTurnToolEvent(turnCaptureKey(bindingKey(input, 'turn')), conversationKey(input), {
+          fileWrite: toolWritesFile(input),
+          durableWrite: isDurableWriteTool(input.knowlToolName),
+        })
+        : null;
       // Runs for `checkpoint` events too -- a host that reports a tool under that event still
       // read or wrote the file it named -- but never for a failed one: a tool that failed
       // returned no contents, so a read-set row from it would record a belief the agent was
@@ -1054,8 +1080,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         const shellCommand = typeof input.payload.command === 'string' ? input.payload.command : '';
         if (shellCommand && !input.knowlTool) {
           try {
-            const eventsConfig = await loadConfig(input.projectRoot).catch(() => null);
-            const eventsMode = captureEventsMode(eventsConfig ?? undefined);
+            const eventsMode = captureEventsMode(captureConfig ?? undefined);
             if (eventsMode !== 'off') {
               const hit = classifyDestructiveCommand(shellCommand);
               // `recordDestructiveLesson` is the once-per-class-per-conversation claim, so the
@@ -1127,6 +1152,15 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
           } else if (existing) {
             await resetHostSuccessfulToolCount(key);
             hostOutput = profile.midTurnContext(renderSkillUseNudge(existing));
+          } else if (shouldPromptTurnCapture(turnOutcome)
+            && await claimTurnCapturePrompt(turnOutcome!.turnKey, turnOutcome!.conversation)) {
+            // Above the knowl-tool branch on purpose: this is the one reminder a query must
+            // not silence. The drift counter below goes quiet the moment any knowl tool runs,
+            // which is exactly how the memory-active session -- the one that queried five
+            // times, diagnosed the hard thing, and stored nothing -- never hears from it.
+            // Only a durable write quiets this one, by zeroing the verdict itself.
+            await resetHostSuccessfulToolCount(key);
+            hostOutput = profile.midTurnContext(renderTurnCapturePrompt());
           } else if (input.knowlTool) {
             // Adaptive continuation reminder: only nudge after a run of tool calls that
             // ignored Knowl. Using a Knowl tool resets the drift counter, so an agent
@@ -1161,6 +1195,9 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // event that fires per turn, and turns -- not tool events -- are what tell a working
     // conversation apart from a single question answered.
     await recordSessionTurn(conversationKey(input));
+    // The turn is over, so its capture counters are too; the prompt ceiling lives on its own
+    // row and survives this.
+    await resetTurnCapture(turnCaptureKey(bindingKey(input, 'turn')));
 
     // gpt-5.5 often share one session binding across turns. Normal Stop only closes the turn
     // binding. Hard failures finish the session and record a host-scoped handoff.

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -7,7 +7,19 @@ import { hostProfile } from './hosts/index.js';
 import { indexFile, listCodeSymbols } from '../code/symbol-index.js';
 import { loadConfig } from '../core/config.js';
 import { isImpactEnabled } from '../store/impact-config.js';
-import { captureNudgeMode } from '../store/capture-config.js';
+import { captureEventsMode, captureNudgeMode } from '../store/capture-config.js';
+import { classifyDestructiveCommand } from '../core/lesson-signals.js';
+import {
+  claimLessonBlock,
+  markPendingLessons,
+  openPendingLessons,
+  recordCorrectionLesson,
+  recordDestructiveLesson,
+  renderCorrectionNudge,
+  renderLessonNudge,
+  renderLessonStopReason,
+  resolveLessonsBefore,
+} from '../store/pending-lessons.js';
 import {
   claimSilenceNudge,
   conversationKey,
@@ -749,6 +761,56 @@ async function evaluateSilenceNudge(input: NormalizedHostHook): Promise<Record<s
   }
 }
 
+/**
+ * Whether unresolved pending lessons should withhold this stop, and the envelope to say it in.
+ *
+ * `evaluateSilenceNudge`'s twin with the opposite scoping: that one speaks once per
+ * conversation about a total, this one speaks about specific events -- a destructive command,
+ * a correction -- that no durable write has settled since they happened. Same discipline
+ * throughout: the same off/shadow/enforce ladder, the delivery capability checked before
+ * anything is spent, the claim spent before the message is delivered, and fail-open without
+ * exception. Two extra rules of its own:
+ *
+ * - The lessons are marked resolved BEFORE the block is emitted, so this can cost at most one
+ *   extra turn per event and can never nag: if the agent stores nothing, the next stop passes.
+ * - The block budget (`MAX_LESSON_BLOCKS`) is a hard ceiling per conversation. Once spent,
+ *   everything else settles silently, whatever else happens.
+ *
+ * Evaluated before the silence nudge and suppressing it for this stop: both spend a blocked
+ * stop, a specific reason beats a general one, and two blocks on one stop is the fatigue that
+ * teaches agents to ignore the channel.
+ */
+async function evaluatePendingLessonStop(input: NormalizedHostHook): Promise<Record<string, unknown> | undefined> {
+  try {
+    const config = await loadConfig(input.projectRoot).catch(() => null);
+    const mode = captureEventsMode(config ?? undefined);
+    if (mode === 'off') return undefined;
+
+    const conversation = conversationKey(input);
+    const open = await openPendingLessons(conversation);
+    if (open.length === 0) return undefined;
+
+    if (mode === 'shadow') {
+      await markPendingLessons(open.map(lesson => lesson.id), 'shadow');
+      return undefined;
+    }
+
+    const profile = hostProfile(input.host);
+    if (!profile.stopContext) return undefined;
+    if (!await claimLessonBlock(conversation)) {
+      // Budget exhausted: settle silently so the rows cannot pile up behind a gate that will
+      // never speak again, and record that silence as what it was.
+      await markPendingLessons(open.map(lesson => lesson.id), 'budget');
+      return undefined;
+    }
+
+    await markPendingLessons(open.map(lesson => lesson.id), 'blocked');
+    return profile.stopContext(renderLessonStopReason(open));
+  } catch {
+    return undefined;
+  }
+}
+
 async function finalizeFailedStop(projectId: string, input: NormalizedHostHook, sessionId: string) {
   await finishMemorySession(
     sessionId,
@@ -865,6 +927,27 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
   }
 
   if (input.event === 'turn-start') {
+    // The correction signal arrives as a derived boolean -- the host hook classified the raw
+    // prompt and forwarded only the verdict, so no user text reaches this layer or the rows
+    // it writes. Recorded as a pending lesson either way; spoken only in enforce, riding the
+    // context envelope this event was already carrying, which is the one moment the lesson
+    // can be stored BEFORE the agent answers -- a correction acted on and not written down is
+    // exactly the shape that gets apologised for and repeated.
+    let correctionLine: string | undefined;
+    if (input.payload.correctionSignal === true) {
+      try {
+        const eventsConfig = await loadConfig(input.projectRoot).catch(() => null);
+        const eventsMode = captureEventsMode(eventsConfig ?? undefined);
+        if (eventsMode !== 'off' && await recordCorrectionLesson(conversationKey(input)) && eventsMode === 'enforce') {
+          correctionLine = renderCorrectionNudge();
+        }
+      } catch {
+        // Advisory.
+      }
+    }
+    const withCorrection = (context: string | undefined): string | undefined =>
+      correctionLine ? (context ? `${correctionLine}\n\n${context}` : correctionLine) : context;
+
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
     if (!sessionBinding && hostProfile(input.host).sharesSessionBinding) {
       const started = await bootstrapWithHandoff(projectId, input, 'session', true);
@@ -874,7 +957,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         sessionId: started.session.id,
         context: started.context,
         contextTruncated: started.truncated,
-        hostOutput: hostContextOutput(input, started.context),
+        hostOutput: hostContextOutput(input, withCorrection(started.context)),
       };
     }
     const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding);
@@ -884,7 +967,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       sessionId: started.session.id,
       context: started.context,
       contextTruncated: started.truncated,
-      hostOutput: hostContextOutput(input, started.context),
+      hostOutput: hostContextOutput(input, withCorrection(started.context)),
     };
   }
 
@@ -941,7 +1024,14 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       // later reads zero when it means "I no longer know". Keyed on the conversation and not on
       // `started.session.id`, which is turn-scoped and would scatter one conversation's writes
       // across a row per turn.
-      if (isDurableWriteTool(input.knowlToolName)) await recordDurableWrite(conversationKey(input));
+      if (isDurableWriteTool(input.knowlToolName)) {
+        await recordDurableWrite(conversationKey(input));
+        // A durable write settles the pending lessons that were already on the table when it
+        // landed -- temporal, not blanket. Clearing everything on any write would be the same
+        // flaw one level down that disarms the drift counter: unrelated activity reading as
+        // the thing it is not.
+        await resolveLessonsBefore(conversationKey(input), new Date().toISOString());
+      }
       // Runs for `checkpoint` events too -- a host that reports a tool under that event still
       // read or wrote the file it named -- but never for a failed one: a tool that failed
       // returned no contents, so a read-set row from it would record a belief the agent was
@@ -955,6 +1045,29 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       if (input.event === 'session-event' && input.status !== 'failed') {
         const key = bindingKey(input, 'turn');
         const profile = hostProfile(input.host);
+        // Event inspection, on the one path that sees command text. Recorded whatever the
+        // delivery situation is -- a host with no mid-turn channel still gets the stop gate --
+        // and only a successful, non-knowl command is inspected: a failed command did no
+        // damage, and knowl's own tools are not the hazard. Failed detection must not fail
+        // the event, so the classifier's verdict is advisory end to end.
+        let lessonCard: string | undefined;
+        const shellCommand = typeof input.payload.command === 'string' ? input.payload.command : '';
+        if (shellCommand && !input.knowlTool) {
+          try {
+            const eventsConfig = await loadConfig(input.projectRoot).catch(() => null);
+            const eventsMode = captureEventsMode(eventsConfig ?? undefined);
+            if (eventsMode !== 'off') {
+              const hit = classifyDestructiveCommand(shellCommand);
+              // `recordDestructiveLesson` is the once-per-class-per-conversation claim, so the
+              // nudge fires exactly when the row is new -- race-safe across hook processes.
+              if (hit && await recordDestructiveLesson(conversationKey(input), hit, shellCommand) && eventsMode === 'enforce') {
+                lessonCard = renderLessonNudge(hit, shellCommand);
+              }
+            }
+          } catch {
+            // Advisory.
+          }
+        }
         // The watermark runs for every host; only delivery depends on the host having a
         // mid-turn channel, which `midTurnContext` answers by returning an envelope.
         changes = await evaluateChangeNotification(input, key);
@@ -971,6 +1084,14 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
           // synthesising an empty one, and why there is still exactly one `hostOutput` here.
           await resetHostSuccessfulToolCount(key);
           hostOutput = profile.midTurnContext(renderChangeCard(changes, impact.length > 0 ? impact : undefined));
+        } else if (lessonCard && profile.midTurnContext('') !== undefined) {
+          // Below the change card, above everything else in the slot: an irreversible command
+          // that just ran is the one signal whose value decays with every tool call between
+          // the event and the asking -- "what else matched that predicate" is only answerable
+          // while the agent still remembers aiming. A "go store" signal resets the drift
+          // counter on the same reasoning as the skill nudges below.
+          await resetHostSuccessfulToolCount(key);
+          hostOutput = profile.midTurnContext(lessonCard);
         } else if (profile.midTurnContext('') !== undefined) {
           // A change card always wins the single mid-turn slot; below it, a specific
           // capture suggestion beats the generic continuation reminder.
@@ -1050,9 +1171,15 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         await closeHostSessionBinding(bindingKey(input, 'session'));
         return { accepted: true, sessionId: session.id, promotion: result.promotion, handoff: result.handoff };
       }
-      const silence = await evaluateSilenceNudge(input);
+      // The lesson gate outranks the silence nudge and suppresses it for this stop: both
+      // withhold the stop, a specific reason beats a general one, and two blocks on one stop
+      // is the fatigue that teaches agents to ignore the channel. The silence nudge's claim
+      // is only spent on delivery, so it keeps its chance at a later stop.
+      const lessonStop = await evaluatePendingLessonStop(input);
+      const silence = lessonStop ? undefined : await evaluateSilenceNudge(input);
+      const stopOutput = lessonStop ?? silence;
       await closeHostSessionBinding(key);
-      return { accepted: true, sessionId: session.id, ...(silence ? { hostOutput: silence } : {}) };
+      return { accepted: true, sessionId: session.id, ...(stopOutput ? { hostOutput: stopOutput } : {}) };
     }
 
     if (input.status === 'failed') {
@@ -1074,9 +1201,13 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // `UserPromptSubmit` sequence gives the turn its own, so a normal Claude stop lands here.
     // Keying the counters on the conversation rather than on either memory session is what lets
     // one verdict serve both paths.
-    const silence = await evaluateSilenceNudge(input);
+    // Same precedence as the shared-binding path above: a specific unstored event beats the
+    // generic "stored nothing" verdict, and at most one of them may withhold this stop.
+    const lessonStop = await evaluatePendingLessonStop(input);
+    const silence = lessonStop ? undefined : await evaluateSilenceNudge(input);
+    const stopOutput = lessonStop ?? silence;
     await closeHostSessionBinding(key);
-    return { accepted: true, sessionId: session.id, promotion, ...(silence ? { hostOutput: silence } : {}) };
+    return { accepted: true, sessionId: session.id, promotion, ...(stopOutput ? { hostOutput: stopOutput } : {}) };
   }
 
   const key = bindingKey(input, 'session');

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -552,6 +552,26 @@ const SCHEMA_STATEMENTS = [
     blocks INTEGER NOT NULL DEFAULT 0
   );`,
 
+  // Turn-scoped capture counters (capture.scope = 'turn'). Working state, not history: the
+  // turn boundary deletes the row, which is what makes the counters per-turn under a host
+  // that reuses one turn key for every main-thread turn. `prompted` is the per-turn one-shot.
+  `CREATE TABLE IF NOT EXISTS capture_turn_outcomes (
+    turn_key TEXT PRIMARY KEY,
+    conversation TEXT NOT NULL,
+    tool_events INTEGER NOT NULL DEFAULT 0,
+    file_writes INTEGER NOT NULL DEFAULT 0,
+    durable_writes INTEGER NOT NULL DEFAULT 0,
+    prompted TEXT
+  );`,
+
+  // The per-conversation prompt ceiling, on its own row because the turn rows above are
+  // deleted at every boundary -- a ceiling kept there would be forgotten with them. Same
+  // one-shot-by-conditional-UPDATE rule as `pending_lesson_claims`.
+  `CREATE TABLE IF NOT EXISTS capture_turn_prompts (
+    conversation TEXT PRIMARY KEY,
+    prompts INTEGER NOT NULL DEFAULT 0
+  );`,
+
   `CREATE TRIGGER IF NOT EXISTS knowledge_items_fts_ai AFTER INSERT ON knowledge_items BEGIN
     INSERT INTO knowledge_items_fts(item_id, category, status, title, content, reasoning, tags)
     VALUES (new.id, new.category, new.status, new.title, new.content, coalesce(new.reasoning, ''), coalesce(new.tags, ''));

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -525,6 +525,33 @@ const SCHEMA_STATEMENTS = [
     nudged TEXT
   );`,
 
+  // Pending lessons: specific events -- a destructive command, a user correction -- whose
+  // knowledge has not been stored yet. The opposite scoping from `capture_outcomes` above,
+  // deliberately: that table asks "did this conversation store anything", which a session
+  // storing plenty of unrelated atoms satisfies while the one event that mattered goes
+  // unwritten. One row per event; `resolved` is NULL while open, then 'write' (a durable
+  // write landed after it), 'blocked' (delivered by withholding a stop), 'shadow' (would
+  // have been delivered), or 'budget' (the block ceiling was already spent, so it settled
+  // silently).
+  `CREATE TABLE IF NOT EXISTS pending_lessons (
+    id TEXT PRIMARY KEY,
+    conversation TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    class TEXT,
+    snippet TEXT,
+    observed_at TEXT NOT NULL,
+    resolved TEXT
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_pending_lessons_conversation ON pending_lessons(conversation);`,
+
+  // The block budget, its own row so the claim can be a conditional UPDATE: two stop hooks
+  // race, exactly one may spend a block, and after MAX_LESSON_BLOCKS the gate goes silent for
+  // the conversation forever. Same claim-before-deliver rule as `capture_outcomes.nudged`.
+  `CREATE TABLE IF NOT EXISTS pending_lesson_claims (
+    conversation TEXT PRIMARY KEY,
+    blocks INTEGER NOT NULL DEFAULT 0
+  );`,
+
   `CREATE TRIGGER IF NOT EXISTS knowledge_items_fts_ai AFTER INSERT ON knowledge_items BEGIN
     INSERT INTO knowledge_items_fts(item_id, category, status, title, content, reasoning, tags)
     VALUES (new.id, new.category, new.status, new.title, new.content, coalesce(new.reasoning, ''), coalesce(new.tags, ''));

--- a/src/store/capture-config.ts
+++ b/src/store/capture-config.ts
@@ -24,3 +24,15 @@ export function captureNudgeMode(config?: ProjectConfig): CaptureNudgeMode {
   const mode = config?.capture?.nudge;
   return NUDGE_MODES.includes(mode as CaptureNudgeMode) ? mode as CaptureNudgeMode : 'off';
 }
+
+/**
+ * How event-shaped lessons -- a destructive command that ran, a prompt that reads as a user
+ * correction -- are handled. Same ladder and same typo rule as `capture.nudge`, and a separate
+ * switch from it for the reason `impact.gate` is separate from `impact.enabled`: the silence
+ * nudge speaks once per conversation about a total; this inspects individual events and can
+ * withhold a stop over one, which is a different risk armed by a different, deliberate act.
+ */
+export function captureEventsMode(config?: ProjectConfig): CaptureNudgeMode {
+  const mode = config?.capture?.events;
+  return NUDGE_MODES.includes(mode as CaptureNudgeMode) ? mode as CaptureNudgeMode : 'off';
+}

--- a/src/store/capture-config.ts
+++ b/src/store/capture-config.ts
@@ -36,3 +36,16 @@ export function captureEventsMode(config?: ProjectConfig): CaptureNudgeMode {
   const mode = config?.capture?.events;
   return NUDGE_MODES.includes(mode as CaptureNudgeMode) ? mode as CaptureNudgeMode : 'off';
 }
+
+export type CaptureScope = 'conversation' | 'turn';
+
+/**
+ * At what granularity the silence question is asked. `conversation` is today's behaviour and
+ * the default; `turn` additionally watches each turn as it runs and can prompt mid-turn --
+ * through the free context channel, never a blocked stop -- when a turn has done substantial
+ * work and stored nothing. A typo falls back to `conversation` by the same rule as the modes
+ * above: the narrower, quieter reading.
+ */
+export function captureScope(config?: ProjectConfig): CaptureScope {
+  return config?.capture?.scope === 'turn' ? 'turn' : 'conversation';
+}

--- a/src/store/capture-outcome.ts
+++ b/src/store/capture-outcome.ts
@@ -210,6 +210,158 @@ export async function captureHealth(): Promise<CaptureHealth> {
   }
 }
 
+/**
+ * Turn-scoped capture: the same negative signal, asked while the turn is still running.
+ *
+ * The conversation-scoped verdict above has a structural blind spot the incident record names:
+ * a session that stores plenty of unrelated atoms reads as healthy for the whole conversation,
+ * so the turn that diagnosed something hard and stored nothing is never spoken to. And the
+ * drift reminder cannot cover it either, because ANY knowl call resets that counter -- the
+ * memory-active session is precisely the one every existing reminder goes quiet for. These
+ * counters are keyed per turn, and the only thing that quiets the prompt is a durable write.
+ *
+ * Rows are working state, not history: the turn boundary deletes them, and `prompted` is the
+ * per-turn one-shot claim with a per-conversation ceiling behind it.
+ */
+
+export type TurnCaptureOutcome = {
+  turnKey: string;
+  conversation: string;
+  toolEvents: number;
+  fileWrites: number;
+  durableWrites: number;
+  prompted: string | null;
+};
+
+/**
+ * Tool events a turn must have produced, including at least one file write, before its
+ * silence is worth interrupting. Deliberately much higher than `MIN_SUBSTANTIVE_TURNS`' bar:
+ * most turns legitimately store nothing, and this prompt spends slot space in the middle of
+ * live work. Twelve tool events with a file write is a turn that built or fixed something.
+ */
+export const MIN_SUBSTANTIVE_TURN_EVENTS = 12;
+/** How many turns of one conversation may be prompted, ever. The fatigue ceiling. */
+export const MAX_TURN_CAPTURE_PROMPTS = 3;
+
+/** The stable identity of one turn, NUL-joined for the reason `conversationKey` gives. */
+export function turnCaptureKey(parts: {
+  host: string;
+  projectRoot: string;
+  externalSessionId?: string;
+  externalTurnId?: string;
+}): string {
+  return [parts.host, parts.projectRoot, parts.externalSessionId ?? '', parts.externalTurnId ?? ''].join('\u0000');
+}
+
+/** Count one tool event into the turn, and read the turn's counters back in the same write. */
+export async function recordTurnToolEvent(
+  turnKey: string,
+  conversation: string,
+  event: { fileWrite: boolean; durableWrite: boolean },
+): Promise<TurnCaptureOutcome | null> {
+  const key = (turnKey ?? '').trim();
+  if (!key) return null;
+  try {
+    const rows = await getClient().execute({
+      sql: `INSERT INTO capture_turn_outcomes (turn_key, conversation, tool_events, file_writes, durable_writes)
+            VALUES (?, ?, 1, ?, ?)
+            ON CONFLICT(turn_key) DO UPDATE SET
+              tool_events = tool_events + 1,
+              file_writes = file_writes + excluded.file_writes,
+              durable_writes = durable_writes + excluded.durable_writes
+            RETURNING turn_key, conversation, tool_events, file_writes, durable_writes, prompted`,
+      args: [key, conversation, event.fileWrite ? 1 : 0, event.durableWrite ? 1 : 0],
+    });
+    const row = rows.rows[0];
+    if (!row) return null;
+    return {
+      // The caller's key and conversation, NOT the row's columns. The keys are NUL-joined and
+      // SQLite stores the full bytes, but the driver's read path stops TEXT at the first NUL --
+      // so a key read back from a row is truncated to its first segment and can never match
+      // the stored value again. Every other claim in this file survives by recomputing its key
+      // instead of round-tripping it; this result must uphold the same rule for its caller.
+      turnKey: key,
+      conversation,
+      toolEvents: Number(row.tool_events ?? 0),
+      fileWrites: Number(row.file_writes ?? 0),
+      durableWrites: Number(row.durable_writes ?? 0),
+      prompted: row.prompted === null || row.prompted === undefined ? null : String(row.prompted),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Whether this turn's silence is worth one prompt. Pure, so the threshold is testable alone. */
+export function shouldPromptTurnCapture(outcome: TurnCaptureOutcome | null): boolean {
+  if (!outcome) return false;
+  if (outcome.prompted) return false;
+  return outcome.durableWrites === 0
+    && outcome.fileWrites > 0
+    && outcome.toolEvents >= MIN_SUBSTANTIVE_TURN_EVENTS;
+}
+
+/**
+ * Claim this turn's one prompt, then one of the conversation's. Two claims because the row
+ * that carries the first cannot carry the second: a Claude main thread reuses one turn key for
+ * every turn -- the boundary delete is what makes it per-turn -- so a ceiling kept on the turn
+ * row would be deleted with it. The ceiling lives on its own conversation row instead, exactly
+ * as the lesson gate's block budget does, and both claims are conditional writes.
+ *
+ * Order matters: the turn's one-shot is spent first, so losing the ceiling race afterwards
+ * leaves the turn marked and silent rather than eligible to race again.
+ */
+export async function claimTurnCapturePrompt(turnKey: string, conversation: string): Promise<boolean> {
+  const key = (turnKey ?? '').trim();
+  const convo = (conversation ?? '').trim();
+  if (!key || !convo) return false;
+  try {
+    const client = getClient();
+    const turn = await client.execute({
+      sql: "UPDATE capture_turn_outcomes SET prompted = 'prompted' WHERE turn_key = ? AND prompted IS NULL",
+      args: [key],
+    });
+    if (Number(turn.rowsAffected ?? 0) === 0) return false;
+    await client.execute({
+      sql: 'INSERT OR IGNORE INTO capture_turn_prompts (conversation, prompts) VALUES (?, 0)',
+      args: [convo],
+    });
+    const ceiling = await client.execute({
+      sql: 'UPDATE capture_turn_prompts SET prompts = prompts + 1 WHERE conversation = ? AND prompts < ?',
+      args: [convo, MAX_TURN_CAPTURE_PROMPTS],
+    });
+    return Number(ceiling.rowsAffected ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete a turn's counters at its boundary, so the next turn under a reused key starts from
+ * zero. The ceiling survives on its own row -- that is the reason it has one.
+ */
+export async function resetTurnCapture(turnKey: string): Promise<void> {
+  const key = (turnKey ?? '').trim();
+  if (!key) return;
+  try {
+    await getClient().execute({
+      sql: 'DELETE FROM capture_turn_outcomes WHERE turn_key = ?',
+      args: [key],
+    });
+  } catch {
+    // Advisory: a stale row costs at most one early prompt, and the per-turn one-shot holds.
+  }
+}
+
+/** The turn-scoped prompt. Mid-turn context, so it must say why it is speaking NOW. */
+export function renderTurnCapturePrompt(): string {
+  return [
+    'KNOWL CAPTURE: this turn has done substantial work and stored nothing durable.',
+    'If something here would help a later session -- a finding you verified, a decision and its reasoning, a diagnosis that will recur -- store it now with knowl_store or knowl_decide, while the details are still in front of you.',
+    'Querying memory does not persist anything; only a write does. If nothing durable exists yet, carry on -- this asks at most once per turn.',
+  ].join(' ');
+}
+
 /** The nudge text, and the only place it is written. */
 /**
  * The mid-session variant, for the MCP channel.

--- a/src/store/pending-lessons.ts
+++ b/src/store/pending-lessons.ts
@@ -1,0 +1,229 @@
+import crypto from 'node:crypto';
+import { getClient } from './database.js';
+import type { DestructiveCommandHit } from '../core/lesson-signals.js';
+
+/**
+ * Pending lessons: specific events whose knowledge has not been stored yet.
+ *
+ * `capture_outcomes` answers "did this conversation store anything at all", and its scoping is
+ * exactly why it missed the incident that motivated this table: a session that stores plenty of
+ * unrelated atoms reads as healthy while the one thing that mattered -- a destructive command
+ * that took out more than it aimed at, a correction the user had to make -- goes unwritten.
+ * Both of the existing backstops (the drift reminder and the silence nudge) are disarmed by
+ * unrelated memory activity for the same structural reason. A pending lesson is the opposite
+ * shape: one row per event, claimed per event, and only a write that lands AFTER the event can
+ * settle it.
+ *
+ * Everything here is advisory-path plumbing and fails open: this runs inside a hook with the
+ * host blocked on the answer, and a lost measurement is always cheaper than a lost session.
+ */
+
+export type PendingLessonKind = 'destructive' | 'correction';
+
+export type PendingLesson = {
+  id: string;
+  conversation: string;
+  kind: PendingLessonKind;
+  /** Command class for destructive lessons; null for corrections. */
+  class: string | null;
+  /** A short clip of the command; corrections deliberately carry no text at all. */
+  snippet: string | null;
+  observedAt: string;
+};
+
+/** One nudge per command class per conversation; corrections capped separately. */
+export const MAX_CORRECTION_LESSONS = 3;
+/** The hard annoyance budget: at most this many blocked stops per conversation, ever. */
+export const MAX_LESSON_BLOCKS = 3;
+const SNIPPET_CHARS = 120;
+
+const clip = (text: string): string => (text.length > SNIPPET_CHARS ? `${text.slice(0, SNIPPET_CHARS)}…` : text);
+
+/**
+ * Record a destructive-command lesson. True only when this class had not fired for this
+ * conversation yet -- the caller nudges exactly when this returns true, so "one nudge per
+ * class per session" is decided here, race-safe, rather than by a read the next hook process
+ * cannot see.
+ */
+export async function recordDestructiveLesson(conversation: string, hit: DestructiveCommandHit, command: string): Promise<boolean> {
+  const id = (conversation ?? '').trim();
+  if (!id) return false;
+  try {
+    const client = getClient();
+    const existing = await client.execute({
+      sql: 'SELECT 1 FROM pending_lessons WHERE conversation = ? AND class = ? LIMIT 1',
+      args: [id, hit.id],
+    });
+    if (existing.rows.length > 0) return false;
+    await client.execute({
+      sql: `INSERT INTO pending_lessons (id, conversation, kind, class, snippet, observed_at)
+            VALUES (?, ?, 'destructive', ?, ?, ?)`,
+      args: [crypto.randomUUID(), id, hit.id, clip(String(command ?? '')), new Date().toISOString()],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Record a correction lesson, capped: two corrections in a session are usually two different things. */
+export async function recordCorrectionLesson(conversation: string): Promise<boolean> {
+  const id = (conversation ?? '').trim();
+  if (!id) return false;
+  try {
+    const client = getClient();
+    const count = await client.execute({
+      sql: "SELECT COUNT(*) AS n FROM pending_lessons WHERE conversation = ? AND kind = 'correction'",
+      args: [id],
+    });
+    if (Number(count.rows[0]?.n ?? 0) >= MAX_CORRECTION_LESSONS) return false;
+    await client.execute({
+      sql: `INSERT INTO pending_lessons (id, conversation, kind, class, snippet, observed_at)
+            VALUES (?, ?, 'correction', NULL, NULL, ?)`,
+      args: [crypto.randomUUID(), id, new Date().toISOString()],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function openPendingLessons(conversation: string): Promise<PendingLesson[]> {
+  const id = (conversation ?? '').trim();
+  if (!id) return [];
+  try {
+    const rows = await getClient().execute({
+      sql: 'SELECT id, conversation, kind, class, snippet, observed_at FROM pending_lessons WHERE conversation = ? AND resolved IS NULL ORDER BY observed_at',
+      args: [id],
+    });
+    return rows.rows.map(row => ({
+      id: String(row.id),
+      conversation: String(row.conversation),
+      kind: String(row.kind) as PendingLessonKind,
+      class: row.class === null || row.class === undefined ? null : String(row.class),
+      snippet: row.snippet === null || row.snippet === undefined ? null : String(row.snippet),
+      observedAt: String(row.observed_at),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * A durable write settles the lessons that were already on the table when it happened --
+ * temporal, not blanket. Clearing everything on any write is the same flaw one level down
+ * that disarms the drift counter: unrelated activity reading as the thing it is not. An
+ * event recorded after the write still stands, because the write cannot have been about it.
+ */
+export async function resolveLessonsBefore(conversation: string, timestamp: string): Promise<void> {
+  const id = (conversation ?? '').trim();
+  if (!id) return;
+  try {
+    await getClient().execute({
+      sql: "UPDATE pending_lessons SET resolved = 'write' WHERE conversation = ? AND resolved IS NULL AND observed_at <= ?",
+      args: [id, timestamp],
+    });
+  } catch {
+    // Advisory; a lesson that stays open one stop longer costs a sentence, not a session.
+  }
+}
+
+async function markLessons(ids: string[], how: 'blocked' | 'shadow' | 'budget'): Promise<void> {
+  if (ids.length === 0) return;
+  try {
+    const client = getClient();
+    for (const id of ids) {
+      await client.execute({ sql: 'UPDATE pending_lessons SET resolved = ? WHERE id = ? AND resolved IS NULL', args: [how, id] });
+    }
+  } catch {
+    // Advisory.
+  }
+}
+
+/**
+ * Settle lessons with the reason they settled: 'blocked' was delivered, 'shadow' would have
+ * been, 'budget' hit the ceiling and was delivered nothing. Three words instead of one so the
+ * measurement this exists to produce cannot conflate a message the agent saw with one it never
+ * could have.
+ */
+export async function markPendingLessons(ids: string[], how: 'blocked' | 'shadow' | 'budget'): Promise<void> {
+  await markLessons(ids, how);
+}
+
+/**
+ * Claim one of the conversation's blocked stops. True only for the caller that won it, by the
+ * same conditional-write rule as `claimSilenceNudge`: two stop hooks race here, and the budget
+ * must be spent exactly once. The budget is a hard ceiling on what this feature may ever cost
+ * a conversation -- after `MAX_LESSON_BLOCKS`, everything else settles silently.
+ */
+export async function claimLessonBlock(conversation: string): Promise<boolean> {
+  const id = (conversation ?? '').trim();
+  if (!id) return false;
+  try {
+    const client = getClient();
+    await client.execute({
+      sql: 'INSERT OR IGNORE INTO pending_lesson_claims (conversation, blocks) VALUES (?, 0)',
+      args: [id],
+    });
+    const result = await client.execute({
+      sql: 'UPDATE pending_lesson_claims SET blocks = blocks + 1 WHERE conversation = ? AND blocks < ?',
+      args: [id, MAX_LESSON_BLOCKS],
+    });
+    return Number(result.rowsAffected ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+const describe = (lesson: PendingLesson): string => {
+  if (lesson.kind === 'correction') return '  - the user corrected you';
+  const label = lesson.class === 'process-kill-broad' ? 'a process kill with a broad selector'
+    : lesson.class === 'git-discard' ? 'a git command that discards uncommitted work'
+    : lesson.class === 'git-rewrite-remote' ? 'a git command that rewrites shared history'
+    : lesson.class === 'recursive-delete' ? 'a recursive force-delete'
+    : lesson.class === 'container-destroy' ? 'a container or image force-removal'
+    : lesson.class === 'db-destructive' ? 'a destructive database statement'
+    : 'an irreversible command';
+  return `  - ${label}${lesson.snippet ? `: \`${lesson.snippet}\`` : ''}`;
+};
+
+const HOW_TO_STORE =
+  'knowl_store (category "constraint", tags ["operational-safety"], provenance "observed") naming the exact command, '
+  + 'what it actually matched beyond what you intended, the damage, and the narrower form to use instead.';
+
+/** The mid-turn nudge for a destructive command, sent while the agent still knows what else matched. */
+export function renderLessonNudge(hit: DestructiveCommandHit, command: string): string {
+  return [
+    `KNOWL LESSON: that was ${hit.label}: \`${clip(String(command ?? ''))}\``,
+    'Ask now, while you still know: what else matched that predicate? If it touched anything you did not own,',
+    `store it immediately -- ${HOW_TO_STORE}`,
+    'If it did exactly what you intended and nothing else, carry on. This fires once per command class per session.',
+  ].join(' ');
+}
+
+/** The turn-start line for a correction. The lesson exists in the agent's own context; no text is echoed. */
+export function renderCorrectionNudge(): string {
+  return [
+    'KNOWL LESSON: this prompt reads as a CORRECTION, not a new task.',
+    'A correction is durable knowledge you were supposed to be holding and were not -- store the rule that',
+    'prevents it next time with knowl_store (or knowl_update if it corrects something already stored), then answer.',
+    'If it is already in memory, say so with the item id in one line. If this is not actually a correction,',
+    'say that instead: this is a local pattern on the prompt text, not a verdict.',
+  ].join(' ');
+}
+
+/** The stop-block reason. Every escape hatch is honest, and (d) exists so the gate can never teach fabrication. */
+export function renderLessonStopReason(lessons: PendingLesson[]): string {
+  return [
+    'KNOWL LESSON GATE: this conversation contains something durable that was never written to memory:',
+    ...lessons.map(describe),
+    'No durable write followed it. Operational hazards and corrections are more important to persist than',
+    'technical findings, not less -- the next session repeats them blind. Do one of these now, then stop again:',
+    `  (a) store it -- ${HOW_TO_STORE}`,
+    '  (b) if it is already in memory, say so in one line with the item id.',
+    '  (c) if it was routine and harmed nothing, say so in one sentence.',
+    '  (d) if no such event actually happened, say so and stop. Never invent an incident to satisfy this',
+    '      gate -- an empty answer is a correct outcome, a fabricated memory is not.',
+    'This gate has already disarmed itself for these events; it will not raise them again.',
+  ].join('\n');
+}

--- a/src/store/pending-lessons.ts
+++ b/src/store/pending-lessons.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { getClient } from './database.js';
-import type { DestructiveCommandHit } from '../core/lesson-signals.js';
+import { DESTRUCTIVE_LABELS, type DestructiveCommandHit, type DestructiveCommandId } from '../core/lesson-signals.js';
 
 /**
  * Pending lessons: specific events whose knowledge has not been stored yet.
@@ -66,7 +66,7 @@ export async function recordDestructiveLesson(conversation: string, hit: Destruc
   }
 }
 
-/** Record a correction lesson, capped: two corrections in a session are usually two different things. */
+/** Record a correction lesson, capped at `MAX_CORRECTION_LESSONS`: separate corrections are usually separate things. */
 export async function recordCorrectionLesson(conversation: string): Promise<boolean> {
   const id = (conversation ?? '').trim();
   if (!id) return false;
@@ -128,7 +128,13 @@ export async function resolveLessonsBefore(conversation: string, timestamp: stri
   }
 }
 
-async function markLessons(ids: string[], how: 'blocked' | 'shadow' | 'budget'): Promise<void> {
+/**
+ * Settle lessons with the reason they settled: 'blocked' was delivered, 'shadow' would have
+ * been, 'budget' hit the ceiling and was delivered nothing. Three words instead of one so the
+ * measurement this exists to produce cannot conflate a message the agent saw with one it never
+ * could have.
+ */
+export async function markPendingLessons(ids: string[], how: 'blocked' | 'shadow' | 'budget'): Promise<void> {
   if (ids.length === 0) return;
   try {
     const client = getClient();
@@ -138,16 +144,6 @@ async function markLessons(ids: string[], how: 'blocked' | 'shadow' | 'budget'):
   } catch {
     // Advisory.
   }
-}
-
-/**
- * Settle lessons with the reason they settled: 'blocked' was delivered, 'shadow' would have
- * been, 'budget' hit the ceiling and was delivered nothing. Three words instead of one so the
- * measurement this exists to produce cannot conflate a message the agent saw with one it never
- * could have.
- */
-export async function markPendingLessons(ids: string[], how: 'blocked' | 'shadow' | 'budget'): Promise<void> {
-  await markLessons(ids, how);
 }
 
 /**
@@ -177,13 +173,10 @@ export async function claimLessonBlock(conversation: string): Promise<boolean> {
 
 const describe = (lesson: PendingLesson): string => {
   if (lesson.kind === 'correction') return '  - the user corrected you';
-  const label = lesson.class === 'process-kill-broad' ? 'a process kill with a broad selector'
-    : lesson.class === 'git-discard' ? 'a git command that discards uncommitted work'
-    : lesson.class === 'git-rewrite-remote' ? 'a git command that rewrites shared history'
-    : lesson.class === 'recursive-delete' ? 'a recursive force-delete'
-    : lesson.class === 'container-destroy' ? 'a container or image force-removal'
-    : lesson.class === 'db-destructive' ? 'a destructive database statement'
-    : 'an irreversible command';
+  // From the classifier's own table, not a second copy: the two had already drifted, and a
+  // class this build does not know (an older row, a newer writer) falls back rather than
+  // renders blank.
+  const label = DESTRUCTIVE_LABELS[lesson.class as DestructiveCommandId] ?? 'an irreversible command';
   return `  - ${label}${lesson.snippet ? `: \`${lesson.snippet}\`` : ''}`;
 };
 

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -179,8 +179,13 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * their delivery spends. Two additive tables, no backfill, and none is possible for the same
  * reason as level 9: the rows ride the events that cause them. `KNOWL_SCHEMA_VERSION` again
  * does not move.
+ *
+ * Level 14 adds `capture_turn_outcomes` and `capture_turn_prompts`: the write-side negative
+ * signal at turn granularity, and the per-conversation ceiling its prompts spend. Additive
+ * tables, no backfill possible -- turn counters exist only while their turn does.
+ * `KNOWL_SCHEMA_VERSION` again does not move.
  */
-export const KNOWL_MIGRATION_LEVEL = 13;
+export const KNOWL_MIGRATION_LEVEL = 14;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -173,8 +173,14 @@ export const KNOWL_SCHEMA_VERSION = 1;
  *
  * `KNOWL_SCHEMA_VERSION` does not move: an older build ignores both columns and pushes exactly
  * as it did before.
+ *
+ * Level 13 adds `pending_lessons` and `pending_lesson_claims`: events -- a destructive
+ * command, a user correction -- whose knowledge has not been stored yet, and the block budget
+ * their delivery spends. Two additive tables, no backfill, and none is possible for the same
+ * reason as level 9: the rows ride the events that cause them. `KNOWL_SCHEMA_VERSION` again
+ * does not move.
  */
-export const KNOWL_MIGRATION_LEVEL = 12;
+export const KNOWL_MIGRATION_LEVEL = 13;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/snapshot-tables.ts
+++ b/src/store/snapshot-tables.ts
@@ -95,6 +95,12 @@ export const SNAPSHOT_TABLE_POLICY: Readonly<Record<string, SnapshotTablePolicy>
   // stop-blocking interrupt against conversations that already answered it.
   pending_lessons: 'preserved',
   pending_lesson_claims: 'preserved',
+  // Turn-scoped capture counters and their prompt ceiling. Preserved for the claims reason
+  // above: `prompted` and the ceiling row are spent one-shots, and restoring an older copy
+  // would re-arm prompts against turns and conversations that already took them. The counter
+  // rows are additionally worthless to restore -- they describe turns that are over.
+  capture_turn_outcomes: 'preserved',
+  capture_turn_prompts: 'preserved',
   // What THIS machine has staged for, and pushed to, a cloud workspace. The server's copy is the
   // truer one and a snapshot cannot roll it back, so restoring an older ledger would only make
   // this machine forget the `remote_version` every republish needs -- turning the next publish

--- a/src/store/snapshot-tables.ts
+++ b/src/store/snapshot-tables.ts
@@ -89,6 +89,12 @@ export const SNAPSHOT_TABLE_POLICY: Readonly<Record<string, SnapshotTablePolicy>
   // from a week-old snapshot would clear the flag on conversations that were already nudged --
   // re-arming a stop-blocking interrupt against sessions that had answered it.
   capture_outcomes: 'preserved',
+  // Pending lessons and their block budget, preserved on exactly `capture_outcomes`' two
+  // reasons: the resolved rows are the measurement any decision to enforce reads, and the
+  // claims table is a spent one-shot -- refilling it from a snapshot would re-arm a
+  // stop-blocking interrupt against conversations that already answered it.
+  pending_lessons: 'preserved',
+  pending_lesson_claims: 'preserved',
   // What THIS machine has staged for, and pushed to, a cloud workspace. The server's copy is the
   // truer one and a snapshot cannot roll it back, so restoring an older ledger would only make
   // this machine forget the `remote_version` every republish needs -- turning the next publish

--- a/src/transcripts/config.ts
+++ b/src/transcripts/config.ts
@@ -16,3 +16,12 @@ export { isTranscriptSearchEnabled } from '../core/config.js';
 export function isTranscriptSharingEnabled(config: ProjectConfig): boolean {
   return isTranscriptSearchEnabled(config) && config.search?.transcripts?.share === true;
 }
+
+/**
+ * Whether a missed `knowl_query` runs transcript search itself rather than suggesting it.
+ * An AND for the same reason `share` is: a fallback into an index that does not exist would
+ * turn every miss into a second, slower miss.
+ */
+export function isTranscriptFallbackEnabled(config: ProjectConfig): boolean {
+  return isTranscriptSearchEnabled(config) && config.search?.transcripts?.fallback === true;
+}

--- a/src/transcripts/mcp-handlers.ts
+++ b/src/transcripts/mcp-handlers.ts
@@ -96,6 +96,13 @@ async function optionalEmbedder(config: ProjectConfig, projectRoot: string) {
   }
 }
 
+/**
+ * How an empty search opens its answer. Exported for the `knowl_query` fallback, which has to
+ * tell a negative from a hit without re-running the search: a shared constant is the only way
+ * the two surfaces cannot drift into disagreeing about what "nothing" looks like.
+ */
+export const NO_TRANSCRIPT_MATCHES_PREFIX = 'No transcript matches';
+
 export async function handleTranscriptSearch(input: {
   config: ProjectConfig | null;
   projectRoot: string | null;
@@ -145,7 +152,7 @@ export async function handleTranscriptSearch(input: {
 
   const lines: string[] = [];
   if (hits.length === 0) {
-    lines.push(`No transcript matches for "${query}".`);
+    lines.push(`${NO_TRANSCRIPT_MATCHES_PREFIX} for "${query}".`);
   } else {
     for (const hit of hits) {
       const parent = hit.parentSessionId ? ` (subagent of ${hit.parentSessionId})` : '';

--- a/tests/cli/posture.test.ts
+++ b/tests/cli/posture.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { DEFAULT_CONFIG, loadConfig } from '../../src/core/config.js';
+import { CONFIG_FIELDS } from '../../src/cli/config/schema.js';
+import { getEffectiveConfigValue, resetConfigValue, setConfigValue, setConfigValues } from '../../src/cli/config/service.js';
+import { captureEventsMode, captureScope } from '../../src/store/capture-config.js';
+import { isTranscriptFallbackEnabled } from '../../src/transcripts/config.js';
+
+/**
+ * The posture keys through the config service -- the same calls the `knowl posture` command
+ * makes. The command itself is a thin loop over these; what has to hold is that every key
+ * parses, round-trips, resets, and lands where its runtime reader looks.
+ */
+
+const ROOT = path.resolve('.knowl-posture-test');
+
+afterEach(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+async function writeConfig() {
+  await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+  await fs.writeFile(path.join(ROOT, '.knowl', 'config.json'), JSON.stringify(DEFAULT_CONFIG, null, 2), 'utf8');
+}
+
+const MAXIMAL: Array<{ key: string; raw: string }> = [
+  { key: 'search.transcripts.enabled', raw: 'true' },
+  { key: 'search.transcripts.fallback', raw: 'true' },
+  { key: 'capture.nudge', raw: 'enforce' },
+  { key: 'capture.events', raw: 'enforce' },
+  { key: 'capture.scope', raw: 'turn' },
+  { key: 'impact.enabled', raw: 'true' },
+  { key: 'impact.gate', raw: 'shadow' },
+];
+
+describe('the posture keys', () => {
+  it('declares every new key in the schema with a default the editor can restore', () => {
+    for (const key of ['search.transcripts.fallback', 'capture.events', 'capture.scope']) {
+      const field = CONFIG_FIELDS.find(entry => entry.key === key);
+      expect(field, key).toBeDefined();
+      expect(field!.defaultValue, key).toBeDefined();
+    }
+  });
+
+  it('sets the maximal posture in one batch and the runtime readers see it', async () => {
+    await writeConfig();
+    await setConfigValues(ROOT, MAXIMAL);
+
+    const config = await loadConfig(ROOT);
+    expect(isTranscriptFallbackEnabled(config)).toBe(true);
+    expect(captureEventsMode(config)).toBe('enforce');
+    expect(captureScope(config)).toBe('turn');
+    expect(config.capture?.nudge).toBe('enforce');
+    expect(config.impact?.gate).toBe('shadow');
+  });
+
+  it('resets back to frugal: every key reads as its shipped default again', async () => {
+    await writeConfig();
+    await setConfigValues(ROOT, MAXIMAL);
+    for (const { key } of MAXIMAL) await resetConfigValue(ROOT, key);
+
+    const config = await loadConfig(ROOT);
+    expect(isTranscriptFallbackEnabled(config)).toBe(false);
+    expect(captureEventsMode(config)).toBe('off');
+    expect(captureScope(config)).toBe('conversation');
+    expect(await getEffectiveConfigValue(ROOT, 'capture.events')).toBe('off');
+    expect(await getEffectiveConfigValue(ROOT, 'capture.scope')).toBe('conversation');
+  });
+
+  it('refuses a value outside the enum instead of storing it', async () => {
+    await writeConfig();
+    await expect(setConfigValue(ROOT, 'capture.events', 'always')).rejects.toThrow();
+    await expect(setConfigValue(ROOT, 'capture.scope', 'session')).rejects.toThrow();
+  });
+
+  it('fallback stays inert without transcripts enabled -- the AND is the contract', async () => {
+    await writeConfig();
+    await setConfigValue(ROOT, 'search.transcripts.fallback', 'true');
+    expect(isTranscriptFallbackEnabled(await loadConfig(ROOT))).toBe(false);
+  });
+});

--- a/tests/core/lesson-signals.test.ts
+++ b/tests/core/lesson-signals.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { classifyDestructiveCommand, detectCorrectionSignal } from '../../src/core/lesson-signals.js';
+
+/**
+ * The probe tables are the point of this suite: every row below is either a command shape that
+ * actually destroyed something on a real machine, or a false positive that actually fired
+ * during live testing of the prototype gate. Precision cases outnumber recall cases because a
+ * gate that cries wolf is a gate that gets switched off.
+ */
+
+describe('classifyDestructiveCommand', () => {
+  const firing: Array<[string, string, string]> = [
+    ['the real incident', 'Get-Process node | Where-Object { $_.StartTime -gt (Get-Date).AddMinutes(-10) } | Stop-Process -Force', 'process-kill-broad'],
+    ['taskkill by image', 'taskkill /IM node.exe /F', 'process-kill-broad'],
+    ['taskkill by filter -- the same broad name-match without /IM', 'taskkill /F /FI "IMAGENAME eq node.exe"', 'process-kill-broad'],
+    ['pkill', 'pkill -f "node server.js"', 'process-kill-broad'],
+    ['pm2 delete', 'pm2 delete api-server', 'process-kill-broad'],
+    ['git reset --hard', 'git reset --hard origin/main', 'git-discard'],
+    ['git clean', 'git clean -fdx', 'git-discard'],
+    ['git checkout -- .', 'git checkout -- .', 'git-discard'],
+    ['git worktree remove --force', 'git worktree remove --force ../some-worktree', 'git-discard'],
+    ['force push', 'git push --force origin staging', 'git-rewrite-remote'],
+    ['branch -D', 'git branch -D feature/old', 'git-rewrite-remote'],
+    ['rm -rf on source', 'rm -rf server/src/journey', 'recursive-delete'],
+    ['rm -r -f split flags', 'rm -r -f server/src/journey', 'recursive-delete'],
+    ['Remove-Item recurse force', 'Remove-Item -Recurse -Force C:\\Code\\app\\content', 'recursive-delete'],
+    ['docker rm -f subshell', 'docker rm -f $(docker ps -aq)', 'container-destroy'],
+    ['docker system prune', 'docker system prune -a', 'container-destroy'],
+    ['DROP TABLE', 'psql -c "DROP TABLE question_variants"', 'db-destructive'],
+    ['DELETE without WHERE', 'psql -c "DELETE FROM users"', 'db-destructive'],
+    ['UPDATE without WHERE', 'psql -c "UPDATE families SET status = \'draft\'"', 'db-destructive'],
+    // Chained after a read: the whole-string read-only exemption was the prototype's worst
+    // defect -- an agent chains a read then a mutation constantly.
+    ['read then delete', 'ls && rm -rf server/src/journey', 'recursive-delete'],
+    ['status then reset', 'git status --short && git reset --hard origin/main', 'git-discard'],
+    ['echo then pkill', 'echo starting; pkill -f node', 'process-kill-broad'],
+    ['cat then drop', 'cat notes.txt && psql -c "DROP TABLE users"', 'db-destructive'],
+    ['cd then delete', 'cd /c/Code/app && rm -rf server/src/journey', 'recursive-delete'],
+    ['pipeline position', 'Get-Process chrome | Stop-Process', 'process-kill-broad'],
+    ['own line', 'cd /c/Code/app\ngit clean -fdx', 'git-discard'],
+    ['under sudo and timeout', 'sudo timeout 30 pkill -f node', 'process-kill-broad'],
+  ];
+  it.each(firing)('fires: %s', (_name, command, expected) => {
+    expect(classifyDestructiveCommand(command)?.id).toBe(expected);
+  });
+
+  const silent: Array<[string, string]> = [
+    ['kill by pipeline of PIDs', '$p = (Get-NetTCPConnection -LocalPort 5000 -State Listen).OwningProcess; $p | ForEach-Object { Stop-Process -Id $_ -Force }'],
+    ['taskkill by PID', 'taskkill /PID 12345 /F'],
+    ['rm -rf node_modules', 'rm -rf node_modules'],
+    ['rm -rf dist', 'rm -rf client/dist'],
+    ['rm -rf a temp path', 'rm -rf /c/Users/Admin/AppData/Local/Temp/claude/scratchpad/x'],
+    ['rm -rf a .tmp dir', 'rm -rf /c/Code/app/.tmp-build-123'],
+    ['DELETE with WHERE', 'psql -c "DELETE FROM users WHERE id = 3"'],
+    ['UPDATE with WHERE', 'psql -c "UPDATE families SET status = \'active\' WHERE id = 7"'],
+    ['migration file without inline SQL', 'psql -f server/migrations/007_drop_legacy.sql'],
+    ['force-with-lease', 'git push --force-with-lease origin staging'],
+    ['branch -d lowercase (safe delete)', 'git branch -d feature/merged'],
+    ['git clean dry-run', 'git clean -fdn'],
+    ['git clean --dry-run', 'git clean -fd --dry-run'],
+    ['git checkout a branch', 'git checkout staging'],
+    ['git checkout one file', 'git checkout -- server/src/config.ts'],
+    ['ordinary build', 'npm run build'],
+    ['grep FOR the pattern', 'grep -rn "Stop-Process" scripts/'],
+    ['rg for drop table', 'rg "DROP TABLE" server/migrations'],
+    ['cat a file that mentions it', 'cat scripts/kill-port.ps1'],
+    // Mentions, not commands -- each of these fired somewhere before quoting was masked.
+    ['agent prompt quoting pkill', 'timeout 300 claude -p "Run exactly this one command and report its exit code: pkill -f probe-xyz" --permission-mode bypassPermissions'],
+    ['agent prompt quoting DROP TABLE', 'claude -p "explain what DROP TABLE does"'],
+    ['commit message naming a migration', 'git commit -m "migration: drop table question_variants"'],
+    ['commit message quoting delete from', 'git commit -m "fix: delete from users had no where clause"'],
+    ['issue body advising against reset', 'gh issue comment 12 --body "do not run git reset --hard here"'],
+    ['pr body with a quoted newline and verb', 'gh pr create --body "steps that were reverted:\ngit reset --hard abc123\nnpm ci"'],
+    ['echo of a scary string', 'echo "DELETE FROM users"'],
+  ];
+  it.each(silent)('stays silent: %s', (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toBeNull();
+  });
+
+  it('returns null for empty and whitespace input', () => {
+    expect(classifyDestructiveCommand('')).toBeNull();
+    expect(classifyDestructiveCommand('   \n  ')).toBeNull();
+  });
+});
+
+describe('detectCorrectionSignal', () => {
+  const corrections = [
+    "that was some really important information that you should have saved into the memory MCP but you didn't right why is that the case",
+    "why didn't you store that?",
+    'we already decided this last week',
+    'I told you not to kill processes by name',
+    'that was careless',
+    'you broke my browser session',
+    'you keep forgetting to run the migration',
+    'for the last time, use the port',
+    'never do that again',
+    'stop doing that',
+  ];
+  it.each(corrections.map(p => [p]))('fires: %s', prompt => {
+    expect(detectCorrectionSignal(prompt)).toBe(true);
+  });
+
+  const benign = [
+    'add a migration for the new column',
+    'can you check whether the dev server is running?',
+    'what did we decide about the pricing model?',
+    'run the tests and tell me what fails',
+    'the build is broken, please fix it',
+    // Each of these fired on the prototype's looser patterns.
+    'you should have write access to the staging bucket now, can you check?',
+    "didn't you already push that branch? just checking",
+    'you keep running the tests in watch mode, that is fine',
+    'add a test case for the string "I told you not to do that"',
+    'Here is the issue text from GitHub: "we already decided to drop node 18 support"',
+    'Read this review brief: the user said "why didn\'t you store that" and the agent apologised.',
+    // A correction buried past the scan window is an aside, not the task.
+    `${'the actual task description goes here and keeps going. '.repeat(8)}also why didn't you store that`,
+  ];
+  it.each(benign.map(p => [p]))('stays silent: %s', prompt => {
+    expect(detectCorrectionSignal(prompt)).toBe(false);
+  });
+
+  it('returns false for empty input', () => {
+    expect(detectCorrectionSignal('')).toBe(false);
+  });
+});

--- a/tests/core/lesson-signals.test.ts
+++ b/tests/core/lesson-signals.test.ts
@@ -36,6 +36,12 @@ describe('classifyDestructiveCommand', () => {
     ['echo then pkill', 'echo starting; pkill -f node', 'process-kill-broad'],
     ['cat then drop', 'cat notes.txt && psql -c "DROP TABLE users"', 'db-destructive'],
     ['cd then delete', 'cd /c/Code/app && rm -rf server/src/journey', 'recursive-delete'],
+    // The safe-target exemption is per SEGMENT. Tested against the whole command it read a
+    // build-dir clean anywhere in the line as a licence for everything after it.
+    ['safe clean then a real delete', 'rm -rf dist && rm -rf /c/Code/app/server/src', 'recursive-delete'],
+    ['safe word merely mentioned', 'echo scratchpad && rm -rf /c/Code/app/server/src', 'recursive-delete'],
+    // Bounded on the right: a path that merely STARTS with a build-dir name is not one.
+    ['a path that only looks like dist', 'rm -rf /var/dist-data', 'recursive-delete'],
     ['pipeline position', 'Get-Process chrome | Stop-Process', 'process-kill-broad'],
     ['own line', 'cd /c/Code/app\ngit clean -fdx', 'git-discard'],
     ['under sudo and timeout', 'sudo timeout 30 pkill -f node', 'process-kill-broad'],
@@ -48,7 +54,15 @@ describe('classifyDestructiveCommand', () => {
     ['kill by pipeline of PIDs', '$p = (Get-NetTCPConnection -LocalPort 5000 -State Listen).OwningProcess; $p | ForEach-Object { Stop-Process -Id $_ -Force }'],
     ['taskkill by PID', 'taskkill /PID 12345 /F'],
     ['rm -rf node_modules', 'rm -rf node_modules'],
-    ['rm -rf dist', 'rm -rf client/dist'],
+    ['rm -rf a nested dist', 'rm -rf client/dist'],
+    // Bare, no leading separator -- how the clean is actually written, and what the pattern
+    // used to miss. `npm run build && rm -rf dist` was firing the gate on every repo on earth.
+    ['rm -rf dist', 'rm -rf dist'],
+    ['rm -rf build', 'rm -rf build'],
+    ['rm -rf coverage', 'rm -rf coverage'],
+    ['rm -rf tmp', 'rm -rf tmp'],
+    ['build then clean', 'npm run build && rm -rf dist'],
+    ['several build dirs at once', 'rm -rf dist build coverage'],
     ['rm -rf a temp path', 'rm -rf /c/Users/Admin/AppData/Local/Temp/claude/scratchpad/x'],
     ['rm -rf a .tmp dir', 'rm -rf /c/Code/app/.tmp-build-123'],
     ['DELETE with WHERE', 'psql -c "DELETE FROM users WHERE id = 3"'],

--- a/tests/mcp/query-paths-changed.test.ts
+++ b/tests/mcp/query-paths-changed.test.ts
@@ -120,7 +120,12 @@ describe('knowl_query pathsChanged marker', () => {
     const projectId = await seedRepo(A);
     await fs.mkdir(path.join(A, 'src'), { recursive: true });
     await fs.writeFile(path.join(A, 'src', 'auth.ts'), 'export const ttl = 15;');
-    // Not backdated: the file was written before the row, so mtime <= updated_at.
+    // The mtime is pinned to a known past instant rather than trusted from the write: a
+    // buffered write's timestamp can land AFTER the store's own clock reading on some
+    // platforms (macOS and Windows on node 22, in CI), so "written before the row" does not
+    // guarantee mtime <= updated_at. utimes does.
+    const pinned = new Date('2019-01-01T00:00:00.000Z');
+    await fs.utimes(path.join(A, 'src', 'auth.ts'), pinned, pinned);
     await storeCiting(projectId, 'Auth token TTL is fifteen minutes', ['src/auth.ts'], false);
 
     const result = await callQuery(A, await loadConfig(A), { query: 'auth token ttl' });

--- a/tests/mcp/query-paths-changed.test.ts
+++ b/tests/mcp/query-paths-changed.test.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The `pathsChanged` marker: a query row whose `affectedPaths` moved after the row was stored
+ * says so, and a clean row says nothing.
+ *
+ * The fixtures backdate `updated_at` by SQL rather than sleeping across an mtime boundary --
+ * deterministic on every filesystem, and the same trick the lineage suite uses for visibility.
+ */
+
+const HOME = path.resolve('./.knowl-pathschanged-home');
+// One root per test, never reused: Windows keeps an opened database locked for the life of
+// the process, so a shared root silently survives the between-test rm and leaks earlier
+// tests' rows into later queries.
+let seq = 0;
+let A = '';
+let B = '';
+
+const BACKDATED = '2020-01-01T00:00:00.000Z';
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+async function callQuery(root: string, config: ProjectConfig, args: Record<string, unknown>) {
+  const server = createMcpServer('local', root, config);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as any);
+  const initialized = new Promise<any>(resolve => { transport.onSend = message => { if (message.id === 'init') resolve(message); }; });
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const response = new Promise<any>(resolve => { transport.onSend = message => { if (message.id === 'call') resolve(message); }; });
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name: 'knowl_query', arguments: args } });
+  const result = await response;
+  await server.close();
+  return result.result;
+}
+
+const rowsOf = (result: any): any[] => {
+  const payload = JSON.parse(result.content[0].text);
+  return Array.isArray(payload) ? payload : Object.values(payload).flat();
+};
+
+async function seedRepo(root: string) {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, DEFAULT_CONFIG);
+  await initDb(root);
+  return (await repo.createProject(root, path.basename(root))).id;
+}
+
+async function storeCiting(projectId: string, title: string, affectedPaths: string[], backdate = true) {
+  const stored = await storeKnowledgeItemDeduped(projectId, {
+    category: 'fact', title, content: `${title} -- body`, affectedPaths,
+  });
+  if (backdate) {
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET updated_at = ? WHERE id = ?',
+      args: [BACKDATED, stored.item.id],
+    });
+  }
+  return stored.item.id;
+}
+
+beforeEach(async () => {
+  process.env.KNOWL_HOME = HOME;
+  await closeDb();
+  await releaseAll();
+  seq += 1;
+  A = path.resolve(`./.knowl-pathschanged-a${seq}`);
+  B = path.resolve(`./.knowl-pathschanged-b${seq}`);
+  for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+});
+
+afterEach(async () => {
+  delete process.env.KNOWL_HOME;
+  await closeDb();
+  await releaseAll();
+  for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('knowl_query pathsChanged marker', () => {
+  it('flags a row whose cited file changed after the row was stored, with the count', async () => {
+    const projectId = await seedRepo(A);
+    await fs.mkdir(path.join(A, 'src'), { recursive: true });
+    await fs.writeFile(path.join(A, 'src', 'auth.ts'), 'export const ttl = 15;');
+    await storeCiting(projectId, 'Auth token TTL is fifteen minutes', ['src/auth.ts', 'src/missing.ts']);
+
+    const result = await callQuery(A, await loadConfig(A), { query: 'auth token ttl' });
+    const row = rowsOf(result).find(r => String(r.title).includes('Auth token TTL'));
+    expect(row).toBeDefined();
+    // Both count: the file is newer than the backdated row, and the missing one is the
+    // strongest form of "moved".
+    expect(row.pathsChanged).toContain('2 of 2');
+    expect(row.pathsChanged).toContain('verify');
+  });
+
+  it('says nothing on a row whose files have not moved since it was stored', async () => {
+    const projectId = await seedRepo(A);
+    await fs.mkdir(path.join(A, 'src'), { recursive: true });
+    await fs.writeFile(path.join(A, 'src', 'auth.ts'), 'export const ttl = 15;');
+    // Not backdated: the file was written before the row, so mtime <= updated_at.
+    await storeCiting(projectId, 'Auth token TTL is fifteen minutes', ['src/auth.ts'], false);
+
+    const result = await callQuery(A, await loadConfig(A), { query: 'auth token ttl' });
+    const row = rowsOf(result).find(r => String(r.title).includes('Auth token TTL'));
+    expect(row).toBeDefined();
+    expect(row.pathsChanged).toBeUndefined();
+  });
+
+  it('a path that escapes the repository counts as changed rather than being resolved', async () => {
+    const projectId = await seedRepo(A);
+    await storeCiting(projectId, 'Escaping citation', ['../outside.ts']);
+
+    const result = await callQuery(A, await loadConfig(A), { query: 'escaping citation' });
+    const row = rowsOf(result).find(r => String(r.title).includes('Escaping'));
+    expect(row).toBeDefined();
+    expect(row.pathsChanged).toContain('1 of 1');
+  });
+
+  it('never marks a foreign row -- its paths resolve against another checkout', async () => {
+    await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
+    const aId = await seedRepo(A);
+    await storeCiting(aId, 'Local unrelated note', []);
+    await closeDb();
+    const bId = await seedRepo(B);
+    const foreignId = await storeCiting(bId, 'Foreign auth rotation fact', ['src/rotation.ts']);
+    await getClient().execute({
+      sql: "UPDATE knowledge_items SET visibility = 'workspace', origin_repo = 'b' WHERE id = ?",
+      args: [foreignId],
+    });
+    await closeDb();
+    await joinWorkspace({ projectRoot: A, workspaceName: 'ws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'ws', repoName: 'b' });
+
+    await initDb(A);
+    const result = await callQuery(A, await loadConfig(A), { query: 'auth rotation', limit: 5 });
+    const row = rowsOf(result).find(r => String(r.title).includes('Foreign auth rotation'));
+    expect(row).toBeDefined();
+    expect(row.pathsChanged).toBeUndefined();
+    expect(row.affectedPaths).toBeUndefined();
+  });
+});

--- a/tests/mcp/query-paths-changed.test.ts
+++ b/tests/mcp/query-paths-changed.test.ts
@@ -134,13 +134,31 @@ describe('knowl_query pathsChanged marker', () => {
     expect(row.pathsChanged).toBeUndefined();
   });
 
-  it('a path that escapes the repository counts as changed rather than being resolved', async () => {
+  it('says nothing about a path that will not resolve against this checkout', async () => {
     const projectId = await seedRepo(A);
-    await storeCiting(projectId, 'Escaping citation', ['../outside.ts']);
+    // `./` is stripped on write, so what actually reaches here unresolvable is an escaping or
+    // absolute citation. Neither is evidence: the marker's sentence claims a MODIFICATION was
+    // observed, and none was -- a permanent "verify" on a row nobody can ever clear is the
+    // warning light that teaches readers to ignore the marker everywhere else.
+    await storeCiting(projectId, 'Escaping citation', ['../outside.ts', '/etc/hosts']);
 
     const result = await callQuery(A, await loadConfig(A), { query: 'escaping citation' });
     const row = rowsOf(result).find(r => String(r.title).includes('Escaping'));
     expect(row).toBeDefined();
+    expect(row.pathsChanged).toBeUndefined();
+  });
+
+  it('counts only the paths it could actually check', async () => {
+    const projectId = await seedRepo(A);
+    await fs.mkdir(path.join(A, 'src'), { recursive: true });
+    await fs.writeFile(path.join(A, 'src', 'auth.ts'), 'export const ttl = 15;');
+    await storeCiting(projectId, 'Mixed citation auth ttl', ['src/auth.ts', '../outside.ts']);
+
+    const result = await callQuery(A, await loadConfig(A), { query: 'mixed citation auth ttl' });
+    const row = rowsOf(result).find(r => String(r.title).includes('Mixed citation'));
+    expect(row).toBeDefined();
+    // One checkable path, and it moved. The unresolvable one is not in the denominator: the
+    // sentence would otherwise understate how much of what it looked at had changed.
     expect(row.pathsChanged).toContain('1 of 1');
   });
 

--- a/tests/mcp/query-transcript-fallback.test.ts
+++ b/tests/mcp/query-transcript-fallback.test.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { closeTranscriptDbs } from '../../src/transcripts/database.js';
+import { runIndexPass } from '../../src/transcripts/index-pass.js';
+import { encodeProjectDir } from '../../src/transcripts/paths.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The recall chain: a `knowl_query` that missed runs transcript search itself when
+ * `search.transcripts.fallback` is on, and reports a verified negative when both stores miss.
+ *
+ * The fixture redirects the home directory the way `mcp-handlers.test.ts` does and for the same
+ * reason: the handlers always read the default archive path, and the search-time top-up would
+ * otherwise look at the developer's real archive -- or delete the fixture's own index on seeing
+ * an empty one.
+ */
+
+let dir: string;
+let homeBefore: { HOME?: string; USERPROFILE?: string };
+
+const projectsDirFor = () => path.join(dir, 'home', '.claude', 'projects');
+
+const configFor = (root: string, fallback: boolean): ProjectConfig => ({
+  version: 1,
+  security: { rejectSecrets: true, secretPatterns: [] },
+  search: { transcripts: { enabled: true, fallback }, vector: { enabled: false } },
+});
+
+const line = (text: string) => JSON.stringify({ type: 'user', message: { content: text } }) + '\n';
+
+async function makeRepo(name: string, options: { transcript?: string; fallback: boolean; items?: Array<{ title: string; content: string }> }) {
+  const root = path.join(dir, name);
+  const projectsDir = projectsDirFor();
+  const encoded = encodeProjectDir(path.resolve(root));
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await fs.mkdir(path.join(projectsDir, encoded), { recursive: true });
+  if (options.transcript) {
+    await fs.writeFile(path.join(projectsDir, encoded, 'session-abc.jsonl'), options.transcript);
+  }
+  const config = configFor(root, options.fallback);
+  // On disk too: `handleTranscriptSearch` re-reads the config so that disabling the feature
+  // takes effect for a running server, and an absent file reads as disabled.
+  await fs.writeFile(path.join(root, '.knowl', 'config.json'), JSON.stringify(config));
+  await initDb(root);
+  const projectId = (await repo.createProject(root, name)).id;
+  for (const item of options.items ?? []) {
+    await storeKnowledgeItemDeduped(projectId, { category: 'fact', title: item.title, content: item.content });
+  }
+  await runIndexPass({ projectRoot: root, dbPath: path.join(root, '.knowl', 'transcripts.db'), projectsDir });
+  return { root, config };
+}
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+async function callQuery(root: string, config: ProjectConfig, args: Record<string, unknown>) {
+  const server = createMcpServer('local', root, config);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as any);
+  const initialized = new Promise<any>(resolve => { transport.onSend = message => { if (message.id === 'init') resolve(message); }; });
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const response = new Promise<any>(resolve => { transport.onSend = message => { if (message.id === 'call') resolve(message); }; });
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name: 'knowl_query', arguments: args } });
+  const result = await response;
+  await server.close();
+  return result.result;
+}
+
+const blocksOf = (result: any): string[] => result.content.map((block: any) => String(block.text));
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-fallback-'));
+  homeBefore = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = path.join(dir, 'home');
+  process.env.USERPROFILE = path.join(dir, 'home');
+  await fs.mkdir(projectsDirFor(), { recursive: true });
+});
+
+afterEach(async () => {
+  process.env.HOME = homeBefore.HOME;
+  process.env.USERPROFILE = homeBefore.USERPROFILE;
+  if (homeBefore.HOME === undefined) delete process.env.HOME;
+  if (homeBefore.USERPROFILE === undefined) delete process.env.USERPROFILE;
+  await closeTranscriptDbs();
+  await closeDb().catch(() => {});
+  await releaseAll().catch(() => {});
+  // Swallowed: Windows keeps the databases locked for the life of the process.
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('knowl_query transcript fallback', () => {
+  it('an empty store runs the archive search and returns its hit', async () => {
+    const { root, config } = await makeRepo('hit', {
+      fallback: true,
+      transcript: line('the deploy secret rotation happens through the vault sidecar'),
+    });
+    const blocks = blocksOf(await callQuery(root, config, { query: 'vault sidecar rotation' }));
+    const chain = blocks.find(text => text.startsWith('RECALL CHAIN:'));
+    expect(chain).toBeDefined();
+    expect(chain).toContain('vault sidecar');
+    expect(chain).not.toContain('VERIFIED NEGATIVE');
+  });
+
+  it('a miss in both stores is reported as a verified negative, not silence', async () => {
+    const { root, config } = await makeRepo('negative', {
+      fallback: true,
+      transcript: line('an unrelated conversation about css grids'),
+    });
+    const blocks = blocksOf(await callQuery(root, config, { query: 'kafka partition rebalancing' }));
+    const chain = blocks.find(text => text.startsWith('RECALL CHAIN'));
+    expect(chain).toBeDefined();
+    expect(chain).toContain('VERIFIED NEGATIVE');
+    // The negative carries the coverage lines, so "searched" is a checkable claim.
+    expect(chain).toContain('Coverage');
+  });
+
+  it('does nothing when the flag is off, even with transcripts enabled', async () => {
+    const { root, config } = await makeRepo('off', {
+      fallback: false,
+      transcript: line('the deploy secret rotation happens through the vault sidecar'),
+    });
+    const blocks = blocksOf(await callQuery(root, config, { query: 'vault sidecar rotation' }));
+    expect(blocks.some(text => text.startsWith('RECALL CHAIN'))).toBe(false);
+  });
+
+  it('does not run when the store answered', async () => {
+    const { root, config } = await makeRepo('answered', {
+      fallback: true,
+      transcript: line('the deploy secret rotation happens through the vault sidecar'),
+      items: [{ title: 'vault sidecar rotation', content: 'Secrets rotate through the vault sidecar on deploy.' }],
+    });
+    const blocks = blocksOf(await callQuery(root, config, { query: 'vault sidecar rotation' }));
+    expect(blocks[0]).toContain('vault sidecar');
+    expect(blocks.some(text => text.startsWith('RECALL CHAIN'))).toBe(false);
+  });
+
+  it('a broken archive costs the addendum, never the answer', async () => {
+    const { root, config } = await makeRepo('broken', { fallback: true });
+    // No transcript DB was ever built for a session file, and the archive dir is now gone.
+    await fs.rm(path.join(root, '.knowl', 'transcripts.db'), { force: true }).catch(() => {});
+    const result = await callQuery(root, config, { query: 'anything at all' });
+    expect(result.isError).toBeFalsy();
+    expect(blocksOf(result).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/store/pending-lessons-lifecycle.test.ts
+++ b/tests/store/pending-lessons-lifecycle.test.ts
@@ -1,0 +1,154 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { handleHostLifecycleEvent } from '../../src/session/host-lifecycle.js';
+import * as repo from '../../src/store/repository.js';
+import { conversationKey } from '../../src/store/capture-outcome.js';
+import { MAX_LESSON_BLOCKS, openPendingLessons } from '../../src/store/pending-lessons.js';
+import type { CaptureNudgeMode } from '../../src/store/capture-config.js';
+
+/**
+ * The pending-lesson gate, end to end through the hook path: a destructive command nudges
+ * mid-turn, an unstored lesson withholds exactly one stop, a durable write settles it, and a
+ * subagent stop is never withheld. Harness follows `capture-nudge-lifecycle.test.ts`,
+ * including its one-root-per-test rule and its reason.
+ */
+let nextRoot = 0;
+const ROOTS: string[] = [];
+
+const hook = (root: string, input: Partial<NormalizedHostHook>): NormalizedHostHook => ({
+  host: 'claude',
+  event: 'turn-start',
+  externalSessionId: 'session-under-test',
+  externalTurnId: undefined,
+  projectRoot: root,
+  payload: {},
+  ...input,
+});
+
+async function withRepo(mode: CaptureNudgeMode | undefined) {
+  const root = path.resolve(`./.knowl-lesson-lifecycle-${nextRoot += 1}`);
+  ROOTS.push(root);
+  await closeDb();
+  await releaseAll();
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG, ...(mode ? { capture: { events: mode } } : {}) });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, 'lesson gate')).id;
+  await handleHostLifecycleEvent(projectId, hook(root, { event: 'session-start' }));
+  await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+  return { root, projectId };
+}
+
+const command = (root: string, text: string, extra: Partial<NormalizedHostHook> = {}) =>
+  hook(root, { event: 'session-event', type: 'command', payload: { command: text, exitCode: 0 }, ...extra });
+
+const contextOf = (result: { hostOutput?: Record<string, unknown> } | undefined): string => {
+  const specific = result?.hostOutput?.hookSpecificOutput as { additionalContext?: string } | undefined;
+  return String(specific?.additionalContext ?? '');
+};
+
+describe('the pending-lesson gate, through the hook path', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('records nothing at all when the feature is off', async () => {
+    const { root, projectId } = await withRepo(undefined);
+    const result = await handleHostLifecycleEvent(projectId, command(root, 'pkill -f node'));
+    expect(contextOf(result)).not.toContain('KNOWL LESSON');
+    expect(await openPendingLessons(conversationKey(hook(root, {})))).toHaveLength(0);
+  });
+
+  it('in shadow: records the lesson, says nothing mid-turn, settles silently at stop', async () => {
+    const { root, projectId } = await withRepo('shadow');
+    const during = await handleHostLifecycleEvent(projectId, command(root, 'pkill -f node'));
+    expect(contextOf(during)).not.toContain('KNOWL LESSON');
+    expect(await openPendingLessons(conversationKey(hook(root, {})))).toHaveLength(1);
+
+    const stop = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    expect(stop.hostOutput).toBeUndefined();
+    expect(await openPendingLessons(conversationKey(hook(root, {})))).toHaveLength(0);
+  });
+
+  it('in enforce: nudges mid-turn, blocks exactly one stop, then lets the next one pass', async () => {
+    const { root, projectId } = await withRepo('enforce');
+
+    const during = await handleHostLifecycleEvent(projectId, command(root, 'pkill -f node'));
+    expect(contextOf(during)).toContain('KNOWL LESSON');
+    expect(contextOf(during)).toContain('pkill -f node');
+
+    const blocked = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    expect(blocked.hostOutput).toMatchObject({ decision: 'block' });
+    expect(String((blocked.hostOutput as { reason?: string }).reason)).toContain('Never invent an incident');
+
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+    const clean = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    expect(clean.hostOutput).toBeUndefined();
+  });
+
+  it('a durable write settles the lesson before the stop ever asks', async () => {
+    const { root, projectId } = await withRepo('enforce');
+    await handleHostLifecycleEvent(projectId, command(root, 'git reset --hard origin/main'));
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await handleHostLifecycleEvent(projectId, command(root, 'stored the lesson', {
+      knowlTool: true, knowlToolName: 'knowl_store',
+      payload: { summary: 'knowl_store completed' }, type: 'checkpoint',
+    }));
+
+    const stop = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    expect(stop.hostOutput).toBeUndefined();
+  });
+
+  it('the same class nudges once, and the block budget is a hard ceiling', async () => {
+    const { root, projectId } = await withRepo('enforce');
+
+    const first = await handleHostLifecycleEvent(projectId, command(root, 'pkill -f node'));
+    const second = await handleHostLifecycleEvent(projectId, command(root, 'pkill -f vite'));
+    expect(contextOf(first)).toContain('KNOWL LESSON');
+    expect(contextOf(second)).not.toContain('KNOWL LESSON');
+
+    // Distinct classes across turns, each blocked in turn; after the budget, silence.
+    const classes = ['git reset --hard origin/main', 'git push --force origin main', 'psql -c "DROP TABLE t"', 'docker system prune -a'];
+    let blocks = 0;
+    // The pkill lesson from above is still open and rides the first block.
+    for (const text of classes) {
+      await handleHostLifecycleEvent(projectId, command(root, text));
+      const stop = await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+      if ((stop.hostOutput as { decision?: string } | undefined)?.decision === 'block') blocks += 1;
+      await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+    }
+    expect(blocks).toBe(MAX_LESSON_BLOCKS);
+  });
+
+  it('a correction signal nudges at turn-start and arms the gate', async () => {
+    const { root, projectId } = await withRepo('enforce');
+    const start = await handleHostLifecycleEvent(projectId, hook(root, {
+      event: 'turn-start', payload: { correctionSignal: true },
+    }));
+    expect(contextOf(start)).toContain('CORRECTION');
+    expect((await openPendingLessons(conversationKey(hook(root, {})))).map(lesson => lesson.kind)).toContain('correction');
+  });
+
+  it('never withholds a subagent stop, whatever is pending', async () => {
+    const { root, projectId } = await withRepo('enforce');
+    await handleHostLifecycleEvent(projectId, command(root, 'pkill -f node'));
+    const agentStop = await handleHostLifecycleEvent(projectId, hook(root, {
+      event: 'agent-stop', agentId: 'sub-1',
+    }));
+    // The engine's own rule for agent-stop: it may not block a subagent from stopping, so it
+    // emits no host output at all -- with or without this feature armed.
+    expect(agentStop.hostOutput).toBeUndefined();
+  });
+});

--- a/tests/store/pending-lessons.test.ts
+++ b/tests/store/pending-lessons.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { captureEventsMode } from '../../src/store/capture-config.js';
+import {
+  claimLessonBlock,
+  markPendingLessons,
+  MAX_CORRECTION_LESSONS,
+  MAX_LESSON_BLOCKS,
+  openPendingLessons,
+  recordCorrectionLesson,
+  recordDestructiveLesson,
+  renderLessonStopReason,
+  resolveLessonsBefore,
+} from '../../src/store/pending-lessons.js';
+
+/** Fresh root per test, for the reason capture-outcome.test.ts gives: an opened libsql file
+ * cannot be unlinked on Windows, so a shared root silently accumulates earlier tests' rows. */
+let nextRoot = 0;
+const ROOTS: string[] = [];
+const freshRoot = (): string => {
+  const root = path.resolve(`./.knowl-pending-lessons-${nextRoot += 1}`);
+  ROOTS.push(root);
+  return root;
+};
+
+const HIT = { id: 'process-kill-broad', label: 'a process kill with a broad selector (name, image, filter or pipeline)' } as const;
+
+describe('capture events mode', () => {
+  it('reads the three known modes, and anything else as off', () => {
+    expect(captureEventsMode({ ...DEFAULT_CONFIG, capture: { events: 'shadow' } })).toBe('shadow');
+    expect(captureEventsMode({ ...DEFAULT_CONFIG, capture: { events: 'enforce' } })).toBe('enforce');
+    expect(captureEventsMode({ ...DEFAULT_CONFIG, capture: { events: 'banana' } as never })).toBe('off');
+    expect(captureEventsMode(undefined)).toBe('off');
+  });
+});
+
+describe('pending lessons on disk', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    const root = freshRoot();
+    await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+    await saveConfig(root, { ...DEFAULT_CONFIG });
+    await initDb(root);
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('records a destructive lesson once per class per conversation', async () => {
+    expect(await recordDestructiveLesson('c1', HIT, 'pkill -f node')).toBe(true);
+    // The second event of the same class is not news, whatever the command text was.
+    expect(await recordDestructiveLesson('c1', HIT, 'taskkill /IM node.exe /F')).toBe(false);
+    expect((await openPendingLessons('c1')).map(lesson => lesson.class)).toEqual(['process-kill-broad']);
+    // A different conversation is its own ledger.
+    expect(await recordDestructiveLesson('c2', HIT, 'pkill -f node')).toBe(true);
+  });
+
+  it('clips the stored snippet and never stores correction text at all', async () => {
+    const long = `pkill -f ${'x'.repeat(300)}`;
+    await recordDestructiveLesson('c1', HIT, long);
+    await recordCorrectionLesson('c1');
+    const open = await openPendingLessons('c1');
+    const destructive = open.find(lesson => lesson.kind === 'destructive');
+    const correction = open.find(lesson => lesson.kind === 'correction');
+    expect(destructive!.snippet!.length).toBeLessThanOrEqual(121);
+    expect(correction!.snippet).toBeNull();
+  });
+
+  it('caps corrections per conversation', async () => {
+    const results: boolean[] = [];
+    for (let i = 0; i < MAX_CORRECTION_LESSONS + 2; i += 1) results.push(await recordCorrectionLesson('c1'));
+    expect(results.filter(Boolean)).toHaveLength(MAX_CORRECTION_LESSONS);
+  });
+
+  it('a durable write settles only the lessons that predate it', async () => {
+    await recordDestructiveLesson('c1', HIT, 'pkill -f node');
+    const betweenEvents = new Date().toISOString();
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await recordDestructiveLesson('c1', { id: 'git-discard', label: 'a git command that discards uncommitted work' }, 'git reset --hard');
+
+    await resolveLessonsBefore('c1', betweenEvents);
+
+    const open = await openPendingLessons('c1');
+    // The write could not have been about an event that had not happened yet.
+    expect(open.map(lesson => lesson.class)).toEqual(['git-discard']);
+  });
+
+  it('spends the block budget exactly MAX_LESSON_BLOCKS times, race-safe', async () => {
+    const claims: boolean[] = [];
+    for (let i = 0; i < MAX_LESSON_BLOCKS + 3; i += 1) claims.push(await claimLessonBlock('c1'));
+    expect(claims).toEqual([true, true, true, false, false, false]);
+    // Another conversation has its own budget.
+    expect(await claimLessonBlock('c2')).toBe(true);
+  });
+
+  it('marking lessons settles them out of the open set', async () => {
+    await recordDestructiveLesson('c1', HIT, 'pkill -f node');
+    const [lesson] = await openPendingLessons('c1');
+    await markPendingLessons([lesson.id], 'shadow');
+    expect(await openPendingLessons('c1')).toHaveLength(0);
+  });
+
+  it('never throws with no database at all', async () => {
+    await closeDb();
+    await expect(recordDestructiveLesson('c1', HIT, 'pkill -f x')).resolves.toBe(false);
+    await expect(openPendingLessons('c1')).resolves.toEqual([]);
+    await expect(claimLessonBlock('c1')).resolves.toBe(false);
+    await expect(resolveLessonsBefore('c1', new Date().toISOString())).resolves.toBeUndefined();
+  });
+});
+
+describe('the stop reason', () => {
+  it('lists every open lesson and carries the honest escape hatches', () => {
+    const reason = renderLessonStopReason([
+      { id: 'a', conversation: 'c1', kind: 'destructive', class: 'process-kill-broad', snippet: 'pkill -f node', observedAt: 'now' },
+      { id: 'b', conversation: 'c1', kind: 'correction', class: null, snippet: null, observedAt: 'now' },
+    ]);
+    expect(reason).toContain('pkill -f node');
+    expect(reason).toContain('the user corrected you');
+    // (d) is what keeps the gate from teaching fabrication: an empty answer must always be a
+    // legal way out.
+    expect(reason).toContain('Never invent an incident');
+    expect(reason).toContain('knowl_store');
+  });
+});

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -77,6 +77,10 @@ const SCHEMA_PINS: Record<number, string> = {
   // whose knowledge has not been stored yet, and the block budget their delivery spends.
   // Additive, so `KNOWL_SCHEMA_VERSION` again does not move.
   13: '966fb32dc577094f2844ed942efe2f56',
+  // 14 adds `capture_turn_outcomes` and `capture_turn_prompts` -- the write-side negative
+  // signal at turn granularity and the ceiling its prompts spend. Additive, so
+  // `KNOWL_SCHEMA_VERSION` again does not move.
+  14: 'efef31ca11c9bddd7973ad0a9129eb86',
 };
 
 let root: string;

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -73,6 +73,10 @@ const SCHEMA_PINS: Record<number, string> = {
   // the skip predicate requires a non-null hash, so every pre-existing row keeps being sent.
   // Additive, so `KNOWL_SCHEMA_VERSION` again does not move.
   12: '8655428a61126c78a4117b827a103703',
+  // 13 adds `pending_lessons`, its conversation index, and `pending_lesson_claims` -- events
+  // whose knowledge has not been stored yet, and the block budget their delivery spends.
+  // Additive, so `KNOWL_SCHEMA_VERSION` again does not move.
+  13: '966fb32dc577094f2844ed942efe2f56',
 };
 
 let root: string;

--- a/tests/store/turn-capture-lifecycle.test.ts
+++ b/tests/store/turn-capture-lifecycle.test.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { NormalizedHostHook } from '../../src/cli/agents/host-hook.js';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { handleHostLifecycleEvent } from '../../src/session/host-lifecycle.js';
+import * as repo from '../../src/store/repository.js';
+import { MIN_SUBSTANTIVE_TURN_EVENTS } from '../../src/store/capture-outcome.js';
+
+/**
+ * The turn-scoped capture prompt through the hook path. The property under test throughout:
+ * querying memory does not quiet it -- only a durable write does -- because the session every
+ * other reminder goes silent for is the memory-active one.
+ */
+let nextRoot = 0;
+const ROOTS: string[] = [];
+
+const hook = (root: string, input: Partial<NormalizedHostHook>): NormalizedHostHook => ({
+  host: 'claude',
+  event: 'turn-start',
+  externalSessionId: 'session-under-test',
+  externalTurnId: undefined,
+  projectRoot: root,
+  payload: {},
+  ...input,
+});
+
+async function withRepo(scope: 'turn' | undefined) {
+  const root = path.resolve(`./.knowl-turn-lifecycle-${nextRoot += 1}`);
+  ROOTS.push(root);
+  await closeDb();
+  await releaseAll();
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG, ...(scope ? { capture: { scope } } : {}) });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, 'turn capture')).id;
+  await handleHostLifecycleEvent(projectId, hook(root, { event: 'session-start' }));
+  await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+  return { root, projectId };
+}
+
+const command = (root: string, text: string) =>
+  hook(root, { event: 'session-event', type: 'command', payload: { command: text, exitCode: 0 } });
+
+const fileWrite = (root: string) =>
+  hook(root, { event: 'session-event', type: 'checkpoint', toolName: 'Edit', payload: { changedPaths: ['src/thing.ts'] } });
+
+// Distinct summaries per call: two byte-identical events would be debounced as one hook
+// firing twice, which is not the shape being simulated.
+const knowlRead = (root: string, n: number) =>
+  hook(root, {
+    event: 'session-event', type: 'checkpoint', knowlTool: true, knowlToolName: 'knowl_query',
+    payload: { summary: `knowl_query completed (${n})` },
+  });
+
+const knowlWrite = (root: string) =>
+  hook(root, {
+    event: 'session-event', type: 'checkpoint', knowlTool: true, knowlToolName: 'knowl_store',
+    payload: { summary: 'knowl_store completed' },
+  });
+
+const contextOf = (result: { hostOutput?: Record<string, unknown> } | undefined): string => {
+  const specific = result?.hostOutput?.hookSpecificOutput as { additionalContext?: string } | undefined;
+  return String(specific?.additionalContext ?? '');
+};
+
+/** Drive a substantive turn: one file write, then harmless commands up to the event floor. */
+async function substantiveTurn(root: string, projectId: string, events = MIN_SUBSTANTIVE_TURN_EVENTS) {
+  const outputs: string[] = [];
+  outputs.push(contextOf(await handleHostLifecycleEvent(projectId, fileWrite(root))));
+  for (let i = 1; i < events; i += 1) {
+    outputs.push(contextOf(await handleHostLifecycleEvent(projectId, command(root, `npm run step-${i}`))));
+  }
+  return outputs;
+}
+
+describe('the turn-scoped capture prompt, through the hook path', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('says nothing at the default scope, however substantive the turn', async () => {
+    const { root, projectId } = await withRepo(undefined);
+    const outputs = await substantiveTurn(root, projectId, MIN_SUBSTANTIVE_TURN_EVENTS + 4);
+    expect(outputs.every(text => !text.includes('KNOWL CAPTURE'))).toBe(true);
+  });
+
+  it('prompts exactly once when a substantive turn has stored nothing', async () => {
+    const { root, projectId } = await withRepo('turn');
+    const outputs = await substantiveTurn(root, projectId, MIN_SUBSTANTIVE_TURN_EVENTS + 6);
+    expect(outputs.filter(text => text.includes('KNOWL CAPTURE'))).toHaveLength(1);
+  });
+
+  it('a knowl query does not quiet it -- the memory-active session is the target', async () => {
+    const { root, projectId } = await withRepo('turn');
+    await handleHostLifecycleEvent(projectId, fileWrite(root));
+    for (let i = 0; i < MIN_SUBSTANTIVE_TURN_EVENTS - 2; i += 1) {
+      await handleHostLifecycleEvent(projectId, command(root, `npm run step-${i}`));
+    }
+    // The threshold-crossing event is itself a query -- the twelfth event of the turn -- which
+    // every other reminder treats as proof of memory health. This one prompts anyway.
+    const crossing = await handleHostLifecycleEvent(projectId, knowlRead(root, 1));
+    expect(contextOf(crossing)).toContain('KNOWL CAPTURE');
+    // And once spent, a further query changes nothing.
+    const after = await handleHostLifecycleEvent(projectId, knowlRead(root, 2));
+    expect(contextOf(after)).not.toContain('KNOWL CAPTURE');
+  });
+
+  it('a durable write quiets it for the turn', async () => {
+    const { root, projectId } = await withRepo('turn');
+    await handleHostLifecycleEvent(projectId, knowlWrite(root));
+    const outputs = await substantiveTurn(root, projectId, MIN_SUBSTANTIVE_TURN_EVENTS + 4);
+    expect(outputs.every(text => !text.includes('KNOWL CAPTURE'))).toBe(true);
+  });
+
+  it('the turn boundary resets the counters', async () => {
+    const { root, projectId } = await withRepo('turn');
+    await substantiveTurn(root, projectId, MIN_SUBSTANTIVE_TURN_EVENTS - 1);
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-stop', status: 'finished' }));
+    await handleHostLifecycleEvent(projectId, hook(root, { event: 'turn-start' }));
+    // One more event in the new turn is nowhere near the floor; the eleven from the last
+    // turn must not carry over.
+    const first = await handleHostLifecycleEvent(projectId, fileWrite(root));
+    expect(contextOf(first)).not.toContain('KNOWL CAPTURE');
+  });
+});

--- a/tests/store/turn-capture.test.ts
+++ b/tests/store/turn-capture.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+import { captureScope } from '../../src/store/capture-config.js';
+import {
+  claimTurnCapturePrompt,
+  MAX_TURN_CAPTURE_PROMPTS,
+  MIN_SUBSTANTIVE_TURN_EVENTS,
+  recordTurnToolEvent,
+  resetTurnCapture,
+  shouldPromptTurnCapture,
+  type TurnCaptureOutcome,
+} from '../../src/store/capture-outcome.js';
+
+let nextRoot = 0;
+const ROOTS: string[] = [];
+const freshRoot = (): string => {
+  const root = path.resolve(`./.knowl-turn-capture-${nextRoot += 1}`);
+  ROOTS.push(root);
+  return root;
+};
+
+describe('capture scope', () => {
+  it('reads turn, and anything else as conversation', () => {
+    expect(captureScope({ ...DEFAULT_CONFIG, capture: { scope: 'turn' } })).toBe('turn');
+    expect(captureScope({ ...DEFAULT_CONFIG, capture: { scope: 'conversation' } })).toBe('conversation');
+    expect(captureScope({ ...DEFAULT_CONFIG, capture: { scope: 'session' } as never })).toBe('conversation');
+    expect(captureScope(undefined)).toBe('conversation');
+  });
+});
+
+describe('the turn verdict', () => {
+  const outcome = (over: Partial<TurnCaptureOutcome>): TurnCaptureOutcome => ({
+    turnKey: 't1', conversation: 'c1',
+    toolEvents: MIN_SUBSTANTIVE_TURN_EVENTS, fileWrites: 1, durableWrites: 0, prompted: null,
+    ...over,
+  });
+
+  it('fires for a turn that built something and stored nothing', () => {
+    expect(shouldPromptTurnCapture(outcome({}))).toBe(true);
+  });
+
+  it('stays quiet below the event floor, without a file write, after a durable write, once prompted, and with no record', () => {
+    expect(shouldPromptTurnCapture(outcome({ toolEvents: MIN_SUBSTANTIVE_TURN_EVENTS - 1 }))).toBe(false);
+    expect(shouldPromptTurnCapture(outcome({ fileWrites: 0 }))).toBe(false);
+    expect(shouldPromptTurnCapture(outcome({ durableWrites: 1 }))).toBe(false);
+    expect(shouldPromptTurnCapture(outcome({ prompted: 'prompted' }))).toBe(false);
+    expect(shouldPromptTurnCapture(null)).toBe(false);
+  });
+});
+
+describe('turn capture on disk', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    const root = freshRoot();
+    await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+    await saveConfig(root, { ...DEFAULT_CONFIG });
+    await initDb(root);
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const root of ROOTS) await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('counts events and returns the updated row from the same write', async () => {
+    await recordTurnToolEvent('t1', 'c1', { fileWrite: false, durableWrite: false });
+    const row = await recordTurnToolEvent('t1', 'c1', { fileWrite: true, durableWrite: false });
+    expect(row).toMatchObject({ toolEvents: 2, fileWrites: 1, durableWrites: 0, prompted: null });
+  });
+
+  it('claims once per turn, and the boundary reset re-arms the next turn', async () => {
+    await recordTurnToolEvent('t1', 'c1', { fileWrite: true, durableWrite: false });
+    expect(await claimTurnCapturePrompt('t1', 'c1')).toBe(true);
+    expect(await claimTurnCapturePrompt('t1', 'c1')).toBe(false);
+
+    // The boundary delete is what makes a reused key per-turn: fresh counters, fresh claim.
+    await resetTurnCapture('t1');
+    const next = await recordTurnToolEvent('t1', 'c1', { fileWrite: true, durableWrite: false });
+    expect(next).toMatchObject({ toolEvents: 1, prompted: null });
+    expect(await claimTurnCapturePrompt('t1', 'c1')).toBe(true);
+  });
+
+  it('the conversation ceiling survives turn resets and stops at the cap', async () => {
+    const claims: boolean[] = [];
+    for (let turn = 0; turn < MAX_TURN_CAPTURE_PROMPTS + 2; turn += 1) {
+      await recordTurnToolEvent('t1', 'c1', { fileWrite: true, durableWrite: false });
+      claims.push(await claimTurnCapturePrompt('t1', 'c1'));
+      await resetTurnCapture('t1');
+    }
+    expect(claims).toEqual([true, true, true, false, false]);
+    // Another conversation has its own ceiling.
+    await recordTurnToolEvent('t9', 'c2', { fileWrite: true, durableWrite: false });
+    expect(await claimTurnCapturePrompt('t9', 'c2')).toBe(true);
+  });
+
+  it('never throws with no database at all', async () => {
+    await closeDb();
+    await expect(recordTurnToolEvent('t1', 'c1', { fileWrite: false, durableWrite: false })).resolves.toBeNull();
+    await expect(claimTurnCapturePrompt('t1', 'c1')).resolves.toBe(false);
+    await expect(resetTurnCapture('t1')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What this is

The recall/capture posture work: four mechanisms and the config surface to arm them, all off by default. The organizing rule throughout: **every "should" in the guidance becomes a mechanism.** The storage-cue taxonomy has now been patched twice (#55 stated intent, #69 recurring diagnoses), each time by adding the noun whose absence had already cost a measured miss. This PR is the alternative to a third noun.

## The incident that forced it

A broad `Get-Process node | ... | Stop-Process -Force` destroyed a live authenticated browser session. The agent apologised in chat and stored nothing; the write only happened when the user asked why it hadn't. Working through why every existing backstop missed it:

- the **drift reminder** resets on ANY knowl call — a memory-active session never sees it;
- the **silence nudge** requires `durableWrites === 0` for the whole conversation — a session that stored plenty of unrelated atoms reads as healthy while the one event that mattered goes unwritten;
- **nothing inspects the event** — no code in the shipped bundle reads command text or user text at all.

Both backstops are session-scoped and disarmed by unrelated activity. That scoping, not the cue taxonomy, is the structural gap.

## The commits (each independently revertable; 3–5 droppable without breaking 1–2)

1. **`feat(mcp)`: recall chain — `search.transcripts.fallback`.** A missed query runs transcript search itself instead of suggesting it in prose, and a miss in both stores returns `RECALL CHAIN — VERIFIED NEGATIVE` with coverage lines, so "that never happened" becomes a checkable claim. The empty-result case is included deliberately: it takes no abstention block today, so it was the one miss shape with no route anywhere. AND-gated on `enabled` exactly as `share` is; fail-open.

2. **`feat(mcp)`: `pathsChanged` on query rows.** Impact detection tells the session that did the writing; the session retrieving the atom three weeks later got a confident answer over files that moved underneath it. mtime vs `updated_at`, absent when clean, local rows only, containment-checked, missing file counts as changed. The field says "verify", never "wrong".

3. **`feat(capture)`: `capture.events` — pending lessons.** Destructive-command classifier (six classes, verbs at command position **per segment**, quoted spans masked) + correction detection in the host hook (only a derived boolean crosses into the payload — raw user text never reaches the store). Pending items are claimed per event; a durable write settles only lessons that *predate* it — temporal, not blanket, or unrelated activity would disarm this exactly the way it disarms the drift counter. Stop gate: claim-before-deliver, hard ceiling of 3 blocks/conversation, honest escape hatches including "no such event happened" so the gate cannot teach fabrication. Never evaluated at SubagentStop. Shadow default — measurement before mechanism, the `impact.gate` ladder.

   The probe tables in `tests/core/lesson-signals.test.ts` are all measured cases: every false positive listed actually fired on a looser prototype (whole-string read-only exemption blind to `ls && rm -rf src`, `git commit -m "drop table x"`, quoted-arg `pkill`, six benign correction phrasings).

4. **`feat(capture)`: `capture.scope: 'turn'`.** The silence question asked per turn, through the free mid-turn channel — never a blocked stop. The pinned property: **a query does not quiet it, only a durable write does**, so the memory-active session — the one every other reminder goes silent for — is still asked. One prompt per turn, ceiling of 3 per conversation on its own row.

5. **`feat(cli)`: schema keys + `knowl posture maximal|frugal`.** The keys are the contract; the word is the convenience. `maximal` = transcripts+fallback on, capture enforce/enforce/turn, impact on with gate in **shadow** (its own contract requires the measured precision bar before blocking).

## Verified

- Full suite: **358 files / 3437 passed**, three consecutive runs; guidance-card and MCP-gating ceilings untouched (zero card-text changes — the 13-char headroom is spent by nobody).
- Two schema migrations (levels 13, 14), pinned in `schema-pin.test.ts`; snapshot ownership classified (`preserved` — the claims are spent one-shots).
- Live probes against the **built dist**: `agent-hook claude` sequence produces mid-turn nudge → one Stop block → clean stop; MCP `knowl_query` returns the `pathsChanged` field after its cited file changes, and `RECALL CHAIN — VERIFIED NEGATIVE` on a genuine two-store miss.

## One upstream finding worth its own look

The NUL-joined keys (`conversationKey`, and now `turnCaptureKey`) store full bytes, but the driver's read path stops TEXT at the first NUL — a key round-tripped through a row is truncated to its first segment and never matches again, and `length()` reports only the first segment. Everything shipped survives by recomputing keys instead of round-tripping them (now stated as a rule in `recordTurnToolEvent`), but worth an audit of any future reader that selects by a stored key value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
