### PR TITLE
feat(query): publish `coverage` beside the product it disappears into

### DIFF
--- a/docs/evals/query-coverage-probe-2026-08-24.json
+++ b/docs/evals/query-coverage-probe-2026-08-24.json
@@ -1,0 +1,159 @@
+{
+  "results": [
+    {
+      "class": "off-technical",
+      "query": "sourdough hydration bulk ferment banneton",
+      "expect": "abstain",
+      "coverage": 0.2,
+      "terms": 5,
+      "hits": 10,
+      "matched": "Retargeted retrieval must retarget hydration too"
+    },
+    {
+      "class": "off-technical",
+      "query": "trombone slide positions overtone series",
+      "expect": "abstain",
+      "coverage": 0.2,
+      "terms": 5,
+      "hits": 5,
+      "matched": "Workspace v2 blocks on a contradiction: it promises cross-owner editing and forbids it"
+    },
+    {
+      "class": "off-technical",
+      "query": "perennial pruning espalier rootstock grafting",
+      "expect": "abstain",
+      "coverage": 0.2,
+      "terms": 5,
+      "hits": 2,
+      "matched": "Resolved failure in tests/store/snapshot-prune-race.probe.test.ts: RUN  v3.2.6 D:/coding/knowl"
+    },
+    {
+      "class": "off-technical",
+      "query": "sonnet volta iambic pentameter enjambment",
+      "expect": "abstain",
+      "coverage": 0.2,
+      "terms": 5,
+      "hits": 1,
+      "matched": "Verified MemoryAgentBench FC-SH @262k baselines from Table 2 — BM25 is 56 not 48, and Zep is not in the paper at all"
+    },
+    {
+      "class": "off-technical",
+      "query": "kayak eskimo roll paddle feathering",
+      "expect": "abstain",
+      "coverage": 0.2,
+      "terms": 5,
+      "hits": 10,
+      "matched": "JSONL skill import requires trusted input"
+    },
+    {
+      "class": "off-technical",
+      "query": "sourdough starter discard crumb",
+      "expect": "abstain",
+      "coverage": 0.5,
+      "terms": 4,
+      "hits": 10,
+      "matched": "Issue 146 root cause: granite-small-en-r2 off-topic cosine 0.7928 clears the 0.76 floor"
+    },
+    {
+      "class": "on-specific",
+      "query": "relevance floor per model preset cosine abstain",
+      "expect": "answer",
+      "coverage": 1,
+      "terms": 7,
+      "hits": 10,
+      "matched": "Relevance floor is per-model: measured floors for all five presets, and why scale-free rules fail"
+    },
+    {
+      "class": "on-specific",
+      "query": "supersession retired active retrieval benchmark",
+      "expect": "answer",
+      "coverage": 1,
+      "terms": 5,
+      "hits": 10,
+      "matched": "MemoryAgentBench CR measured: supersession is worth +56 points; LongMemEval fully removed"
+    },
+    {
+      "class": "on-specific",
+      "query": "workspace federated query grouping repo scope",
+      "expect": "answer",
+      "coverage": 1,
+      "terms": 6,
+      "hits": 10,
+      "matched": "3.4.0 published: workspace query results are keyed by owning repo"
+    },
+    {
+      "class": "on-vague",
+      "query": "how do we do releases",
+      "expect": "answer",
+      "coverage": 1,
+      "terms": 2,
+      "hits": 10,
+      "matched": "All 12 tags have GitHub releases; cd.yml now creates them automatically"
+    },
+    {
+      "class": "on-vague",
+      "query": "why is startup slow",
+      "expect": "answer",
+      "coverage": 0.5,
+      "terms": 2,
+      "hits": 10,
+      "matched": "Resolved failure in src/core/startup-trace.ts: ❯ tests/core/startup-trace.test.ts (8 tests | 8 failed) 23ms"
+    },
+    {
+      "class": "on-vague",
+      "query": "what happens when two facts disagree",
+      "expect": "answer",
+      "coverage": 0.5,
+      "terms": 4,
+      "hits": 10,
+      "matched": "Shadow mode must not release read-set rows, and that forces the unique index"
+    },
+    {
+      "class": "on-vague",
+      "query": "how does it decide what to show me",
+      "expect": "answer",
+      "coverage": 1,
+      "terms": 3,
+      "hits": 10,
+      "matched": "Dogfooding two linked repos: cross-repo advisory was silent for decisions"
+    },
+    {
+      "class": "on-vague",
+      "query": "where does the data live",
+      "expect": "answer",
+      "coverage": 1,
+      "terms": 2,
+      "hits": 10,
+      "matched": "withDbPath misroutes concurrent writes into the wrong namespace database"
+    },
+    {
+      "class": "on-vague",
+      "query": "what did we decide about staleness",
+      "expect": "answer",
+      "coverage": 0.8,
+      "terms": 5,
+      "hits": 10,
+      "matched": "Staleness for prose atoms (knowl#98) is deferred until the corpus ages, not built now; revisit at ~180 days old (~2027-02)"
+    },
+    {
+      "class": "on-vague",
+      "query": "is there a way to see all the settings",
+      "expect": "answer",
+      "coverage": 0.8,
+      "terms": 5,
+      "hits": 10,
+      "matched": "fix(transcripts): say what --all left behind, and match a Codex worktree the way the Claude half does"
+    },
+    {
+      "class": "on-vague",
+      "query": "how do agents talk to this",
+      "expect": "answer",
+      "coverage": 0.5,
+      "terms": 2,
+      "hits": 10,
+      "matched": "fix(serve): keep the startup trace from changing the process it observes"
+    }
+  ],
+  "onMin": 0.5,
+  "offMax": 0.5
+}

