### PR TITLE
fix(transcripts): a floor measured on atoms is not a floor for transcripts

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -520,21 +520,20 @@ canonical tool table below:
   `transcript://<repo>/<session>#L<line>` locators.
 - **`knowl_transcript_read`** — open one locator with the surrounding turns.
 
-Transcript search carries the same relevance verdict `knowl_query` does, and it means the same
-narrow thing: **off-subject, not unanswerable** (see [above](#what-abstained-means-and-what-it-does-not)).
-When a semantic half ran and the best hit falls below the model's floor, the results arrive under a
-`NO CONFIDENT MATCH` notice rather than silently — before this, a query of pure gibberish returned
-plausible-looking hits with nothing marking them.
+Transcript hits carry `cosine`, the absolute similarity on a stable scale — the one number that
+means the same thing from one search to the next, where the fused `score` is a rank-position total
+and cannot. Use it to judge how strong a match actually is.
 
-The two callers are treated differently on purpose:
+**There is currently no relevance verdict on transcript search, deliberately.** The machinery
+exists and is wired, but its floor is `null`, so no `NO CONFIDENT MATCH` notice fires and the
+`search.transcripts.fallback` chain withholds nothing. The per-model floors are measured over
+knowledge-atom fixtures, and a floor cannot be borrowed across corpora any more than across models
+— applied to transcripts it judged *every* query off-subject, including ones the archive answers,
+which through the fallback chain reported "nothing here" over an archive holding the answer.
 
-- **You typed `knowl_transcript_search`** — you asked for whatever is closest, so weak hits are
-  returned with the notice attached and you judge the bodies.
-- **The `search.transcripts.fallback` chain ran it for you** after a `knowl_query` miss — nobody
-  asked, so an off-subject page is withheld and reported as a verified negative. Appending
-  nearest-neighbour noise there spends context at the moment the agent is already lost, and it was
-  measured doing exactly that: across 40 replayed real misses it recovered **0**, while 7 of 15
-  healthy queries would have had junk appended.
+Arming it needs a measurement on transcript data using the two-class probe method in
+[`evals/preset-floor-sweep.md`](evals/preset-floor-sweep.md). If the classes overlap there as they
+did for knowledge atoms, it stays off — `cosine` published with no verdict is the honest answer.
 
 Disabling the feature **deletes** `.knowl/transcripts.db`. An index nothing will refresh is not
 something to leave on the disk of the person who just turned it off.

--- a/src/transcripts/federate.ts
+++ b/src/transcripts/federate.ts
@@ -5,7 +5,10 @@ import { resolveStorage } from '../store/storage-roles.js';
 import type { ActiveWorkspace } from '../workspace/resolve.js';
 import { isTranscriptSharingEnabled } from './config.js';
 import { openTranscriptDb, TranscriptIndexMissingError } from './database.js';
-import { fuseRankings, judgeRelevanceFloor, searchTranscripts, type TranscriptHit } from './search.js';
+import {
+  fuseRankings, judgeRelevanceFloor, searchTranscripts,
+  TRANSCRIPT_RELEVANCE_FLOOR, type TranscriptHit,
+} from './search.js';
 
 export type FederatedTranscriptHit = TranscriptHit & { repo: string };
 export type TranscriptSkipReason = 'absent' | 'not-shared' | 'unreadable';
@@ -152,7 +155,7 @@ export async function searchTranscriptsFederated(input: {
   // Re-judged on the FUSED page rather than carried from any one repo: the question is whether
   // the query is about anything the workspace holds, and a repo that missed says nothing about
   // the one that hit.
-  const belowRelevanceFloor = judgeRelevanceFloor(hits, input.embedder?.relevanceFloor ?? null);
+  const belowRelevanceFloor = judgeRelevanceFloor(hits, TRANSCRIPT_RELEVANCE_FLOOR);
 
   return { hits, skipped, coverage, ambiguous, localRepo: localName, belowRelevanceFloor };
 }

--- a/src/transcripts/search.ts
+++ b/src/transcripts/search.ts
@@ -375,6 +375,34 @@ export async function semanticRank(
  * absent, not adverse, and reading absence as a low score is how a half-indexed archive would
  * report every query as off-subject. `undefined` therefore means unjudged, never "fine".
  */
+/**
+ * The floor for TRANSCRIPT similarity -- which is not the floor for knowledge atoms, and is
+ * deliberately `null` because nobody has measured one.
+ *
+ * `null` means no verdict: `judgeRelevanceFloor` returns `undefined`, neither surface acts on it,
+ * and `cosine` is still published so a caller keeps the number and loses only the opinion.
+ *
+ * WHY THIS IS NOT `embedder.relevanceFloor` (issue #189). It was, and it was wrong. Those floors
+ * come from `docs/evals/per-model-floor.md`, measured over 50 knowledge-atom fixtures. Transcript
+ * messages are a different corpus with a different cosine distribution, and borrowing the number
+ * across corpora is the same mistake that document exists to prevent one level up -- it proved a
+ * floor cannot be borrowed across MODELS, and said nothing licensing a loan across CORPORA.
+ *
+ * Measured on a real 13MB archive with granite-small's 0.76 knowledge floor applied, every query
+ * was judged off-subject including ones the archive answers (`relevance floor cosine abstain`
+ * 0.4946, `transcript search fusion` 0.4817, `how do we do releases` 0.5626). On the typed tool
+ * that is a false notice; through `search.transcripts.fallback`, which withholds an off-subject
+ * page, it silently reported "nothing here" over an archive holding the answer.
+ *
+ * THE BAR FOR ARMING THIS. Not a guess and not another borrow: a measurement on transcript data
+ * quantized under `QUANTIZE_VERSION` 2 or later -- the pre-#186 scale was depressed ~25% by a
+ * clipped component, so anything measured before that measured the clip -- using the two-class
+ * probe method in `docs/evals/preset-floor-sweep.md`, general AND technical off-subject probes
+ * against real on-topic queries. If the classes overlap, as they did for knowledge atoms, this
+ * stays null and that is the honest answer rather than a failure.
+ */
+export const TRANSCRIPT_RELEVANCE_FLOOR: number | null = null;
+
 export function judgeRelevanceFloor(hits: TranscriptHit[], floor: number | null): boolean | undefined {
   if (floor === null) return undefined;
   const judged = hits.map(hit => hit.cosine).filter((value): value is number => value !== undefined);
@@ -456,7 +484,7 @@ export async function searchTranscripts(
 
   const fused = fuseRankings(rankings, limit);
 
-  const belowRelevanceFloor = judgeRelevanceFloor(fused, input.embedder?.relevanceFloor ?? null);
+  const belowRelevanceFloor = judgeRelevanceFloor(fused, TRANSCRIPT_RELEVANCE_FLOOR);
 
   // Bodies are read only for what is actually returned -- ranking never touches disk. Grouped
   // by file so one file is opened once for all of its hits, and each hit inside it is read by

--- a/tests/transcripts/search-relevance-floor.test.ts
+++ b/tests/transcripts/search-relevance-floor.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { fuseRankings, judgeRelevanceFloor, type TranscriptHit } from '../../src/transcripts/search.js';
+import {
+  fuseRankings, judgeRelevanceFloor, TRANSCRIPT_RELEVANCE_FLOOR, type TranscriptHit,
+} from '../../src/transcripts/search.js';
 
 /**
  * #183: transcript search returned nearest-neighbour noise with nothing marking it, because the
@@ -74,5 +76,19 @@ describe('judgeRelevanceFloor', () => {
 
   it('returns undefined on an empty page', () => {
     expect(judgeRelevanceFloor([], 0.76)).toBeUndefined();
+  });
+});
+
+describe('TRANSCRIPT_RELEVANCE_FLOOR', () => {
+  it('is null, so no page is judged until a floor is measured on transcripts', () => {
+    // Pins the #189 decision rather than the value. The knowledge floors are measured over
+    // atom fixtures, and borrowing one here judged EVERY query off-subject -- including ones the
+    // archive answers -- which the fallback chain turned into "nothing here" over an archive
+    // holding the answer. Arming this needs its own measurement, not a different borrow.
+    expect(TRANSCRIPT_RELEVANCE_FLOOR).toBeNull();
+
+    // A strong hit and pure noise reach the same verdict while the floor is null: none.
+    expect(judgeRelevanceFloor([hit(1, 5, 0.95)], TRANSCRIPT_RELEVANCE_FLOOR)).toBeUndefined();
+    expect(judgeRelevanceFloor([hit(2, 5, 0.10)], TRANSCRIPT_RELEVANCE_FLOOR)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #189. Regression from #185, which is mine.

`searchTranscripts` judged transcript hits with `embedder.relevanceFloor` --
0.76 for granite-small-en-r2, measured in docs/evals/per-model-floor.md over 50
KNOWLEDGE-ATOM fixtures. Transcript messages are a different corpus with a
different cosine distribution and no measured floor of their own.

Against this repo's live 13MB archive, every query was judged off-subject:

  belowFloor  cosine  query
  true        0.4936  zzzzz qqqqq xxxxx vvvvv wwwww
  true        0.4946  relevance floor cosine abstain      <- on-topic
  true        0.4817  transcript search fusion            <- on-topic
  true        0.5626  how do we do releases               <- on-topic

On the typed tool that is a false notice over hits still returned. Through
`search.transcripts.fallback`, which I gave `confidentOnly: true`, it withheld
everything and reported a verified negative -- so the agent was told the archive
holds nothing, over an archive holding the answer. That is worse than the defect
#183 reported: #183 was noise shown as signal, this was signal reported as
absence.

per-model-floor.md exists to prove a floor cannot be borrowed across MODELS. It
licenses no loan across CORPORA, and I made one.

THE FIX IS TO WITHHOLD THE VERDICT, NOT TO PICK ANOTHER NUMBER.
`TRANSCRIPT_RELEVANCE_FLOOR` is null, so `judgeRelevanceFloor` returns undefined
and neither surface acts on it. `cosine` is still published -- the caller keeps
the number and loses only an opinion that was wrong. This follows the standing
decision from #182: when no measurement supports a cut, do not ship one.

A named constant rather than deleting the call, because the machinery is right
and only the number is missing. One place to arm it, and its doc states the bar:
a measurement on data quantized under QUANTIZE_VERSION 2 or later -- anything
measured before #186 measured the clip, not the corpus -- using the two-class
probe method from docs/evals/preset-floor-sweep.md. If the classes overlap as
they did for atoms, it stays null and that is the honest answer, not a failure.

docs/reference.md corrected: it described the verdict as working, which I wrote
yesterday and which was never true.

Verified: build, 362 files / 3520 passed / 5 skipped, typecheck, docs:check.