### PR TITLE
feat(capture): ask what the session is relying on but never verified

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -242,6 +242,30 @@ Titles are capped separately at 200 characters, and previews of things retrievab
 elsewhere — evidence excerpts, timeline assertions, skill markdown, `knowl_skill_run` output —
 stay at 600.
 
+#### The assumption checkpoint
+
+`capture.checkpoint` (`off` by default, `ask` to arm; `knowl posture maximal` arms it) asks one
+question every 20 assistant turns: **what is this session currently relying on that it never
+verified?**
+
+It is looking for claims that became load-bearing without being checked — a number taken from a
+summary rather than the source, a fix called done without re-running its proof, an attribution
+never confirmed, one observation generalised into a rule.
+
+It **asks the agent**, and calls no model. The proposal it came from measured a separate judge
+reading recorded sessions, because offline that is the only thing that can answer; in a live
+session the agent already holds the context, so a prompt costs nothing and keeps the capture path
+free of network calls. That matters concretely: `agent-hook` is a fresh process per tool call, and
+an inline model call there would block every tool the agent runs.
+
+The honest caveat: a self-audit is not the same instrument as an independent judge, so the ~90%
+precision measured for the judge version does not transfer, and this ships unmeasured on that axis.
+
+It **never withholds a stop.** Checkpoint flags are recorded as pending lessons so a durable write
+settles them, but they are excluded from the gate that can block — that gate is for things that
+happened, and a checkpoint fires on a counter. In the mid-turn channel it ranks below every
+observed-event card and above the generic continuation reminder.
+
 #### Cross-repo search when repos embed differently
 
 Each linked repo is searched under **its own** embedding profile, and its results are ranked

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -32,6 +32,7 @@ export type ConfigKey =
   | 'capture.nudge'
   | 'capture.events'
   | 'capture.scope'
+  | 'capture.checkpoint'
   | 'cloud.autoStage'
   | 'updateCheck.enabled';
 
@@ -108,6 +109,7 @@ const IMPACT_GATE_MODES = ['off', 'shadow', 'enforce'] as const;
 // than shared: they mean different things (one refuses a write, one withholds a stop), and a
 // shared list is how a fourth mode added for one of them silently becomes settable on the other.
 const CAPTURE_NUDGE_MODES = ['off', 'shadow', 'enforce'] as const;
