### PR TITLE
fix(workspace): search each peer under its own embedding profile

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -242,6 +242,31 @@ Titles are capped separately at 200 characters, and previews of things retrievab
 elsewhere — evidence excerpts, timeline assertions, skill markdown, `knowl_skill_run` output —
 stay at 600.
 
+#### Cross-repo search when repos embed differently
+
+Each linked repo is searched under **its own** embedding profile, and its results are ranked
+against its own scale and judged against its own floor.
+
+This matters because a workspace does not in fact pin one embedding identity, though the code
+assumed it did. The link-time check compares provider, model, dtype and pooling; the filter
+applied to a peer's vectors compares a fingerprint that also covers the embedding recipe version.
+Two repos with identical vector config therefore diverge as soon as they sit on different knowl
+versions, and nothing re-checks after linking. A cloud-connected repo cannot converge even in
+principle — its atoms must stay on the model its workspace serves.
+
+Before this, a mismatched peer contributed **no vector candidates at all** and cross-repo search
+quietly fell back to keyword-only while still returning rows, so it read as healthy.
+
+Two consequences worth knowing:
+
+- **Cosines from different models are never compared.** Ranges are normalised per profile, so a
+  model whose scores naturally run high cannot outrank one whose scores run low on scale alone.
+  Repos sharing a profile still share one range, because their scores genuinely are comparable.
+- **A peer whose model cannot be loaded here degrades to keyword-only for that repo**, rather
+  than failing the search.
+
+The cost is one extra forward pass per distinct profile and both models' weights resident.
+
 #### What `abstained` means, and what it does not
 
 `abstained` (and the `NO CONFIDENT MATCH` notice that reports it) means **the query does not look

--- a/src/ai/embeddings.ts
+++ b/src/ai/embeddings.ts
@@ -1,6 +1,7 @@
 ﻿import path from 'node:path';
 import fsPromises from 'node:fs/promises';
 import { ProjectConfig } from '../core/types.js';
+import { loadConfig } from '../core/config.js';
 import { EmbedOptions, KnowledgeEmbedder } from '../store/vector-index.js';
 import { fingerprintProfile, relevanceFloorFor, resolveVectorProfile, type VectorPooling } from '../core/vector-profile.js';
 import { noteModelLoad } from '../core/startup-trace.js';
@@ -281,14 +282,85 @@ export interface LocalEmbeddingProviderOptions {
   onFirstLoad?: (details: { model: string; cacheDir: string; cached: boolean }) => void;
 }
 
-let localPipeline: TransformersPipeline | null = null;
-let localPipelineKey: string | null = null;
+/**
+ * Built pipelines, keyed by profile, because a federated search embeds one query under several.
+ *
+ * This was a single slot, and the embedder returned by `createLocalEmbeddingProvider` read it at
+ * CALL time rather than closing over the pipeline it built. So a second provider for a different
+ * model silently repointed the first: embedder A would go on answering, using B's weights, with
+ * plausible vectors and nothing to notice at runtime -- the same failure mode the per-model
+ * pooling comment below warns about. Latent while nothing built two, and immediate the moment
+ * federation began embedding per peer.
+ *
+ * ponytail: unbounded map, keyed by `model:dtype:pooling:cacheDir`. Bounded in practice by the
+ * distinct profiles in one workspace, which is at most the preset count. Add eviction if a
+ * caller ever iterates models.
+ */
+const localPipelines = new Map<string, TransformersPipeline>();
 
-/** Drop the in-process pipeline. Tests need it; nothing in the product does. */
+/** Drop the in-process pipelines. Tests need it; nothing in the product does. */
 export function resetLocalEmbeddingPipeline(): void {
-  localPipeline = null;
-  localPipelineKey = null;
+  localPipelines.clear();
 }
