### PR TITLE
fix(feedback): flag the corrected item, not only its siblings

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1445,9 +1445,15 @@ export function registerTools(
         const tierNote = tierChange
           ? `\n\nStanding: item ${tierChange.reason} to ${tierChange.tier}.`
           : '';
-        const blastNote = blast && blast.flaggedIds.length > 0
-          ? `\n\nBlast radius: ${blast.flaggedIds.length} sibling item(s) marked needs_review${blast.capped ? ' (capped)' : ''}.`
-          : '';
+        // Two separate facts. Reporting them as one number is how the missing self-flag hid:
+        // "3 sibling item(s)" read as though the corrected item were among them.
+        const blastParts = [
+          blast?.correctedItemFlagged ? 'this item marked needs_review' : '',
+          blast && blast.flaggedIds.length > 0
+            ? `${blast.flaggedIds.length} sibling item(s) marked needs_review${blast.capped ? ' (capped)' : ''}`
+            : '',
+        ].filter(Boolean);
+        const blastNote = blastParts.length > 0 ? `\n\nReview: ${blastParts.join('; ')}.` : '';
         return { content: [{ type: 'text', text: `Recorded feedback for ${itemId}:\n\n${JSON.stringify(feedback, null, 2)}${tierNote}${blastNote}` }] };
       }
 

--- a/src/store/blast-radius.ts
+++ b/src/store/blast-radius.ts
@@ -25,9 +25,15 @@ export const MAX_BLAST_RADIUS = 12;
 const CANDIDATE_SCAN_LIMIT = 500;
 
 export type BlastRadiusResult = {
+  /** The siblings, never the corrected item itself — see `correctedItemFlagged` for that. */
   flaggedIds: string[];
   /** True when more siblings matched than the cap allowed; the rest were left untouched. */
   capped: boolean;
+  /**
+   * Whether the corrected item itself was flagged. False when it was already inactive, stale
+   * or flagged — so a caller can report what happened without counting it as a sibling.
+   */
+  correctedItemFlagged: boolean;
 };
 
 /**
@@ -136,7 +142,7 @@ async function siblingsFromSharedEvidence(itemId: string): Promise<string[]> {
  * of atoms made a single correction pay hundreds of sequential round trips inside one
  * MCP call. One row over the cap is fetched so the caller can still report the overflow.
  */