--- a/docs/evals/query-coverage-probe.md
+++ b/docs/evals/query-coverage-probe.md
@@ -1,0 +1,118 @@
+# `queryCoverage` as a relevance floor — probe, 2026-08-24
+
+[#169](https://github.com/dat999zx/knowl/issues/169) left three directions after
+[`preset-floor-sweep.md`](preset-floor-sweep.md) closed direction 2. Direction 1 was the only one
+with evidence behind it: *a relative or corpus-free signal instead of an absolute cosine cut.*
+
+`queryCoverage` (`src/store/search.ts`) looked like that signal already existed. It is the share of
+the query's distinct terms an item contains, prefix-matched, computed on every lexical hit, and its
+own doc comment claims exactly the missing property:
+
+> unlike BM25 it means the same thing in every repo: it is a property of the item and the query,
+> with no corpus statistics in it.
+
+**Verdict: it cannot be a floor, and the reason is arithmetic rather than tuning.** It stays what it
+already is — a ranking factor.
+
+Reproduce with `npx tsx scripts/probe-query-coverage.ts`. Raw output:
+[`query-coverage-probe-2026-08-24.json`](query-coverage-probe-2026-08-24.json).
+
+## Method
+
+Against this repo's real ~1,200-atom store, not a fixture corpus — coverage is model-independent, so
+it needs no preset loop, and the interesting failure only appears against real prose. Three probe
+classes, `searchKnowledgeItemsRanked` at limit 10, taking the maximum coverage over hits.
+
+The third class is the whole point. The first two were never in doubt.
+
+1. **off-technical** — jargon from domains this project has never written about.
+2. **on-specific** — questions phrased in the corpus's own vocabulary.
+3. **on-vague** — questions this store genuinely answers, phrased the way somebody half-remembers
+   them. Few terms, no jargon, no overlap engineered in.
+
+## Results
+
+| class | n | min | p50 | max |
+| --- | --- | --- | --- | --- |
+| off-technical | 6 | 0.200 | 0.200 | 0.500 |
+| on-specific | 3 | 1.000 | 1.000 | 1.000 |
+| **on-vague** | 8 | **0.500** | 0.800 | 1.000 |
+
+**On-topic min 0.500 against off-technical max 0.500 — a gap of exactly 0.000.** No threshold
+divides them.
+
+The per-probe table, with the term count that explains it:
+
+| class | coverage | terms | query |
+| --- | --- | --- | --- |
+| off | 0.200 | 5 | `trombone slide positions overtone series` |
+| off | 0.200 | 5 | `kayak eskimo roll paddle feathering` |
+| off | **0.500** | 4 | `sourdough starter discard crumb` |
+| on-vague | **0.500** | 2 | `why is startup slow` |
+| on-vague | 0.500 | 2 | `how do agents talk to this` |
+| on-vague | 0.500 | 4 | `what happens when two facts disagree` |
+| on-vague | 0.800 | 5 | `what did we decide about staleness` |
+| on-vague | 1.000 | 2 | `where does the data live` |
+| on-specific | 1.000 | 7 | `relevance floor per model preset cosine abstain` |
+
+## Why: coverage is quantized at `1 / n`
+
+Coverage is a fraction whose denominator is the number of distinct query terms surviving
+stop-word removal. **A short query has few reachable values.** `why is startup slow` is two terms
+after stop-words, so it can only ever score 0, 0.5 or 1 — and it scored 0.5 against a store that
+answers it in detail, because one of its two terms matched.
+
+Genuinely on-topic questions are often short *precisely because they are vague*, which is the same
+population a floor most needs to get right. Partially-matching junk lands on the same coarse grid:
+`sourdough starter discard crumb` is 4 terms with 2 matched, also 0.500.
+
+So the two distributions do not merely overlap — they are forced onto the same small set of values
+at exactly the query lengths where the question is hard. That is not a threshold that needs moving.
+It is a resolution limit.
+
+This is a different failure from the cosine one, and worth keeping distinct. Cosine fails because a
+question in the corpus's register is *semantically* close to the corpus whether or not anything
+answers it. Coverage fails because it is *too coarse* to express the difference at short query
+lengths. Neither is fixed by picking a better number.
+
+## Shipped anyway: `coverage` is now published
+
+Independent of the floor question, coverage was being destroyed at the API boundary, and that part
+was a real defect. In `src/store/agent-query.ts`:
+
+```ts
+const lexical = raw === undefined ? 0 : (best > 0 ? Math.min(raw / best, 1) * coverage : coverage);
+```
+
+`best` is this page's top raw BM25, so `raw / best` is min-max *within the page* and means nothing
+across queries — the same non-comparable shape as `score`. Multiplying coverage into it destroys the
+one property coverage had, and `contributions` published only the product.
+
+**This is structurally identical to [#146](https://github.com/dat999zx/knowl/issues/146)**: an
+absolute number computed internally, folded into a normalized one, and only the normalized one
+handed to the caller. That was fixed for the semantic half by publishing `cosine` alongside `score`.
+The lexical half still had it. `contributions.coverage` now publishes the factor beside the product.
+
+Additive, no behaviour change, and it is what lets anyone re-run this measurement — or a better one
+— without patching `src`.
+
+## Limits
+
+Small: 6 off-technical, 3 on-specific, 8 on-vague probes, one store. Enough to establish the
+quantization argument, because that argument is about the arithmetic and the probes only have to
+demonstrate it once. **Not** enough to claim the exact 0.000 gap generalizes.
+
+**Contamination warning, and it bit twice while writing this.** This store contains atoms *about*
+retrieval evaluation, and those atoms quote probe strings verbatim. `recipe for sourdough bread
+starter` scores 1.000 here — correctly, because the terms really are in the corpus. A first run of
+this probe used technical strings taken from a stored finding and two of them scored 1.000 for the
+same reason. **Never probe a Knowl store with a string its own eval documents discuss**, and always
+report which atom a probe matched so the contamination is visible rather than silent.
+
+## What is left for #169
+
+Direction 1 is not closed by this — coverage is one candidate for a corpus-free signal and it
+failed. Untried: a *relative* signal rather than an absolute one, which is what the issue actually
+proposed first — the margin between the best and second-best result, or the store's own
+self-similarity distribution measured at index time. Both are unmeasured, and neither has the
+resolution problem, because a margin between two continuous scores is itself continuous.

--- a/scripts/probe-query-coverage.ts
+++ b/scripts/probe-query-coverage.ts
@@ -1,0 +1,144 @@
+/**
+ * The measurement that decides whether #169 direction 1 is alive.
+ *
+ * `docs/evals/preset-floor-sweep.md` closed direction 2: no embedding preset separates on-topic
+ * from technical off-topic queries, because the overlap is a property of cosine rather than of any
+ * one model. That left direction 1 -- a relative or corpus-free signal instead of an absolute
+ * cosine cut.
+ *
+ * `queryCoverage` (`src/store/search.ts:84`) is a candidate that already exists and is already
+ * computed on every lexical hit: the share of the query's distinct terms an item contains,
+ * prefix-matched. Its own doc comment claims exactly the property the floor needs -- "unlike BM25
+ * it means the same thing in every repo: it is a property of the item and the query, with no
+ * corpus statistics in it."
+ *
+ * THE RISK THIS SCRIPT EXISTS TO TEST. Coverage separates junk only if genuinely on-topic queries
+ * score high. A correctly-VAGUE on-topic question -- "how do we do releases", asked of a store that
+ * knows exactly how -- contains few distinct terms and may match none of them literally, so it
+ * could score as low as junk. If that class scores low, coverage is a precision trap that abstains
+ * on the queries a human is most likely to type, and direction 1 dies here rather than after
+ * someone ships a threshold. That is the whole point: measure the failure mode first.
+ *
+ * Probes are three classes, and the vague class is the verdict.
+ *
+ * CONTAMINATION WARNING, learned the hard way. This runs against the repo's REAL store, which
+ * contains atoms about retrieval evaluation -- and those atoms quote off-topic probe strings
+ * verbatim. `recipe for sourdough bread starter` scores coverage 1.000 here, correctly, because
+ * the terms really are in the corpus. Never probe a Knowl store with a string its own eval docs
+ * discuss. The technical probes below were chosen to name domains this project has never written
+ * about, and each is checked against that failure by reporting the atom it matched.
+ *
+ * Usage: npx tsx scripts/probe-query-coverage.ts [--json out.json]
+ */
+import fs from 'node:fs/promises';
+import { findProjectRoot } from '../src/core/config.js';
+import { closeDb, initDb } from '../src/store/database.js';
+import { getProjectByRootPath } from '../src/store/repository.js';
+import { searchKnowledgeItemsRanked, queryTermCount } from '../src/store/search.js';
+
+type Probe = { query: string; expect: 'abstain' | 'answer' };
+
+/** Technical, same register as the corpus, about domains this project has never touched. */
+const OFF_TECHNICAL: Probe[] = [
+  { query: 'sourdough hydration bulk ferment banneton', expect: 'abstain' },
+  { query: 'trombone slide positions overtone series', expect: 'abstain' },
+  { query: 'perennial pruning espalier rootstock grafting', expect: 'abstain' },
+  { query: 'sonnet volta iambic pentameter enjambment', expect: 'abstain' },
+  { query: 'kayak eskimo roll paddle feathering', expect: 'abstain' },
+  { query: 'sourdough starter discard crumb', expect: 'abstain' },
+];
+
+/** On-topic and specific: the easy case, and the one already known to score 1.000. */
+const ON_SPECIFIC: Probe[] = [
+  { query: 'relevance floor per model preset cosine abstain', expect: 'answer' },
+  { query: 'supersession retired active retrieval benchmark', expect: 'answer' },
+  { query: 'workspace federated query grouping repo scope', expect: 'answer' },
+];
+
+/**
+ * On-topic and VAGUE -- the class that decides this. Each is a question this store can genuinely
+ * answer, phrased the way somebody half-remembers it rather than the way the atom is written.
+ * Few distinct terms, none of them jargon, no overlap engineered in.
+ */
+const ON_VAGUE: Probe[] = [
+  { query: 'how do we do releases', expect: 'answer' },
+  { query: 'why is startup slow', expect: 'answer' },
+  { query: 'what happens when two facts disagree', expect: 'answer' },
+  { query: 'how does it decide what to show me', expect: 'answer' },
+  { query: 'where does the data live', expect: 'answer' },
+  { query: 'what did we decide about staleness', expect: 'answer' },
+  { query: 'is there a way to see all the settings', expect: 'answer' },
+  { query: 'how do agents talk to this', expect: 'answer' },
+];
+
+const jsonOut = (() => {
+  const i = process.argv.indexOf('--json');
+  return i >= 0 ? process.argv[i + 1] : undefined;
+})();
+
+const root = await findProjectRoot(process.cwd());
+if (!root) throw new Error('No Knowl project found from the working directory.');
+await initDb(root);
+const project = await getProjectByRootPath(root);
+if (!project) throw new Error('Project not found in the database.');
+
+async function probe(p: Probe) {
+  const hits = await searchKnowledgeItemsRanked(project!.id, { query: p.query, status: 'active', limit: 10 });
+  const terms = queryTermCount(p.query);
+  let best = 0;
+  let bestTitle = '(no hit)';
+  for (const hit of hits as Array<{ item: { title: string }; coverage: number }>) {
+    if (hit.coverage > best) { best = hit.coverage; bestTitle = hit.item.title; }
+  }
+  return { ...p, coverage: best, terms, hits: hits.length, matched: bestTitle };
+}
+
+const classes: Array<[string, Probe[]]> = [
+  ['off-technical', OFF_TECHNICAL],
+  ['on-specific', ON_SPECIFIC],
+  ['on-vague', ON_VAGUE],
+];
+
+const results: any[] = [];
+for (const [label, probes] of classes) {
+  console.log(`\n## ${label}\n`);
+  console.log('| coverage | terms | query | best-covering atom |');
+  console.log('| --- | --- | --- | --- |');
+  for (const p of probes) {
+    const r = await probe(p);
+    results.push({ class: label, ...r });
+    const title = r.matched.length > 58 ? `${r.matched.slice(0, 58)}…` : r.matched;
+    console.log(`| **${r.coverage.toFixed(3)}** | ${r.terms} | \`${r.query}\` | ${title} |`);
+  }
+}
+
+const by = (label: string) => results.filter(r => r.class === label).map(r => r.coverage).sort((a, b) => a - b);
+const off = by('off-technical');
+const spec = by('on-specific');
+const vague = by('on-vague');
+const line = (label: string, xs: number[]) =>
+  `${label.padEnd(14)} n=${xs.length}  min ${xs[0].toFixed(3)}  p50 ${xs[Math.floor(xs.length / 2)].toFixed(3)}  max ${xs[xs.length - 1].toFixed(3)}`;
+
+console.log('\n## Distributions\n');
+console.log('```');
+console.log(line('off-technical', off));
+console.log(line('on-specific', spec));
+console.log(line('on-vague', vague));
+console.log('```');
+
+// The verdict is a single comparison: does the WEAKEST on-topic query outscore the STRONGEST
+// piece of junk? That is the gap a threshold would have to live in, and it is measured against
+// the vague class because the specific class was never in doubt.
+const onMin = Math.min(spec[0], vague[0]);
+const offMax = off[off.length - 1];
+console.log(`\n**Gap: on-topic min ${onMin.toFixed(3)} vs off-technical max ${offMax.toFixed(3)} = `
+  + `${onMin - offMax >= 0 ? '+' : ''}${(onMin - offMax).toFixed(3)}**`);
+console.log(onMin > offMax
+  ? '\nSEPARABLE on this probe set: a threshold exists between them.'
+  : '\nNOT SEPARABLE: the vague on-topic class reaches down into the junk, which is the failure mode this script was written to find.');
+
+if (jsonOut) {
+  await fs.writeFile(jsonOut, JSON.stringify({ results, onMin, offMax }, null, 2));
+  console.error(`\nwrote ${jsonOut}`);
+}
+await closeDb();

--- a/src/store/agent-query.ts
+++ b/src/store/agent-query.ts
@@ -651,6 +651,14 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
       const contributions = {
         semantic, lexical, relevance, prior,
         category, recency, confidence, freshness, exactIdentifier, standing,
+        // `coverage` is the factor, published beside the product it disappears into. `lexical`
+        // above multiplies it by `raw / best`, and `best` is this page's top BM25 -- so `lexical`
+        // is min-max within the page and means nothing across queries, exactly like `score`.
+        // Coverage itself is the opposite: a property of the item and the query with no corpus
+        // statistics in it, so it is the same quantity in every repo. Folding the comparable
+        // number into the incomparable one and publishing only the product is the #146 defect,
+        // which was fixed for the semantic half by publishing `cosine` and stayed live here.
+        coverage,
       };
       return { result, score: relevance * prior, semantic, contributions };
     })

