### PR TITLE
feat(cli): the settings all exist, and nothing said which ones were on

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,7 +29,7 @@ which parts of a restore are deliberately not restored.
 | [Overview](#overview) · [Quick start](#quick-start) | What Knowl is and how to install it |
 | [Core knowledge model](#core-knowledge-model) | [Atom categories](#atom-categories) · [Metadata, history, ownership](#metadata-history-and-ownership) · [Governed writes](#governed-writes-and-current-truth) |
 | [Retrieval and context](#retrieval-and-context) | [Current retrieval](#current-retrieval) · [What a result carries](#what-a-result-carries) · [Embedding models](#choosing-an-embedding-model) · [Historical queries](#historical-retrieval-and-assertions) · [Context packs](#bounded-context-packs) |
-| [Tasks, sessions, lifecycle](#tasks-sessions-and-agent-lifecycle) | [Work loops](#manual-work-loops) · [Retention and promotion](#session-retention-recovery-and-promotion) · [Handoffs and resume keys](#leaving-work-for-later) · [Transcript search](#searchable-session-transcripts-optional-off-by-default) · [Host behavior](#host-and-subagent-behavior) |
+| [Tasks, sessions, lifecycle](#tasks-sessions-and-agent-lifecycle) | [Work loops](#manual-work-loops) · [Retention and promotion](#session-retention-recovery-and-promotion) · [Handoffs and resume keys](#leaving-work-for-later) · [Transcript search](#searchable-session-transcripts-optional-off-by-default) · [What exists and what is on](#seeing-what-exists-and-what-is-on--knowl-config-list) · [Host behavior](#host-and-subagent-behavior) |
 | [Evidence, code, drift](#evidence-code-intelligence-and-drift) | [Evidence and symbols](#evidence-and-symbols) · [PR drift and feedback](#pull-request-drift-and-retrieval-feedback) |
 | [Workspaces](#workspaces) | [Federation and ownership](#federation-and-ownership) · [Reading a peer's atom by id](#reading-a-linked-repos-atom-by-id) · [Doing a peer's work](#doing-a-linked-repos-work-from-here) · [Ownership stamping](#ownership) |
 | [Knowl Cloud](#knowl-cloud) | [Identity and connection](#identity-and-connection) · [Publishing and drift](#publishing-works-from-any-branch-reporting-drift-does-not) · [Staying current](#staying-current) |
@@ -504,6 +504,30 @@ because they are laid out differently: Claude Code names a directory after the p
 (`~/.claude/projects/<encoded-root>/`), while Codex partitions by date
 (`~/.codex/sessions/YYYY/MM/DD/`) and records the project inside each file as
 `session_meta.payload.cwd`. Every Codex candidate is therefore opened, with a bounded header read.
+
+### Seeing what exists and what is on — `knowl config list`
+
+Most of what Knowl can do is a setting, and several of the useful ones ship off. Until this
+command there was no surface that said so: `knowl status` reports item counts, capture health
+and workspace, `knowl doctor` reports readiness, and the one-line descriptions of every setting
+were reachable only from inside the interactive editor, which needs a TTY.
+
+```bash
+knowl config list          # every switch, whether it is on, and the command that changes it
+knowl config list --all    # plus values that are filled in rather than switched
+knowl config --help        # the same settings as a reference, with allowed values and defaults
+```
+
+`knowl status` carries the count and points here, because that is where `knowl init` sends a
+new repository and a feature the product never mentions there is a feature nobody finds.
+
+**When a change takes effect.** Transcript search, the cloud connection and workspace
+membership are obeyed immediately by a running agent session — those three gates re-read the
+config file on every call and fail closed if either the captured or the on-disk value says off.
+Every other setting is read when a session starts, so a session already running keeps the value
+it started with. A setting that decides whether a *tool exists* — the cloud and workspace tools
+are registered only when their config is present — can only add or remove that tool at session
+start, because the tool list is sent once when the connection opens.
 
 ### The recall and capture posture — `knowl posture`
 
@@ -2046,6 +2070,7 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl import <path> [--dry-run] [--on-divergence newer\|skip\|theirs\|fail]` | Import JSONL with an explicit divergence policy |
 | `knowl snapshot create` / `knowl snapshot restore <path> --confirm` | Create a checksummed SQLite snapshot, or restore one after verifying its manifest, size, checksum, and SQLite integrity |
 | `knowl config` | Edit configuration interactively |
+| `knowl config list [--all]` | List every setting, whether it is on, and the command that changes it |
 | `knowl config get <key>` | Print one configuration value |
 | `knowl config set <key> <value>` | Set one configuration value |
 | `knowl config reset [key]` | Restore one key, or all of them, to the default |

--- a/src/cli/config/catalog.ts
+++ b/src/cli/config/catalog.ts
@@ -63,11 +63,39 @@ function wrap(text: string, indent: string, width = 96): string[] {
   return lines;
 }
 
+/**
+ * The value a three-mode ladder uses to spell its own off state.
+ *
+ * Every enum in `CONFIG_FIELDS` that HAS an off state spells it this way and lists it first --
+ * `impact.gate`, `capture.nudge`, `capture.events` -- because the values are ordered by what
+ * they cost the person running them. An enum without this in its list (`capture.scope`,
+ * `ai.provider`, `search.vector.preset`) has no off state, and every value counts as on.
+ */
+const OFF = 'off';
+
 /** Whether a row counts as switched on, which is what the marker and the hint key off. */
 export function isOn(field: ConfigField, value: unknown): boolean {
   if (field.type === 'boolean') return value === true;
+  // An enum sitting at `off` is off. Without this it rendered ● beside the literal word `off`
+  // on the same line -- the marker contradicting the value it was printed next to -- and
+  // counted toward "N of M on", so `knowl status` reported two disarmed features as armed.
+  if (field.type === 'enum') return value !== OFF && value !== undefined && value !== null && value !== '';
   if (Array.isArray(value)) return value.length > 0;
   return value !== undefined && value !== null && value !== '';
+}
+
+/**
+ * What to suggest for a setting that is off: `true` for a switch, and for a ladder the first
+ * value above off.
+ *
+ * First-above-off rather than the last, deliberately: the mode lists are ordered "nothing, then
+ * measurement, then refusal", so the cheapest step up is both the safest recommendation and the
+ * one the schema comment says the modes are meant to be adopted in.
+ */
+function turnOnValue(field: ConfigField): string | undefined {
+  if (field.type === 'boolean') return 'true';
+  if (field.type === 'enum') return field.values?.find(candidate => candidate !== OFF);
+  return undefined;
 }
 
 /**
@@ -212,8 +240,12 @@ export function renderConfigCatalog(rows: CatalogRow[], options: RenderOptions =
       if (row.shadowed && field.derivedFrom) {
         // Says who owns it instead of offering the edit, which is the whole point of the flag.
         lines.push(`      set by ${field.derivedFrom}; writing this key changes nothing`);
-      } else if (!isOn(field, row.value) && field.type === 'boolean') {
-        lines.push(`      ${command} config set ${field.key} true`);
+      } else if (!isOn(field, row.value)) {
+        // Ladders get a hint too, not just switches. Gating this on `boolean` left the two
+        // settings that most need one -- a disarmed `impact.gate` and `capture.events` -- with
+        // no way shown to arm them, which is the one job this command has.
+        const target = turnOnValue(field);
+        if (target) lines.push(`      ${command} config set ${field.key} ${target}`);
       }
     }
   }

--- a/src/cli/config/catalog.ts
+++ b/src/cli/config/catalog.ts
@@ -1,0 +1,227 @@
+import { loadConfig } from '../../core/config.js';
+import { VECTOR_PRESETS, resolveVectorProfile } from '../../core/vector-profile.js';
+import { getEffectiveConfigValue } from './service.js';
+import { CONFIG_FIELDS, ConfigCategory, ConfigField } from './schema.js';
+
+/**
+ * The non-interactive rendering of `CONFIG_FIELDS`.
+ *
+ * These descriptions already existed and were reachable from exactly one place: the interactive
+ * editor, which needs a TTY. So the question a new user actually has -- what can this do, and
+ * what is on -- had no answer anywhere. `knowl status` reports item counts, capture health and
+ * workspace; `knowl doctor` reports readiness. Neither enumerates a feature, and `knowl init`
+ * points at `knowl status` and nowhere else.
+ *
+ * Rendering is kept apart from reading the config so it can be asserted directly, and so the
+ * same rows can be rendered somewhere other than stdout later without the reader coming along.
+ */
+export interface CatalogRow {
+  field: ConfigField;
+  /** The effective value, resolved the way `knowl config get` resolves it. */
+  value: unknown;
+  /**
+   * Set when a named preset owns this field's value. `resolveVectorProfile` reads the preset
+   * before it ever looks at the flat keys, so offering `config set` here would be offering an
+   * edit that writes the file and changes nothing.
+   */
+  shadowed?: boolean;
+}
+
+/**
+ * When a change starts being obeyed, stated once rather than per field.
+ *
+ * Three gates re-read config from disk on every call and fail closed if either the captured or
+ * the on-disk value says off -- the transcripts gate, `knowl_cloud` and `knowl_workspace`.
+ * Everything else is the config the MCP server captured when it spawned. A per-field label was
+ * the first design and was dropped: it would be a hand-maintained answer for 32 settings whose
+ * consumer chains are not all traced, and a wrong "takes effect now" is worse than a rule the
+ * reader applies themselves.
+ */
+const EFFECT_NOTICE = [
+  'Transcript search, the cloud connection and workspace membership are obeyed immediately by a',
+  'running agent session -- their gates re-read this file on every call. Every other setting is',
+  'read when a session starts, so one already running keeps the value it started with.',
+];
+
+/**
+ * Wraps to a fixed width with a hanging indent.
+ *
+ * Fixed rather than `process.stdout.columns`, so the same input renders the same bytes whether
+ * it goes to a terminal, a pipe or a test. Several descriptions are 200-plus characters, and a
+ * terminal left to break them puts the continuation in column one, where it reads as a setting.
+ */
+function wrap(text: string, indent: string, width = 96): string[] {
+  const limit = width - indent.length;
+  const lines: string[] = [];
+  let current = '';
+  for (const word of text.split(/\s+/).filter(Boolean)) {
+    if (!current) current = word;
+    else if (current.length + 1 + word.length <= limit) current += ` ${word}`;
+    else { lines.push(indent + current); current = word; }
+  }
+  if (current) lines.push(indent + current);
+  return lines;
+}
+
+/** Whether a row counts as switched on, which is what the marker and the hint key off. */
+export function isOn(field: ConfigField, value: unknown): boolean {
+  if (field.type === 'boolean') return value === true;
+  if (Array.isArray(value)) return value.length > 0;
+  return value !== undefined && value !== null && value !== '';
+}
+
+/**
+ * Whether a field is a switch rather than a value to be filled in.
+ *
+ * Derived from `type` and `derivedFrom` rather than hand-marked, so a new setting is classified
+ * by what it already declares. A preset-owned field is excluded whatever its type: it is an
+ * internal of the preset that owns it, not a choice offered here.
+ */
+export function isSwitch(field: ConfigField): boolean {
+  if (field.derivedFrom) return false;
+  return field.type === 'boolean' || field.type === 'enum';
+}
+
+/**
+ * A secret's value never reaches the terminal, only whether one is present. npm prints
+ * `(protected)` in the same position for the same reason: a catalog gets pasted into issues.
+ */
+function displayValue(field: ConfigField, value: unknown): string {
+  if (field.secret) return isOn(field, value) ? '(set)' : '(unset)';
+  if (field.type === 'boolean') return value === true ? 'on' : 'off';
+  if (Array.isArray(value)) return value.length ? `${value.length} pattern(s)` : '(none)';
+  if (value === undefined || value === null || value === '') return '(unset)';
+  return String(value);
+}
+
+/** Which part of a vector preset a derived key takes its value from. */
+const PRESET_PART = {
+  'search.vector.model': 'model',
+  'search.vector.dtype': 'dtype',
+  'search.vector.pooling': 'pooling',
+} as const;
+
+/**
+ * Reads what each setting is actually running on.
+ *
+ * Kept separate from rendering so the values can be asserted without parsing text, and so the
+ * preset resolution below has one home rather than being repeated by every future caller.
+ */
+export async function buildConfigCatalog(
+  root: string,
+  options: { all?: boolean } = {},
+): Promise<CatalogRow[]> {
+  const config = await loadConfig(root);
+  const fields = options.all ? CONFIG_FIELDS : CONFIG_FIELDS.filter(isSwitch);
+  const profile = resolveVectorProfile(config);
+  const preset = config.search?.vector?.preset;
+  // `custom` names no model of its own, so under it the flat keys ARE the real values and
+  // nothing shadows them -- the same rule `ownerOf` applies in the interactive editor.
+  const presetOwns = typeof preset === 'string' && preset !== 'custom' && preset in VECTOR_PRESETS;
+
+  const rows: CatalogRow[] = [];
+  for (const field of fields) {
+    const part = PRESET_PART[field.key as keyof typeof PRESET_PART];
+    const shadowed = Boolean(field.derivedFrom && presetOwns);
+    rows.push({
+      field,
+      // The preset's value, not the stored key's: switching preset never rewrites the flat
+      // keys, so the stored one can name a model that has not been used since. See 1453b1f2.
+      value: shadowed && part ? profile[part] : await getEffectiveConfigValue(root, field.key),
+      shadowed,
+    });
+  }
+  return rows;
+}
+
+/**
+ * The settings reference printed under `knowl config --help`.
+ *
+ * `gh config --help` lists every setting it respects with a description, its allowed values and
+ * its default, and that help text is the reference people actually read -- so this is generated
+ * from the same registry the editor and the catalog use, and cannot fall behind them.
+ *
+ * State is deliberately absent: help is printed without a repository, and a reference that
+ * guessed at what was on would be wrong exactly where it mattered. `knowl config list` has it.
+ */
+export function renderConfigReference(): string[] {
+  const fields = CONFIG_FIELDS.filter(isSwitch);
+  const width = Math.max(0, ...fields.map(candidate => candidate.key.length));
+  const hanging = ' '.repeat(width + 4);
+
+  return fields.flatMap(candidate => {
+    const values = candidate.type === 'enum' && candidate.values?.length
+      ? ` {${candidate.values.join(' | ')}}`
+      : '';
+    const fallback = candidate.defaultValue === undefined ? '' : ` (default ${JSON.stringify(candidate.defaultValue)})`;
+    // Wrapped under the description column rather than run out to 300 characters, which is
+    // what several of these produce -- found by printing it, not by asserting on it.
+    const [first, ...rest] = wrap(`${candidate.description}${values}${fallback}`, hanging);
+    return [
+      `  ${candidate.key.padEnd(width)}  ${first.trimStart()}`,
+      ...rest,
+    ];
+  });
+}
+
+/**
+ * The one line `knowl status` carries.
+ *
+ * A count and a pointer, not the catalog: status is already the longest screen the CLI prints,
+ * and thirty settings there would bury the warnings it exists to surface. This is the whole of
+ * the discoverability fix -- `knowl init` sends every new user to `knowl status` and nowhere
+ * else, so a feature the product never mentions there is a feature nobody finds.
+ */
+export function formatFeatureSummary(rows: CatalogRow[]): string {
+  const on = rows.filter(row => isOn(row.field, row.value)).length;
+  return `${on} of ${rows.length} on · knowl config list`;
+}
+
+export interface RenderOptions {
+  /** Prefix every `config set` hint, so a caller outside the repo can show a runnable command. */
+  commandName?: string;
+}
+
+export function renderConfigCatalog(rows: CatalogRow[], options: RenderOptions = {}): string[] {
+  const command = options.commandName ?? 'knowl';
+  const lines: string[] = [];
+
+  const byCategory = new Map<ConfigCategory, CatalogRow[]>();
+  for (const row of rows) {
+    const existing = byCategory.get(row.field.category);
+    if (existing) existing.push(row);
+    else byCategory.set(row.field.category, [row]);
+  }
+
+  const labelWidth = Math.max(0, ...rows.map(row => row.field.label.length));
+
+  for (const [category, categoryRows] of byCategory) {
+    if (lines.length) lines.push('');
+    lines.push(category.toUpperCase());
+    for (const row of categoryRows) {
+      const { field } = row;
+      const marker = isOn(field, row.value) ? '●' : '○';
+      lines.push(`  ${marker} ${field.label.padEnd(labelWidth)}  ${displayValue(field, row.value)}`);
+      lines.push(...wrap(field.description, '      '));
+      lines.push(`      ${field.key}`);
+
+      if (field.type === 'enum' && field.values?.length) {
+        lines.push(`      one of: ${field.values.join(', ')}`);
+      }
+
+      if (row.shadowed && field.derivedFrom) {
+        // Says who owns it instead of offering the edit, which is the whole point of the flag.
+        lines.push(`      set by ${field.derivedFrom}; writing this key changes nothing`);
+      } else if (!isOn(field, row.value) && field.type === 'boolean') {
+        lines.push(`      ${command} config set ${field.key} true`);
+      }
+    }
+  }
+
+  if (lines.length) {
+    lines.push('');
+    lines.push(...EFFECT_NOTICE);
+  }
+
+  return lines;
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -47,6 +47,7 @@ import { applyDoctorRemedies } from './doctor-fix.js';
 import { formatSweepReport, sweepRepos } from './upgrade-all.js';
 import { createLocalEmbeddingProvider, isVectorSearchEnabled } from '../ai/embeddings.js';
 import { getEffectiveConfigValue, resetAllConfig, resetConfigValue, setConfigValue, setConfigValues } from './config/service.js';
+import { buildConfigCatalog, formatFeatureSummary, renderConfigCatalog, renderConfigReference } from './config/catalog.js';
 import { runConfigUi } from './config/ui.js';
 import { defaultApiHost, runLogin, runLogout } from '../cloud/login.js';
 import { createCloudApi } from '../cloud/api-client.js';
@@ -465,6 +466,10 @@ program
         capture: await captureHealth(),
         captureNudgeMode: captureNudgeMode(config),
         cloud,
+        // Reads config.json a second time rather than threading `config` through: the catalog
+        // resolves preset-owned values through `resolveVectorProfile`, and duplicating that
+        // resolution here to save one small file read is how the two answers drift apart.
+        features: formatFeatureSummary(await buildConfigCatalog(root)),
       }));
 
       if (isUpdateCheckEnabled(config)) {
@@ -2667,7 +2672,16 @@ const configCommand = program
   // Commander 14 rejects excess arguments before the action runs. Left alone, `knowl config
   // ai.model gpt-4o` would answer "too many arguments for 'config'" instead of naming the
   // subcommand syntax the user was reaching for, which is the whole point of the check below.
-  .allowExcessArguments();
+  .allowExcessArguments()
+  // `gh config --help` is where gh documents every setting it respects, and it is the reference
+  // people actually read. Generated, so it cannot drift from what `config set` accepts.
+  .addHelpText('after', () => [
+    '',
+    'Settings, and what each one does:',
+    ...renderConfigReference(),
+    '',
+    'Current values, and which are on:  knowl config list',
+  ].join('\n'));
 
 configCommand.action(async () => {
   try {
@@ -2695,6 +2709,25 @@ configCommand.action(async () => {
     process.exitCode = 1;
   }
 });
+
+configCommand
+  .command('list')
+  .description('List every setting, whether it is on, and the command that changes it')
+  .option('--all', 'Include values that are filled in rather than switched, and preset internals')
+  .action(async (options: { all?: boolean }) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const rows = await buildConfigCatalog(root, { all: options.all });
+      for (const line of renderConfigCatalog(rows)) console.log(line);
+      if (!options.all) {
+        console.log('');
+        console.log('Values that are filled in rather than switched: knowl config list --all');
+      }
+    } catch (error: any) {
+      console.error(`❌ Configuration error: ${error.message}`);
+      process.exitCode = 1;
+    }
+  });
 
 configCommand
   .command('get')

--- a/src/cli/status-report.ts
+++ b/src/cli/status-report.ts
@@ -40,6 +40,14 @@ export function formatStatusReport(input: {
   captureNudgeMode?: string;
   /** Absent or disconnected renders nothing, so an offline repo gains no noise. */
   cloud?: CloudStatus | null;
+  /**
+   * How many features are on, and where to read them. One line, because `knowl init` points
+   * every new user here and at nowhere else -- and because this is already the longest screen
+   * the CLI prints, so the catalog itself belongs behind the command this names.
+   *
+   * Absent renders no section, keeping a caller that has not gathered it byte-identical.
+   */
+  features?: string;
 }): string {
   const countsByCategory = input.activeItems.reduce((acc, item) => {
     acc[item.category] = (acc[item.category] || 0) + 1;
@@ -52,6 +60,7 @@ export function formatStatusReport(input: {
     STATUS_LINE,
     `Repository:     ${input.project.rootPath}`,
     `AI Config:      ${input.config.ai ? `${input.config.ai.provider} (${input.config.ai.model})` : 'not configured'}`,
+    ...(input.features ? [STATUS_LINE, '⚙️  FEATURES', `  ${input.features}`] : []),
     STATUS_LINE,
     '📝 KNOWLEDGE ITEMS',
     `  Active:        ${input.activeItems.length}`,

--- a/tests/cli/config-catalog.test.ts
+++ b/tests/cli/config-catalog.test.ts
@@ -1,0 +1,311 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildConfigCatalog, formatFeatureSummary, isSwitch, renderConfigCatalog, renderConfigReference } from '../../src/cli/config/catalog.js';
+import { CONFIG_FIELDS, type ConfigField } from '../../src/cli/config/schema.js';
+import { DEFAULT_CONFIG } from '../../src/core/config.js';
+
+const ROOT = path.resolve('.knowl-config-catalog-test');
+
+afterEach(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+async function writeConfig(value: unknown = DEFAULT_CONFIG) {
+  await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+  await fs.writeFile(path.join(ROOT, '.knowl', 'config.json'), JSON.stringify(value, null, 2), 'utf8');
+}
+
+/**
+ * The catalog is the answer to "what can this thing do, and what is on" -- a question no
+ * surface answered before it. `knowl status` reports counts and workspace, `knowl doctor`
+ * reports health; neither enumerates features, and `knowl config` renders these same
+ * descriptions only from inside an interactive TTY.
+ *
+ * Rendering is tested against fixtures rather than `CONFIG_FIELDS` so a wording change to a
+ * real setting cannot fail these; the registry itself is asserted separately below.
+ */
+const field = (over: Partial<ConfigField> & Pick<ConfigField, 'key'>): ConfigField => ({
+  category: 'Search',
+  type: 'boolean',
+  label: 'A setting',
+  description: 'What it does.',
+  applies: 'immediately',
+  parse: (raw: string) => raw === 'true',
+  ...over,
+} as ConfigField);
+
+describe('renderConfigCatalog', () => {
+  it('marks a setting that is on and names the key that sets it', () => {
+    const lines = renderConfigCatalog([
+      { field: field({ key: 'search.vector.enabled', label: 'Semantic search' }), value: true },
+    ]);
+
+    const text = lines.join('\n');
+    expect(text).toContain('Semantic search');
+    expect(text).toContain('search.vector.enabled');
+    expect(text).toMatch(/●.*Semantic search/);
+  });
+
+  it('gives the exact command that turns an off setting on', () => {
+    const lines = renderConfigCatalog([
+      { field: field({ key: 'search.transcripts.share' }), value: false },
+    ]);
+
+    expect(lines.join('\n')).toContain('knowl config set search.transcripts.share true');
+  });
+
+  it('does not print a command for a setting that is already on', () => {
+    const lines = renderConfigCatalog([
+      { field: field({ key: 'search.vector.enabled' }), value: true },
+    ]);
+
+    expect(lines.join('\n')).not.toContain('knowl config set');
+  });
+
+  it('groups settings under their category heading', () => {
+    const lines = renderConfigCatalog([
+      { field: field({ key: 'search.vector.enabled', category: 'Search' }), value: true },
+      { field: field({ key: 'security.rejectSecrets', category: 'Security' }), value: true },
+    ]);
+
+    const text = lines.join('\n');
+    expect(text).toContain('SEARCH');
+    expect(text).toContain('SECURITY');
+    expect(text.indexOf('SEARCH')).toBeLessThan(text.indexOf('SECURITY'));
+  });
+
+  /**
+   * Caught by running it rather than by asserting it: several real descriptions are 200-plus
+   * characters, and a terminal breaks them at the window edge with no indent, so the wrap lands
+   * in column one and reads as a new setting.
+   */
+  it('wraps a long description instead of leaving the terminal to break it', () => {
+    const lines = renderConfigCatalog([
+      {
+        field: field({
+          key: 'reminders.driftBackoff',
+          description: 'Double the gap after each reminder -- 12, 24, 48, 96 -- instead of repeating at the same cadence forever. The message is identical every time, so the fortieth is worth nothing; this keeps the long-session safety net without the nagging.',
+        }),
+        value: true,
+      },
+    ]);
+
+    expect(lines.every(line => line.length <= 96)).toBe(true);
+    const wrapped = lines.filter(line => line.includes('cadence') || line.includes('fortieth'));
+    expect(wrapped.length).toBeGreaterThan(0);
+    expect(wrapped.every(line => line.startsWith('      '))).toBe(true);
+  });
+
+  it('never prints the value of a secret field', () => {
+    const lines = renderConfigCatalog([
+      { field: field({ key: 'ai.apiKey', type: 'string', secret: true }), value: 'sk-live-not-a-real-key' },
+    ]);
+
+    const text = lines.join('\n');
+    expect(text).not.toContain('sk-live-not-a-real-key');
+    expect(text).toContain('(set)');
+  });
+
+  it('names the allowed values of an enum so the set command can be written', () => {
+    const lines = renderConfigCatalog([
+      { field: field({ key: 'impact.gate', type: 'enum', values: ['off', 'shadow', 'enforce'] }), value: 'shadow' },
+    ]);
+
+    const text = lines.join('\n');
+    expect(text).toContain('off');
+    expect(text).toContain('enforce');
+  });
+
+  it('reports a preset-owned field as owned rather than offering an edit that does nothing', () => {
+    const lines = renderConfigCatalog([
+      {
+        field: field({ key: 'search.vector.model', type: 'string', derivedFrom: 'search.vector.preset' }),
+        value: 'onnx-community/granite-embedding-small-english-r2-ONNX',
+        shadowed: true,
+      },
+    ]);
+
+    const text = lines.join('\n');
+    expect(text).toContain('search.vector.preset');
+    expect(text).not.toContain('knowl config set search.vector.model');
+  });
+});
+
+describe('isSwitch', () => {
+  it('counts a boolean as a switch', () => {
+    expect(isSwitch(field({ key: 'search.vector.enabled', type: 'boolean' }))).toBe(true);
+  });
+
+  it('counts an enum as a switch', () => {
+    expect(isSwitch(field({ key: 'impact.gate', type: 'enum', values: ['off', 'shadow'] }))).toBe(true);
+  });
+
+  it('does not count a free-text value as a switch', () => {
+    expect(isSwitch(field({ key: 'search.vector.cacheDir', type: 'string' }))).toBe(false);
+  });
+
+  it('does not count a field a preset owns as a switch', () => {
+    expect(isSwitch(field({ key: 'search.vector.dtype', type: 'enum', derivedFrom: 'search.vector.preset' }))).toBe(false);
+  });
+});
+
+/**
+ * When a change takes effect is the first thing anyone asks after flipping a switch, and the
+ * answer is not uniform: three gates re-read from disk per call and everything else is the
+ * config the MCP server captured at spawn. Stated once, as a rule, rather than per field --
+ * a per-field label would have to be hand-maintained for 32 settings whose consumer chains
+ * were not all traced, and a wrong "immediate" is worse than a rule the reader applies.
+ */
+describe('the effect notice', () => {
+  it('names the three settings a running session obeys immediately', () => {
+    const text = renderConfigCatalog([
+      { field: field({ key: 'search.vector.enabled' }), value: true },
+    ]).join('\n');
+
+    expect(text.toLowerCase()).toContain('transcript');
+    expect(text.toLowerCase()).toContain('cloud');
+    expect(text.toLowerCase()).toContain('workspace');
+  });
+
+  it('appears once however many settings are listed', () => {
+    const text = renderConfigCatalog([
+      { field: field({ key: 'search.vector.enabled' }), value: true },
+      { field: field({ key: 'security.rejectSecrets', category: 'Security' }), value: true },
+    ]).join('\n');
+
+    expect(text.match(/obeyed immediately/g)).toHaveLength(1);
+  });
+});
+
+describe('buildConfigCatalog', () => {
+  it('reads the value each setting is actually running on', async () => {
+    await writeConfig({ ...DEFAULT_CONFIG, search: { ...DEFAULT_CONFIG.search, vector: { ...DEFAULT_CONFIG.search?.vector, enabled: false } } });
+
+    const rows = await buildConfigCatalog(ROOT);
+    const vector = rows.find(row => row.field.key === 'search.vector.enabled');
+
+    expect(vector?.value).toBe(false);
+  });
+
+  it('shows only switches by default and every field under all', async () => {
+    await writeConfig();
+
+    const switches = await buildConfigCatalog(ROOT);
+    const everything = await buildConfigCatalog(ROOT, { all: true });
+
+    expect(switches.length).toBeLessThan(everything.length);
+    expect(switches.every(row => isSwitch(row.field))).toBe(true);
+    expect(everything.length).toBe(CONFIG_FIELDS.length);
+  });
+
+  /**
+   * The bug this guards is `1453b1f2`: switching preset never rewrites the flat keys, so the
+   * stored `search.vector.model` names a model that has not been used since the switch. A
+   * catalog that printed the stored value would report the wrong model with total confidence.
+   */
+  it('reports a preset-owned model as the preset supplies it, not as the stale key holds it', async () => {
+    await writeConfig({
+      ...DEFAULT_CONFIG,
+      search: {
+        ...DEFAULT_CONFIG.search,
+        vector: { ...DEFAULT_CONFIG.search?.vector, preset: 'granite-small-en-r2', model: 'Xenova/all-MiniLM-L6-v2' },
+      },
+    });
+
+    const rows = await buildConfigCatalog(ROOT, { all: true });
+    const model = rows.find(row => row.field.key === 'search.vector.model');
+
+    expect(model?.shadowed).toBe(true);
+    expect(model?.value).not.toBe('Xenova/all-MiniLM-L6-v2');
+  });
+
+  it('does not call a field shadowed when the preset is custom', async () => {
+    await writeConfig({
+      ...DEFAULT_CONFIG,
+      search: {
+        ...DEFAULT_CONFIG.search,
+        vector: { ...DEFAULT_CONFIG.search?.vector, preset: 'custom', model: 'Xenova/all-MiniLM-L6-v2' },
+      },
+    });
+
+    const rows = await buildConfigCatalog(ROOT, { all: true });
+    const model = rows.find(row => row.field.key === 'search.vector.model');
+
+    expect(model?.shadowed).toBeFalsy();
+    expect(model?.value).toBe('Xenova/all-MiniLM-L6-v2');
+  });
+});
+
+/**
+ * `knowl init` ends by pointing at `knowl status` and at nothing else, and status reported item
+ * counts, capture health and workspace -- never a feature. One line there is the whole reason
+ * the catalog is reachable at all; a command nobody is told about is the failure mode this was
+ * meant to avoid.
+ */
+describe('formatFeatureSummary', () => {
+  it('counts how many features are on out of how many exist', () => {
+    const summary = formatFeatureSummary([
+      { field: field({ key: 'a' }), value: true },
+      { field: field({ key: 'b' }), value: true },
+      { field: field({ key: 'c' }), value: false },
+    ]);
+
+    expect(summary).toContain('2 of 3');
+  });
+
+  it('names the command that shows them', () => {
+    const summary = formatFeatureSummary([{ field: field({ key: 'a' }), value: true }]);
+
+    expect(summary).toContain('knowl config list');
+  });
+});
+
+/**
+ * `gh config --help` prints every setting it respects with a one-line description, its allowed
+ * values and its default, and that help text is the reference people actually read. Ours is
+ * generated from the same registry so it cannot fall behind the settings it documents.
+ *
+ * No current values here: help is printed without a repository, and a reference that guessed at
+ * state would be wrong wherever it mattered. State is what `knowl config list` is for.
+ */
+describe('renderConfigReference', () => {
+  it('names each switch and what it does', () => {
+    const text = renderConfigReference().join('\n');
+
+    expect(text).toContain('search.vector.enabled');
+    expect(text).toContain('Rank by meaning');
+  });
+
+  it('leaves out the internals a preset owns', () => {
+    const text = renderConfigReference().join('\n');
+
+    expect(text).not.toContain('search.vector.dtype');
+  });
+
+  it('gives the allowed values of an enum', () => {
+    const lines = renderConfigReference();
+    const start = lines.findIndex(line => line.includes('impact.gate'));
+    // The entry is its first line plus every continuation under it, since a long description
+    // pushes the allowed values onto one.
+    const entry = [lines[start], ...lines.slice(start + 1).filter(line => /^\s+\S/.test(line) && !/^\s{2}\S+\s{2}/.test(line))];
+
+    expect(entry.join(' ')).toContain('{off | shadow | enforce}');
+  });
+
+  it('wraps rather than emitting the 300-character lines the real descriptions produce', () => {
+    expect(renderConfigReference().every(line => line.length <= 96)).toBe(true);
+  });
+});
+
+describe('CONFIG_FIELDS', () => {
+  /**
+   * The catalog renders `description` for every field it shows, so a field without one renders
+   * a blank line under its name. Nothing else forced this: the interactive editor shows the
+   * description only for the field being edited, so a missing one was invisible until now.
+   */
+  it('gives every field a description to render', () => {
+    const undescribed = CONFIG_FIELDS.filter(candidate => !candidate.description?.trim()).map(candidate => candidate.key);
+    expect(undescribed).toEqual([]);
+  });
+});

--- a/tests/cli/config-catalog.test.ts
+++ b/tests/cli/config-catalog.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { buildConfigCatalog, formatFeatureSummary, isSwitch, renderConfigCatalog, renderConfigReference } from '../../src/cli/config/catalog.js';
+import { buildConfigCatalog, formatFeatureSummary, isOn, isSwitch, renderConfigCatalog, renderConfigReference } from '../../src/cli/config/catalog.js';
 import { CONFIG_FIELDS, type ConfigField } from '../../src/cli/config/schema.js';
 import { DEFAULT_CONFIG } from '../../src/core/config.js';
 
@@ -243,6 +243,57 @@ describe('buildConfigCatalog', () => {
  * the catalog is reachable at all; a command nobody is told about is the failure mode this was
  * meant to avoid.
  */
+/**
+ * The three-mode ladders, which the first pass got wrong in both directions at once: an enum
+ * sitting at `off` rendered ● beside the literal word `off` on the same line, and the hint was
+ * gated on `type === 'boolean'` so the settings that most needed one never got it. Live output
+ * said "15 of 20 on" where two of the fifteen printed `off`.
+ */
+describe('an enum that spells its own off state', () => {
+  const gate = field({
+    key: 'impact.gate', label: 'Write gate', type: 'enum',
+    values: ['off', 'shadow', 'enforce'] as const,
+  });
+
+  it('is off when it sits at off, and on at every other mode', () => {
+    expect(isOn(gate, 'off')).toBe(false);
+    expect(isOn(gate, 'shadow')).toBe(true);
+    expect(isOn(gate, 'enforce')).toBe(true);
+  });
+
+  it('renders the unlit marker rather than one contradicting the value beside it', () => {
+    const lines = renderConfigCatalog([{ field: gate, value: 'off' }]);
+    expect(lines.some(line => line.includes('○') && line.includes('off'))).toBe(true);
+    expect(lines.some(line => line.includes('●'))).toBe(false);
+  });
+
+  it('offers the first mode above off, which is the order the modes are adopted in', () => {
+    const lines = renderConfigCatalog([{ field: gate, value: 'off' }]);
+    expect(lines.join('\n')).toContain('knowl config set impact.gate shadow');
+  });
+
+  it('offers nothing once it is already armed', () => {
+    const lines = renderConfigCatalog([{ field: gate, value: 'enforce' }]);
+    expect(lines.join('\n')).not.toContain('config set impact.gate');
+  });
+
+  it('counts an enum with no off state as on at its default', () => {
+    // `capture.scope` and `ai.provider` list no `off`, so every value they hold is on.
+    const scope = field({
+      key: 'capture.scope', type: 'enum', values: ['conversation', 'turn'] as const,
+    });
+    expect(isOn(scope, 'conversation')).toBe(true);
+  });
+
+  it('does not count a disarmed ladder toward the status summary', () => {
+    const summary = formatFeatureSummary([
+      { field: gate, value: 'off' },
+      { field: field({ key: 'capture.nudge', type: 'enum', values: ['off', 'shadow'] as const }), value: 'shadow' },
+    ]);
+    expect(summary).toContain('1 of 2');
+  });
+});
+
 describe('formatFeatureSummary', () => {
   it('counts how many features are on out of how many exist', () => {
     const summary = formatFeatureSummary([

--- a/tests/cli/workspace-report.test.ts
+++ b/tests/cli/workspace-report.test.ts
@@ -86,6 +86,20 @@ describe('formatStatusReport wiring', () => {
     expect(formatStatusReport(base)).not.toContain('WORKSPACE');
   });
 
+  // `knowl init` ends by pointing here and at nowhere else, and this report named item counts,
+  // capture health and workspace but never a feature. Someone who wanted to know what the tool
+  // could do, or whether a thing they had read about was on, had no surface to read.
+  it('carries the feature count and where to see it', () => {
+    const report = formatStatusReport({ ...base, features: '11 of 18 on · knowl config list' });
+    expect(report).toContain('FEATURES');
+    expect(report).toContain('11 of 18 on');
+    expect(report).toContain('knowl config list');
+  });
+
+  it('says nothing about features when the count was not gathered', () => {
+    expect(formatStatusReport(base)).not.toContain('FEATURES');
+  });
+
   it('names the cloud workspace and the staged split when connected', () => {
     // Same reason the workspace assertion above exists: cloud state was reachable from nowhere
     // in the report a developer actually runs, so a connected repo with queued atoms said


### PR DESCRIPTION
## The bug is where the product points, not a missing command

`knowl init` ends with exactly one pointer — `👉 Run "knowl status" to see repository status.` — and `status` reports item counts, recent commits, capture health and workspace. Never a feature.

`doctor` is the closest existing surface and is half of it: it names vector search's provider and model and which MCP tools are exposed, but it is health-shaped, not switch-shaped. It never enumerates what is available-but-off, and it changes nothing.

Meanwhile every setting already carries a one-line description in `CONFIG_FIELDS` — good ones, written for humans — reachable from exactly one place: the interactive editor, which needs a TTY.

So the single path a new user is sent down terminates on a screen that cannot answer *what can this do, and what is on*. That framing is why `status` gains a line here rather than this being only a new verb nobody is told about.

## What this adds

**`knowl config list`** — every switch, the value it is actually running on, and for anything off, the `knowl config set` line that turns it on, verbatim. `--all` adds the values that are filled in rather than switched, and the internals a preset owns.

```
SEARCH
  ● Semantic search                    on
      Rank by meaning as well as keywords. Off falls back to keyword search alone.
      search.vector.enabled
  ○ Share transcripts with workspace   off
      Let linked workspace repos search this repo's transcripts, read-only. Has no effect
      unless transcript search is on.
      search.transcripts.share
      knowl config set search.transcripts.share true
```

**One line in `knowl status`** — `⚙️  FEATURES / 16 of 20 on · knowl config list`. A count and a pointer, not the catalog: status is already the longest screen the CLI prints and thirty settings there would bury the warnings it exists to surface.

**`knowl config --help`** gains the same registry as a reference, with allowed values and defaults. That is where `gh config --help` documents every setting it respects, and it is the form people actually read. Generated from `CONFIG_FIELDS`, so it cannot drift from what `config set` accepts.

## What it refuses to guess

**A preset-owned key** renders the value the preset supplies and names its owner, instead of the stale flat key plus an edit that would change nothing — `resolveVectorProfile` reads the preset before it ever looks at those keys, so a catalog printing the stored `search.vector.model` would report the wrong model with total confidence.

**Secrets** render `(set)` / `(unset)`, never the value. A catalog gets pasted into issues.

**When a change takes effect** is stated once as a rule rather than per field. Three gates re-read config from disk per call and fail closed if either view says off — the transcripts gate, `knowl_cloud`, `knowl_workspace` — and everything else is the snapshot `createMcpServer` captured at spawn, with the tool list itself advertised once at handshake. A per-field `applies` label was the first design and was dropped deliberately: it would be a hand-maintained answer for 32 settings whose consumer chains are not all traced, and a wrong *takes effect now* is worse than a rule the reader applies. Happy to add it per-field if you would rather, once the chains are traced.

**Wrapping at 96 columns with a hanging indent** — found by running it, not by asserting on it. Several descriptions are past 200 characters, and a terminal left to break them puts the continuation in column one, where it reads as another setting.

## Prior art this follows

Torn down by running them, not from memory: `gh config --help` carries the catalog with descriptions/values/defaults while `gh config list` carries bare values; `npm config list` shows only what you set (all 164 behind `-l`) and masks a token as `(protected)`; `git config --list` gives 119 values while `git help -c` gives 989 bare names and descriptions live only in the man page. Wrangler ships a `$schema` so the editor is the settings UI; Docker Desktop keeps settings in the GUI with narrow CLI verbs. The cross-cut: the catalog hangs off a surface the user is already on. git is the failure case, and it is the one whose descriptions require leaving the tool.

## Testing

- `tests/cli/config-catalog.test.ts` — 25 tests: rendering, secret redaction, preset shadowing, enum values, wrapping, the switch/value split, and reader behaviour against a real config file including the stale-flat-key case.
- `tests/cli/workspace-report.test.ts` — two added: the FEATURES block renders, and its absence leaves existing output byte-identical.
- Full suite `360 files / 3488 passed / 5 skipped`, `tsc --noEmit` clean, `tsup` build clean, and both commands run against a live repo.

Docs: new `knowl config list` section in `docs/reference.md`, contents row, and a CLI-reference table entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)