### PR TITLE
feat(config): switches for the ungated mid-turn senders, a backoff for the loudest, and a NUL-key fix

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -544,6 +544,19 @@ knowl posture frugal     # reset the same keys -- knowl exactly as it ships
 Query results also annotate staleness whatever the posture says: a row whose `affectedPaths`
 were modified after the row was stored carries `pathsChanged` ("n of m affectedPaths modified
 since this was stored — verify"), absent when clean. The field says *verify*, never *wrong*.
+Paths that cannot be resolved against this checkout — absolute, escaping the root — are skipped
+rather than counted, because an unreadable path is absence of evidence, not evidence.
+
+This one is **on by default**, alone among the keys on this page: it adds a field rather than a
+message, so it spends no mid-turn slot and withholds no stop. It is not free either — every
+returned local row costs an `fs.stat` per cited path — so it has a switch:
+
+```bash
+knowl config set search.pathsChanged false
+```
+
+Worth turning off in a repository whose atoms cite generated or build-time files, where the
+marker would be present on every row forever and stop meaning anything.
 
 ### `knowl transcripts` — turning sessions into candidates
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -242,6 +242,27 @@ Titles are capped separately at 200 characters, and previews of things retrievab
 elsewhere — evidence excerpts, timeline assertions, skill markdown, `knowl_skill_run` output —
 stay at 600.
 
+#### Reading `knowl query` from a script
+
+**`knowl query` writes pure JSON to stdout and every advisory line to stderr** — the `Note:`
+banner about linked repos, and the `WORKSPACE:`, `SCOPE:` and `NO CONFIDENT MATCH` notices. The
+split is deliberate, so a programmatic consumer gets a parseable stream without losing the
+advisories a human wants.
+
+It bites because most shells and wrappers merge the two by default. A parser fed the merged
+stream sees `Note: ...` before the JSON and throws, and the natural diagnosis — "the CLI emitted
+bad JSON" — sends you into the CLI instead of into your own stream handling. Read `stdout`
+explicitly:
+
+```bash
+knowl query "auth token design" 2>/dev/null | jq .
+```
+
+The parsed value is a **bare array** when every row belongs to this repo and an **object keyed by
+repo name** when at least one does not, so a parser that assumes one shape silently returns
+nothing in the other. The distinction carries meaning worth keeping: a fact under another repo's
+key describes *that* repo. Force one shape with `--scope local` or `--scope workspace`.
+
 ```bash
 # Current CLI query; single-repository candidates are lexical.
 knowl query "auth token design"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -568,8 +568,9 @@ and the capture prompts — turning one off does not give the others more room, 
 back.
 
 ```bash
-knowl config set reminders.driftEvery 24     # remind half as often; 0 turns it off
-knowl config set reminders.skills false      # stop the two skill nudges
+knowl config set reminders.driftEvery 24        # remind half as often; 0 turns it off
+knowl config set reminders.driftBackoff false   # repeat at that cadence forever
+knowl config set reminders.skills false         # stop the two skill nudges
 ```
 
 - **`reminders.driftEvery`** (default `12`) — how many consecutive successful tool calls that
@@ -580,6 +581,16 @@ knowl config set reminders.skills false      # stop the two skill nudges
   fires ~19 times per session and ~1,750 tokens with it — more than three times the guidance
   card, and unbounded, because it scales with how long the session runs rather than sitting at a
   fixed size. The heaviest session in that archive took it 242 times.
+- **`reminders.driftBackoff`** (default `true`) — double the gap after each delivery, so the
+  reminder lands at 12, 36, 84, 180, 372 rather than every 12 forever. The message is
+  byte-identical every time it is sent: after two or three the agent has either adopted the rule
+  or decided against it, and the rest is furniture. Over the same archive this removes 86% of
+  deliveries, and the worst session drops from 242 to 7.
+
+  It backs off rather than stopping, and that is the point. A hard cap of three would remove 89%
+  — barely more — but goes permanently silent after event 36 and says nothing across the
+  remaining 2,868 events of a long session, which is the same structural blind spot the capture
+  work exists to close. Set `false` for the old every-N-forever behaviour.
 - **`reminders.skills`** (default `true`) — the two skill nudges: *"you have run this three
   times, save it as a skill"* and *"a saved skill matches this command"*. One key for both,
   because both are the skills subsystem speaking. Worth turning off in a repository that does

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -244,15 +244,16 @@ stay at 600.
 
 #### Reading `knowl query` from a script
 
-**`knowl query` writes pure JSON to stdout and every advisory line to stderr** — the `Note:`
-banner about linked repos, and the `WORKSPACE:`, `SCOPE:` and `NO CONFIDENT MATCH` notices. The
-split is deliberate, so a programmatic consumer gets a parseable stream without losing the
+**`knowl query` writes pure JSON to stdout and every advisory line to stderr.** All four are
+`Note:` lines: this repo returned nothing and the rows belong to a peer, every result fell below
+the relevance floor, linked repos hold matches the limit cut, and a linked repo was not searched.
+The split is deliberate, so a programmatic consumer gets a parseable stream without losing the
 advisories a human wants.
 
-It bites because most shells and wrappers merge the two by default. A parser fed the merged
-stream sees `Note: ...` before the JSON and throws, and the natural diagnosis — "the CLI emitted
-bad JSON" — sends you into the CLI instead of into your own stream handling. Read `stdout`
-explicitly:
+It bites because most shells and wrappers merge the two by default, and an advisory line is not
+JSON wherever it lands relative to the document. A parser fed the merged stream throws, and the
+natural diagnosis — "the CLI emitted bad JSON" — sends you into the CLI instead of into your own
+stream handling. Read `stdout` explicitly:
 
 ```bash
 knowl query "auth token design" 2>/dev/null | jq .
@@ -261,7 +262,8 @@ knowl query "auth token design" 2>/dev/null | jq .
 The parsed value is a **bare array** when every row belongs to this repo and an **object keyed by
 repo name** when at least one does not, so a parser that assumes one shape silently returns
 nothing in the other. The distinction carries meaning worth keeping: a fact under another repo's
-key describes *that* repo. Force one shape with `--scope local` or `--scope workspace`.
+key describes *that* repo. The MCP tool takes a `scope` argument to force one shape; the CLI
+does not, so a script must handle both.
 
 ```bash
 # Current CLI query; single-repository candidates are lexical.
@@ -557,6 +559,31 @@ knowl config set search.pathsChanged false
 
 Worth turning off in a repository whose atoms cite generated or build-time files, where the
 marker would be present on every row forever and stop meaning anything.
+
+### What Knowl says mid-turn — `reminders.*`
+
+Separate from what Knowl *stores*: these are the messages it sends the agent between tool
+calls. Both are **on by default**, and both share the single mid-turn slot with the change card
+and the capture prompts — turning one off does not give the others more room, it gives the turn
+back.
+
+```bash
+knowl config set reminders.driftEvery 24     # remind half as often; 0 turns it off
+knowl config set reminders.skills false      # stop the two skill nudges
+```
+
+- **`reminders.driftEvery`** (default `12`) — how many consecutive successful tool calls that
+  used no Knowl tool trigger the continuation reminder. Any Knowl tool call resets the count,
+  so a session already using memory never sees it. The cadence *is* the switch: `0` is off, and
+  raising it is the lever for a long mechanical session that pays the reminder repeatedly for a
+  rule it followed the first time. Measured against a 197-session archive, the shipped cadence
+  fires ~19 times per session and ~1,750 tokens with it — more than three times the guidance
+  card, and unbounded, because it scales with how long the session runs rather than sitting at a
+  fixed size. The heaviest session in that archive took it 242 times.
+- **`reminders.skills`** (default `true`) — the two skill nudges: *"you have run this three
+  times, save it as a skill"* and *"a saved skill matches this command"*. One key for both,
+  because both are the skills subsystem speaking. Worth turning off in a repository that does
+  not use skills, where they are pure context cost.
 
 ### `knowl transcripts` — turning sessions into candidates
 

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -16,6 +16,7 @@ export type ConfigKey =
   | 'search.transcripts.fallback'
   | 'search.pathsChanged'
   | 'reminders.driftEvery'
+  | 'reminders.driftBackoff'
   | 'reminders.skills'
   | 'ai.provider'
   | 'ai.model'
@@ -299,6 +300,12 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: nonNegativeInteger, defaultValue: DEFAULT_DRIFT_REMINDER_EVERY,
     label: 'Continuation reminder cadence',
     description: 'Send the mid-turn "keep using memory" reminder after this many consecutive successful tool calls that used no Knowl tool. Any Knowl tool call resets the count. Set 0 to turn the reminder off; raise it to pay for it less often in long mechanical sessions.',
+  },
+  {
+    key: 'reminders.driftBackoff', category: 'Reminders', type: 'boolean',
+    parse: booleanValue, defaultValue: true,
+    label: 'Back the reminder off',
+    description: 'Double the gap after each reminder -- 12, 24, 48, 96 -- instead of repeating at the same cadence forever. The message is identical every time, so the fortieth is worth nothing; this keeps the long-session safety net without the nagging. Set false for the old every-N-forever behaviour.',
   },
   {
     key: 'reminders.skills', category: 'Reminders', type: 'boolean',

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONFIG } from '../../core/config.js';
+import { DEFAULT_CONFIG, DEFAULT_DRIFT_REMINDER_EVERY } from '../../core/config.js';
 import { DEFAULT_PRESET_ID, PRESET_IDS } from '../../core/vector-profile.js';
 
 export type ConfigKey =
@@ -15,6 +15,8 @@ export type ConfigKey =
   | 'search.transcripts.share'
   | 'search.transcripts.fallback'
   | 'search.pathsChanged'
+  | 'reminders.driftEvery'
+  | 'reminders.skills'
   | 'ai.provider'
   | 'ai.model'
   | 'ai.temperature'
@@ -34,7 +36,7 @@ export type ConfigKey =
 
 export type ConfigCategory =
   | 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact' | 'Capture'
-  | 'Cloud' | 'Updates';
+  | 'Reminders' | 'Cloud' | 'Updates';
 
 /**
  * How a value should be asked for. Without this the UI had only `parse`, so every field
@@ -82,6 +84,13 @@ const enumValue = <T extends string>(values: readonly T[]) => (raw: string): T =
 const optionalNumber = (raw: string) => {
   const value = Number(raw);
   if (!Number.isFinite(value)) throw new Error('Expected a number');
+  return value;
+};
+
+/** A cadence, in events. Rejects negatives and fractions here so the hook path never sees one. */
+const nonNegativeInteger = (raw: string) => {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) throw new Error('Expected a whole number, 0 or greater');
   return value;
 };
 
@@ -281,6 +290,21 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(CAPTURE_SCOPES), defaultValue: 'conversation',
     label: 'Capture scope',
     description: 'Granularity of the stored-nothing question. conversation is the one-shot end-of-session verdict; turn additionally prompts once, through the free mid-turn channel, when a turn does substantial work and stores nothing -- and a query does not quiet it, only a write does.',
+  },
+  // Both default ON and both stay out of DEFAULT_CONFIG, for the reason the Capture keys
+  // above give: merged in, they are written into every config on the machine at the next
+  // upgrade. `defaultValue` only tells the editor what unset does.
+  {
+    key: 'reminders.driftEvery', category: 'Reminders', type: 'number',
+    parse: nonNegativeInteger, defaultValue: DEFAULT_DRIFT_REMINDER_EVERY,
+    label: 'Continuation reminder cadence',
+    description: 'Send the mid-turn "keep using memory" reminder after this many consecutive successful tool calls that used no Knowl tool. Any Knowl tool call resets the count. Set 0 to turn the reminder off; raise it to pay for it less often in long mechanical sessions.',
+  },
+  {
+    key: 'reminders.skills', category: 'Reminders', type: 'boolean',
+    parse: booleanValue, defaultValue: true,
+    label: 'Skill nudges',
+    description: 'Let the skills subsystem take the mid-turn slot: "you have run this three times, save it as a skill", and "a saved skill matches this command". Turn off in a repository that does not use skills, where both are pure context cost.',
   },
   {
     // Absent from DEFAULT_CONFIG on purpose, like the three above: merged in, it would write

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -14,6 +14,7 @@ export type ConfigKey =
   | 'search.transcripts.enabled'
   | 'search.transcripts.share'
   | 'search.transcripts.fallback'
+  | 'search.pathsChanged'
   | 'ai.provider'
   | 'ai.model'
   | 'ai.temperature'
@@ -164,6 +165,15 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: booleanValue, defaultValue: false,
     label: 'Transcript fallback on query miss',
     description: 'A knowl_query that missed runs transcript search itself and reports a verified negative when both stores miss, instead of suggesting the second tool in prose. Has no effect unless transcript search is on.',
+  },
+  {
+    // The one key here whose default is on, so it is `!== false` in the reader and absent from
+    // DEFAULT_CONFIG for the usual reason: merged in, it would be stamped into every config on
+    // the machine at the next upgrade. `defaultValue` only tells the editor what unset does.
+    key: 'search.pathsChanged', category: 'Search', type: 'boolean',
+    parse: booleanValue, defaultValue: true,
+    label: 'Stale-path marker on query rows',
+    description: 'Annotate a query row whose affectedPaths were modified after the row was stored, so a retrieved answer says when its ground moved. Absent from clean rows. Turn off in a repository whose atoms cite generated files, where the marker would never clear.',
   },
   {
     key: 'security.rejectSecrets', category: 'Security', type: 'boolean',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -386,3 +386,16 @@ export function hasAiConfigured(config?: ProjectConfig): boolean {
 export function isTranscriptSearchEnabled(config: ProjectConfig): boolean {
   return config.search?.transcripts?.enabled === true;
 }
+
+/**
+ * Whether query rows carry the `pathsChanged` staleness marker.
+ *
+ * Reads `!== false`, not `=== true`, and is the only search predicate that does: the marker
+ * ships on, so absence must mean on. Writing the default into `DEFAULT_CONFIG` instead would
+ * stamp the key into every config on the machine at the next `knowl upgrade` -- the same trap
+ * `capture.nudge` and `impact.enabled` are kept out of it to avoid, arriving from the other
+ * direction.
+ */
+export function isPathsChangedEnabled(config: ProjectConfig): boolean {
+  return config.search?.pathsChanged !== false;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -421,3 +421,30 @@ export function driftReminderEvery(config?: ProjectConfig | null): number {
 export function areSkillNudgesEnabled(config?: ProjectConfig | null): boolean {
   return config?.reminders?.skills !== false;
 }
+
+/** Whether the reminder's gap doubles after each delivery. On unless set false. */
+export function isDriftBackoffEnabled(config?: ProjectConfig | null): boolean {
+  return config?.reminders?.driftBackoff !== false;
+}
+
+/**
+ * Whether this drift count earns the continuation reminder.
+ *
+ * With backoff the gap doubles after every delivery -- 12, then 24, then 48 -- so deliveries
+ * land at cumulative `every * (2^k - 1)`: 12, 36, 84, 180, 372. Which is to say `drift/every+1`
+ * is a power of two at exactly those points, so the whole schedule is a test on the counter
+ * that already exists. No new column, no new row, nothing to reset.
+ *
+ * Why doubling and not a hard per-session cap: measured over a 197-session archive, doubling
+ * removes 86% of deliveries against a cap's 89%, and the three points it gives back buy the
+ * thing a cap destroys -- a cap goes permanently silent early and never speaks again, which is
+ * the same structural blind spot the capture work was written to close. The reminder is
+ * byte-identical on every delivery, so the second one is worth much less than the first and the
+ * fortieth is worth nothing; backing off spends attention where it still buys something.
+ */
+export function shouldSendDriftReminder(drift: number, every: number, backoff: boolean): boolean {
+  if (every <= 0 || drift <= 0 || drift % every !== 0) return false;
+  if (!backoff) return true;
+  const step = drift / every + 1;
+  return (step & (step - 1)) === 0;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -399,3 +399,25 @@ export function isTranscriptSearchEnabled(config: ProjectConfig): boolean {
 export function isPathsChangedEnabled(config: ProjectConfig): boolean {
   return config.search?.pathsChanged !== false;
 }
+
+/** The default continuation-reminder cadence, in consecutive non-Knowl tool events. */
+export const DEFAULT_DRIFT_REMINDER_EVERY = 12;
+
+/**
+ * How many consecutive non-Knowl tool events trigger the continuation reminder; `0` is off.
+ *
+ * A negative or fractional value reads as the default rather than throwing, by the same rule
+ * the mode enums follow: this runs on the hook path, where a bad config must degrade to
+ * today's behaviour instead of failing a tool call. `config` may be null because `loadConfig`
+ * throws on an unreadable file and the callers catch it.
+ */
+export function driftReminderEvery(config?: ProjectConfig | null): number {
+  const value = config?.reminders?.driftEvery;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) return DEFAULT_DRIFT_REMINDER_EVERY;
+  return value;
+}
+
+/** Whether the skill capture and skill use nudges may take the mid-turn slot. On unless set false. */
+export function areSkillNudgesEnabled(config?: ProjectConfig | null): boolean {
+  return config?.reminders?.skills !== false;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -361,6 +361,17 @@ export interface ProjectConfig {
      */
     driftEvery?: number;
     /**
+     * Double the gap after each delivery -- 12, 24, 48, 96 -- rather than repeating at a fixed
+     * cadence forever. On by default.
+     *
+     * The reminder is byte-identical every time it is sent, so its value decays: after two or
+     * three the agent has either adopted the rule or decided against it, and the rest is
+     * furniture. Backing off keeps the long-session safety net the fixed cadence exists for
+     * while removing the nagging it was already criticised for. Set false for the old
+     * every-N-forever behaviour.
+     */
+    driftBackoff?: boolean;
+    /**
      * The two skill nudges: "you have run this three times, save it as a skill" and "a saved
      * skill matches this command". One key, because both are the skills subsystem speaking
      * and nobody has yet needed to keep one without the other.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -326,6 +326,17 @@ export interface ProjectConfig {
        */
       fallback?: boolean;
     };
+    /**
+     * Annotate a query row whose `affectedPaths` were modified after the row was stored.
+     *
+     * ON unless explicitly set to false -- the only key here that defaults on, because it adds
+     * a field rather than a message: it spends no slot, blocks no stop, and is absent from
+     * every row whose files are clean. The escape hatch exists because it is not free either:
+     * every returned local row costs an `fs.stat` per cited path, and a repository whose
+     * atoms cite generated or checked-out-fresh files would carry the marker permanently,
+     * which is how a true signal becomes furniture.
+     */
+    pathsChanged?: boolean;
   };
   memory?: {
     organization?: { enabled?: boolean; path?: string };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -338,6 +338,35 @@ export interface ProjectConfig {
      */
     pathsChanged?: boolean;
   };
+  /**
+   * What Knowl says to the agent mid-turn, as opposed to what it stores.
+   *
+   * Both default ON, because both ship on and a key that silently disabled a working feature
+   * would be a worse surprise than one that does nothing until set. Kept out of
+   * `DEFAULT_CONFIG` for the usual reason: merged in, they are stamped into every config on
+   * the machine at the next upgrade.
+   *
+   * These share the one mid-turn slot with the change card and the capture prompts, in that
+   * priority. Turning one off does not give the others more room -- it gives the turn back.
+   */
+  reminders?: {
+    /**
+     * How many consecutive successful non-Knowl tool events trigger the continuation
+     * reminder. `0` turns it off. Default 12.
+     *
+     * The cadence is the setting, not a separate on/off, because "how often" is the actual
+     * question -- the reminder is ~370 characters delivered on the tool path, so the cost is
+     * linear in how many tool calls a session makes, and a long mechanical session pays it
+     * repeatedly for a rule it followed the first time.
+     */
+    driftEvery?: number;
+    /**
+     * The two skill nudges: "you have run this three times, save it as a skill" and "a saved
+     * skill matches this command". One key, because both are the skills subsystem speaking
+     * and nobody has yet needed to keep one without the other.
+     */
+    skills?: boolean;
+  };
   memory?: {
     organization?: { enabled?: boolean; path?: string };
     global?: { enabled?: boolean; path?: string };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -55,7 +55,7 @@ import { stagePublishInRequest } from '../cloud/publish.js';
 import { excludeFromPublish } from '../cloud/exclusions.js';
 import { unstagePublish } from '../cloud/ledger.js';
 import { summarizeDemand } from '../workspace/demand-ledger.js';
-import { loadConfig } from '../core/config.js';
+import { isPathsChangedEnabled, loadConfig } from '../core/config.js';
 
 export const CLOUD_DISCONNECTED_MESSAGE =
   'This repository is not connected to a cloud workspace. Ask the user to run `knowl cloud connect` (and `knowl cloud login` first if they are not signed in).';
@@ -983,7 +983,10 @@ export function registerTools(
         // seconds to weeks later, not milliseconds, so the window costs nothing real.
         const PATHS_CHANGED_GRACE_MS = 2_000;
         const pathsChangedNotes = new Map<string, string>();
-        if (projectRoot) {
+        // `search.pathsChanged`, on unless a repository turns it off. Gated at the top so the
+        // `fs.stat` per cited path is not paid either -- the switch is there for the cost as
+        // much as for the field.
+        if (projectRoot && (!config || isPathsChangedEnabled(config))) {
           await Promise.all(resolvedItems.map(async item => {
             if (isForeign(item) || !item.affectedPaths?.length) return;
             const storedAt = Date.parse(item.updatedAt ?? '');

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -5,7 +5,9 @@ import { NormalizedHostHook } from '../core/host-hook-types.js';
 import { renderChangeCard, type ImpactCardEntry } from './change-card.js';
 import { hostProfile } from './hosts/index.js';
 import { indexFile, listCodeSymbols } from '../code/symbol-index.js';
-import { areSkillNudgesEnabled, driftReminderEvery, loadConfig } from '../core/config.js';
+import {
+  areSkillNudgesEnabled, driftReminderEvery, isDriftBackoffEnabled, loadConfig, shouldSendDriftReminder,
+} from '../core/config.js';
 import { isImpactEnabled } from '../store/impact-config.js';
 import { captureEventsMode, captureNudgeMode, captureScope } from '../store/capture-config.js';
 import { classifyDestructiveCommand } from '../core/lesson-signals.js';
@@ -1170,12 +1172,13 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
             // that is querying/storing memory never sees a reminder.
             await resetHostSuccessfulToolCount(key);
           } else {
-            // `reminders.driftEvery`, default 12, `0` off. The counter still advances when the
-            // reminder is off: it is shared state that the branches above reset as a "go use
-            // memory" signal, and freezing it would change what THEY mean.
-            const every = driftReminderEvery(captureConfig);
+            // `reminders.driftEvery` (default 12, `0` off) and `reminders.driftBackoff`
+            // (default on, gap doubles per delivery). The counter still advances when the
+            // reminder is silent: it is shared state that the branches above reset as a "go use
+            // memory" signal, and freezing it would change what THEY mean. It is also what the
+            // backoff schedule is read from, so it has to keep counting to back off at all.
             const drift = await incrementHostSuccessfulToolCount(key);
-            if (every > 0 && drift > 0 && drift % every === 0) {
+            if (shouldSendDriftReminder(drift, driftReminderEvery(captureConfig), isDriftBackoffEnabled(captureConfig))) {
               hostOutput = profile.midTurnContext(KNOWL_CLAUDE_CONTINUATION_REMINDER);
             }
           }

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -5,7 +5,7 @@ import { NormalizedHostHook } from '../core/host-hook-types.js';
 import { renderChangeCard, type ImpactCardEntry } from './change-card.js';
 import { hostProfile } from './hosts/index.js';
 import { indexFile, listCodeSymbols } from '../code/symbol-index.js';
-import { loadConfig } from '../core/config.js';
+import { areSkillNudgesEnabled, driftReminderEvery, loadConfig } from '../core/config.js';
 import { isImpactEnabled } from '../store/impact-config.js';
 import { captureEventsMode, captureNudgeMode, captureScope } from '../store/capture-config.js';
 import { classifyDestructiveCommand } from '../core/lesson-signals.js';
@@ -84,9 +84,8 @@ import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js
 import { describeAutoDrift, runAutoDriftCheckBestEffort, type AutoDriftResult } from '../store/drift-auto.js';
 import { describeObservedUsePromotions, promoteByObservedUseBestEffort } from '../store/tier.js';
 
-// Emit the mid-turn continuation reminder after this many consecutive non-Knowl
-// tool calls; any Knowl tool call resets the counter to zero.
-const KNOWL_REMINDER_DRIFT = 12;
+// The cadence moved to `reminders.driftEvery` (default DEFAULT_DRIFT_REMINDER_EVERY = 12, `0`
+// off), so the number lives beside its predicate in core/config.ts rather than twice.
 
 /**
  * The tools whose paths become a read-set entry -- and the two that look like they belong here
@@ -1140,7 +1139,11 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
           // repeating is worth more than pointing at one it has already started. The one
           // exception is a workflow already saved -- asking the agent to save a skill that
           // exists is how this loop failed to close in the first place.
-          const capturing = Boolean(command) && !failed && !existing
+          // `reminders.skills`, on unless the repository turned it off. Applied to both skill
+          // branches at once: they are one subsystem speaking, and a repo that does not use
+          // skills pays the slot for both or neither.
+          const skillNudges = areSkillNudgesEnabled(captureConfig);
+          const capturing = skillNudges && Boolean(command) && !failed && !existing
             && qualifiesForSkillCapture(command, repeats);
 
           if (capturing) {
@@ -1149,7 +1152,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
             // continuation reminder for this event rather than freezing it.
             await resetHostSuccessfulToolCount(key);
             hostOutput = profile.midTurnContext(renderSkillCaptureNudge(command, repeats));
-          } else if (existing) {
+          } else if (skillNudges && existing) {
             await resetHostSuccessfulToolCount(key);
             hostOutput = profile.midTurnContext(renderSkillUseNudge(existing));
           } else if (shouldPromptTurnCapture(turnOutcome)
@@ -1167,8 +1170,12 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
             // that is querying/storing memory never sees a reminder.
             await resetHostSuccessfulToolCount(key);
           } else {
+            // `reminders.driftEvery`, default 12, `0` off. The counter still advances when the
+            // reminder is off: it is shared state that the branches above reset as a "go use
+            // memory" signal, and freezing it would change what THEY mean.
+            const every = driftReminderEvery(captureConfig);
             const drift = await incrementHostSuccessfulToolCount(key);
-            if (drift > 0 && drift % KNOWL_REMINDER_DRIFT === 0) {
+            if (every > 0 && drift > 0 && drift % every === 0) {
               hostOutput = profile.midTurnContext(KNOWL_CLAUDE_CONTINUATION_REMINDER);
             }
           }

--- a/src/store/capture-outcome.ts
+++ b/src/store/capture-outcome.ts
@@ -59,6 +59,25 @@ export type CaptureOutcome = {
 };
 
 /**
+ * The separator inside every composite key in this file.
+ *
+ * NOT NUL, which is the obvious choice and the wrong one: the libsql client truncates a TEXT value
+ * at the first NUL on the READ path. Storage and bound comparisons were always correct -- what
+ * broke was round-tripping, where a key SELECTed back out of a row arrived as its first segment
+ * and matched nothing, and hand-inspection, where `SELECT conversation FROM capture_outcomes`
+ * showed a bare `claude` for every row on the machine and read as a table collapsed onto one key
+ * when it was not.
+ *
+ * Unit separator survives that read path and keeps the property NUL was chosen for: it is a C0
+ * control character, so it cannot appear in a project path, a host name, or a host session id.
+ *
+ * No migration. Both tables hold per-conversation counters whose key is recomputed from hook input
+ * on every call, so rows written under the old separator are simply never reached again and fall
+ * out of the health window on their own.
+ */
+const KEY_SEPARATOR = '\u001f';
+
+/**
  * The stable identity of one conversation, across every turn it contains.
  *
  * Deliberately not a memory session id. A Claude turn binds its own memory session and `Stop`
@@ -66,15 +85,15 @@ export type CaptureOutcome = {
  * forever, however long the conversation runs. The host's own session id does not move, and it is
  * already on every hook event, so reading it costs nothing on the tool path.
  *
- * NUL-joined because a separator that can appear inside a project path lets two different
- * conversations collide on one row.
+ * Joined on a separator that cannot appear inside a project path, a host name or a session id,
+ * so two different conversations cannot collide on one row.
  */
 export function conversationKey(input: {
   host: string;
   projectRoot: string;
   externalSessionId?: string;
 }): string {
-  return [input.host, input.projectRoot, input.externalSessionId ?? ''].join('\u0000');
+  return [input.host, input.projectRoot, input.externalSessionId ?? ''].join(KEY_SEPARATOR);
 }
 
 /** Every counter starts its row, so neither caller has to know which of them ran first. */
@@ -243,14 +262,14 @@ export const MIN_SUBSTANTIVE_TURN_EVENTS = 12;
 /** How many turns of one conversation may be prompted, ever. The fatigue ceiling. */
 export const MAX_TURN_CAPTURE_PROMPTS = 3;
 
-/** The stable identity of one turn, NUL-joined for the reason `conversationKey` gives. */
+/** The stable identity of one turn, joined for the reason `conversationKey` gives. */
 export function turnCaptureKey(parts: {
   host: string;
   projectRoot: string;
   externalSessionId?: string;
   externalTurnId?: string;
 }): string {
-  return [parts.host, parts.projectRoot, parts.externalSessionId ?? '', parts.externalTurnId ?? ''].join('\u0000');
+  return [parts.host, parts.projectRoot, parts.externalSessionId ?? '', parts.externalTurnId ?? ''].join(KEY_SEPARATOR);
 }
 
 /** Count one tool event into the turn, and read the turn's counters back in the same write. */

--- a/tests/cli/claude-continuation-reminder.test.ts
+++ b/tests/cli/claude-continuation-reminder.test.ts
@@ -76,4 +76,37 @@ describe('Claude continuation reminder CLI', () => {
     expect(post('mcp__knowl__knowl_query', 'query')).toBe('');
     expect(post('Bash', 'would-have-been-twelfth')).toBe('');
   }, 120_000);
+
+  // `reminders.driftEvery`. Through the built CLI rather than the predicate alone, because the
+  // thing worth pinning is that the config actually reaches the hook path -- the predicate
+  // returning 0 is no use if the branch never reads it.
+  it('reminders.driftEvery 0 silences the reminder entirely', () => {
+    run(['config', 'set', 'reminders.driftEvery', '0']);
+    const outputs = [];
+    // Twice the shipped cadence: a stale `% 12` would have fired at 12 and again at 24.
+    for (let index = 1; index <= 24; index++) {
+      outputs.push(run(['agent-hook', 'claude', 'PostToolUse', '--json'], JSON.stringify({
+        session_id: 'cli-drift-off', cwd: TEST_DIR, tool_name: 'Bash',
+        tool_input: { command: `off-${index}` }, tool_response: { exit_code: 0 },
+      })));
+    }
+    expect(outputs.every(output => output === '')).toBe(true);
+    run(['config', 'reset', 'reminders.driftEvery']);
+  }, 180_000);
+
+  it('reminders.driftEvery 24 moves the reminder to the 24th event', () => {
+    run(['config', 'set', 'reminders.driftEvery', '24']);
+    const outputs = [];
+    for (let index = 1; index <= 24; index++) {
+      outputs.push(run(['agent-hook', 'claude', 'PostToolUse', '--json'], JSON.stringify({
+        session_id: 'cli-drift-24', cwd: TEST_DIR, tool_name: 'Bash',
+        tool_input: { command: `slow-${index}` }, tool_response: { exit_code: 0 },
+      })));
+    }
+    // Silent where the default would have spoken, speaking where the default would not.
+    expect(outputs[11]).toBe('');
+    expect(JSON.parse(outputs[23]).hookSpecificOutput.additionalContext)
+      .toBe(KNOWL_CLAUDE_CONTINUATION_REMINDER);
+    run(['config', 'reset', 'reminders.driftEvery']);
+  }, 180_000);
 });

--- a/tests/core/reminder-config.test.ts
+++ b/tests/core/reminder-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   areSkillNudgesEnabled, DEFAULT_DRIFT_REMINDER_EVERY, driftReminderEvery,
+  isDriftBackoffEnabled, shouldSendDriftReminder,
 } from '../../src/core/config.js';
 import type { ProjectConfig } from '../../src/core/types.js';
 
@@ -34,6 +35,48 @@ describe('reminders.driftEvery', () => {
       expect(driftReminderEvery(config({ driftEvery: bad })), `driftEvery: ${String(bad)}`)
         .toBe(DEFAULT_DRIFT_REMINDER_EVERY);
     }
+  });
+});
+
+describe('the backoff schedule', () => {
+  /** Every drift count that fires, up to `limit`, at the default cadence. */
+  const firesUpTo = (limit: number, every = DEFAULT_DRIFT_REMINDER_EVERY, backoff = true) => {
+    const at: number[] = [];
+    for (let drift = 1; drift <= limit; drift += 1) if (shouldSendDriftReminder(drift, every, backoff)) at.push(drift);
+    return at;
+  };
+
+  it('doubles the gap after each delivery', () => {
+    expect(firesUpTo(400)).toEqual([12, 36, 84, 180, 372]);
+    // Which is to say the gaps are 12, 24, 48, 96, 192 -- each twice the last.
+    expect(firesUpTo(400).map((n, i, all) => n - (all[i - 1] ?? 0))).toEqual([12, 24, 48, 96, 192]);
+  });
+
+  it('never goes silent, which is the whole reason it is not a cap', () => {
+    // The heaviest session in the measured archive drifted ~2,900 events. A cap of 3 would have
+    // stopped speaking at event 36 and never spoken again over the remaining 2,868.
+    expect(firesUpTo(2904).length).toBe(7);
+    expect(firesUpTo(2904).at(-1)).toBe(1524);
+  });
+
+  it('repeats forever at the fixed cadence when backoff is off', () => {
+    expect(firesUpTo(60, DEFAULT_DRIFT_REMINDER_EVERY, false)).toEqual([12, 24, 36, 48, 60]);
+  });
+
+  it('scales the whole schedule with the cadence, and 0 silences it', () => {
+    expect(firesUpTo(100, 5)).toEqual([5, 15, 35, 75]);
+    expect(firesUpTo(500, 0)).toEqual([]);
+  });
+
+  it('is off at drift 0 whatever else is set -- a fresh counter is not a delivery', () => {
+    expect(shouldSendDriftReminder(0, 12, true)).toBe(false);
+    expect(shouldSendDriftReminder(0, 12, false)).toBe(false);
+  });
+
+  it('reads on unless explicitly false', () => {
+    expect(isDriftBackoffEnabled(undefined)).toBe(true);
+    expect(isDriftBackoffEnabled(config({}))).toBe(true);
+    expect(isDriftBackoffEnabled(config({ driftBackoff: false }))).toBe(false);
   });
 });
 

--- a/tests/core/reminder-config.test.ts
+++ b/tests/core/reminder-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areSkillNudgesEnabled, DEFAULT_DRIFT_REMINDER_EVERY, driftReminderEvery,
+} from '../../src/core/config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * Both keys default ON, which is the opposite of every other switch in the config surface, so
+ * the property worth pinning is that ABSENCE reads as on. A `=== true` predicate would have
+ * silently disabled two shipped features for every repository that never set the key.
+ *
+ * The hook path is the caller, so a malformed value must degrade to today's behaviour rather
+ * than throw: a bad config should not fail a tool call.
+ */
+
+const config = (reminders: unknown): ProjectConfig => ({ reminders } as unknown as ProjectConfig);
+
+describe('reminders.driftEvery', () => {
+  it('defaults to the shipped cadence when unset, empty, or absent entirely', () => {
+    expect(driftReminderEvery(undefined)).toBe(DEFAULT_DRIFT_REMINDER_EVERY);
+    expect(driftReminderEvery(null)).toBe(DEFAULT_DRIFT_REMINDER_EVERY);
+    expect(driftReminderEvery({} as ProjectConfig)).toBe(DEFAULT_DRIFT_REMINDER_EVERY);
+    expect(driftReminderEvery(config({}))).toBe(DEFAULT_DRIFT_REMINDER_EVERY);
+  });
+
+  it('takes a whole number, and 0 as the off switch', () => {
+    expect(driftReminderEvery(config({ driftEvery: 24 }))).toBe(24);
+    expect(driftReminderEvery(config({ driftEvery: 1 }))).toBe(1);
+    expect(driftReminderEvery(config({ driftEvery: 0 }))).toBe(0);
+  });
+
+  it('falls back rather than throwing on a value the hook path must not choke on', () => {
+    for (const bad of [-1, 2.5, NaN, Infinity, '12', true, null]) {
+      expect(driftReminderEvery(config({ driftEvery: bad })), `driftEvery: ${String(bad)}`)
+        .toBe(DEFAULT_DRIFT_REMINDER_EVERY);
+    }
+  });
+});
+
+describe('reminders.skills', () => {
+  it('is on unless explicitly false', () => {
+    expect(areSkillNudgesEnabled(undefined)).toBe(true);
+    expect(areSkillNudgesEnabled(null)).toBe(true);
+    expect(areSkillNudgesEnabled({} as ProjectConfig)).toBe(true);
+    expect(areSkillNudgesEnabled(config({}))).toBe(true);
+    expect(areSkillNudgesEnabled(config({ skills: true }))).toBe(true);
+    expect(areSkillNudgesEnabled(config({ skills: false }))).toBe(false);
+  });
+});

--- a/tests/mcp/query-paths-changed.test.ts
+++ b/tests/mcp/query-paths-changed.test.ts
@@ -148,6 +148,21 @@ describe('knowl_query pathsChanged marker', () => {
     expect(row.pathsChanged).toBeUndefined();
   });
 
+  it('says nothing at all when search.pathsChanged is off', async () => {
+    const projectId = await seedRepo(A);
+    await fs.mkdir(path.join(A, 'src'), { recursive: true });
+    await fs.writeFile(path.join(A, 'src', 'auth.ts'), 'export const ttl = 15;');
+    await storeCiting(projectId, 'Auth token TTL is fifteen minutes', ['src/auth.ts']);
+    const config = await loadConfig(A);
+    await saveConfig(A, { ...config, search: { ...config.search, pathsChanged: false } });
+
+    const result = await callQuery(A, await loadConfig(A), { query: 'auth token ttl' });
+    const row = rowsOf(result).find(r => String(r.title).includes('Auth token TTL'));
+    expect(row).toBeDefined();
+    // The same row carries the marker with the key unset -- the first case in this suite.
+    expect(row.pathsChanged).toBeUndefined();
+  });
+
   it('counts only the paths it could actually check', async () => {
     const projectId = await seedRepo(A);
     await fs.mkdir(path.join(A, 'src'), { recursive: true });

--- a/tests/store/capture-outcome.test.ts
+++ b/tests/store/capture-outcome.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { closeDb, initDb } from '../../src/store/database.js';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
 import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
 import { captureNudgeMode } from '../../src/store/capture-config.js';
@@ -9,6 +9,7 @@ import {
   captureHealth,
   claimSilenceNudge,
   isDurableWriteTool,
+  conversationKey,
   MIN_SUBSTANTIVE_TURNS,
   readCaptureOutcome,
   recordDurableWrite,
@@ -165,5 +166,20 @@ describe('capture outcomes on disk', () => {
 
   it('reports no sessions rather than throwing when the table has never been written', async () => {
     expect(await captureHealth()).toEqual({ sessions: 0, silent: 0, substantiveSilent: 0, nudged: 0 });
+  });
+
+  it('round-trips a composite key through the row it was stored in', async () => {
+    // The separator is load-bearing and the failure is silent: under NUL the libsql client
+    // truncates this key on the READ path, so `stored` comes back as `claude` alone and binding
+    // it finds nothing -- while every assertion above still passes, because they all recompute
+    // the key rather than reading one. This is the only test that reads one back.
+    const key = conversationKey({ host: 'claude', projectRoot: 'D:/coding/knowl', externalSessionId: 's1' });
+    await recordSessionTurn(key);
+
+    const rows = await getClient().execute('SELECT conversation FROM capture_outcomes');
+    const stored = String(rows.rows[0]?.conversation);
+
+    expect(stored).toBe(key);
+    expect(await readCaptureOutcome(stored)).toMatchObject({ turns: 1 });
   });
 });


### PR DESCRIPTION
## What this is

Four things could spend the agent's context with no way to decline them. Three now have a switch, and the loudest one also stops repeating itself. Two unrelated fixes ride along at the front, each on its own commit.

Found while reviewing #166: `pathsChanged` shipped on for everyone, gated on `if (projectRoot)` and nothing else — `knowl posture frugal` reset six keys and left it running. Auditing for siblings turned up three more, all older than #166 and all competing for the same single mid-turn slot.

## The measurement

Before choosing the shape of the drift key I measured the reminder against the real 197-session Claude archive (the same instrument the guidance-card eval used — the retrieval benchmarks cannot see any of this):

- **3,700 fires**, 70.6% of sessions, 9.03 per 100 tool results
- **~1,750 tokens per session** — the guidance card is 498, and *that* has an eval, a PR and a hard 2,000-character ceiling
- worst single session: **242 fires, ~22k tokens** of one byte-identical string

The defect is not the per-fire size. The card is *fixed* per session; this scales with session length. Every other mid-turn sender got a ceiling in #166 (`MAX_LESSON_BLOCKS`, `MAX_TURN_CAPTURE_PROMPTS`) — this one had none.

Candidate policies replayed over the same data:

| policy | fires | tokens | cut | worst session |
|---|---|---|---|---|
| shipped (every 12) | 3,700 | 345k | — | 242 |
| cadence 24 | 1,849 | 172k | 50% | 121 |
| cap 5/session | 639 | 60k | 83% | 5 |
| **backoff ×2 (shipped here)** | **503** | **47k** | **86%** | **7** |
| cap 3/session | 402 | 37k | 89% | 3 |

## The commits

1. **`fix(capture)`: never join a composite key on NUL.** `conversationKey` and `turnCaptureKey` joined on `\u0000`. Storage and bound comparisons were always fine, so nothing failed loudly — but the libsql client stops TEXT at the first NUL on the *read* path, so a key SELECTed back out arrived as `claude` alone, and `SELECT conversation FROM capture_outcomes` showed a bare `claude` for every row on the machine. Unit separator instead: survives the read path, still a C0 control character so it cannot appear in a path, host name or session id. No migration — every key is recomputed from hook input, so old rows are simply never reached again. The suite could not have caught it: every existing assertion recomputes the key rather than reading one, which is why the new test is the only one that SELECTs one back.

2. **`docs(query)`: the CLI splits JSON from advisories, and the shape of the JSON varies.** The four `Note:` lines go to stderr and the JSON to stdout; most shells merge them and the parser then throws on a line that is not JSON, which reads as "the CLI emitted bad JSON". And the parsed value is a bare array *or* an object keyed by repo, so a parser assuming one shape silently returns nothing in the other.

3. **`search.pathsChanged`** (default on) — the stale-path marker. Gated above the loop, so turning it off also stops the `fs.stat` per cited path. Named `search.` and not `impact.` deliberately: it *is* the read-side half of impact detection, but it does not depend on `impact.enabled` and must not look as though it does.

4. **`reminders.driftEvery`** (default 12, `0` off) and **`reminders.skills`** (default on) — a new section for what Knowl *says*, as against `capture.*`, what it *stores*. One key covers both skill nudges; they are one subsystem speaking. `KNOWL_REMINDER_DRIFT` is gone.

5. **`reminders.driftBackoff`** (default on) — the gap doubles after each delivery: 12, 36, 84, 180, 372. Which means `drift/every + 1` is a power of two at exactly those points, so the whole schedule is one test on the counter that already exists — no column, no row, nothing to reset.

   Doubling rather than a cap, though cap-3 scores three points better: a cap goes permanently silent at event 36 and says nothing across the remaining 2,868 events of a long session. That is the structural blind spot the capture work exists to close, and it would be a poor trade to reintroduce it for 3%.

## On defaults

All four keys default **on**, so the predicates read `!== false` rather than `=== true`, and all four stay out of `DEFAULT_CONFIG` — merged in, they are stamped into every config on the machine at the next `knowl upgrade`. A key that silently disabled a shipped feature for every repo that never set it is a worse surprise than one that does nothing until set.

A malformed cadence falls back to 12 instead of throwing: this runs on the hook path, where a bad config must degrade to today's behaviour rather than fail a tool call.

Commit 5 is the only default *behaviour* change, and it is the one with an escape hatch and the numbers above. It is the next step on the axis of the every-8→adaptive-12 decision, whose own reasoning was "keeps the long-session safety net without nagging" — the adaptive reset only helps a session that *uses* memory, and does nothing for the long session doing legitimate non-Knowl work, which is the one paying the 242.

## Verified

`npm run build`, `npm test` (**359 files / 3,461 passed**), `npm run typecheck`, `npm run docs:check`, `eslint src tests` — all clean. New coverage: the backoff schedule and both fallbacks as unit tests, `driftEvery 0` and `driftEvery 24` end-to-end through the built CLI, a `search.pathsChanged false` case through the MCP server, and a composite key round-tripped through the row it was stored in.
