### PR TITLE
feat(gc): protect memory an agent keeps re-deriving for itself

### DIFF
--- a/src/store/access-feedback.ts
+++ b/src/store/access-feedback.ts
@@ -37,6 +37,23 @@ function generateId(): string {
   return crypto.randomUUID().replace(/-/g, '').slice(0, 16);
 }
 
+/**
+ * Surfaces that record something other than the ranker choosing to show an item.
+ *
+ * `feedback` is an agent reporting on an item it already had. `rederived` is a write the store
+ * recognised as something it already holds -- the agent concluded it again from scratch. Neither
+ * is a read, and counting either as one would inflate `retrievalCount`, which is the number
+ * behind the never-read lens and behind GC's `isHot`. That number has been measured and argued
+ * about; quietly widening what it counts would invalidate every one of those measurements.
+ */
+const REDERIVED_SURFACE = 'rederived';
+
+/**
+ * SQL fragment rather than a bound parameter: both queries below are aggregates run with no
+ * args, and these values are compile-time constants, never anything a caller supplies.
+ */
+const IS_RETRIEVAL = `surface NOT IN ('feedback', '${REDERIVED_SURFACE}')`;
+
 function fingerprint(query?: string): string | null {
   return query ? crypto.createHash('sha256').update(query).digest('hex') : null;
 }
@@ -93,6 +110,28 @@ export async function recordKnowledgeFeedback(input: Omit<KnowledgeAccessInput, 
   return recordKnowledgeAccess({ ...input, surface: 'feedback', rank: 0 });
 }
 
