### PR TITLE
feat(capture): turn an answered question into a decision memory

### DIFF
--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -161,6 +161,52 @@ function toolCaptureKey(toolName: string, input: Record<string, unknown>): strin
   }
 }
 
+/**
+ * The decision a user just made, when the tool they answered was a question.
+ *
+ * `decision` events have had an extractor since the beginning (`session-candidates.ts`, the
+ * rule that turns one into a decision atom) and NOTHING has ever emitted one -- measured at
+ * zero across the whole store. This is the emitter. A question the user actually answered is
+ * the highest-signal capture point in a session: a real choice, made by a person, with the
+ * options they rejected sitting next to it.
+ *
+ * WHAT IS DEPRECIATED ON PURPOSE: only the question header and the label of the option chosen,
+ * and only when that label matches one the tool itself offered. Both are text the AGENT wrote.
+ * A free-text "Other" answer and any notes the user typed are dropped, because the hook
+ * boundary does not carry user prose -- the same rule that keeps prompts, stdout and diffs out
+ * of capture, and the one the README's "never prompts, transcripts" promise rests on. Matching
+ * against the offered labels enforces that mechanically instead of trusting a field name.
+ */
+function questionDecision(input: Record<string, unknown>, raw: Record<string, unknown>): string | undefined {
+  const questions = Array.isArray(input.questions) ? input.questions : undefined;
+  if (!questions) return undefined;
+  // Hosts have put the selections in either place; neither spelling is guaranteed across
+  // versions, so read both rather than pick one and silently capture nothing when it moves.
+  const answers = recordValue(recordValue(raw.tool_response)?.answers)
+    ?? recordValue(recordValue(raw.toolResponse)?.answers)
+    ?? recordValue(input.answers);
+  if (!answers) return undefined;
+  const decided: string[] = [];
+  for (const entry of questions) {
+    const question = recordValue(entry);
+    if (!question) continue;
+    const asked = stringValue(question.question);
+    if (!asked) continue;
+    const chosen = stringValue(answers[asked]);
+    if (!chosen) continue;
+    const offered = (Array.isArray(question.options) ? question.options : [])
+      .map(option => stringValue(recordValue(option)?.label))
+      .filter((label): label is string => Boolean(label));
+    // An answer that is not one of the offered labels is the user's own words. Drop it.
+    if (!offered.includes(chosen)) continue;
+    const rejected = offered.filter(label => label !== chosen);
+    decided.push(rejected.length > 0
+      ? `${stringValue(question.header) ?? asked}: ${chosen} (over ${rejected.join(', ')})`
+      : `${stringValue(question.header) ?? asked}: ${chosen}`);
+  }
+  return decided.length > 0 ? decided.join('; ').slice(0, MAX_STRING) : undefined;
+}
+
 function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: Record<string, unknown>): Pick<NormalizedHostHook, 'type' | 'payload' | 'status' | 'toolName' | 'knowlTool' | 'knowlToolName' | 'knowlChangeKeys' | 'captureKey'> {
   const input = toolInput(raw);
   const toolName = stringValue(raw.tool_name) ?? stringValue(raw.toolName) ?? '';
@@ -177,6 +223,8 @@ function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: 
   if (isShell) return { ...commandEvent(projectRoot, raw), status: typeof raw.exit_code === 'number' && raw.exit_code !== 0 ? 'failed' : undefined, ...named, knowlTool, ...changeKeys };
 
   const captureKey = toolCaptureKey(toolName, input);
+  const decision = questionDecision(input, raw);
+  if (decision) return { type: 'decision', payload: { text: decision }, ...named, knowlTool, captureKey, ...changeKeys };
   const paths = changedPaths(projectRoot, { ...raw, ...input });
   if (paths.length > 0) return { type: 'checkpoint', payload: { changedPaths: paths }, ...named, knowlTool, captureKey, ...changeKeys };
   return { type: 'checkpoint', payload: { summary: `${toolName || 'Tool'} completed`.slice(0, MAX_STRING) }, ...named, knowlTool, captureKey, ...changeKeys };

--- a/tests/cli/host-hook.test.ts
+++ b/tests/cli/host-hook.test.ts
@@ -69,6 +69,45 @@ describe('host hook normalization', () => {
     expect(JSON.stringify([success, failure])).not.toContain('discard me');
   });
 
+  it('turns an answered question into a decision event carrying the rejected options', () => {
+    const result = normalizeHostHook('claude', 'PostToolUse', {
+      session_id: 'session-decision',
+      cwd: ROOT,
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [{
+          question: 'Which database should we use?',
+          header: 'Database',
+          options: [{ label: 'SQLite' }, { label: 'Postgres' }, { label: 'MongoDB' }],
+        }],
+      },
+      tool_response: { answers: { 'Which database should we use?': 'SQLite' } },
+    });
+
+    expect(result.type).toBe('decision');
+    expect(result.payload).toMatchObject({ text: 'Database: SQLite (over Postgres, MongoDB)' });
+  });
+
+  it('drops a free-text answer rather than storing words the user typed', () => {
+    const result = normalizeHostHook('claude', 'PostToolUse', {
+      session_id: 'session-freetext',
+      cwd: ROOT,
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [{
+          question: 'Which database should we use?',
+          header: 'Database',
+          options: [{ label: 'SQLite' }, { label: 'Postgres' }],
+        }],
+      },
+      tool_response: { answers: { 'Which database should we use?': 'Private answer nobody offered' } },
+    });
+
+    // Not a decision, and the sentence the user typed reaches no field of the event.
+    expect(result.type).toBe('checkpoint');
+    expect(JSON.stringify(result)).not.toContain('Private answer');
+  });
+
   it('normalizes Cursor shell and file-edit events', () => {
     const command = normalizeHostHook('cursor', 'afterShellExecution', {
       conversation_id: 'session-3',


### PR DESCRIPTION
## Why this is 87 lines and not a subsystem

`session-candidates.ts` has had a rule since the beginning that promotes a `decision` session event into a decision atom. A measurement of the live store found **zero decision events had ever been written** — the extractor was built and starving. `'decision'` is already a valid `SessionEventType` and `text` is already in the generic normalizer's payload allowlist, so all that was missing is an emitter.

## Where it fires

`toolEvent` in `src/cli/agents/host-hook.ts`, on the existing PostToolUse path. AskUserQuestion is a tool rather than a hook event, so nothing new is registered with any host. Answers are read from `tool_response.answers`, `toolResponse.answers` or `input.answers` — three spellings because none is guaranteed across versions.

## The privacy cut

Only the question header and the label of the chosen option are captured, and only when that label matches one the tool itself offered. Both are agent-authored strings. A free-text "Other" answer and any user notes are dropped. Matching against the offered labels enforces the hook boundary's "never prompts, transcripts, stdout" rule mechanically instead of trusting a field name. Rejected options ride along as `(over X, Y)` — the alternatives not taken are exactly what re-reading the code can never recover.

## Not done deliberately

No posture key. `capture.checkpoint` (#192) defaults off because it spends a turn asking the agent a question; this spends no turn and calls no model, so gating it would only keep it as inert as the extractor it feeds.

## Verification

- `npm run build` — success
- `npm test` — 365 files, 3533 passed, 5 skipped
- `tsc --noEmit` — clean
- `git diff --check` — clean

Two tests cover it: an answered question becomes a decision event carrying the rejected options, and a free-text answer stays a checkpoint with the typed words absent from every field.