--- a/src/store/search.ts
+++ b/src/store/search.ts
@@ -62,6 +62,16 @@ function queryTokenGroups(query: string): string[][] {
   return groups;
 }
 
+/**
+ * How many distinct terms a query contributes to coverage -- the DENOMINATOR `queryCoverage`
+ * divides by. Exported for measurement only: coverage is a fraction, and a fraction whose
+ * denominator is 1 carries no information, so any judgement about coverage as a relevance
+ * signal has to be able to see this number alongside it.
+ */
+export function queryTermCount(query: string): number {
+  return queryTokenGroups(query).length;
+}
+
 function tokenizeSearchQuery(query: string): string[] {
   return [...new Set(queryTokenGroups(query).flat())];
 }
@@ -80,6 +90,22 @@ function buildFtsQuery(query: string): string | null {
  * Coverage does, and unlike BM25 it means the same thing in every repo: it is a property of
  * the item and the query, with no corpus statistics in it. Prefix-matched, because that is
  * what the FTS query asked for.
+ *
+ * IT IS QUANTIZED AT `1 / groups.length`, AND THAT IS WHY IT CANNOT BE A RELEVANCE FLOOR.
+ * Measured 2026-08-24 against this repo's ~1,200-atom store (`scripts/probe-query-coverage.ts`,
+ * written up in `docs/evals/query-coverage-probe.md`), while looking for a corpus-free
+ * replacement for the cosine floor that issue #169 showed cannot exist per-model.
+ *
+ * A short query has few groups, so it has few reachable values: a two-term question can only
+ * score 0, 0.5 or 1. Genuinely on-topic questions are often short precisely because they are
+ * vague -- `why is startup slow` is two terms after stop-words and scored **0.500** against a
+ * store that answers it in detail. Partially-matching junk lands on the same value: `sourdough
+ * starter discard crumb` also scored **0.500**. On-topic min and off-topic max met exactly, a
+ * gap of 0.000, so no threshold divides them.
+ *
+ * Coverage is still the right thing to RANK with, which is what it does here. It is not a thing
+ * to abstain on, and the reason is arithmetic rather than tuning: the grid is too coarse at the
+ * query lengths where the question is hard.
  */
 function queryCoverage(item: KnowledgeItem, groups: string[][]): number {
   if (groups.length === 0) return 1;


### PR DESCRIPTION
Refs #169, #146.

`queryCoverage` looked like the corpus-free signal #169 direction 1 wants. Its
own doc comment claims the property the cosine floor could never have -- "it
means the same thing in every repo: it is a property of the item and the query,
with no corpus statistics in it." Probed against this repo's real ~1,200-atom
store, it fails, and the reason is arithmetic rather than tuning.

  class          n  min    p50    max
  off-technical  6  0.200  0.200  0.500
  on-specific    3  1.000  1.000  1.000
  on-vague       8  0.500  0.800  1.000

On-topic min 0.500 against off-technical max 0.500. Gap exactly 0.000.

Coverage is covered/groups, so a short query has few reachable values. `why is
startup slow` is TWO terms after stop-words -- it can only score 0, 0.5 or 1 --
and scored 0.500 against a store that answers it in detail. On-topic questions
are often short precisely because they are vague, which is the population a
floor most needs to get right, and partial junk lands on the same grid:
`sourdough starter discard crumb` is 4 terms with 2 matched, also 0.500. The
distributions are not merely overlapping, they are forced onto the same small
value set at exactly the query lengths where the question is hard.

Different failure from cosine's, and worth keeping distinct. Cosine fails
because a question in the corpus's register is semantically close to the corpus
whether or not anything answers it. Coverage fails because it is too coarse.
Neither is fixed by picking a better number, so coverage stays a ranking factor
and does not become a floor.

WHAT SHIPS HERE IS THE SEPARATE DEFECT THAT TURNED UP ON THE WAY.

  const lexical = raw === undefined ? 0 : (best > 0 ? min(raw/best, 1) * coverage : coverage)

`best` is this page's top raw BM25, so `raw / best` is min-max WITHIN THE PAGE
and means nothing across queries -- the same non-comparable shape as `score`.
Multiplying coverage into it destroys the one property coverage had, and
`contributions` published only the product. That is structurally identical to
#146: an absolute number computed internally, folded into a normalized one, and
only the normalized one handed to the caller. #146 was fixed for the semantic
half by publishing `cosine`; the lexical half still had it.

`contributions.coverage` now publishes the factor. Additive, no behaviour
change, and it is what lets the next person re-run this measurement -- or a
better one -- without patching src. `queryTermCount` is exported for the same
reason: coverage is a fraction, and a fraction whose denominator is 1 carries no
information, so the denominator has to be observable.

Contamination warning in the doc, because it bit twice: this store holds atoms
ABOUT retrieval evaluation and they quote probe strings verbatim, so a first run
scored 1.000 on two technical probes copied from a stored finding. The script
prints which atom each probe matched so that is visible rather than silent.

Verified: build, 360 files / 3494 passed / 5 skipped, typecheck, docs:check.