### PR TITLE
perf(cli): enable the V8 compile cache at the entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import module from 'node:module';
 import dotenv from 'dotenv';
 
 /**
@@ -22,7 +23,24 @@ import dotenv from 'dotenv';
  *
  * `dotenv` stays here rather than in either branch: it is a few kilobytes, and a `.env` that
  * applied to some commands and not others would be a worse surprise than the cost.
+ *
+ * The compile cache is enabled here for the same reason, and it is the larger half: it caches
+ * V8's compiled bytecode for every module compiled *after* the call, which is both dynamic
+ * branches and everything they pull in. Measured at roughly 115ms off a cold start, against a
+ * ~218ms floor that `agent-hook` pays hundreds of times a session.
+ *
+ * Guarded twice on purpose. `engines` is `>=22` and `enableCompileCache` landed in 22.1.0, so
+ * the method can be absent; and the cache directory can be unwritable, so the call can throw.
+ * A startup optimisation must never be what fails a command. Called with no argument, so the
+ * cache lands in `NODE_COMPILE_CACHE` if the user set one and node's own default otherwise --
+ * choosing a directory for them is a decision this does not need to make.
  */
+try {
+  module.enableCompileCache?.();
+} catch {
+  // Pre-22.1, or a read-only cache directory. Neither is worth failing the command over.
+}
+
 // `quiet` is not optional decoration. dotenv 17 prints "injected env (N) from .env" plus a
 // rotating tip to STDOUT on every call, which lands in front of the JSON that `--json`
 // commands emit and makes it unparseable -- caught by four CLI suites on the upgrade.


### PR DESCRIPTION
Closes #170.

`src/index.ts` already exists as a startup-cost optimisation -- it defers the
whole command surface behind a dynamic import so `agent-hook`, a fresh process
per agent tool call, does not construct the MCP server and the code indexer to
read one hook event. That bought ~55ms. The compile cache is the same argument
for more, and it does not have to be traded against import scope: it caches V8
bytecode for every module compiled after the call, which is both dynamic
branches and everything they pull in.

Measured here, `dist/index.js --version`, 10 runs per condition, A/B via
`NODE_DISABLE_COMPILE_CACHE`, node v24.15.0:

| | per run |
| --- | --- |
| cache on | 180ms, 177ms |
| cache off | 246ms, 219ms |

41-66ms, not the ~115ms the issue recorded -- different machine and a newer
node. Directionally the same and worth having on a path paid hundreds of times
a session.

Called with no argument, deliberately. That writes to `NODE_COMPILE_CACHE` if
the user set one and otherwise to node's own default, which is a versioned
directory under the OS temp dir (`node-compile-cache/v24.15.0-x64-<hash>`) --
self-evicting, and not a dotfile this CLI invented in someone's home or repo.
Choosing a directory for the user is a decision this does not need to make.

Guarded twice, and neither guard is decoration. `engines` is `>=22` while
`enableCompileCache` landed in 22.1.0, so the method can be absent -- hence the
optional call rather than a named import, which would fail at link time on
22.0 before any catch could run. And the cache directory can be unwritable, so
the call itself can throw. A startup optimisation must never be what fails a
command.