+
+/**
+ * The embedder a given repo's OWN config describes, or null when it cannot have one.
+ *
+ * Federation reads peer stores whose vectors were written under the peer's profile, not this
+ * repo's, so the query has to be embedded under theirs to match anything (#187). Null rather
+ * than throwing: a peer with vectors off, or a model this machine cannot load, is a normal
+ * state that must degrade that peer to lexical rather than fail the whole search.
+ */
+export async function embedderForRepo(root: string): Promise<KnowledgeEmbedder | null> {
+  try {
+    const config = await loadConfig(root);
+    if (!isVectorSearchEnabled(config)) return null;
+    return await createLocalEmbeddingProvider(config, root);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A per-peer vector resolver for `queryFederated`, memoised by profile.
+ *
+ * Injected rather than imported because `workspace` and `ai` are the same layer, so
+ * `workspace -> ai` is a sideways edge the architecture test forbids. The caller lives in `cli`
+ * or `mcp` and may reach both.
+ *
+ * Memoised on the peer's fingerprint, not its path: several repos usually share one profile, and
+ * the whole point is that embedding the query is cheap ONCE PER DISTINCT PROFILE rather than
+ * once per repo. `createLocalEmbeddingProvider` already caches the pipeline itself, so the
+ * saving here is the forward pass.
+ */
+export function peerVectorResolver(
+  relevanceFloorOf?: (embedder: KnowledgeEmbedder) => number | null,
+): (peer: { root: string }, query: string) => Promise<VectorQueryOption | undefined> {
+  const byFingerprint = new Map<string, Promise<number[]>>();
+  return async (peer, query) => {
+    const embedder = await embedderForRepo(peer.root);
+    if (!embedder) return undefined;
+    let embedding = byFingerprint.get(embedder.profileFingerprint);
+    if (!embedding) {
+      embedding = embedder.embedQuery(query);
+      byFingerprint.set(embedder.profileFingerprint, embedding);
+    }
+    return {
+      enabled: true,
+      profileFingerprint: embedder.profileFingerprint,
+      embedding: await embedding,
+      relevanceFloor: relevanceFloorOf ? relevanceFloorOf(embedder) : embedder.relevanceFloor,
+    };
+  };
+}
+
+/** The shape `RankOptions['vector']` needs, declared here so `workspace` need not be imported. */
+export type VectorQueryOption = {
+  enabled: boolean;
+  profileFingerprint: string;
+  embedding: number[];
+  relevanceFloor: number | null;
+};
 
 export function isVectorSearchEnabled(config: ProjectConfig): boolean {
   return config.search?.vector?.enabled === true;
@@ -368,24 +440,28 @@ export async function createLocalEmbeddingProvider(
   const { dir: cacheDir, present: cached } = await resolveModelCache(config, projectRoot);
   const pipelineKey = `${vector.model}:${vector.dtype}:${vector.pooling}:${cacheDir}`;
 
-  if (!localPipeline || localPipelineKey !== pipelineKey) {
+  let pipeline = localPipelines.get(pipelineKey);
+  if (!pipeline) {
     options.onFirstLoad?.({ model: vector.model, cacheDir, cached });
     // How long building the pipeline actually costs, recorded rather than assumed. The model
     // was blamed for stalls it cannot cause -- serve never loads one during startup -- and the
     // only way that claim gets settled is a number per process, per model, cold and warm.
     const loadStartedAt = Date.now();
     if (options.loadPipeline) {
-      localPipeline = await options.loadPipeline(vector.model, vector.dtype, cacheDir);
+      pipeline = await options.loadPipeline(vector.model, vector.dtype, cacheDir);
     } else {
       const transformers = await import('@huggingface/transformers');
       transformers.env.cacheDir = cacheDir;
-      localPipeline = await transformers.pipeline('feature-extraction', vector.model, {
+      pipeline = await transformers.pipeline('feature-extraction', vector.model, {
         dtype: vector.dtype as any,
       }) as TransformersPipeline;
     }
     noteModelLoad(vector.model, cached, Date.now() - loadStartedAt);
-    localPipelineKey = pipelineKey;
+    localPipelines.set(pipelineKey, pipeline);
   }
+  // Captured, never re-read from the map: this embedder must keep answering with the weights it
+  // was built for, whatever another profile does to the cache afterwards.
+  const built = pipeline;
 
   return {
     provider: 'local',
@@ -401,7 +477,7 @@ export async function createLocalEmbeddingProvider(
     embed: async (texts: string[], options?: EmbedOptions) => {
       const vectors: number[][] = [];
       for (const batch of planEmbeddingBatches(texts, options)) {
-        const output = await localPipeline!(batch.map(entry => entry.text), {
+        const output = await built(batch.map(entry => entry.text), {
           // Per-model, not a constant: MiniLM is mean-pooled while both Granite R2
           // models and BGE are CLS-pooled. Using the wrong one produces plausible
           // vectors that rank badly, with nothing to notice at runtime.
@@ -417,7 +493,7 @@ export async function createLocalEmbeddingProvider(
       return vectors;
     },
     embedQuery: async (text: string) => {
-      const output = await localPipeline!([queryPrefixFor(vector.model, config) + text], {
+      const output = await built([queryPrefixFor(vector.model, config) + text], {
         pooling: vector.pooling,
         normalize: true,
       });

--- a/src/cli/query-command.ts
+++ b/src/cli/query-command.ts
@@ -5,6 +5,7 @@ import { rankKnowledge, type RankOptions } from '../store/agent-query.js';
 import { queryKnowledgeBase } from '../store/queries.js';
 import { queryFederated, type FederatedResult } from '../workspace/federated-query.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
+import { peerVectorResolver } from '../ai/embeddings.js';
 
 /**
  * How many results `knowl query` returns when no `--limit` is given.
@@ -122,6 +123,8 @@ export async function runCliQuery(input: {
   if (active) {
     const federated = await queryFederated({
       workspace: active, query: input.query ?? '', limit, vector,
+      // See the MCP call site: a peer's vectors live under the peer's profile (#187).
+      peerVector: peerVectorResolver(),
     });
     const groups = federated.groups.map(group => ({
       repo: group.repo,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -38,6 +38,7 @@ import { finishMemorySession, listActiveMemorySessions } from '../store/session-
 import { isImpactEnabled } from '../store/impact-config.js';
 import { openFindingsForSession, resolveFinding, type ImpactFinding, type ImpactTier } from '../session/impact.js';
 import { activeReadSetForSession, containedRepoPath } from '../store/read-set.js';
+import { peerVectorResolver } from '../ai/embeddings.js';
 import { formatPendingHandoffContext, recordDeliberateHandoff } from '../session/session-handoff.js';
 import { createResumePoint, formatResumeBrief, listResumePoints, readResumePoint } from '../session/resume-points.js';
 import { resumeInstruction } from '../session/resume-keys.js';
@@ -916,6 +917,10 @@ export function registerTools(
             repos,
             scope,
             vector,
+            // Each peer searched under its own embedding profile (#187). Absent here, every
+            // peer was filtered on this repo's fingerprint and a mismatched one contributed
+            // no vector candidates at all -- silently, because BM25 still returned rows.
+            peerVector: peerVectorResolver(),
           });
           // Everything downstream of the payload -- the kin block, the abstention verdict, the
           // demand ledger -- asks questions about the result set rather than about its shape, so

--- a/src/store/agent-query.ts
+++ b/src/store/agent-query.ts
@@ -532,6 +532,26 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
     /** The sweep knob. Production callers omit it and get FUSION_ALPHA. */
     alpha?: number;
     /**
+     * Per-corpus relevance floors, keyed the way `corpusOf` keys a candidate -- the repo name,
+     * or `''` for the local store.
+     *
+     * Federation searches each peer under that peer's own embedding profile (#187), and a floor
+     * belongs to the model it was measured on. An entry here wins over `minRelevance` for that
+     * corpus; a corpus with no entry uses `minRelevance`, so a single-profile workspace is
+     * unaffected. An explicit `null` entry means that corpus has no measured floor and is not
+     * judged, which is the honest reading rather than borrowing the local number.
+     */
+    minRelevanceByCorpus?: Map<string, number | null>;
+    /**
+     * Which embedding scale each corpus's cosines are on, keyed the way `corpusOf` keys a
+     * candidate. Corpora sharing a value share one min-max range; corpora with no entry share
+     * the default one.
+     *
+     * Omit it -- the normal case -- and every row shares a single range, which is the behaviour
+     * this file had before federation could search peers under their own models.
+     */
+    semanticScaleByCorpus?: Map<string, string>;
+    /**
      * This model's relevance floor, from `relevanceFloorFor`. Also the sweep knob.
      *
      * `null` or absent means **do not abstain**. That is the honest reading of "no calibration
@@ -583,20 +603,39 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
     corpusBest.set(corpus, Math.max(corpusBest.get(corpus) ?? 0, raw));
   }
   const anyLexical = corpusBest.size > 0;
-  // Semantic range across this candidate page, for the rescale below.
+  // Semantic range per EMBEDDING SCALE -- one shared range by default, and one per profile when
+  // the caller says the page holds more than one.
+  //
+  // It was a single min-max over the page, which is right exactly while every row's cosine came
+  // from the same model. Federation stopped guaranteeing that (#187): a peer is searched under
+  // its own profile now. Granite's distribution sits roughly 0.5 above arctic's on identical
+  // inputs, so one min-max over a mixed union rescales every granite row near 1 and every arctic
+  // row near 0 -- every local row beating every peer row on the semantic term regardless of what
+  // either says. That is not the bug #187 reported, it is a worse one pointing the other way.
+  //
+  // Keyed by PROFILE and not by corpus, which the cross-repo archetype baseline is what caught:
+  // repos sharing a profile produce genuinely comparable cosines, and splitting their ranges
+  // rescales each repo's own best hit to 1.0 however mediocre it is. `client-projects` recall@3
+  // fell 1.0 -> 0.9722 that way. Same-profile repos must share one range; only a different model
+  // earns a different one.
   //
   // Folded rather than spread: `Math.max(...values)` passes one argument per candidate and blows
   // the stack on a large page. The candidate set is bounded by `limit * OVERFETCH` in the normal
   // path but not in every caller, and a ranking helper must not carry a size ceiling nobody
   // states.
-  let semanticCeiling = 0;
-  let semanticFloor = 1;
+  const scaleOf = (candidate: { repo?: string }): string =>
+    options.semanticScaleByCorpus?.get(corpusOf(candidate)) ?? '';
+  const semanticRange = new Map<string, { floor: number; ceiling: number }>();
   for (const candidate of candidates) {
     const value = Math.min(Math.max(candidate.vectorScore ?? 0, 0), 1);
-    if (value > semanticCeiling) semanticCeiling = value;
-    if (value < semanticFloor) semanticFloor = value;
+    const scale = scaleOf(candidate);
+    const held = semanticRange.get(scale);
+    if (!held) semanticRange.set(scale, { floor: value, ceiling: value });
+    else {
+      if (value > held.ceiling) held.ceiling = value;
+      if (value < held.floor) held.floor = value;
+    }
   }
-  if (!candidates.length) semanticFloor = 0;
   // Alpha renormalises over the signals that exist, and does so globally rather than per
   // corpus: two repos scored under different alphas would not be comparable, which is the
   // whole reason scoring runs over the union.
@@ -606,6 +645,9 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
     .map(result => {
       const raw = rawLexical(result);
       const best = corpusBest.get(corpusOf(result)) ?? 0;
+      // The range of the SCALE this row's cosine is on, which is one shared range unless the
+      // caller says otherwise. Absent only for an empty page.
+      const range = semanticRange.get(scaleOf(result)) ?? { floor: 0, ceiling: 0 };
       // No lexical evidence and the worst lexical evidence both score 0. That is deliberate:
       // "did lexical return this at all" used to be a step worth 0.0333 while the whole
       // lexical ordering was worth 0.0158 -- the presence of a signal outweighing what the
@@ -627,7 +669,7 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
       const lexical = raw === undefined ? 0 : (best > 0 ? Math.min(raw / best, 1) * coverage : coverage);
       const semantic = Math.min(Math.max(result.vectorScore ?? 0, 0), 1);
       const relevance = usingVector
-        ? alpha * rescaleSemantic(semantic, semanticFloor, semanticCeiling) + (1 - alpha) * lexical
+        ? alpha * rescaleSemantic(semantic, range.floor, range.ceiling) + (1 - alpha) * lexical
         : lexical;
 
       const recency = normalizedRecencyScore(result.item, timestamps);
@@ -698,13 +740,35 @@ export function scoreCandidates<T extends Candidate & { repo?: string }>(
     // calibrated score, so a weak answer arrives visibly weak, and silence was never the richer
     // signal: it could not be told apart from an empty store or a missing index.
     const judged = scored.filter(candidate => floorApplies(candidate.result));
-    const bestCosine = judged.reduce((best, candidate) => Math.max(best, candidate.semantic), 0);
     // No floor means no verdict. An uncalibrated model is one this build has never measured,
     // and "I cannot tell" has to read as silence rather than as confidence in either direction.
-    const floor = typeof options.minRelevance === 'number' && Number.isFinite(options.minRelevance)
-      ? options.minRelevance
-      : null;
-    const answerable = floor === null || judged.length === 0 || bestCosine >= floor;
+    const asFloor = (value: unknown): number | null =>
+      typeof value === 'number' && Number.isFinite(value) ? value : null;
+    // PER CORPUS, because a floor is measured for one model and federation now searches each
+    // peer under its own (#187). Granite's 0.76 against an arctic row's 0.16-0.27 would judge
+    // every peer row off-subject on scale alone -- the same borrowed-threshold mistake as #189,
+    // one level out. A corpus with no entry falls back to the caller's single floor, so a
+    // workspace on one profile behaves exactly as before.
+    const floorOf = (corpus: string): number | null =>
+      options.minRelevanceByCorpus?.has(corpus)
+        ? asFloor(options.minRelevanceByCorpus.get(corpus))
+        : asFloor(options.minRelevance);
+    // The page answers if ANY corpus cleared its own bar. A corpus that judged nothing, or has
+    // no floor to judge against, reaches no verdict and cannot make the page unanswerable.
+    const bestByCorpus = new Map<string, number>();
+    for (const candidate of judged) {
+      const corpus = corpusOf(candidate.result);
+      bestByCorpus.set(corpus, Math.max(bestByCorpus.get(corpus) ?? 0, candidate.semantic));
+    }
+    let anyJudgedAgainstAFloor = false;
+    let answerable = false;
+    for (const [corpus, best] of bestByCorpus) {
+      const floor = floorOf(corpus);
+      if (floor === null) continue;
+      anyJudgedAgainstAFloor = true;
+      if (best >= floor) answerable = true;
+    }
+    if (!anyJudgedAgainstAFloor) answerable = true;
     // Exactly the set the destructive floor used to KEEP is the set left unlabelled; everything
     // it used to delete is returned and labelled. The rule is unchanged, only its consequence:
     //

--- a/src/transcripts/federate.ts
+++ b/src/transcripts/federate.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import type { KnowledgeEmbedder } from '../store/vector-index.js';
 import { loadConfig } from '../core/config.js';
+import { embedderForRepo } from '../ai/embeddings.js';
 import { resolveStorage } from '../store/storage-roles.js';
 import type { ActiveWorkspace } from '../workspace/resolve.js';
 import { isTranscriptSharingEnabled } from './config.js';
@@ -81,7 +82,7 @@ export async function searchTranscriptsFederated(input: {
   // Read-only for every repo including this one. Searching writes nothing, and a writable open
   // creates the file -- which would resurrect an index the user deleted by turning the feature
   // off, from a code path that only reads.
-  const search = async (repo: string, dbPath: string) => {
+  const search = async (repo: string, dbPath: string, embedder = input.embedder) => {
     const client = await openTranscriptDb(dbPath, { readOnly: true });
     const result = await searchTranscripts({
       client,
@@ -89,7 +90,7 @@ export async function searchTranscriptsFederated(input: {
       limit: input.limit,
       sessionId: input.sessionId,
       projectRoot: input.projectRoot,
-      embedder: input.embedder,
+      embedder,
     });
     rankings.push(result.hits.map(hit => ({ ...hit, repo })));
     coverage.push({ repo, ...result.coverage, indexComplete: result.indexComplete });
@@ -139,7 +140,12 @@ export async function searchTranscriptsFederated(input: {
         skipped.push({ repo: peer.name, reason: 'not-shared' });
         continue;
       }
-      await search(peer.name, peerDb);
+      // The peer's OWN embedder, not this repo's (#187). Its transcript vectors were written
+      // under its profile, so searching them with ours matched nothing and the peer degraded to
+      // lexical silently. `transcripts` sits above `ai`, so this import is a legal downward edge
+      // -- the knowledge half has to inject the equivalent because `workspace` is `ai`'s peer.
+      const peerEmbedder = (await embedderForRepo(peer.root)) ?? undefined;
+      await search(peer.name, peerDb, peerEmbedder);
     } catch (error) {
       skipped.push({
         repo: peer.name,

--- a/src/workspace/federated-query.ts
+++ b/src/workspace/federated-query.ts
@@ -170,10 +170,34 @@ export async function queryFederated(input: {
   /**
    * The local vector config, including the query embedding when one was produced.
    *
-   * A workspace pins one embedding identity (`assertSafeToLink`), so the peer's vectors live
-   * in the same space and the same provider/model filter is the right one to apply there.
+   * Applies to THIS repo's store and to the cloud replica, which is embedded under this
+   * project's own profile. Peers get `peerVector` instead -- see below for why they must.
    */
   vector?: RankOptions['vector'];
+  /**
+   * The vector option for one peer, embedded under THAT repo's profile.
+   *
+   * This file used to hand `vector` to every peer, on the stated grounds that a workspace pins
+   * one embedding identity at link time. It does not hold (#187). `assertEmbeddingCompatible`
+   * compares four fields -- provider, model, dtype, pooling -- while the filter applied to a
+   * peer store compares `profile_fingerprint`, a hash of those four PLUS
+   * `EMBEDDING_BATCH_POLICY` and `EMBED_RECIPE_VERSION`. So two repos with identical vector
+   * config mismatch whenever they sit on different knowl versions, and nothing re-checks after
+   * linking. A cloud-connected repo cannot align even in principle: its atoms must stay on the
+   * cloud's serving model while the manifest pins another.
+   *
+   * The failure was silent. A mismatched peer contributed zero vector candidates and the search
+   * degraded to BM25-only while still returning rows, so it read as healthy.
+   *
+   * Fusing per-repo native models is what this file already assumes elsewhere: ranking merges
+   * positions rather than raw scores precisely because scores are not comparable across repos,
+   * so arctic at 0.16 and granite at 0.76 never have to meet on one scale.
+   *
+   * Injected rather than imported: `workspace` and `ai` are the same layer, so `workspace -> ai`
+   * is a sideways edge the architecture test forbids. Returning `undefined` degrades that one
+   * peer to lexical, which is the honest answer when its model cannot be loaded here.
+   */
+  peerVector?: (peer: { name: string; root: string }, query: string) => Promise<RankOptions['vector'] | undefined>;
 }): Promise<FederatedResult> {
   const cap = input.perRepoCap ?? DEFAULT_PER_REPO_CAP;
   const named = input.repos && input.repos.length > 0 ? input.repos : null;
@@ -201,6 +225,28 @@ export async function queryFederated(input: {
     }
   }
 
+  // Per-corpus embedding facts, filled in as each peer is searched. Empty when every peer used
+  // this repo's profile, which is what keeps a single-profile workspace scoring exactly as it
+  // did: `scoreCandidates` falls back to one shared range and one floor.
+  //
+  // Every corpus gets an entry, including this repo's and the replica's, so that a peer sharing
+  // this repo's profile lands in the SAME bucket rather than a differently-named one. Keying
+  // local implicitly and peers explicitly would split a range that is genuinely shared, which is
+  // the regression the archetype baseline catches.
+  const semanticScaleByCorpus = new Map<string, string>();
+  const minRelevanceByCorpus = new Map<string, number | null>();
+  if (input.vector?.enabled && input.vector.embedding) {
+    const localScale = input.vector.profileFingerprint ?? '';
+    const localFloor = input.vector.relevanceFloor ?? null;
+    semanticScaleByCorpus.set(input.workspace.repo, localScale);
+    minRelevanceByCorpus.set(input.workspace.repo, localFloor);
+    // The replica is embedded under this project's own profile, so it shares both.
+    if (input.workspace.cloud) {
+      semanticScaleByCorpus.set(input.workspace.cloud.workspaceId, localScale);
+      minRelevanceByCorpus.set(input.workspace.cloud.workspaceId, localFloor);
+    }
+  }
+
   const selection: RankOptions = {
     query: input.query,
     category: input.category,
@@ -223,8 +269,21 @@ export async function queryFederated(input: {
     }
     try {
       const store = await openPeerStore(peer.databasePath);
+      // The peer's own profile, not this repo's. Absent resolver keeps the old behaviour for
+      // callers that have not been wired up; `undefined` from the resolver means this peer
+      // searches lexically, which is right when its model is unavailable here.
+      const peerVector = input.peerVector
+        ? await input.peerVector({ name: peer.name, root: peer.root }, input.query)
+        : input.vector;
+      // What scale this peer's cosines are on, and what floor may judge them. Recorded only
+      // when it actually searched with vectors -- a lexical-only peer has no cosines to place.
+      if (peerVector?.enabled && peerVector.embedding) {
+        semanticScaleByCorpus.set(peer.name, peerVector.profileFingerprint ?? '');
+        minRelevanceByCorpus.set(peer.name, peerVector.relevanceFloor ?? null);
+      }
       const found = await selectCandidates('local', {
         ...selection,
+        vector: peerVector,
         // Not a post-filter: the predicate is in the SQL, so a peer's repo-private row is
         // never read into this process at all.
         visibility: 'workspace',
@@ -317,6 +376,10 @@ export async function queryFederated(input: {
     // workspace is where "the store does not hold this" is most expensive to get wrong, because
     // the alternative on offer is the peer's near-miss. Same expression as `rankKnowledge`.
     minRelevance: input.vector?.relevanceFloor ?? null,
+    // Both empty unless a peer searched under a different profile, so the single-profile path
+    // is untouched. See #187.
+    semanticScaleByCorpus,
+    minRelevanceByCorpus,
   });
 
   // Which peers are the same lineage as the caller. Read from the manifest rather than from the

--- a/tests/ai/embedding-pipeline-cache.test.ts
+++ b/tests/ai/embedding-pipeline-cache.test.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createLocalEmbeddingProvider, resetLocalEmbeddingPipeline } from '../../src/ai/embeddings.js';
+import { DEFAULT_CONFIG } from '../../src/core/config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * #187: federation embeds one query under several profiles, so a process now holds more than one
+ * embedder at a time. It could not before — the returned embedder read a single module-level
+ * pipeline slot at CALL time, so building a second provider silently repointed the first.
+ */
+
+const ROOT = path.resolve('./.knowl-pipeline-cache-test');
+
+const config = (model: string): ProjectConfig => ({
+  ...DEFAULT_CONFIG,
+  search: { vector: { enabled: true, provider: 'local', model, dtype: 'q8' } },
+} as ProjectConfig);
+
+/** A pipeline that reports which model it was built for, so a swap is visible in the output. */
+const pipelineFor = (model: string) => async () =>
+  (async () => ({ data: [model.length, 0, 0], dims: [1, 3] })) as never;
+
+describe('local embedding pipeline cache', () => {
+  beforeEach(async () => {
+    resetLocalEmbeddingPipeline();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+  });
+  afterEach(async () => {
+    resetLocalEmbeddingPipeline();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('keeps each embedder on its own weights after a second profile is built', async () => {
+    const first = await createLocalEmbeddingProvider(config('Xenova/all-MiniLM-L6-v2'), ROOT, {
+      loadPipeline: pipelineFor('Xenova/all-MiniLM-L6-v2'),
+    });
+    const second = await createLocalEmbeddingProvider(config('Xenova/bge-small-en-v1.5'), ROOT, {
+      loadPipeline: pipelineFor('Xenova/bge-small-en-v1.5'),
+    });
+
+    // The regression: `first` answered with `second`'s pipeline once the module slot moved on.
+    // Plausible vectors, wrong model, nothing to notice at runtime.
+    const [a] = await first.embedQuery('anything');
+    const [b] = await second.embedQuery('anything');
+
+    expect(a).toBe('Xenova/all-MiniLM-L6-v2'.length);
+    expect(b).toBe('Xenova/bge-small-en-v1.5'.length);
+    expect(a).not.toBe(b);
+  });
+
+  it('builds one pipeline per profile and reuses it', async () => {
+    let builds = 0;
+    const counting = (model: string) => async () => {
+      builds++;
+      return (async () => ({ data: [model.length, 0, 0], dims: [1, 3] })) as never;
+    };
+
+    await createLocalEmbeddingProvider(config('Xenova/all-MiniLM-L6-v2'), ROOT, { loadPipeline: counting('a') });
+    await createLocalEmbeddingProvider(config('Xenova/all-MiniLM-L6-v2'), ROOT, { loadPipeline: counting('a') });
+    expect(builds).toBe(1);
+
+    await createLocalEmbeddingProvider(config('Xenova/bge-small-en-v1.5'), ROOT, { loadPipeline: counting('b') });
+    expect(builds).toBe(2);
+
+    // Back to the first profile: served from the map, not rebuilt. This is what stops a mixed
+    // workspace thrashing a pipeline build on every federated query.
+    await createLocalEmbeddingProvider(config('Xenova/all-MiniLM-L6-v2'), ROOT, { loadPipeline: counting('a') });
+    expect(builds).toBe(2);
+  });
+
+  it('gives the two profiles different fingerprints, which is what the peer filter keys on', async () => {
+    const first = await createLocalEmbeddingProvider(config('Xenova/all-MiniLM-L6-v2'), ROOT, {
+      loadPipeline: pipelineFor('a'),
+    });
+    const second = await createLocalEmbeddingProvider(config('Xenova/bge-small-en-v1.5'), ROOT, {
+      loadPipeline: pipelineFor('b'),
+    });
+
+    expect(first.profileFingerprint).not.toBe(second.profileFingerprint);
+  });
+});

--- a/tests/store/mixed-profile-scoring.test.ts
+++ b/tests/store/mixed-profile-scoring.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { scoreCandidates } from '../../src/store/agent-query.js';
+import type { KnowledgeItem } from '../../src/core/types.js';
+
+/**
+ * #187: federation searches each peer under that peer's own embedding profile, so one page can
+ * carry cosines from two models. Granite's distribution sits roughly 0.5 above arctic's on
+ * identical inputs, so the two must not be min-maxed together and must not be judged by one
+ * floor.
+ */
+
+const item = (id: string): KnowledgeItem => ({
+  id,
+  category: 'fact',
+  status: 'active',
+  title: `title ${id}`,
+  content: `content ${id}`,
+  tags: [],
+  confidence: 1,
+  freshness: 'fresh',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+} as unknown as KnowledgeItem);
+
+const candidate = (id: string, repo: string, vectorScore: number) =>
+  ({ item: item(id), repo, vectorScore, embedded: true } as never);
+
+/** Granite-scale local rows and arctic-scale peer rows, as a mixed workspace produces. */
+const mixed = () => [
+  candidate('local-strong', 'here', 0.90),
+  candidate('local-weak', 'here', 0.78),
+  candidate('peer-strong', 'there', 0.26),
+  candidate('peer-weak', 'there', 0.17),
+];
+
+const scales = new Map([['here', 'granite'], ['there', 'arctic']]);
+
+describe('scoring a page that mixes embedding profiles', () => {
+  it('does not let one model\'s scale outrank the other wholesale', () => {
+    // Without per-scale ranges a single min-max over 0.17-0.90 puts both arctic rows near 0 and
+    // both granite rows near 1, so every local row beats every peer row on the semantic term
+    // whatever either actually says. The peer's best must be able to reach the page.
+    const scored = scoreCandidates(mixed(), {
+      query: 'anything',
+      limit: 4,
+      usingVector: true,
+      semanticScaleByCorpus: scales,
+    });
+
+    const order = scored.map(entry => entry.item.id);
+    expect(order.indexOf('peer-strong')).toBeLessThan(order.indexOf('local-weak'));
+  });
+
+  it('judges each corpus against its own floor', () => {
+    // Arctic's floor is 0.16 and granite's is 0.76. Both corpora clear their own bar here, so
+    // nothing abstains. Judging arctic's 0.26 against granite's 0.76 would call the peer
+    // off-subject on scale alone -- the #189 mistake, one level out.
+    const scored = scoreCandidates(mixed(), {
+      query: 'anything',
+      limit: 4,
+      usingVector: true,
+      semanticScaleByCorpus: scales,
+      minRelevance: 0.76,
+      minRelevanceByCorpus: new Map([['here', 0.76], ['there', 0.16]]),
+    });
+
+    const abstained = scored.filter(entry => entry.explanation?.abstained);
+    expect(abstained.map(entry => entry.item.id)).toEqual([]);
+  });
+
+  it('leaves a single-profile page scored exactly as before', () => {
+    // The regression the cross-repo archetype baseline caught: repos sharing a profile produce
+    // genuinely comparable cosines, and splitting their ranges rescales each repo's own best hit
+    // to 1.0 however mediocre. With no scale map, every row shares one range.
+    const shared = [
+      candidate('a', 'here', 0.90),
+      candidate('b', 'there', 0.40),
+    ];
+
+    const withoutMap = scoreCandidates(shared, { query: 'q', limit: 2, usingVector: true });
+    const withOneScale = scoreCandidates(shared, {
+      query: 'q',
+      limit: 2,
+      usingVector: true,
+      semanticScaleByCorpus: new Map([['here', 'same'], ['there', 'same']]),
+    });
+
+    expect(withoutMap.map(e => e.item.id)).toEqual(withOneScale.map(e => e.item.id));
+    expect(withoutMap[0].item.id).toBe('a');
+  });
+});


### PR DESCRIPTION
Closes #187.

Federation applied THIS repo's fingerprint to every peer store, so a mismatched
peer contributed zero vector candidates and cross-repo search fell back to
BM25-only -- silently, because rows still came back and it read as healthy.
`federated-query.ts` said so in a comment: "A workspace pins one embedding
identity (assertSafeToLink), so the peer's vectors live in the same space."

IT DOES NOT HOLD, AND NOT ONLY FOR THE REASON FILED. `assertEmbeddingCompatible`
compares four fields -- provider, model, dtype, pooling -- while the peer filter
compares `profile_fingerprint`, a hash of those four PLUS EMBEDDING_BATCH_POLICY
and EMBED_RECIPE_VERSION. Two repos with identical vector config therefore
diverge the moment they sit on different knowl versions, with no
misconfiguration and nothing re-checking after link time. A cloud-connected repo
cannot converge even in principle: its atoms must stay on the model its
workspace serves while the manifest pins another.

Measured cost, from the reporter: arctic 0.5442 vs granite 0.4157 MRR@10 over
160 queries on three corpora -- the invisible half was also the better half.

WHAT THE ISSUE PROPOSED IS RIGHT FOR TRANSCRIPTS AND WRONG FOR KNOWLEDGE, and
that is the substance of this diff. Its rationale was that `fuseRankings` merges
positions rather than scores, so per-repo native models never meet on one scale.
True of transcript search. The knowledge path does not rank-fuse -- it scores a
UNION, min-maxing the semantic half across the page and applying one floor. Give
peers native embeddings there and granite's 0.76-0.93 and arctic's 0.16-0.27
land in one min-max: every local row beats every peer row on the semantic term
regardless of what either says, and the local floor judges peer rows off-subject
on scale alone. That is a worse bug than the one being fixed, pointing the other
way.

So the scorer gained two seams:

  - `semanticScaleByCorpus` -- the semantic range is per PROFILE, not per repo.
    Per repo was the first attempt and the cross-repo archetype baseline caught
    it: repos sharing a profile produce genuinely comparable cosines, and
    splitting their ranges rescales each repo's mediocre best to 1.0.
    `client-projects` recall@3 fell 1.0 -> 0.9722. Same-profile repos share one
    range; only a different model earns a different one.
  - `minRelevanceByCorpus` -- each corpus judged against its own floor, the page
    answerable if any corpus clears its own bar. Judging arctic rows by
    granite's 0.76 is #189's borrowed-threshold mistake one level out.

Both are empty unless a peer actually searched under a different profile, so a
single-profile workspace scores exactly as before -- pinned by a test.

ALSO FIXED, because the rest is unsafe without it: the embedder returned by
`createLocalEmbeddingProvider` read a single module-level pipeline slot at CALL
time rather than closing over the pipeline it built, so building a second
provider silently repointed the first. Embedder A would go on answering with B's
weights -- plausible vectors, wrong model, nothing to notice at runtime. Latent
while nothing built two; immediate the moment federation embeds per peer. Now a
Map keyed by profile, captured in the closure.

Layering: `workspace` and `ai` are the same layer, so `workspace -> ai` is a
sideways edge the architecture test forbids -- hence `peerVector` is injected by
the cli/mcp callers. `transcripts` sits above `ai` and imports `embedderForRepo`
directly. The resolver memoises on fingerprint, so the query is embedded once
per distinct profile rather than once per repo.

Costs, named: both models' weights resident, and a second pipeline build on
first query in a mixed workspace.

Verified: build, 363 files / 3526 passed / 5 skipped, typecheck, docs:check,
eslint clean.