+const CHECKPOINT_MODES = ['off', 'ask'] as const;
 const CAPTURE_SCOPES = ['conversation', 'turn'] as const;
 
 export const CONFIG_FIELDS: ConfigField[] = [
@@ -285,6 +287,12 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(CAPTURE_NUDGE_MODES), defaultValue: 'off',
     label: 'Event lessons',
     description: 'Watch for destructive commands and user corrections, and hold each as a pending lesson until a durable write settles it: shadow records what it would have said, enforce nudges mid-turn and withholds a stop over unstored lessons, at most three times per conversation.',
+  },
+  {
+    key: 'capture.checkpoint', category: 'Capture', type: 'enum', values: CHECKPOINT_MODES,
+    parse: enumValue(CHECKPOINT_MODES), defaultValue: 'off',
+    label: 'Assumption checkpoint',
+    description: 'Every 20 assistant turns, ask the session what it is currently relying on that it never verified -- a number taken from a summary rather than the source, a fix called done without re-running its proof. Asks in the free mid-turn channel and never withholds a stop.',
   },
   {
     key: 'capture.scope', category: 'Capture', type: 'enum', values: CAPTURE_SCOPES,

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2875,7 +2875,7 @@ configCommand.on('command:*', () => {
  */
 const POSTURE_KEYS = [
   'search.transcripts.enabled', 'search.transcripts.fallback',
-  'capture.nudge', 'capture.events', 'capture.scope',
+  'capture.nudge', 'capture.events', 'capture.scope', 'capture.checkpoint',
   'impact.enabled', 'impact.gate',
 ] as const;
 const MAXIMAL_POSTURE: Array<{ key: (typeof POSTURE_KEYS)[number]; raw: string }> = [
@@ -2884,6 +2884,9 @@ const MAXIMAL_POSTURE: Array<{ key: (typeof POSTURE_KEYS)[number]; raw: string }
   { key: 'capture.nudge', raw: 'enforce' },
   { key: 'capture.events', raw: 'enforce' },
   { key: 'capture.scope', raw: 'turn' },
+  // Armed here and nowhere else. It asks the agent rather than calling a model, so unlike the
+  // rest of maximal it costs no provider and no network -- which is why it can be on at all.
+  { key: 'capture.checkpoint', raw: 'ask' },
   { key: 'impact.enabled', raw: 'true' },
   // Shadow, not enforce, even here: the write gate refuses tool calls, and its own contract
   // requires the measured precision bar before anything is permitted to block.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -509,6 +509,8 @@ export interface ProjectConfig {
      * still asked.
      */
     scope?: 'conversation' | 'turn';
+    /** The periodic assumption checkpoint. `ask` arms it; absent means off. See #184. */
+    checkpoint?: 'off' | 'ask';
   };
   /**
    * This repo's half of workspace membership. The other half is the workspace manifest

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -9,15 +9,20 @@ import {
   areSkillNudgesEnabled, driftReminderEvery, isDriftBackoffEnabled, loadConfig, shouldSendDriftReminder,
 } from '../core/config.js';
 import { isImpactEnabled } from '../store/impact-config.js';
-import { captureEventsMode, captureNudgeMode, captureScope } from '../store/capture-config.js';
+import {
+  captureCheckpointMode, captureEventsMode, captureNudgeMode, captureScope,
+  CHECKPOINT_EVERY_TURNS,
+} from '../store/capture-config.js';
 import { classifyDestructiveCommand } from '../core/lesson-signals.js';
 import {
   claimLessonBlock,
   markPendingLessons,
+  claimAssumptionCheckpoint,
   openPendingLessons,
   recordCorrectionLesson,
   recordDestructiveLesson,
   renderCorrectionNudge,
+  renderAssumptionCheckpoint,
   renderLessonNudge,
   renderLessonStopReason,
   resolveLessonsBefore,
@@ -1063,6 +1068,22 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       // read or wrote the file it named -- but never for a failed one: a tool that failed
       // returned no contents, so a read-set row from it would record a belief the agent was
       // never given, and the certain tier would later interrupt it over text it never saw.
+      // Which checkpoint window this conversation is in, or null when the feature is off.
+      //
+      // The read is gated on the mode so it costs nothing for anyone who has not armed it --
+      // and when armed it is one primary-key lookup, unlike the turn counters above which ride
+      // on a write that was happening anyway. Counted in TURNS rather than tool events, because
+      // the sessions worth checkpointing are long on reasoning and short on tools, which is the
+      // same reason `MIN_SUBSTANTIVE_TURNS` counts turns.
+      const checkpointWindow = captureCheckpointMode(captureConfig ?? undefined) === 'ask'
+        ? await readCaptureOutcome(conversationKey(input))
+          .then(outcome => {
+            const turns = outcome?.turns ?? 0;
+            const window = Math.floor(turns / CHECKPOINT_EVERY_TURNS);
+            return window >= 1 ? window : null;
+          })
+          .catch(() => null)
+        : null;
       const impact = input.status === 'failed' ? [] : await runToolEventImpact(input, started.session.id);
       // Adaptive continuation reminder: only nudge Claude after a run of tool calls
       // that ignored Knowl. Using a Knowl tool resets the drift counter, so an agent
@@ -1166,6 +1187,20 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
             // Only a durable write quiets this one, by zeroing the verdict itself.
             await resetHostSuccessfulToolCount(key);
             hostOutput = profile.midTurnContext(renderTurnCapturePrompt());
+          } else if (checkpointWindow !== null
+            && await claimAssumptionCheckpoint(conversationKey(input), checkpointWindow)) {
+            // Below every observed-event branch and above the drift reminder, deliberately.
+            //
+            // It must not displace a change card or a destructive-command lesson: those carry
+            // something that HAPPENED, while this is raised on a counter. But it is strictly
+            // better than the byte-identical continuation reminder it sits above -- a specific
+            // question about this session's own work against a generic nudge -- which is the
+            // same trade the skill nudges already make for this slot.
+            //
+            // Not reset here: unlike the branches above, this is not a "go use memory" signal,
+            // and zeroing the drift counter on a timer would mute the reminder for sessions
+            // that genuinely are ignoring Knowl.
+            hostOutput = profile.midTurnContext(renderAssumptionCheckpoint());
           } else if (input.knowlTool) {
             // Adaptive continuation reminder: only nudge after a run of tool calls that
             // ignored Knowl. Using a Knowl tool resets the drift counter, so an agent

--- a/src/store/capture-config.ts
+++ b/src/store/capture-config.ts
@@ -49,3 +49,34 @@ export type CaptureScope = 'conversation' | 'turn';
 export function captureScope(config?: ProjectConfig): CaptureScope {
   return config?.capture?.scope === 'turn' ? 'turn' : 'conversation';
 }
+
+/**
+ * How often, in assistant turns, the assumption checkpoint asks. `0` is off.
+ *
+ * Twenty because the checkpoint has to span enough work to have accumulated something taken on
+ * trust, and asking inside a short exchange finds nothing and costs a slot. Issue #184 measured
+ * a ~34% fire rate at three checkpoints per session on real transcripts.
+ */
+export const CHECKPOINT_EVERY_TURNS = 20;
+
+/**
+ * Whether the periodic assumption checkpoint is armed.
+ *
+ * `ask` puts one question into the mid-turn channel every `CHECKPOINT_EVERY_TURNS` turns: what
+ * is this session currently relying on that it never verified. Off by default; `knowl posture
+ * maximal` arms it.
+ *
+ * **It asks the agent rather than a judge model, and that is a deliberate departure from #184.**
+ * That issue proposed sending the recent window to a separate model, and measured ~90% precision
+ * doing so. The measurement was offline, over recorded sessions, where a judge was the only
+ * thing that COULD answer. In production the agent is already there with the full live context --
+ * which is the property #184 itself credits for the result -- so a prompt costs nothing, needs no
+ * provider, and keeps the capture path free of network calls. `agent-hook` is a fresh process per
+ * tool call; an inline model call there would block every tool the agent runs.
+ *
+ * The honest cost of that swap: a self-audit is not the same instrument as an independent judge,
+ * so #184's precision number does NOT transfer and this ships unmeasured on that axis.
+ */
+export function captureCheckpointMode(config?: ProjectConfig): 'off' | 'ask' {
+  return config?.capture?.checkpoint === 'ask' ? 'ask' : 'off';
+}

--- a/src/store/pending-lessons.ts
+++ b/src/store/pending-lessons.ts
@@ -18,7 +18,17 @@ import { DESTRUCTIVE_LABELS, type DestructiveCommandHit, type DestructiveCommand
  * host blocked on the answer, and a lost measurement is always cheaper than a lost session.
  */
 
-export type PendingLessonKind = 'destructive' | 'correction';
+export type PendingLessonKind = 'destructive' | 'correction' | 'assumption';
+
+/**
+ * The kinds the stop gate may withhold a stop over.
+ *
+ * `assumption` is deliberately absent. A checkpoint flag is a question about work that may be
+ * perfectly fine, raised on a counter rather than on an observed event -- blocking a stop over
+ * one would spend the annoyance budget on a guess. Issue #184 asked for exactly this: "flags go
+ * to `pending_lessons` as a question, never a block."
+ */
+const BLOCKING_KINDS: PendingLessonKind[] = ['destructive', 'correction'];
 
 export type PendingLesson = {
   id: string;
@@ -93,8 +103,14 @@ export async function openPendingLessons(conversation: string): Promise<PendingL
   if (!id) return [];
   try {
     const rows = await getClient().execute({
-      sql: 'SELECT id, conversation, kind, class, snippet, observed_at FROM pending_lessons WHERE conversation = ? AND resolved IS NULL ORDER BY observed_at',
-      args: [id],
+      // Filtered to BLOCKING_KINDS, and this is the whole guard. The one consumer is the stop
+      // gate, so a kind reaching this read is a kind that can withhold a stop -- returning
+      // assumption flags here would arm the gate on them the moment the checkpoint shipped.
+      sql: `SELECT id, conversation, kind, class, snippet, observed_at FROM pending_lessons
+            WHERE conversation = ? AND resolved IS NULL
+              AND kind IN (${BLOCKING_KINDS.map(() => '?').join(', ')})
+            ORDER BY observed_at`,
+      args: [id, ...BLOCKING_KINDS],
     });
     return rows.rows.map(row => ({
       id: String(row.id),
@@ -219,4 +235,48 @@ export function renderLessonStopReason(lessons: PendingLesson[]): string {
     '      gate -- an empty answer is a correct outcome, a fabricated memory is not.',
     'This gate has already disarmed itself for these events; it will not raise them again.',
   ].join('\n');
+}
+
+/**
+ * Claim this conversation's checkpoint for the current window, once.
+ *
+ * The window number is the class, so the existing "one row per conversation and class" shape
+ * gives idempotency for free: two hook processes racing the same window both try to insert, the
+ * second sees the row and returns false. No new table and no migration -- `kind` carries no CHECK
+ * constraint.
+ *
+ * Recorded as a lesson rather than a bare counter so a durable write settles it like any other:
+ * `resolveLessonsBefore` is kind-agnostic, so storing something after the checkpoint closes it.
+ * It never reaches the stop gate -- see `BLOCKING_KINDS`.
+ */
+export async function claimAssumptionCheckpoint(conversation: string, window: number): Promise<boolean> {
+  const id = (conversation ?? '').trim();
+  if (!id) return false;
+  const className = `checkpoint:${window}`;
+  try {
+    const client = getClient();
+    const existing = await client.execute({
+      sql: 'SELECT 1 FROM pending_lessons WHERE conversation = ? AND class = ? LIMIT 1',
+      args: [id, className],
+    });
+    if (existing.rows.length > 0) return false;
+    await client.execute({
+      sql: `INSERT INTO pending_lessons (id, conversation, kind, class, snippet, observed_at)
+            VALUES (?, ?, 'assumption', ?, NULL, ?)`,
+      args: [crypto.randomUUID(), id, className, new Date().toISOString()],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The checkpoint question, and the only place it is written. */
+export function renderAssumptionCheckpoint(): string {
+  return [
+    'KNOWL CHECKPOINT: what is this session currently relying on that it has not actually verified?',
+    'Look for claims that became load-bearing without being checked -- a number taken from a summary rather than the source, a fix called done without re-running its proof, an attribution never confirmed, one observation generalised into a rule.',
+    'Name each one with the cheap check that would settle it, and do the check if it is cheap. If something turns out to be true and worth keeping, store it; if it turns out wrong, say so now rather than building further on it.',
+    'If nothing here is unverified, carry on -- this asks once per stretch of work, not once per turn.',
+  ].join(' ');
 }

--- a/tests/store/assumption-checkpoint.test.ts
+++ b/tests/store/assumption-checkpoint.test.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import {
+  claimAssumptionCheckpoint,
+  openPendingLessons,
+  recordCorrectionLesson,
+  resolveLessonsBefore,
+} from '../../src/store/pending-lessons.js';
+import { captureCheckpointMode, CHECKPOINT_EVERY_TURNS } from '../../src/store/capture-config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * #184: a periodic checkpoint asking what the session is relying on but never verified. It is a
+ * question, never a block — the two tests that matter are that it claims once per window and
+ * that it stays out of the stop gate.
+ */
+
+let root: string;
+const CONVERSATION = 'host/reposession-1';
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowl-checkpoint-'));
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await initDb(root);
+});
+
+afterEach(async () => {
+  await closeDb();
+  await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('assumption checkpoint', () => {
+  it('claims a window once, however many tool events race it', async () => {
+    const first = await claimAssumptionCheckpoint(CONVERSATION, 1);
+    const again = await claimAssumptionCheckpoint(CONVERSATION, 1);
+    const later = await claimAssumptionCheckpoint(CONVERSATION, 2);
+
+    expect(first).toBe(true);
+    // The hook is a fresh process per tool call, so "already fired" cannot live in memory.
+    expect(again).toBe(false);
+    expect(later).toBe(true);
+  });
+
+  it('never reaches the stop gate', async () => {
+    await claimAssumptionCheckpoint(CONVERSATION, 1);
+    await recordCorrectionLesson(CONVERSATION);
+
+    // `openPendingLessons` has exactly one consumer: the gate that withholds a stop. A checkpoint
+    // is raised on a counter rather than an observed event, so blocking over one would spend the
+    // annoyance budget on a guess.
+    const open = await openPendingLessons(CONVERSATION);
+
+    expect(open.map(lesson => lesson.kind)).toEqual(['correction']);
+  });
+
+  it('is settled by a durable write, like any other lesson', async () => {
+    await claimAssumptionCheckpoint(CONVERSATION, 1);
+    await resolveLessonsBefore(CONVERSATION, new Date(Date.now() + 1000).toISOString());
+
+    // Settled means the next window can still ask, but this one is closed rather than pending.
+    const reclaimed = await claimAssumptionCheckpoint(CONVERSATION, 1);
+    expect(reclaimed, 'a settled window is not re-asked').toBe(false);
+  });
+
+  it('is off unless armed, and does not read a mode it was not given', () => {
+    expect(captureCheckpointMode(undefined)).toBe('off');
+    expect(captureCheckpointMode({} as ProjectConfig)).toBe('off');
+    expect(captureCheckpointMode({ capture: {} } as ProjectConfig)).toBe('off');
+    expect(captureCheckpointMode({ capture: { checkpoint: 'off' } } as ProjectConfig)).toBe('off');
+    expect(captureCheckpointMode({ capture: { checkpoint: 'ask' } } as ProjectConfig)).toBe('ask');
+    // A typo falls back to the quieter reading, matching every other capture mode.
+    expect(captureCheckpointMode({ capture: { checkpoint: 'enforce' } } as unknown as ProjectConfig)).toBe('off');
+  });
+
+  it('counts in turns, and the first window needs a real stretch of work', () => {
+    const windowFor = (turns: number) => Math.floor(turns / CHECKPOINT_EVERY_TURNS);
+
+    expect(windowFor(0)).toBe(0);
+    expect(windowFor(CHECKPOINT_EVERY_TURNS - 1)).toBe(0);
+    expect(windowFor(CHECKPOINT_EVERY_TURNS)).toBe(1);
+    expect(windowFor(CHECKPOINT_EVERY_TURNS * 2)).toBe(2);
+  });
+});


### PR DESCRIPTION
Implements #184, folded into the existing posture rather than shipped as its
own opt-in.

`capture.checkpoint` (off by default, `ask` to arm) puts one question into the
mid-turn channel every 20 assistant turns: what is this session currently
relying on that it has not actually verified? A number taken from a summary
rather than the source, a fix called done without re-running its proof, an
attribution never confirmed, one observation generalised into a rule.

IT ASKS THE AGENT AND CALLS NO MODEL, which is the one real departure from the
issue and the reason it can be in `posture maximal` at all.

#184 proposed sending the recent window to a judge model, and measured ~90%
precision doing so. That measurement was offline, over recorded sessions, where
a judge is the only thing that COULD answer -- and the issue itself credits the
result to the answerer having the full live context. In a live session the agent
already has it. So a prompt costs nothing, needs no provider, and keeps the
capture path free of network calls.

That last part is not a preference. `agent-hook` is a fresh process per tool
call, hundreds per session; an inline model call there blocks every tool the
agent runs. The alternative -- a detached background process writing flags for a
later event to surface -- is a much larger change for a feature nobody has run
in production yet.

The honest cost of the swap, stated because it is not nothing: a self-audit is
not the same instrument as an independent judge, so #184's precision number does
NOT transfer and this ships unmeasured on that axis. It is off by default and
the harness in the issue re-runs against it.

IT NEVER WITHHOLDS A STOP. Flags are recorded as pending lessons so a durable
write settles them like any other -- `resolveLessonsBefore` is kind-agnostic --
but `openPendingLessons` is now filtered to BLOCKING_KINDS and `assumption` is
not one. That read has exactly one consumer, the stop gate, so an unfiltered
kind is a kind that can block: this is what the issue meant by "as a question,
never a block", and it needed a guard rather than a convention.

Placement in the contended single mid-turn slot: below every observed-event
branch (change card, destructive lesson, skill nudges, turn capture) and above
the continuation reminder. It must not displace something that HAPPENED, and it
is strictly better than the byte-identical generic nudge it sits above -- the
same trade the skill nudges already make. It deliberately does not reset the
drift counter: that is a "go use memory" signal, and zeroing it on a timer would
mute the reminder for sessions genuinely ignoring Knowl.

No migration. `pending_lessons.kind` carries no CHECK constraint, and the window
number as `class` reuses the existing one-row-per-conversation-and-class shape,
so two hook processes racing the same window resolve without new machinery.

The turn count is read only when the mode is armed, so anyone who has not turned
it on pays nothing. Counted in turns rather than tool events for the same reason
MIN_SUBSTANTIVE_TURNS is: the sessions worth checkpointing are long on reasoning
and short on tools.

Verified: build, 3531 passed / 5 skipped, typecheck, docs:check, eslint clean.