+/**
+ * Record that a write turned out to be something the store already holds.
+ *
+ * This is the only POSITIVE capture signal in the system: every other rule says what not to
+ * store. An agent that reaches the same conclusion again, in a later session, without the store
+ * having handed it the answer, is evidence the fact is load-bearing -- and unlike a read it is
+ * not the ranker's opinion, it is the agent's own reasoning over the code arriving in the same
+ * place twice.
+ *
+ * It is NOT the retrieval feedback loop the store refuses elsewhere: a no-op write stores
+ * nothing, so no amount of re-derivation can multiply copies of a bad atom. Dedup is what
+ * stands in the way of that loop, and this counts the times dedup fired.
+ *
+ * ponytail: an agent that retrieved the atom this session and then re-stored it verbatim also
+ * lands here, and `knowledge_access` has no session column to tell the two apart. That inflates
+ * the count without creating atoms or ranking pressure, which is why this protects from GC and
+ * is deliberately not wired into ranking. Wire it there only behind a measurement.
+ */
+export async function recordRederivationBestEffort(itemId: string): Promise<void> {
+  await recordKnowledgeAccessBestEffort({ itemId, surface: REDERIVED_SURFACE, rank: 0 });
+}
+
 export async function listKnowledgeAccess(itemId: string): Promise<KnowledgeAccess[]> {
   const result = await getClient().execute({
     // Ties break on rowid, not id. `retrieved_at` is millisecond text, so an access and the
@@ -120,7 +159,7 @@ export async function getKnowledgeAccessReport(): Promise<{
 }> {
   const result = await getClient().execute(`
     SELECT ki.id AS item_id, ki.title, ki.freshness,
-      SUM(CASE WHEN ka.surface != 'feedback' THEN 1 ELSE 0 END) AS retrieval_count,
+      SUM(CASE WHEN ka.${IS_RETRIEVAL} THEN 1 ELSE 0 END) AS retrieval_count,
       SUM(CASE WHEN ka.useful = 1 THEN 1 ELSE 0 END) AS useful_count,
       SUM(CASE WHEN ka.caused_correction = 1 THEN 1 ELSE 0 END) AS caused_correction_count
     FROM knowledge_items ki
@@ -135,20 +174,35 @@ export async function getKnowledgeAccessReport(): Promise<{
   };
 }
 
-export type KnowledgeAccessSummary = { retrievalCount: number; lastRetrievedAt: string };
+export type KnowledgeAccessSummary = {
+  retrievalCount: number;
+  /**
+   * Null when an item has only ever been re-derived and never retrieved. A caller that reads
+   * this as a date must handle that: treating the absence as "read just now" is how a
+   * never-read atom would silently become protected.
+   */
+  lastRetrievedAt: string | null;
+  /** Times a write was recognised as something the store already held. */
+  rederivedCount: number;
+};
 
 // Per-item retrieval frequency and recency — used by GC to protect hot memory
 // from decay and to collect only genuinely cold items.
 export async function getAccessSummary(): Promise<Map<string, KnowledgeAccessSummary>> {
   const rows = (await getClient().execute(`
-    SELECT knowledge_item_id, COUNT(*) AS retrieval_count, MAX(retrieved_at) AS last_retrieved_at
-    FROM knowledge_access WHERE surface != 'feedback' GROUP BY knowledge_item_id
+    SELECT knowledge_item_id,
+      SUM(CASE WHEN ${IS_RETRIEVAL} THEN 1 ELSE 0 END) AS retrieval_count,
+      MAX(CASE WHEN ${IS_RETRIEVAL} THEN retrieved_at END) AS last_retrieved_at,
+      SUM(CASE WHEN surface = '${REDERIVED_SURFACE}' THEN 1 ELSE 0 END) AS rederived_count
+    FROM knowledge_access GROUP BY knowledge_item_id
   `)).rows;
   const summary = new Map<string, KnowledgeAccessSummary>();
   for (const row of rows) {
     summary.set(String(row.knowledge_item_id), {
       retrievalCount: Number(row.retrieval_count),
-      lastRetrievedAt: String(row.last_retrieved_at),
+      // Null survives as null: an item with only re-derivations has no read to date.
+      lastRetrievedAt: row.last_retrieved_at == null ? null : String(row.last_retrieved_at),
+      rederivedCount: Number(row.rederived_count),
     });
   }
   return summary;

--- a/src/store/gc.ts
+++ b/src/store/gc.ts
@@ -48,12 +48,21 @@ const DEFAULT_MIN_COMPRESS_BYTES = 180;
 // even once it passes the staleness age, so useful memory is not archived away.
 const HOT_RETRIEVAL_COUNT = 3;
 const HOT_RECENT_DAYS = 21;
+// One re-derivation can be a coincidence of phrasing; two is the fact earning its place --
+// the same bar and the same reasoning as VERIFY_THRESHOLD in tier.ts.
+const HOT_REDERIVED_COUNT = 2;
 
 export function isHot(itemId: string, access: Map<string, KnowledgeAccessSummary>, now: Date): boolean {
   const a = access.get(itemId);
   if (!a) return false;
   if (a.retrievalCount >= HOT_RETRIEVAL_COUNT) return true;
-  return daysSince(a.lastRetrievedAt, now) <= HOT_RECENT_DAYS;
+  // An item the agent keeps concluding for itself is load-bearing whether or not anything ever
+  // retrieved it -- which is the case the read-side signals cannot see at all, because a fact
+  // nobody queries for is exactly the one that looks cold right up until it matters.
+  if (a.rederivedCount >= HOT_REDERIVED_COUNT) return true;
+  // Null means never retrieved. Reading that as a recent read would protect the whole
+  // never-read population, which is the opposite of what this function is for.
+  return a.lastRetrievedAt !== null && daysSince(a.lastRetrievedAt, now) <= HOT_RECENT_DAYS;
 }
 const PROTECTED_CATEGORIES = new Set<KnowledgeCategory>([
   'decision',

--- a/src/store/knowledge-writer.ts
+++ b/src/store/knowledge-writer.ts
@@ -10,6 +10,7 @@ import type { ActiveWorkspace } from '../workspace/resolve.js';
 import { attachEvidenceToKnowledge, listEvidenceForItem, normalizeEvidenceLocator } from './evidence-repository.js';
 import { normalizeAffectedPaths } from './freshness.js';
 import { indexKnowledgeItemsBestEffort } from './write-embedding.js';
+import { recordRederivationBestEffort } from './access-feedback.js';
 import { governingDecisionForWrite, type GoverningDecision } from './governing-decision.js';
 
 /**
@@ -766,6 +767,9 @@ export async function storeKnowledgeItemDeduped(
     ? resolveDuplicate(input, duplicate, await heldPayloadFor(input, duplicate))
     : null;
   if (duplicate && resolution === 'no-op' && !input.supersedes) {
+    // The agent reached this conclusion again and the store already had it. That is the one
+    // positive capture signal in the system, and until now it was computed and discarded.
+    await recordRederivationBestEffort(duplicate.id);
     return { action: 'duplicate', item: duplicate };
   }
 
@@ -887,6 +891,7 @@ export async function storeKnowledgeAtomsDeduped(
         ? resolveDuplicate(atom, duplicate, await heldPayloadFor(atom, duplicate))
         : null;
       if (duplicate && resolution === 'no-op' && !atom.supersedes) {
+        await recordRederivationBestEffort(duplicate.id);
         itemIds.push(duplicate.id);
         duplicateCount++;
         outcomes.push({ action: 'duplicate', itemId: duplicate.id, title: atom.title });

--- a/tests/store/rederivation-signal.test.ts
+++ b/tests/store/rederivation-signal.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { getAccessSummary } from '../../src/store/access-feedback.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { previewKnowledgeGc } from '../../src/store/gc.js';
+
+/**
+ * A no-op duplicate write means an agent concluded something the store already held, without the
+ * store having handed it over. It is the only positive capture signal in the system, and it used
+ * to be computed and thrown away. These pin the two halves of what it is now allowed to do:
+ * protect an item from decay, and stay out of the retrieval numbers while doing it.
+ */
+
+const ROOT = path.resolve('./.knowl-rederivation-test');
+const OLD = new Date(Date.now() - 90 * 86_400_000).toISOString();
+const NOW = new Date().toISOString();
+
+async function backdate(itemId: string) {
+  await getClient().execute({ sql: 'UPDATE knowledge_items SET updated_at = ? WHERE id = ?', args: [OLD, itemId] });
+}
+
+const state = (title: string, content: string) => ({ category: 'state' as const, title, content });
+
+describe('re-derivation signal', () => {
+  let projectId = '';
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'rederivation')).id;
+  });
+  afterAll(async () => { await closeDb(); await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {}); });
+
+  it('counts a no-op duplicate write without calling it a retrieval', async () => {
+    const atom = state('Vector index rebuild runs nightly', 'The rebuild is scheduled at 02:00 and takes about four minutes.');
+    const first = await storeKnowledgeItemDeduped(projectId, atom);
+    expect(first.action).not.toBe('duplicate');
+
+    const second = await storeKnowledgeItemDeduped(projectId, atom);
+    expect(second.action).toBe('duplicate');
+    expect(second.item.id).toBe(first.item.id);
+
+    const summary = (await getAccessSummary()).get(first.item.id);
+    expect(summary?.rederivedCount).toBe(1);
+    // The whole reason for a separate surface: the never-read lens and `isHot` both read these
+    // two, and a write must not make an atom look like it was read.
+    expect(summary?.retrievalCount).toBe(0);
+    expect(summary?.lastRetrievedAt).toBeNull();
+  });
+
+  it('protects a stale item re-derived twice, and archives one re-derived once', async () => {
+    const twice = state('Session ids are host-scoped', 'A host session id is unique per host, not globally.');
+    const once = state('Snapshot files are gzip framed', 'Every snapshot payload carries a gzip frame header.');
+    const repeated = (await storeKnowledgeItemDeduped(projectId, twice)).item;
+    const single = (await storeKnowledgeItemDeduped(projectId, once)).item;
+
+    await storeKnowledgeItemDeduped(projectId, twice);
+    await storeKnowledgeItemDeduped(projectId, twice);
+    await storeKnowledgeItemDeduped(projectId, once);
+
+    await backdate(repeated.id);
+    await backdate(single.id);
+
+    const result = await previewKnowledgeGc(projectId, { now: NOW });
+    const archived = result.candidates.filter(candidate => candidate.action === 'archive').map(candidate => candidate.itemId);
+    expect(archived).not.toContain(repeated.id);
+    // One re-derivation is under the bar -- a single phrasing coincidence must not pin an atom
+    // in place forever, or nothing stale would ever be collected.
+    expect(archived).toContain(single.id);
+
+    // --ignore-access still overrides it, same as for a retrieved item.
+    const forced = await previewKnowledgeGc(projectId, { now: NOW, ignoreAccess: true });
+    expect(forced.candidates.filter(c => c.action === 'archive').map(c => c.itemId)).toContain(repeated.id);
+  });
+});


### PR DESCRIPTION
## What

A no-op duplicate write means an agent concluded something the store already held, without the store having handed it the answer. That is the only *positive* capture signal in the system — every other rule says what not to store — and until now it was computed and thrown away.

It is now recorded as a `knowledge_access` row under a new `rederived` surface, and two of them protect an item from GC decay the way three retrievals already do.

## Why the read-side signals miss this

`isHot` protects on retrieval count and recency. Both are the ranker's opinion of an item. An atom nobody queries for looks cold right up until the moment it matters — and re-derivation is the one case that catches it, because it is the agent's own reasoning over the code arriving in the same place twice.

## Why a separate surface

`retrievalCount` backs the never-read lens and `isHot`. Quietly widening what it counts would invalidate every measurement taken against it, so `getAccessSummary` now splits retrievals from re-derivations, and `lastRetrievedAt` is `null` for an item that has only ever been re-derived. The null is handled explicitly in `isHot` — reading it as a recent read would have protected the entire never-read population, the exact opposite of what the function is for.

## Not wired into ranking

An agent that retrieved an atom this session and then re-stored it verbatim lands in the same counter, and `knowledge_access` has no session column to tell the two apart. Protecting from decay is safe under that ambiguity; ranking pressure would not be. Marked with a `ponytail:` comment naming the ceiling.

It is also not the retrieval feedback loop the store refuses elsewhere: a no-op write stores nothing, so no amount of re-derivation can multiply copies of a bad atom. Dedup is what stands in the way of that loop, and this counts the times dedup fired.

## Threshold

`HOT_REDERIVED_COUNT = 2` — one re-derivation can be a phrasing coincidence; two is the fact earning its place. Same bar and same reasoning as `VERIFY_THRESHOLD`.

## Tests

`tests/store/rederivation-signal.test.ts`:
- a no-op duplicate write bumps `rederivedCount` and leaves `retrievalCount` at 0 with a null `lastRetrievedAt`
- a stale item re-derived twice survives GC; one re-derived once is still archived
- `--ignore-access` still overrides the protection

Full set green: build, 3535 tests, typecheck.