-async function eligibleSiblings(candidateIds: string[]): Promise<string[]> {
+async function eligibleForReview(candidateIds: string[]): Promise<string[]> {
   const scanned = candidateIds.slice(0, CANDIDATE_SCAN_LIMIT);
   const placeholders = scanned.map(() => '?').join(', ');
   const rows = (await getClient().execute({
@@ -153,22 +159,39 @@ export async function flagCorrectionSiblings(
   correctedItemId: string,
   reason: string,
 ): Promise<BlastRadiusResult> {
+  // The corrected item is resolved on its own, before the siblings and outside their cap.
+  //
+  // It used to be the one item in the neighbourhood NOT flagged: `siblingsFromInsertCommits`
+  // excludes it by id, so a correction demoted its tier, flipped up to twelve batch-mates to
+  // needs_review on the strength of shared provenance, and left the item the agent actually
+  // named sitting at `fresh`. Measured on this repo's store: of 14 items that ever caused a
+  // correction, 6 were still active and still fresh. Weaker evidence earned the flag and
+  // direct evidence did not.
+  //
+  // Kept out of the candidate pool rather than added to it, for two reasons. The cap below
+  // could drop it in a wide batch — the one item that must never be the one dropped — and the
+  // empty-candidate early-out would skip it entirely for a correction with no siblings at
+  // all, which is the common shape.
+  //
+  // Same eligibility as a sibling, which is what makes this safe on the deprecate/reject path
+  // in `knowledge-actions.ts`: that caller flips status first, so an inactive item filters
+  // itself out here and neither caller needs special-casing.
+  const self = await eligibleForReview([correctedItemId]);
+
   const groups = await Promise.all([
     siblingsFromInsertCommits(correctedItemId),
     siblingsFromSource(correctedItemId),
     siblingsFromSharedEvidence(correctedItemId),
   ]);
   const candidateIds = [...new Set(groups.flat())];
-  if (candidateIds.length === 0) return { flaggedIds: [], capped: false };
-
-  const eligible = await eligibleSiblings(candidateIds);
-  if (eligible.length === 0) return { flaggedIds: [], capped: false };
+  const eligible = candidateIds.length > 0 ? await eligibleForReview(candidateIds) : [];
 
   const capped = eligible.length > MAX_BLAST_RADIUS;
-  const toFlag = eligible.slice(0, MAX_BLAST_RADIUS);
+  const toFlag = [...self, ...eligible.slice(0, MAX_BLAST_RADIUS)];
+  if (toFlag.length === 0) return { flaggedIds: [], capped: false, correctedItemFlagged: false };
 
-  // Full rows are loaded only for what is actually flagged — at most the cap — because the
-  // commit records each item's before state.
+  // Full rows are loaded only for what is actually flagged — at most the cap, plus the
+  // corrected item — because the commit records each item's before state.
   const changes: CommitChange[] = [];
   for (const id of toFlag) {
     const item = await repo.getKnowledgeItem(id);
@@ -176,13 +199,22 @@ export async function flagCorrectionSiblings(
     const updated = await repo.updateKnowledgeItem(id, { freshness: 'needs_review' });
     changes.push({ itemId: id, action: 'update', before: item, after: updated });
   }
+  // `flaggedIds` stays exactly what it has always meant: the siblings. The corrected item is
+  // reported through its own field instead, so no caller has to know to filter an id out of a
+  // list named for something else. Both rows are in the commit either way — the audit trail
+  // records every write, whatever the return shape calls them.
+  const siblingIds = changes.map(change => change.itemId).filter(id => id !== correctedItemId);
   await repo.createKnowledgeCommit(
     projectId,
-    `Correction blast radius: ${changes.length} sibling(s) of ${reason}`,
+    `Correction blast radius: ${siblingIds.length} sibling(s) of ${reason}`,
     changes,
   );
 
-  return { flaggedIds: changes.map(change => change.itemId), capped };
+  return {
+    flaggedIds: siblingIds,
+    capped,
+    correctedItemFlagged: changes.some(change => change.itemId === correctedItemId),
+  };
 }
 
 /**

--- a/tests/store/blast-radius.test.ts
+++ b/tests/store/blast-radius.test.ts
@@ -9,6 +9,7 @@ import { storeKnowledgeAtomsDeduped, storeKnowledgeItemDeduped } from '../../src
 import * as repo from '../../src/store/repository.js';
 
 const ROOT = path.resolve('.knowl-blast-radius-test');
+const SELF_ROOT = path.resolve('.knowl-blast-radius-self-test');
 
 const freshnessOf = async (id: string): Promise<string> => {
   const row = (await getClient().execute({
@@ -303,5 +304,98 @@ describe('K-48: finding the insert commit without scanning the table', () => {
     const left = (await getClient().execute('SELECT COUNT(*) c FROM knowledge_commit_items')).rows[0].c;
     expect(Number(left)).toBe(0);
     void batch;
+  });
+});
+
+/**
+ * The corrected item is the one with direct evidence against it. It used to be the only item
+ * in the neighbourhood left at `fresh` while its batch-mates were flagged on the far weaker
+ * evidence of shared provenance.
+ */
+describe('the corrected item itself', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(SELF_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(SELF_ROOT, '.knowl'), { recursive: true });
+    await initDb(SELF_ROOT);
+    projectId = (await repo.createProject(SELF_ROOT, 'Blast radius self test')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_evidence`);
+    await db.run(sql`DELETE FROM evidence`);
+    await db.run(sql`DELETE FROM knowledge_commits`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(SELF_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('is flagged alongside its siblings, and reported apart from them', async () => {
+    const batch = await storeKnowledgeAtomsDeduped(projectId, [
+      { category: 'fact', title: 'Self alpha', content: 'The atom that misled the agent.' },
+      { category: 'fact', title: 'Self beta', content: 'A batch-mate of the wrong one.' },
+    ]);
+
+    const result = await flagCorrectionSiblings(projectId, batch.itemIds[0], 'a correction');
+
+    expect(await freshnessOf(batch.itemIds[0])).toBe('needs_review');
+    expect(result.correctedItemFlagged).toBe(true);
+    // `flaggedIds` still means the siblings, so no caller has to filter an id out of a list
+    // named for something else.
+    expect(result.flaggedIds).toEqual([batch.itemIds[1]]);
+  });
+
+  it('is flagged even when the correction has no siblings at all', async () => {
+    // The common shape, and the one an empty-candidate early-out used to skip entirely.
+    const lone = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Lone wrong atom', content: 'Written by itself, corrected by itself.',
+    });
+
+    const result = await flagCorrectionSiblings(projectId, lone.item.id, 'a correction');
+
+    expect(await freshnessOf(lone.item.id)).toBe('needs_review');
+    expect(result.correctedItemFlagged).toBe(true);
+    expect(result.flaggedIds).toEqual([]);
+  });
+
+  it('survives a batch wide enough to fill the cap, which it does not compete for', async () => {
+    // Written through `createKnowledgeItem` and a shared source rather than a real batch
+    // write, because titles this close collapse under dedup: `Wide batch member 3` and
+    // `Wide batch member 4` are the same subject once tokenized, so a genuine batch write
+    // supersedes its way down to a single active item and there is no cap left to test.
+    const corrected = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'The wrong member', content: 'The one that misled the agent.', source: 'wide-self-batch',
+    });
+    for (let index = 0; index < MAX_BLAST_RADIUS + 5; index++) {
+      await repo.createKnowledgeItem(projectId, {
+        category: 'fact', title: `Wide self member ${index}`, content: `Member number ${index}.`,
+        source: 'wide-self-batch',
+      });
+    }
+
+    const result = await flagCorrectionSiblings(projectId, corrected.id, 'a correction');
+
+    expect(result.capped).toBe(true);
+    expect(result.flaggedIds).toHaveLength(MAX_BLAST_RADIUS);
+    // The one item that must never be the one dropped, however wide the batch it came from.
+    expect(result.correctedItemFlagged).toBe(true);
+    expect(await freshnessOf(corrected.id)).toBe('needs_review');
+  });
+
+  it('does not flag an item already retired, so the deprecate path stays a no-op on itself', async () => {
+    const item = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Retired already', content: 'Deprecated before the blast radius ran.',
+    });
+    await updateKnowledgeItemWithCommit(projectId, item.item.id, { status: 'deprecated' }, { projectRoot: SELF_ROOT });
+
+    const result = await flagCorrectionSiblings(projectId, item.item.id, 'a correction');
+
+    expect(result.correctedItemFlagged).toBe(false);
+    expect(await freshnessOf(item.item.id)).not.toBe('needs_review');
   });
 });


### PR DESCRIPTION
## The asymmetry

An agent calls `knowl_feedback` with `causedCorrection: true` — it is telling you this specific item misled it. Today that:

- demotes the item's tier to `asserted`
- flips up to 12 of its **batch-mates** to `needs_review`, on the strength of nothing more than shared provenance
- leaves **the item the agent actually named** at `fresh`

`siblingsFromInsertCommits` excludes the corrected item by id, and nothing else picked it up. So the weakest evidence in the neighbourhood earned the flag and the direct evidence did not.

## Measured, not assumed

On this repo's store: **14 items have ever caused a correction. 6 are still active and still `fresh`.** The other 8 were superseded by other means.

```
freshness  tier      status       n
fresh      asserted  active       6
fresh      asserted  superseded   5
stale      asserted  superseded   3
```

## The fix

`flagCorrectionSiblings` resolves the corrected item first, through the same eligibility filter as a sibling (`status = 'active' AND freshness = 'fresh'`).

Kept **out of the candidate pool** rather than added to it, for two reasons:

- `slice(0, MAX_BLAST_RADIUS)` could drop it in a wide batch — the one item that must never be the one dropped.
- The empty-candidate early-out would skip it entirely for a correction with no siblings at all, which is the common shape.

Sharing the eligibility filter is what keeps the **deprecate/reject** caller in `knowledge-actions.ts` correct without special-casing: that path flips status before calling, so an inactive item filters itself out.

## API shape

`flaggedIds` still means the siblings and nothing else — **all 13 existing tests pass unchanged**. The corrected item is reported through a new `correctedItemFlagged` boolean, so no caller has to know to filter an id out of a list named for something else. The commit record still carries both writes; only the return shape distinguishes them.

The feedback note now reports the two facts separately. Collapsing them into one count is how the missing flag hid: "3 sibling item(s) marked needs_review" read as though the corrected item were among them.

## Tests

Four new, in their own fixture root:
- flagged alongside siblings, reported apart from them
- flagged when the correction has **no** siblings at all
- flagged in a batch wide enough to fill the cap, which it does not compete for
- **not** flagged when already retired, so the deprecate path stays a no-op on itself

One note on the third: it builds its fixture with `createKnowledgeItem` and a shared source rather than a real batch write, because titles that close collapse under dedup — `Wide self member 3` and `Wide self member 4` are the same subject once tokenized, so a genuine batch write supersedes down to one active item and there is no cap left to test.

Full set green: build, 367 test files / 3539 tests, typecheck.
