### PR TITLE
docs(query): the floor says off-subject, and it was claiming unanswerable

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -242,6 +242,34 @@ Titles are capped separately at 200 characters, and previews of things retrievab
 elsewhere — evidence excerpts, timeline assertions, skill markdown, `knowl_skill_run` output —
 stay at 600.
 
+#### What `abstained` means, and what it does not
+
+`abstained` (and the `NO CONFIDENT MATCH` notice that reports it) means **the query does not look
+like it is about this store**. It does **not** mean the store lacks the answer, and it must not be
+built on as though it did.
+
+The difference is not a caveat, it is the measured result. A question phrased in a store's own
+vocabulary is close to that store whether or not anything in it answers the question — so a score
+above the floor cannot mean "the answer is here", and one below it only weakly suggests the
+question reads as foreign. Two candidate signals were measured and both fail, for different
+reasons:
+
+- **Cosine similarity** — on-topic and off-topic distributions overlap on all five shipped presets,
+  and the current default has the *smallest* overlap of them, so there is no better preset to move
+  to. See [`evals/preset-floor-sweep.md`](evals/preset-floor-sweep.md).
+- **Lexical coverage** — quantized at `1 / terms`, so short vague on-topic questions land on the
+  same values as partially-matching junk. `why is startup slow` scores 0.500 against a store that
+  answers it in full. See [`evals/query-coverage-probe.md`](evals/query-coverage-probe.md).
+
+**So: do not drop abstained rows on the assumption they are irrelevant, and do not treat their
+absence as a relevance claim.** The rows are returned rather than withheld precisely because the
+floor is wrong often enough to matter. An agent reading three results can judge whether any answers
+its question far better than a single threshold can, and that is the intended use — the floor
+narrows what to read, it does not decide it.
+
+The honest consumer pattern is to surface abstained rows with the caveat attached rather than to
+filter on it, and to fall back to the files when nothing read actually answers the question.
+
 #### Reading `knowl query` from a script
 
 **`knowl query` writes pure JSON to stdout and every advisory line to stderr.** All four are

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -711,8 +711,14 @@ program.command('query').argument('[query]').description('Search project memory 
     // The floor's verdict, said out loud, in the only terms the measurement supports. Results
     // below it are printed rather than withheld, so without this line a weak page looks exactly
     // like a strong one.
+    //
+    // The score/cosine warning stays even though this rewrite is about narrowing the floor's
+    // claim: that trap is a different one -- `score` is scaled per page, so an abstained page's
+    // top row still reads 0.98 -- and MCP callers get it from the knowl_query tool description
+    // while a CLI reader has no description to get it from. Dropping it here dropped it
+    // everywhere the moment it is needed.
     if (items.some((item: { abstained?: boolean }) => item.abstained)) {
-      console.error('Note: nothing here reads as being about this project. That is all the relevance floor can tell you — it does not mean the store lacks the answer, and a question in this project\'s own vocabulary scores like a real one either way. Read the results and judge.');
+      console.error('Note: nothing here reads as being about this project. That is all the relevance floor can tell you — it does not mean the store lacks the answer, and a question in this project\'s own vocabulary scores like a real one either way. Read the results and judge them by "cosine", the absolute similarity the floor is measured against, or by simply reading them — never by "score", which is min-max scaled across this page and so sits near 1.0 on the top row however weak that row is.');
     }
     // Names and counts, never content: the knowledge stays findable without this line being
     // able to stand in for it.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -708,10 +708,11 @@ program.command('query').argument('[query]').description('Search project memory 
     } else {
       console.log(JSON.stringify(items, null, 2));
     }
