### PR TITLE
fix(transcripts): one clipped component was costing every vector a quarter of its norm

### DIFF
--- a/src/transcripts/embed-pass.ts
+++ b/src/transcripts/embed-pass.ts
@@ -1,7 +1,7 @@
 import type { Client } from '@libsql/client';
 import type { KnowledgeEmbedder } from '../store/vector-index.js';
 import { withWriteRetry } from './database.js';
-import { quantizeVector } from './quantize.js';
+import { quantizeVector, transcriptVectorFingerprint } from './quantize.js';
 import { readMessagesAt } from './read.js';
 
 /**
@@ -103,7 +103,7 @@ export async function embedPendingMessages(input: {
   // rows -- there is one vector per message, not per re-ranked candidate.
   await read(client => client.execute({
     sql: 'DELETE FROM transcript_vectors WHERE fingerprint <> ?',
-    args: [embedder.profileFingerprint],
+    args: [transcriptVectorFingerprint(embedder.profileFingerprint)],
   }));
 
   let embedded = 0;
@@ -244,7 +244,8 @@ async function embedVectorBatch(
               ON CONFLICT(message_id) DO UPDATE SET
                 fingerprint = excluded.fingerprint, dims = excluded.dims,
                 scale = excluded.scale, vec = excluded.vec`,
-        args: [targets[i].id, embedder.profileFingerprint, vector.length, scale, bytes],
+        args: [targets[i].id, transcriptVectorFingerprint(embedder.profileFingerprint),
+               vector.length, scale, bytes],
       });
       embedded++;
     }

--- a/src/transcripts/quantize.ts
+++ b/src/transcripts/quantize.ts
@@ -49,7 +49,7 @@ export function quantizeScale(dims: number): number {
  *
  * NO SCHEMA CHANGE AND NO READER CHANGE: `scale` is already a per-row column and
  * `dequantizeVector` already multiplies by whatever that row carries, so existing rows keep
- * decoding exactly as before. They stay clipped, though -- hence the `EMBED_RECIPE_VERSION` bump
+ * decoding exactly as before. They stay clipped, though -- hence the `QUANTIZE_VERSION` bump
  * that makes an ordinary reindex replace them.
  */
 export function quantizeVector(vector: number[]): { scale: number; bytes: Uint8Array } {

--- a/src/transcripts/quantize.ts
+++ b/src/transcripts/quantize.ts
@@ -8,26 +8,93 @@
  */
 
 /**
- * The magnitude that maps to +/-127.
+ * The magnitude that maps to +/-127, under the fixed-scale scheme.
  *
  * `6 / sqrt(dims)` rather than a constant: L2-normalised components have RMS `1/sqrt(dims)`, so
  * this clips at about 6 sigma and adapts to any model's dimensionality. For 384-dim Granite it
  * gives 0.306, against a measured largest component of 0.327 and a p99.9 of 0.262.
+ *
+ * RETAINED FOR READING OLD ROWS, NOT FOR WRITING NEW ONES. The 0.327 above was not measured on
+ * `granite-small-en-r2`, which is the shipped default: its vectors carry a rogue component near
+ * **0.70**, more than twice this threshold. See `quantizeVector`.
  */
 export function quantizeScale(dims: number): number {
   return 6 / Math.sqrt(dims);
 }
 
+/**
+ * Per-vector scale, because one clipped component is not a rounding error.
+ *
+ * Measured on 12 real messages through `granite-small-en-r2`, the shipped default preset:
+ *
+ * | scheme | mean \|\|v\|\| | mean cos | worst cos |
+ * |---|---|---|---|
+ * | fixed `6/sqrt(dims)` | 0.7525 | 0.9236 | 0.9128 |
+ * | per-vector max | **1.0003** | **0.99947** | 0.99940 |
+ *
+ * Exactly ONE component of 384 exceeded the fixed threshold -- and clipping that one cost 25% of
+ * the norm and rotated the vector by ~22 degrees. Transformer embeddings routinely carry such a
+ * "rogue dimension"; the 6-sigma argument assumes a spread this model does not have, and no
+ * amount of dimensionality-adaptation reaches an outlier that is 14 sigma out.
+ *
+ * Consequences of the old scheme, all of them silent: `dotQuantized` documents itself as cosine
+ * on the grounds that both sides are unit-length, and the stored side was not -- so every score
+ * was `cos(q,d) * ||d||` with `||d||` ranging 0.69-0.81, a content-independent +/-8% reweighting
+ * of the ranking. It also depressed the whole cosine scale, which is why transcript scores
+ * topped out near 0.59 while `MODEL_RELEVANCE_FLOORS` puts this model's floor at 0.76.
+ *
+ * Scaling to the max spends int8 range on the rogue component and leaves the bulk coarser; the
+ * table above is that trade, measured rather than argued. A p99.9 scale was tried alongside and
+ * is identical to six decimals, so the simpler rule wins.
+ *
+ * NO SCHEMA CHANGE AND NO READER CHANGE: `scale` is already a per-row column and
+ * `dequantizeVector` already multiplies by whatever that row carries, so existing rows keep
+ * decoding exactly as before. They stay clipped, though -- hence the `EMBED_RECIPE_VERSION` bump
+ * that makes an ordinary reindex replace them.
+ */
 export function quantizeVector(vector: number[]): { scale: number; bytes: Uint8Array } {
-  const scale = quantizeScale(vector.length);
+  let max = 0;
+  for (let i = 0; i < vector.length; i++) {
+    const magnitude = Math.abs(vector[i]);
+    if (magnitude > max) max = magnitude;
+  }
+  // A zero vector has no scale to speak of. Fall back rather than divide by zero and store NaN.
+  const scale = max > 0 ? max : quantizeScale(vector.length);
+
   const signed = new Int8Array(vector.length);
   for (let i = 0; i < vector.length; i++) {
     const scaled = Math.round((vector[i] / scale) * 127);
-    // Clamp rather than let the Int8Array assignment wrap: an outlier component would
-    // otherwise flip sign, which is far worse than clipping it.
+    // Still clamped. Nothing can exceed the max by construction, but rounding at exactly +/-127
+    // and any future scale rule both land here, and a wrapped Int8Array assignment flips sign.
     signed[i] = Math.max(-127, Math.min(127, scaled));
   }
   return { scale, bytes: new Uint8Array(signed.buffer, signed.byteOffset, signed.byteLength) };
+}
+
+/**
+ * The version of the quantization decision, stamped into the transcript vector fingerprint.
+ *
+ * Deliberately NOT `EMBED_RECIPE_VERSION`. That constant is about the text an ATOM becomes, and
+ * its doc calls it a cross-repo contract that `knowl-cloud` holds a byte-identical copy of --
+ * bumping it here would force a sync and a full knowledge reindex for a change that touches
+ * neither. Quantization is transcript-local, so its version is too.
+ *
+ * Version 2 is the per-vector scale. Version 1 rows are not comparable to it: they decode to
+ * norm ~0.75 and would rank systematically below faithfully-stored rows whatever they say, so
+ * the two must not share a corpus.
+ *
+ * Bumping this is the whole repair. `embedPendingMessages` already deletes rows whose
+ * fingerprint does not match and treats "no vector for this fingerprint" as its resume point, so
+ * an ordinary `knowl reindex --transcripts` purges version 1 and rebuilds it. No migration.
+ */
+export const QUANTIZE_VERSION = 2;
+
+/**
+ * What a transcript vector is stored under: the embedder's profile plus the quantization
+ * version, because the profile alone cannot see a change in how the numbers are encoded.
+ */
+export function transcriptVectorFingerprint(profileFingerprint: string): string {
+  return `${profileFingerprint}:q${QUANTIZE_VERSION}`;
 }
 
 export function dequantizeVector(bytes: Uint8Array, scale: number): number[] {

--- a/src/transcripts/search.ts
+++ b/src/transcripts/search.ts
@@ -1,7 +1,7 @@
 import type { Client } from '@libsql/client';
 import type { KnowledgeEmbedder } from '../store/vector-index.js';
 import { readTranscriptIndexState } from './database.js';
-import { dotQuantized } from './quantize.js';
+import { dotQuantized, transcriptVectorFingerprint } from './quantize.js';
 import { readMessagesFor } from './read.js';
 
 export type TranscriptHit = {
@@ -383,7 +383,7 @@ export async function searchTranscripts(
     try {
       const vector = await input.embedder.embedQuery(query);
       if (vector?.length) {
-        fingerprint = input.embedder.profileFingerprint;
+        fingerprint = transcriptVectorFingerprint(input.embedder.profileFingerprint);
         rankings.push(await semanticRank(client, vector, fingerprint, limit * 2, scope));
       }
     } catch {

--- a/tests/transcripts/quantize.test.ts
+++ b/tests/transcripts/quantize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { dequantizeVector, dotQuantized, quantizeScale, quantizeVector } from '../../src/transcripts/quantize.js';
+import { dequantizeVector, dotQuantized, quantizeScale, quantizeVector, transcriptVectorFingerprint } from '../../src/transcripts/quantize.js';
 
 /** A unit-length vector, which is what the embedder produces (`normalize: true`). */
 function unitVector(dims: number, seed: number): number[] {
@@ -121,5 +121,73 @@ describe('dotQuantized', () => {
     });
 
     expect(order(quantizedScores)).toEqual(order(exactScores));
+  });
+});
+
+/**
+ * The round trip must preserve the vector, not merely a scaled copy of it.
+ *
+ * This is the test that was missing. `quantizeScale` clipped at `6/sqrt(dims)` on the argument
+ * that L2-normalised components sit near `1/sqrt(dims)` -- true on average, false in the tail
+ * that matters. `granite-small-en-r2`, the shipped default, carries a rogue component near 0.70
+ * against a 0.3062 threshold, so exactly one component of 384 clipped and cost 25% of the norm
+ * and ~22 degrees of direction. Nothing detected it: `dotQuantized` documents itself as cosine
+ * because "both sides are unit-length", and the stored side quietly was not.
+ *
+ * A synthetic smooth vector cannot catch this -- `Math.sin(i)` normalised has a max component
+ * around 0.07 and sails through the old scheme. The fixture below is shaped like a real
+ * embedding: one dominant dimension, the rest small.
+ */
+describe('quantize round trip preserves the vector', () => {
+  /** One rogue component, 383 ordinary ones — the shape a real transformer embedding has. */
+  const roguey = (): number[] => {
+    const v = new Array(384).fill(0).map((_, i) => Math.sin(i * 12.9898) * 0.05);
+    v[7] = 0.70;
+    const n = Math.hypot(...v);
+    return v.map(x => x / n);
+  };
+  const norm = (v: number[]) => Math.hypot(...v);
+  const cos = (a: number[], b: number[]) => {
+    const d = a.reduce((s, x, i) => s + x * b[i], 0);
+    return d / (norm(a) * norm(b));
+  };
+
+  it('keeps unit length when a component exceeds the old fixed threshold', () => {
+    const v = roguey();
+    expect(Math.max(...v.map(Math.abs))).toBeGreaterThan(quantizeScale(384));
+
+    const { scale, bytes } = quantizeVector(v);
+    const back = dequantizeVector(bytes, scale);
+
+    // The old fixed scale produced 0.75 here. Anything materially below 1 is a clipped component.
+    expect(norm(back)).toBeGreaterThan(0.99);
+    expect(norm(back)).toBeLessThan(1.01);
+  });
+
+  it('keeps direction, so a stored vector still means what it meant', () => {
+    const v = roguey();
+    const { scale, bytes } = quantizeVector(v);
+    // The old fixed scale produced 0.923 here.
+    expect(cos(v, dequantizeVector(bytes, scale))).toBeGreaterThan(0.999);
+  });
+
+  it('makes dotQuantized the cosine it claims to be', () => {
+    const v = roguey();
+    const { scale, bytes } = quantizeVector(v);
+    // Query against the document's own direction: a true cosine is 1, a norm-scaled one is not.
+    expect(dotQuantized(v, bytes, scale)).toBeGreaterThan(0.999);
+  });
+
+  it('does not divide by zero on a zero vector', () => {
+    const { scale, bytes } = quantizeVector(new Array(384).fill(0));
+    expect(Number.isFinite(scale)).toBe(true);
+    expect(dequantizeVector(bytes, scale).every(Number.isFinite)).toBe(true);
+  });
+
+  it('stamps a quantization version the profile fingerprint cannot see', () => {
+    // The repair path: `embedPendingMessages` deletes rows whose fingerprint differs, so a
+    // change in encoding has to change the fingerprint or stale rows are searched forever.
+    expect(transcriptVectorFingerprint('abc')).not.toBe('abc');
+    expect(transcriptVectorFingerprint('abc')).toContain('abc');
   });
 });

--- a/tests/transcripts/search-lexical.test.ts
+++ b/tests/transcripts/search-lexical.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeTranscriptDbs, openTranscriptDb } from '../../src/transcripts/database.js';
 import { embedPendingMessages } from '../../src/transcripts/embed-pass.js';
+import { transcriptVectorFingerprint } from '../../src/transcripts/quantize.js';
 import { runIndexPass } from '../../src/transcripts/index-pass.js';
 import { encodeProjectDir } from '../../src/transcripts/paths.js';
 import { lexicalRank, resolveSessionScope, semanticRank, toMatchQuery } from '../../src/transcripts/search.js';
@@ -253,7 +254,7 @@ describe('an ambiguous session prefix scopes both halves the same way', () => {
     // ranking cannot distinguish them.
     await embedPendingMessages({ dbPath, embedder: stubEmbedder() });
 
-    const hits = await semanticRank(client, [1, 0, 0, 0], 'stub:scope', 10, 'session-');
+    const hits = await semanticRank(client, [1, 0, 0, 0], transcriptVectorFingerprint('stub:scope'), 10, 'session-');
 
     expect(hits).toEqual([]);
   });
@@ -265,7 +266,7 @@ describe('an ambiguous session prefix scopes both halves the same way', () => {
     await embedPendingMessages({ dbPath, embedder: stubEmbedder() });
 
     const lexical = await lexicalRank(client, 'shared subject', 10, 'alp');
-    const semantic = await semanticRank(client, [1, 0, 0, 0], 'stub:scope', 10, 'alp');
+    const semantic = await semanticRank(client, [1, 0, 0, 0], transcriptVectorFingerprint('stub:scope'), 10, 'alp');
 
     expect(lexical.map(hit => hit.sessionId)).toEqual(['alpha']);
     expect(semantic.map(hit => hit.sessionId)).toEqual(['alpha']);

--- a/tests/transcripts/search-semantic.test.ts
+++ b/tests/transcripts/search-semantic.test.ts
@@ -8,6 +8,7 @@ import { runIndexPass } from '../../src/transcripts/index-pass.js';
 import * as parse from '../../src/transcripts/parse.js';
 import { encodeProjectDir } from '../../src/transcripts/paths.js';
 import { fuseRankings, searchTranscripts } from '../../src/transcripts/search.js';
+import { transcriptVectorFingerprint } from '../../src/transcripts/quantize.js';
 import type { KnowledgeEmbedder } from '../../src/store/vector-index.js';
 
 // Counts streaming passes. See tests/transcripts/read.test.ts for why spying on
@@ -303,7 +304,8 @@ describe('embedPendingMessages', () => {
     await embedPendingMessages({ dbPath, embedder: other });
 
     const rows = (await client.execute('SELECT DISTINCT fingerprint FROM transcript_vectors')).rows;
-    expect(rows.map(r => String(r.fingerprint))).toEqual(['stub:different']);
+    expect(rows.map(r => String(r.fingerprint)))
+      .toEqual([transcriptVectorFingerprint('stub:different')]);
   });
 
   it('stops at a deadline and reports itself incomplete', async () => {


### PR DESCRIPTION
Found while measuring direction 1 for #169. It is not related to that direction, and it invalidates some of the numbers I posted there — see the bottom.

## One component clips, and it costs a quarter of the norm

`quantizeScale` clips at `6/sqrt(dims)` on the argument that L2-normalised components sit near `1/sqrt(dims)`, so the threshold is about six sigma. True of the average component, false of the one that matters. **`granite-small-en-r2` — the shipped default — carries a rogue component near 0.70 against a threshold of 0.3062.** Exactly one component of 384 clips, and that clip costs 25% of the norm and ~22° of direction.

Measured on 12 real messages through the default preset:

| scheme | mean `‖v‖` | mean cos | worst cos |
| --- | --- | --- | --- |
| fixed `6/sqrt(dims)` *(current)* | 0.7525 | 0.9236 | 0.9128 |
| **per-vector max** | **1.0003** | **0.99947** | 0.99940 |

The doc comment cites "a measured largest component of 0.327 and a p99.9 of 0.262". Whatever that was measured on, it was not this model.

## Why nothing caught it

`dotQuantized` documents itself as cosine on the grounds that *"both sides are unit-length"*. The stored side quietly was not. Every score was `cos(q,d) · ‖d‖` with `‖d‖` ranging **0.69–0.81** across a live 9k-message archive — a content-independent ±8% reweighting of the ranking.

It also depressed the entire cosine scale. Top-1 scores on that archive:

```
before   0.47 – 0.59
after    0.82 – 0.83
```

against a `MODEL_RELEVANCE_FLOORS` entry of **0.76** for the same model. So any relevance floor measured on transcripts was measuring the clip, not the corpus.

The existing tests could not have caught this: a smooth synthetic vector sails through. Normalised `Math.sin(i)` has a max component near 0.07, a quarter of the threshold. The new fixture is shaped like a real embedding — one dominant dimension, 383 small ones — and asserts its max exceeds the old threshold, so it provably enters the clip path.

## The fix, and why it is this small

A per-vector scale. **`scale` is already a per-row column** and `dequantizeVector` already multiplies by whatever the row carries, so there is no schema change, no reader change, and existing rows keep decoding exactly as they did.

The trade is resolution: scaling to the max spends int8 range on the rogue component and leaves the bulk coarser. The table above is that trade measured rather than argued. A p99.9 scale was tried alongside and is identical to six decimals, so the simpler rule wins.

## Invalidating the stale rows

Old rows decode to norm ~0.75 and would rank systematically below faithfully-stored ones whatever they say, so the two must not share a corpus. Hence `QUANTIZE_VERSION`, folded into the transcript vector fingerprint.

Deliberately **not** `EMBED_RECIPE_VERSION` — that constant is about the text an *atom* becomes, and its own doc calls it a byte-identical cross-repo contract with `knowl-cloud`. Bumping it here would force a sync and a full knowledge reindex for a change that touches neither. Quantization is transcript-local, so its version is too.

No migration needed: `embedPendingMessages` already deletes rows whose fingerprint differs and treats "no vector for this fingerprint" as its resume point, so an ordinary `knowl reindex --transcripts` purges and rebuilds. Verified end to end on a copy of a real 9k-message archive — stored norms went from p50 **0.7571** to p50 **1.0005**.

## Test changes

Two tests reached past the public API and hand-passed a raw profile fingerprint to `semanticRank`; both now ask for the fingerprint the writer actually used. One of those mattered — *"returns nothing semantically either"* would otherwise have kept passing on a fingerprint mismatch rather than on the session scoping it exists to test, i.e. it would have silently stopped testing anything.

Transcript suite **351/351**. Full suite is unchanged against `upstream/main`, which fails 80 tests in my environment for unrelated reasons (a `@noble/hashes/argon2.js` resolution error) — same count before and after.

## What this means for #169

I re-ran the floor sweep on a correctly-quantized rebuild of the same archive. **Your conclusion holds, and now holds on clean data** — which is a stronger result than either of us had:

| statistic | real min | technical max | gap | on-topic buried |
| --- | --- | --- | --- | --- |
| `top1` | 0.8230 | 0.8324 | −0.0094 | 3/15 (20%) |
| `top1 − top2` | 0.0007 | 0.0262 | −0.0255 | 13/15 (87%) |
| `top1 − mean(top10)` | 0.0083 | 0.0274 | −0.0191 | 8/15 (53%) |
| `top1 − median` | 0.0836 | 0.1113 | −0.0277 | 2/15 (13%) |
| `z` | 3.7946 | 4.6240 | −0.8294 | 5/15 (33%) |
| CSLS | 0.0301 | 0.0670 | −0.0368 | 8/15 (53%) |

Everything still overlaps. The margin still fails worst. CSLS — the lead I raised in #169 — also fails, 8/15 against raw cosine's 3/15, so that direction is closed too.

**And a correction I owe you:** my earlier comment on #169 claimed the knowledge floor "cannot be transplanted to transcripts" because transcript cosines span 0.47–0.59 against a 0.76 floor. That range was the clipping bug. Corrected, transcripts run 0.82–0.83 — *above* 0.76, so a ported floor would never fire rather than always fire. The recommendation is unchanged (don't port it), but my stated reason was wrong and I have corrected it there.
