### PR TITLE
fix(ci): fail loudly when the optional embedding stack is rolled back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # `@huggingface/transformers` is an optionalDependency so that a CDN blip on
+      # `onnxruntime-node`'s postinstall cannot fail a user's install. The cost of that is
+      # paid here: when the blip happens, npm rolls the whole optional subtree back and `npm
+      # ci` still exits 0, so CI would go on to run the suite with no embedding model at all.
+      # Three suites load a real one -- that is what the cache above exists for -- and they
+      # fail three minutes later with `Cannot find package`, which reads like a code bug.
+      #
+      # Observed on `44f5a8a`: green on three legs, this failure on ubuntu/22 alone.
+      #
+      # So say it here instead. One retry, because the blip is transient by definition; if it
+      # is still missing after that, fail loudly rather than silently lose the semantic path.
+      - name: Verify the optional embedding stack installed
+        shell: bash
+        run: |
+          have() { test -d node_modules/@huggingface/transformers && test -d node_modules/onnxruntime-node; }
+          if ! have; then
+            echo "::warning::optional embedding stack was rolled back by npm ci -- retrying once"
+            npm ci
+          fi
+          if ! have; then
+            echo "::error::@huggingface/transformers or onnxruntime-node is missing after npm ci."
+            echo "The optional install failed twice. Every suite on the semantic path would now"
+            echo "fail with 'Cannot find package' for a reason that has nothing to do with the change."
+            exit 1
+          fi
+
       - name: Check version sync
         run: npm run check:versions
 


### PR DESCRIPTION
## main is red, and this is why

`44f5a8a` (making `@huggingface/transformers` an `optionalDependency`) went green on three of four test legs and failed on `ubuntu-latest, node 22` with:

```
Error: Cannot find package '@huggingface/transformers' imported from src/ai/embeddings.ts
```

Roughly 40 tests across `cross-repo-semantic`, `workspace-query`, `federated-query` and the retrieval-evaluation suites went down with it.

## What actually happened

Making the package optional stopped a CDN blip from failing a *user's* install. It also stopped it from failing *CI's*, and those are not the same thing.

When `onnxruntime-node`'s postinstall times out — the same `ETIMEDOUT` that failed #195's install outright, back when the dependency was required — npm rolls the whole optional subtree back and `npm ci` still exits 0. Three suites load a real embedding model; the model cache in this same job exists for them. So the job installs nothing, builds fine, and fails three minutes later with an error that reads like a bug in the change under test.

The trade #196 made was right for users and wrong for CI, silently. This makes it loud for CI only.

## The change

One step after `npm ci`: check both package directories, retry once because the blip is transient by definition, then fail with a message naming the cause.

## User-facing behaviour is unchanged

An install that hits the blip still succeeds. `resolveEmbedder` returns null and retrieval reports `degraded`; doctor's `vectorCoverageCheck` reports zero of N active items embedded. That path is not touched here.

## Correction to #196

Its description claimed the move was coverage-neutral because embedding tests inject `loadPipeline`. That is true of `write-embedding.test.ts` and friends; it is not true of the semantic-path suites, which import the real package. The dependency change stands — the claim about its blast radius did not.
