### PR TITLE
fix(transcripts): the cosine was computed and then thrown away by the fusion

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -520,6 +520,22 @@ canonical tool table below:
   `transcript://<repo>/<session>#L<line>` locators.
 - **`knowl_transcript_read`** — open one locator with the surrounding turns.
 
+Transcript search carries the same relevance verdict `knowl_query` does, and it means the same
+narrow thing: **off-subject, not unanswerable** (see [above](#what-abstained-means-and-what-it-does-not)).
+When a semantic half ran and the best hit falls below the model's floor, the results arrive under a
+`NO CONFIDENT MATCH` notice rather than silently — before this, a query of pure gibberish returned
+plausible-looking hits with nothing marking them.
+
+The two callers are treated differently on purpose:
+
+- **You typed `knowl_transcript_search`** — you asked for whatever is closest, so weak hits are
+  returned with the notice attached and you judge the bodies.
+- **The `search.transcripts.fallback` chain ran it for you** after a `knowl_query` miss — nobody
+  asked, so an off-subject page is withheld and reported as a verified negative. Appending
+  nearest-neighbour noise there spends context at the moment the agent is already lost, and it was
+  measured doing exactly that: across 40 replayed real misses it recovered **0**, while 7 of 15
+  healthy queries would have had junk appended.
+
 Disabling the feature **deletes** `.knowl/transcripts.db`. An index nothing will refresh is not
 something to leave on the disk of the person who just turned it off.
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1207,6 +1207,9 @@ export function registerTools(
               query,
               repos: Array.isArray(repos) ? repos.map(String) : undefined,
               limit: TRANSCRIPT_FALLBACK_LIMIT,
+              // Nobody asked for this search, so it has to clear the floor to be worth the
+              // context it spends. The typed tool still returns weak hits with a caveat.
+              confidentOnly: true,
             });
             const negative = fallback.startsWith(NO_TRANSCRIPT_MATCHES_PREFIX);
             const bounded = fallback.length > TRANSCRIPT_FALLBACK_CHARS
@@ -1215,7 +1218,7 @@ export function registerTools(
             blocks.push({
               type: 'text',
               text: negative
-                ? 'RECALL CHAIN — VERIFIED NEGATIVE: the knowledge store missed and the transcript archive holds no match for these words either (coverage below). If the user believes this happened, it predates the archive or used different words — try knowl_transcript_search with other words before concluding, and state the negative truthfully rather than guessing.\n'
+                ? 'RECALL CHAIN — VERIFIED NEGATIVE: the knowledge store missed and the transcript archive holds no confident match for these words either (coverage below). Anything that scored as off-subject was withheld rather than shown, because nothing asked for this search — run knowl_transcript_search yourself to see it. If the user believes this happened, it predates the archive or used different words — try other words before concluding, and state the negative truthfully rather than guessing.\n'
                   + bounded
                 : 'RECALL CHAIN: the knowledge store missed, so the transcript archive was searched automatically with the same words:\n'
                   + bounded,

--- a/src/transcripts/federate.ts
+++ b/src/transcripts/federate.ts
@@ -5,7 +5,7 @@ import { resolveStorage } from '../store/storage-roles.js';
 import type { ActiveWorkspace } from '../workspace/resolve.js';
 import { isTranscriptSharingEnabled } from './config.js';
 import { openTranscriptDb, TranscriptIndexMissingError } from './database.js';
-import { fuseRankings, searchTranscripts, type TranscriptHit } from './search.js';
+import { fuseRankings, judgeRelevanceFloor, searchTranscripts, type TranscriptHit } from './search.js';
 
 export type FederatedTranscriptHit = TranscriptHit & { repo: string };
 export type TranscriptSkipReason = 'absent' | 'not-shared' | 'unreadable';
@@ -56,6 +56,15 @@ export async function searchTranscriptsFederated(input: {
    * which resolves a named repo against the workspace peer list -- answers "Unknown repo".
    */
   localRepo: string;
+  /**
+   * The query does not read as being about any archive that answered: a semantic half ran, and
+   * the best hit across every repo scored below this model's relevance floor.
+   *
+   * Off-subject, not unanswerable -- the narrow reading `abstained` carries on `knowl_query`.
+   * `undefined` means unjudged: no embedder, no measured floor for this model, or nothing
+   * returned carried a cosine.
+   */
+  belowRelevanceFloor?: boolean;
 }> {
   const localName = input.localRepoName ?? input.workspace?.repo ?? 'local';
   const wanted = input.repos?.length ? new Set(input.repos) : null;
@@ -140,5 +149,10 @@ export async function searchTranscriptsFederated(input: {
   // default key would silently merge two repos' message 5 into one hit.
   const hits = fuseRankings(rankings, input.limit, hit => `${hit.repo}:${hit.messageId}`);
 
-  return { hits, skipped, coverage, ambiguous, localRepo: localName };
+  // Re-judged on the FUSED page rather than carried from any one repo: the question is whether
+  // the query is about anything the workspace holds, and a repo that missed says nothing about
+  // the one that hit.
+  const belowRelevanceFloor = judgeRelevanceFloor(hits, input.embedder?.relevanceFloor ?? null);
+
+  return { hits, skipped, coverage, ambiguous, localRepo: localName, belowRelevanceFloor };
 }

--- a/src/transcripts/mcp-handlers.ts
+++ b/src/transcripts/mcp-handlers.ts
@@ -110,6 +110,17 @@ export async function handleTranscriptSearch(input: {
   sessionId?: string;
   repos?: string[];
   limit?: number;
+  /**
+   * Treat an off-subject page as no matches at all, rather than returning it with a caveat.
+   *
+   * For the automatic fallback only. When the agent TYPED `knowl_transcript_search`, it asked
+   * for whatever is closest and can judge the bodies itself, so hits are returned with the
+   * notice attached. When the fallback runs the search on its own after a `knowl_query` miss,
+   * nobody asked -- and appending nearest-neighbour noise there spends context at the exact
+   * moment the agent is already lost, which is what #183 measured: 0 of 40 replayed misses
+   * recovered anything, and 7 of 15 healthy queries would have had junk appended.
+   */
+  confidentOnly?: boolean;
 }): Promise<string> {
   const { projectRoot } = input;
   if (!input.config || !projectRoot) return DISABLED_MESSAGE;
@@ -134,7 +145,7 @@ export async function handleTranscriptSearch(input: {
   const embedder = await optionalEmbedder(config, projectRoot);
   const workspace = await resolveWorkspace(projectRoot, config).catch(() => null);
 
-  const { hits, skipped, coverage, ambiguous, localRepo } = await searchTranscriptsFederated({
+  const { hits, skipped, coverage, ambiguous, localRepo, belowRelevanceFloor } = await searchTranscriptsFederated({
     projectRoot, workspace, query, limit,
     sessionId: input.sessionId, repos: input.repos,
     embedder: embedder ?? undefined,
@@ -150,8 +161,12 @@ export async function handleTranscriptSearch(input: {
       .join('\n');
   }
 
+  // An off-subject page IS no match, for a caller that did not ask for the search. Decided
+  // before the bodies are rendered so the noise never reaches the block at all.
+  const offSubject = belowRelevanceFloor === true && input.confidentOnly === true;
+
   const lines: string[] = [];
-  if (hits.length === 0) {
+  if (hits.length === 0 || offSubject) {
     lines.push(`${NO_TRANSCRIPT_MATCHES_PREFIX} for "${query}".`);
   } else {
     for (const hit of hits) {
@@ -179,6 +194,23 @@ export async function handleTranscriptSearch(input: {
         : fenceUntrusted(hit.text));
       lines.push('');
     }
+  }
+
+  // Said out loud, because otherwise nearest-neighbour noise is indistinguishable from a real
+  // recall -- which is #183: a query of pure gibberish returned hits and nothing marked them.
+  //
+  // The rows are still returned rather than withheld, for the reason `docs/reference.md` gives
+  // for `abstained`: the floor detects off-subject, not unanswerable, and a reader looking at
+  // the bodies judges better than the number does. What changes is that the reader is now told.
+  if (belowRelevanceFloor && hits.length > 0 && !offSubject) {
+    lines.push(
+      'NO CONFIDENT MATCH: none of these reads as being about the words you searched for.'
+      + ' Take that narrowly — it means off-subject, not that the archive lacks the answer, and'
+      + ' a search phrased in this project\'s own vocabulary scores like a real one either way.'
+      + ' Read the bodies and judge; if none of them is what you meant, the archive probably'
+      + ' predates it or it was said in other words.',
+    );
+    lines.push('');
   }
 
   // Required, not decorative. "BM25 + semantic" over 8% of an archive is a different claim

--- a/src/transcripts/search.ts
+++ b/src/transcripts/search.ts
@@ -13,6 +13,21 @@ export type TranscriptHit = {
   role: 'user' | 'assistant';
   score: number;
   /**
+   * The raw similarity from the semantic half, on the same absolute scale the per-model
+   * relevance floor is measured against -- and the only number here that means the same thing
+   * from one query to the next.
+   *
+   * `score` cannot: after `fuseRankings` it is a Reciprocal Rank Fusion total, built from
+   * POSITIONS, so the top hit scores about the same whether it was a perfect match or the least
+   * bad of five bad ones. That is exactly the shape that made `knowl_query` publish `cosine`
+   * alongside `score` (#146), and transcript search had the same hole (#183): the absolute
+   * number was computed in `semanticRank` and thrown away by the fusion.
+   *
+   * Absent when the semantic half never ran or never saw this row -- lexical-only, no embedder,
+   * or not embedded under this fingerprint. Absent means UNJUDGED, never "certainly irrelevant".
+   */
+  cosine?: number;
+  /**
    * Where the message's line starts, and how long its text was when indexed. Carried so the
    * body can be read with a seek instead of a scan, and so a stale offset can be rejected
    * rather than rendered as the wrong message. Null on rows indexed before offsets existed.
@@ -244,7 +259,13 @@ export function fuseRankings<T extends TranscriptHit>(
     ranking.forEach((hit, index) => {
       const key = keyOf(hit);
       scores.set(key, (scores.get(key) ?? 0) + 1 / (RRF_K + index + 1));
-      if (!byKey.has(key)) byKey.set(key, hit);
+      const kept = byKey.get(key);
+      if (!kept) byKey.set(key, hit);
+      // The first ranking wins the object, and the lexical arm is pushed first -- so a message
+      // found by BOTH halves would keep the lexical copy and silently lose the cosine the
+      // semantic half computed for it. Carry it across rather than reordering the arms, which
+      // would change which hit's metadata survives for every other field.
+      else if (kept.cosine === undefined && hit.cosine !== undefined) kept.cosine = hit.cosine;
     });
   }
 
@@ -317,19 +338,47 @@ export async function semanticRank(
   })).rows;
 
   return rows
-    .map(row => ({
-      messageId: Number(row.id),
-      path: String(row.path),
-      sessionId: String(row.session_id),
-      parentSessionId: row.parent_session_id === null ? null : String(row.parent_session_id),
-      line: Number(row.line),
-      role: String(row.role) as 'user' | 'assistant',
-      byteOffset: row.byte_offset === null || row.byte_offset === undefined ? null : Number(row.byte_offset),
-      chars: row.chars === null || row.chars === undefined ? null : Number(row.chars),
-      score: dotQuantized(queryVector, new Uint8Array(row.vec as ArrayBuffer), Number(row.scale)),
-    }))
+    .map(row => {
+      // Computed once and carried twice, on purpose: `score` is consumed by the fusion and
+      // replaced with a position total, `cosine` survives it. This runs over every embedded
+      // message in scope, so the similarity is not worth computing a second time to say it.
+      const similarity = dotQuantized(queryVector, new Uint8Array(row.vec as ArrayBuffer), Number(row.scale));
+      return {
+        messageId: Number(row.id),
+        path: String(row.path),
+        sessionId: String(row.session_id),
+        parentSessionId: row.parent_session_id === null ? null : String(row.parent_session_id),
+        line: Number(row.line),
+        role: String(row.role) as 'user' | 'assistant',
+        byteOffset: row.byte_offset === null || row.byte_offset === undefined ? null : Number(row.byte_offset),
+        chars: row.chars === null || row.chars === undefined ? null : Number(row.chars),
+        score: similarity,
+        cosine: similarity,
+      };
+    })
     .sort((left, right) => right.score - left.score)
     .slice(0, limit);
+}
+
+/**
+ * Whether a page of hits reads as off-subject for the corpus that produced it.
+ *
+ * One rule, exported because federation fuses a second time across repos and has to reach the
+ * same verdict -- two copies of this would drift, and the drift would be invisible.
+ *
+ * Judged on the BEST hit rather than per hit, because that is the only claim the floor was
+ * measured to support: it answers "is this query about this corpus at all", so one verdict
+ * covers the page. Applied per hit it would also cut the tail of a genuinely good recall, which
+ * is the mistake `knowl_query`'s floor already made once and was measured making.
+ *
+ * Rows with no cosine are SKIPPED, not counted as zero. An unembedded message's semantic half is
+ * absent, not adverse, and reading absence as a low score is how a half-indexed archive would
+ * report every query as off-subject. `undefined` therefore means unjudged, never "fine".
+ */
+export function judgeRelevanceFloor(hits: TranscriptHit[], floor: number | null): boolean | undefined {
+  if (floor === null) return undefined;
+  const judged = hits.map(hit => hit.cosine).filter((value): value is number => value !== undefined);
+  return judged.length === 0 ? undefined : Math.max(...judged) < floor;
 }
 
 export type SearchInput = {
@@ -361,6 +410,19 @@ export async function searchTranscripts(
    * which, and searching all of them is not what was asked.
    */
   ambiguousSession: string[] | null;
+  /**
+   * The query does not read as being about this archive: a semantic half ran, and every hit it
+   * judged scored below this model's relevance floor.
+   *
+   * **Off-subject, not unanswerable** -- the same narrow reading `abstained` carries on
+   * `knowl_query`, and for the same measured reason (see `docs/reference.md`). A question
+   * phrased in the archive's own vocabulary scores like a real one whether or not any session
+   * actually discussed it, so this cannot say the archive lacks the answer.
+   *
+   * `undefined` means UNJUDGED rather than fine: no embedder, the semantic half failed, this
+   * model has no measured floor, or nothing returned carried a cosine at all.
+   */
+  belowRelevanceFloor?: boolean;
 }> {
   const { client, query, limit, sessionId } = input;
 
@@ -394,6 +456,8 @@ export async function searchTranscripts(
 
   const fused = fuseRankings(rankings, limit);
 
+  const belowRelevanceFloor = judgeRelevanceFloor(fused, input.embedder?.relevanceFloor ?? null);
+
   // Bodies are read only for what is actually returned -- ranking never touches disk. Grouped
   // by file so one file is opened once for all of its hits, and each hit inside it is read by
   // seeking to the offset the indexer recorded rather than counting newlines from byte zero.
@@ -426,5 +490,8 @@ export async function searchTranscripts(
     coverage: { embedded, indexed },
     indexComplete: passState?.complete === true,
     ambiguousSession: null,
+    // Present only when the floor actually reached a verdict, so an ordinary answered query and
+    // an unjudged one stay distinguishable from a judged-and-passed one.
+    ...(belowRelevanceFloor === undefined ? {} : { belowRelevanceFloor }),
   };
 }

--- a/tests/transcripts/search-relevance-floor.test.ts
+++ b/tests/transcripts/search-relevance-floor.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { fuseRankings, judgeRelevanceFloor, type TranscriptHit } from '../../src/transcripts/search.js';
+
+/**
+ * #183: transcript search returned nearest-neighbour noise with nothing marking it, because the
+ * absolute cosine was computed in `semanticRank` and thrown away by the fusion. These pin the
+ * two halves of the fix that are easy to reintroduce.
+ */
+
+const hit = (id: number, score: number, cosine?: number): TranscriptHit => ({
+  messageId: id,
+  path: '/p',
+  sessionId: 's',
+  parentSessionId: null,
+  line: id,
+  role: 'user',
+  score,
+  ...(cosine === undefined ? {} : { cosine }),
+});
+
+describe('fuseRankings carries the cosine', () => {
+  it('keeps the semantic cosine when the lexical arm won the key', () => {
+    // The order the real caller uses: lexical first, so its object wins the key and would have
+    // silently dropped the cosine. This is the whole reason the merge exists.
+    const lexical = [hit(1, 5)];
+    const semantic = [hit(1, 0.91, 0.91)];
+
+    const [fused] = fuseRankings([lexical, semantic], 10);
+
+    expect(fused.messageId).toBe(1);
+    expect(fused.cosine).toBe(0.91);
+  });
+
+  it('leaves a lexical-only hit without a cosine rather than inventing one', () => {
+    const [fused] = fuseRankings([[hit(2, 5)]], 10);
+
+    // Absent means unjudged. A 0 here would read as "certainly irrelevant" and would make a
+    // half-indexed archive report every query as off-subject.
+    expect(fused.cosine).toBeUndefined();
+  });
+});
+
+describe('judgeRelevanceFloor', () => {
+  it('judges the best hit, not each one', () => {
+    // A real recall with a weak tail must not be called off-subject.
+    const hits = [hit(1, 5, 0.90), hit(2, 4, 0.40), hit(3, 3, 0.20)];
+
+    expect(judgeRelevanceFloor(hits, 0.76)).toBe(false);
+  });
+
+  it('is true only when every judged hit is below the floor', () => {
+    const hits = [hit(1, 5, 0.51), hit(2, 4, 0.40)];
+
+    expect(judgeRelevanceFloor(hits, 0.76)).toBe(true);
+  });
+
+  it('skips unembedded rows instead of scoring them zero', () => {
+    // One good hit plus rows the semantic half never saw. Counting the absent ones as 0 would
+    // not change the max here, but treating the whole page as unjudgeable would -- so this pins
+    // that a mixed page is still judged on the row that has a number.
+    const hits = [hit(1, 5), hit(2, 4, 0.88), hit(3, 3)];
+
+    expect(judgeRelevanceFloor(hits, 0.76)).toBe(false);
+  });
+
+  it('returns undefined when nothing was judged at all', () => {
+    expect(judgeRelevanceFloor([hit(1, 5), hit(2, 4)], 0.76)).toBeUndefined();
+  });
+
+  it('returns undefined when the model has no measured floor', () => {
+    // `relevanceFloor: null` is a withheld claim, not a floor of zero.
+    expect(judgeRelevanceFloor([hit(1, 5, 0.02)], null)).toBeUndefined();
+  });
+
+  it('returns undefined on an empty page', () => {
+    expect(judgeRelevanceFloor([], 0.76)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #183.

`knowl_transcript_search` returned hits for `zzzzz qqqqq xxxxx vvvvv wwwww` and
nothing marked them, so nearest-neighbour noise was indistinguishable from a real
recall. The number needed to tell them apart already existed.

`semanticRank` computes a real cosine, then `fuseRankings` replaces every score
with a Reciprocal Rank Fusion total built from POSITIONS -- so the top hit scores
about the same whether it was a perfect match or the least bad of five bad ones.
The absolute number was computed and discarded at the boundary.

THIS IS THE THIRD INSTANCE OF ONE PATTERN, not a third unrelated bug. #146: the
semantic half folded into a rescaled `relevance`, fixed by publishing `cosine`.
#181: `queryCoverage` multiplied into a page-normalised `raw/best`, fixed by
publishing `coverage`. Now the transcript fusion. Every time: an absolute number
computed internally, folded into a page-relative one, and only the page-relative
one handed to the caller.

`TranscriptHit.cosine` now survives the fusion. `fuseRankings` merges it across
arms rather than reordering them -- the lexical arm is pushed first and wins the
key, so a message found by both halves would otherwise keep the lexical copy and
lose the cosine. `judgeRelevanceFloor` is one exported rule because federation
fuses a second time across repos and two copies would drift invisibly.

Judged on the BEST hit, not per hit: that is the only claim the floor was
measured to support, and per-hit would cut the tail of a genuinely good recall --
the mistake knowl_query's floor already made once and was measured making. Rows
with no cosine are SKIPPED, never scored zero; absence is unjudged, not adverse,
and reading it as a low score is how a half-indexed archive would call every
query off-subject.

THE TWO CALLERS ARE TREATED DIFFERENTLY, and that is the point.

  - The TYPED tool returns weak hits with the notice attached. The caller asked
    for whatever is closest and can read the bodies.
  - The `search.transcripts.fallback` chain gets `confidentOnly: true` and
    withholds an off-subject page as a verified negative. Nobody asked for that
    search, and it runs at the moment the agent is already lost.

The issue's own backtest is why the fallback filters rather than flags: across 40
replayed real misses it recovered 0, every pre-event hit a lexical collision, and
7 of 15 healthy queries would have had junk appended.

WORDING FOLLOWS #182, NOT THE ISSUE. #183 describes knowl_query's floor as
telling a caller "the best available match is genuinely weak" from "this is the
answer". #182 corrected exactly that claim hours earlier -- the floor detects
off-subject, not unanswerable -- so the notice here says the narrow thing and
points the reader at the bodies. The issue's evidence survives that correction
untouched: gibberish and off-domain collisions are precisely the class the floor
does catch.

Verified: build, 362 files / 3514 passed / 5 skipped, typecheck, docs:check.