### PR TITLE
feat(update): let knowl_update correct a misfiled category

### DIFF
--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -619,6 +619,11 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
                 minLength: 1,
                 description: 'New content markdown.',
               },
+              category: {
+                type: 'string',
+                enum: ['fact', 'decision', 'goal', 'constraint', 'architecture', 'state', 'skill'],
+                description: 'Corrected category, when an item was filed as the wrong kind of thing. Use it rather than re-storing the item: category is what garbage collection reads, so an item that is really a decision but filed as state is on the archive path, and re-storing to fix that discards the assertion history and access record that show it mattered.',
+              },
               status: {
                 type: 'string',
                 enum: ['active', 'deprecated', 'rejected', 'archived', 'superseded'],

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1459,7 +1459,7 @@ export function registerTools(
       }
       
       else if (name === 'knowl_update') {
-        const { id, title, content, status, reasoning, source, sourceCommit, affectedPaths, freshness, supersedeId } = args as any;
+        const { id, title, content, category, status, reasoning, source, sourceCommit, affectedPaths, freshness, supersedeId } = args as any;
         const owner = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
         // Both ids, not just the one being edited. Retiring an item is a write to that item,
         // and `supersedeId` reached `supersedeKnowledgeItem` with no ownership check at all
@@ -1481,6 +1481,7 @@ export function registerTools(
         const updated = await updateKnowledgeItemWithCommit(projectId!, id, {
           title,
           content,
+          category: category as KnowledgeCategory,
           status: status as KnowledgeStatus,
           reasoning,
           source,

--- a/src/store/freshness.ts
+++ b/src/store/freshness.ts
@@ -58,6 +58,7 @@ export function hashKnowledgeLifecycle(input: {
   supersededById?: string | null;
   originRepo?: string | null;
   visibility?: string | null;
+  category?: string | null;
 }): string {
   const fingerprint = {
     status: input.status ?? 'active',
@@ -65,6 +66,14 @@ export function hashKnowledgeLifecycle(input: {
     supersededById: input.supersededById ?? null,
     originRepo: input.originRepo ?? null,
     visibility: input.visibility ?? 'repo',
+    // Here rather than in `content_hash` because a re-category leaves every word of the item
+    // alone. It is a lifecycle change in the literal sense: `category` is what GC archives on
+    // (`state` only) and what it refuses to purge (decision, constraint, architecture, skill),
+    // so promoting an atom out of `state` changes how long it lives and nothing else. Without
+    // it here, `classifyIncomingItem` compares two identical content hashes, finds matching
+    // lifecycle hashes, and calls the pair `identical` -- the re-category never travels, which
+    // is the same bug status and visibility had before this hash existed.
+    category: input.category ?? null,
   };
 
   return createHash('sha256')

--- a/src/store/knowledge-actions.ts
+++ b/src/store/knowledge-actions.ts
@@ -1,4 +1,4 @@
-import { ProjectConfig, CommitChange, EvidenceInput, KnowledgeItem, KnowledgeStatus } from '../core/types.js';
+import { ProjectConfig, CommitChange, EvidenceInput, KnowledgeCategory, KnowledgeItem, KnowledgeStatus } from '../core/types.js';
 import * as repo from './repository.js';
 import { crossRepoOverlapForWrite, findLikelyDuplicateKnowledgeItem, heldPayloadFor, resolveDuplicate } from './knowledge-writer.js';
 import type { CrossRepoOverlap } from '../workspace/cross-repo-overlap.js';
@@ -149,6 +149,15 @@ export async function updateKnowledgeItemWithCommit(
   updates: {
     title?: string;
     content?: string;
+    /**
+     * Correcting what kind of thing an item is, without rewriting it. A capture that landed as
+     * `state` and turned out to be a standing decision could previously only be fixed by storing
+     * it again and retiring the original, which throws away its assertion history, its access
+     * telemetry and its re-derivation count -- the evidence that it mattered -- to change one
+     * enum. The category is also the only thing GC reads to decide whether an item is archivable
+     * at all, so the misfiled copy was the one being collected.
+     */
+    category?: KnowledgeCategory;
     status?: KnowledgeStatus;
     reasoning?: string;
     source?: string | null;

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -194,7 +194,7 @@ export async function createKnowledgeItem(
     // reconciles and nothing reports.
     visibility,
     lifecycleHash: hashKnowledgeLifecycle({
-      status: 'active', freshness, supersededById: null, originRepo, visibility,
+      status: 'active', freshness, supersededById: null, originRepo, visibility, category: item.category,
     }),
     freshness,
     confidence: item.confidence ?? 1.0,
@@ -385,6 +385,7 @@ export async function updateKnowledgeItem(
       supersededById: updates.supersededById !== undefined ? updates.supersededById : current[0].supersededById,
       originRepo: updates.originRepo !== undefined ? updates.originRepo : current[0].originRepo,
       visibility: updates.visibility !== undefined ? updates.visibility : current[0].visibility,
+      category: updates.category !== undefined ? updates.category : current[0].category,
     };
 
     // Normalized here as well as on create. A key written raw through update never collides

--- a/tests/store/recategorize.test.ts
+++ b/tests/store/recategorize.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { updateKnowledgeItemWithCommit } from '../../src/store/knowledge-actions.js';
+import { hashKnowledgeLifecycle } from '../../src/store/freshness.js';
+import { classifyIncomingItem } from '../../src/store/import-policy.js';
+
+/**
+ * Correcting a misfiled category without rewriting the item.
+ *
+ * The point is not the enum. `category` is the only thing GC reads to decide whether an item is
+ * archivable at all, so an atom that is really a decision but was captured as `state` is on the
+ * archive path -- and the only previous fix was to store it again and retire the original, which
+ * throws away exactly the record showing it mattered.
+ */
+
+const ROOT = path.resolve('./.knowl-recategorize-test');
+
+describe('re-categorizing an item', () => {
+  let projectId = '';
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'recategorize')).id;
+  });
+  afterAll(async () => { await closeDb(); await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {}); });
+
+  it('promotes a state atom to a decision, keeping its identity and its words', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'state',
+      title: 'Retries are capped at three attempts',
+      content: 'Three, chosen because the fourth attempt never once succeeded in the sampled runs.',
+    });
+
+    const updated = await updateKnowledgeItemWithCommit(projectId, item.id, { category: 'decision' }, { projectRoot: ROOT });
+
+    expect(updated.id).toBe(item.id);
+    expect(updated.category).toBe('decision');
+    // The words did not change, so neither does the fingerprint over them -- a re-category is
+    // not an edit, and must not read as one to drift or to import's divergence check.
+    expect(updated.contentHash).toBe(item.contentHash);
+    expect(updated.title).toBe(item.title);
+    expect(updated.content).toBe(item.content);
+
+    // The commit log carries it, so the change is attributable rather than a silent mutation.
+    const reread = await repo.getKnowledgeItem(item.id);
+    expect(reread?.category).toBe('decision');
+  });
+
+  it('moves the lifecycle hash, so the change can travel through an export', () => {
+    const base = { status: 'active', freshness: 'fresh', supersededById: null, originRepo: null, visibility: 'repo' };
+    const asState = hashKnowledgeLifecycle({ ...base, category: 'state' });
+    const asDecision = hashKnowledgeLifecycle({ ...base, category: 'decision' });
+    expect(asState).not.toBe(asDecision);
+
+    // Without category in that hash this pair is `identical` and the plan skips it: same words,
+    // same content hash, and the receiving side keeps the misfiled category forever. That is the
+    // bug status and visibility had before the lifecycle hash existed.
+    const contentHash = 'same-words';
+    expect(classifyIncomingItem(
+      { id: 'a', contentHash, updatedAt: '2026-07-09T00:00:00.000Z', version: 2, lifecycleHash: asDecision },
+      { id: 'a', contentHash, updatedAt: '2026-07-01T00:00:00.000Z', version: 1, lifecycleHash: asState },
+    )).toBe('metadata-divergent');
+  });
+});

--- a/tests/store/write-visibility.test.ts
+++ b/tests/store/write-visibility.test.ts
@@ -62,7 +62,7 @@ describe('default write visibility', { timeout: 60_000 }, () => {
     // permanent divergence that change-watermark and import-policy would never reconcile.
     expect(row.lifecycle_hash).toBe(hashKnowledgeLifecycle({
       status: 'active', freshness: DEFAULT_FRESHNESS, supersededById: null,
-      originRepo: 'notes', visibility: 'workspace',
+      originRepo: 'notes', visibility: 'workspace', category: 'fact',
     }));
     await closeDb();
   });
@@ -79,7 +79,7 @@ describe('default write visibility', { timeout: 60_000 }, () => {
     expect(row.visibility).toBe('repo');
     expect(row.lifecycle_hash).toBe(hashKnowledgeLifecycle({
       status: 'active', freshness: DEFAULT_FRESHNESS, supersededById: null,
-      originRepo: 'notes', visibility: 'repo',
+      originRepo: 'notes', visibility: 'repo', category: 'fact',
     }));
     await closeDb();
   });


### PR DESCRIPTION
## The gap

`knowl_update` could change title, content, status, reasoning, source, sourceCommit, affectedPaths and freshness — but not `category`. An item captured as `state` that turns out to be a standing decision could only be fixed by storing it again and retiring the original, which throws away its assertion history, its access telemetry and its re-derivation count to change one enum.

## Why category isn't cosmetic

It is the only field GC reads to decide whether an item is archivable at all. Archive targets `state` alone; purge skips `decision`, `constraint`, `architecture` and `skill`. So the misfiled item is precisely the one on the collection path — and the only fix for it was the operation that erased the evidence against collecting it.

## The part that isn't a one-liner

`category` now joins `hashKnowledgeLifecycle`.

A re-category leaves every word of the item alone, so `content_hash` doesn't move. Without category in the lifecycle hash either, `classifyIncomingItem` compares two identical content hashes, finds matching lifecycle hashes, and returns `identical` — the plan skips the item and the correction never travels through an export. That is exactly the bug `hashKnowledgeLifecycle` was created to fix for status, visibility and supersession.

**One-time effect:** widening it moves every existing row's lifecycle hash. `lifecycleFingerprint` prefers a stored hash over a recomputed one, so same-build pairs still agree. A mixed-build import sees one round of `metadata-divergent`, which resolves under the existing `newer` policy rather than losing anything. Chose that over a backfill migration — it is one noisy sync, not a correctness hole.

## What is deliberately unchanged

- A category change does not refresh freshness. It does not change the claim, so it should not read as a review.
- `content_hash` is untouched, so drift and the divergence check still see the item as unedited.
- No restriction on which transitions are allowed. `knowl_store` lets you pick any category; update mirrors it rather than inventing a promotion ladder nobody asked for.

## Tests

`tests/store/recategorize.test.ts` — a `state` atom promoted to `decision` keeps its id, title, content and `content_hash`; the lifecycle hash moves; the resulting pair classifies `metadata-divergent` rather than `identical`.

`tests/store/write-visibility.test.ts` needed the category threaded into its recomputation. That test pins the row and the hash against each other across two stamping sites, and it failed the moment one side moved — which is what it is for.

Full set green: build, 367 test files / 3535 tests, typecheck.