-    // The floor's verdict, said out loud. Results below it are printed rather than withheld,
-    // so without this line a weak page looks exactly like a strong one.
+    // The floor's verdict, said out loud, in the only terms the measurement supports. Results
+    // below it are printed rather than withheld, so without this line a weak page looks exactly
+    // like a strong one.
     if (items.some((item: { abstained?: boolean }) => item.abstained)) {
-      console.error('Note: every result scored below the relevance floor — this store probably does not hold the answer. Read "cosine" and judge, not "score": "cosine" is the absolute similarity the floor is measured against, while "score" only orders this page.');
+      console.error('Note: nothing here reads as being about this project. That is all the relevance floor can tell you — it does not mean the store lacks the answer, and a question in this project\'s own vocabulary scores like a real one either way. Read the results and judge.');
     }
     // Names and counts, never content: the knowledge stays findable without this line being
     // able to stand in for it.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -213,12 +213,26 @@ export type KnowledgeSearchExplanation = {
   contributions: Record<string, number>;
   reason: string;
   /**
-   * The relevance floor found no confident match for this query, and this row is one of the
-   * stores it judged. Present only when true, so an answered query costs nothing.
+   * The query does not look like it is about this store, and this row is one the floor judged.
+   * Present only when true, so an answered query costs nothing.
    *
-   * A verdict rather than a filter. The floor used to delete the whole ranking here; it was
-   * measured deleting real answers, because a fixed absolute cosine does not transfer between
-   * corpora (docs/evals/floor-sweep.md).
+   * **READ THE NAME NARROWLY.** It says off-subject, NOT unanswerable, and the difference is the
+   * whole of what three separate measurements found. A question phrased in the store's own
+   * vocabulary is close to that store whether or not anything in it answers the question, so a
+   * high score cannot mean "the answer is here" and this flag's absence cannot mean it either.
+   * What it does support is the negative direction, and only loosely: a question written in a
+   * register foreign to the corpus tends to fall below.
+   *
+   * Why no threshold fixes this, so nobody re-tunes it a fourth time:
+   * - Cosine: on-topic and off-topic distributions OVERLAP on all five shipped presets, and the
+   *   current default has the smallest overlap of them, so there is no preset to move to
+   *   (docs/evals/preset-floor-sweep.md).
+   * - Lexical coverage: quantized at 1/n, so short vague on-topic queries land on the same
+   *   values as partially-matching junk (docs/evals/query-coverage-probe.md).
+   *
+   * A verdict rather than a filter. The floor used to delete the whole ranking here and was
+   * measured deleting real answers (docs/evals/floor-sweep.md), which is why the rows are
+   * returned and the caller is asked to judge them.
    */
   abstained?: boolean;
   /**

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1166,7 +1166,7 @@ export function registerTools(
               : '');
           blocks.push({
             type: 'text',
-            text: 'NO CONFIDENT MATCH: every result above scored below the relevance floor, so this store probably does not hold the answer. They are returned rather than withheld because the floor is a fixed threshold on a corpus-dependent scale and is wrong often enough to matter — read `cosine` and judge, not `score`: `cosine` is the absolute similarity the floor itself is measured against, while `score` only orders this page. If none of them answers the question, treat this as a miss and go to the files.'
+            text: 'NO CONFIDENT MATCH: nothing above reads as being about this project. Take that narrowly — it means OFF-SUBJECT, not unanswerable, and it cannot tell you whether this store holds the answer. A question phrased in this project\'s own vocabulary scores like a real one whether or not anything here answers it, on every shipped embedding model, which is why the rows are returned rather than withheld. Read them and judge whether any actually answers the question; you are better at that than the score is. If none does, treat it as a miss and go to the files.'
               + transcriptRoute,
           });
         }


### PR DESCRIPTION
Refs #169, #146.

Three measurements now say the same thing, so stop making the stronger claim.

The MCP notice said "every result above scored below the relevance floor, so
this store probably does not hold the answer." The second half is not something
the floor can know. What it detects is whether a question READS as being about
this store -- off-subject, not unanswerable -- and those come apart exactly
where it matters: a question phrased in the store's own vocabulary is close to
that store whether or not anything in it answers the question.

The old notice also explained itself wrongly. It blamed "a fixed threshold on a
corpus-dependent scale", which was the 2026-08-04 floor-sweep conclusion and has
been superseded twice. The floor is per-model now, and the failure is not that
the scale moves between corpora:

  - cosine: on-topic and off-topic distributions OVERLAP on all five presets,
    and the default has the smallest overlap of them, so there is nowhere to
    move to (docs/evals/preset-floor-sweep.md)
  - coverage: quantized at 1/n, so short vague on-topic queries land on the same
    values as partial junk (docs/evals/query-coverage-probe.md)

Neither is a tuning problem, so the fix is not a fourth number. It is saying
what the signal supports.

Changed: the MCP notice body, the CLI note, and the `abstained` doc comment,
which still cited only the superseded floor-sweep reasoning. Plus a new
reference section stating what the flag means and what it does not, because the
consumers building on the strong reading are integrators and this is where they
look.

The `NO CONFIDENT MATCH:` prefix is deliberately KEPT. Three tests and any
integrator matching on it key off that marker, the false claim lived in the body
rather than the prefix, and renaming a marker string to fix a sentence is churn
with a real cost. Same reason `abstained` keeps its name.

The guidance now points at the caller's own judgement rather than at another
number: an agent reading three results can tell whether any answers its question
better than a threshold can, and it was always being handed the rows anyway --
they are returned rather than withheld precisely because the floor is wrong
often enough to matter.

Verified: build, 360 files / 3494 passed / 5 skipped, typecheck, docs:check.