### PR TITLE
chore: release 5.13.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
-  "version": "5.12.0",
+  "version": "5.13.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,67 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## 5.13.0 — 2026-08-26
+
+Knowl starts counting what it never asked for, and stops discarding the evidence that something
+mattered.
+
+The theme is signals that existed and went nowhere. A no-op duplicate write — an agent reaching a
+conclusion the store already held, unaided — was computed and thrown away, though it is the only
+positive capture signal in the system. An agent reporting that an item misled it flagged that
+item's batch-mates and left the named item untouched. And on the read side there was no signal at
+all: nothing measured how often an agent acted on a file the store already knew something about
+without ever retrieving it, which is the one failure a session cannot observe about itself.
+
+**New: the recall gap.** On every tool call that reads or writes a file, the touched paths are
+matched against active atoms citing them, and one row records whether the store held anything and
+whether it had already been retrieved. Read it in `knowl status` under `RECALL GAP`. Nothing is
+shown to the agent and there is no configuration key — a count gated behind the feature it exists
+to justify can never justify it. It counts *touches* rather than atoms, takes its share over
+"held" rather than over every tool call, and prints that it is a lower bound: only knowledge
+carrying `affectedPaths` can be matched to a file. Migration level 15, additive;
+`KNOWL_SCHEMA_VERSION` does not move and an older build ignores the table entirely.
+
+**Re-derivation now protects memory from garbage collection.** A no-op duplicate write is recorded
+as a `knowledge_access` row under a new `rederived` surface, and two of them protect an item from
+GC decay the way three retrievals already do. The surface is deliberately separate from retrieval:
+`retrievalCount` backs the never-read lens and `isHot`, and quietly widening what it counts would
+invalidate every measurement taken against it. The read-side signals cannot see this case at all —
+a fact nobody queries for looks cold right up until it matters.
+
+**`knowl_update` can correct a misfiled category.** An item captured as `state` that turns out to
+be a standing decision previously had to be stored again and the original retired, discarding its
+assertion history, access telemetry and re-derivation count to change one enum. Category is not
+cosmetic: it is the only field GC reads to decide whether an item is archivable at all, so the
+misfiled copy was precisely the one on the collection path, and the only fix for it erased the
+evidence against collecting it.
+
+**A correction now flags the item that caused it.** Reporting that an item misled you demoted its
+tier, flipped up to twelve batch-mates to `needs_review` on shared provenance, and left the named
+item at `fresh`. Measured on this repo's store: of 14 items that have ever caused a correction, 6
+were still active and still fresh. Weaker evidence earned the flag and direct evidence did not.
+
+**An answered question becomes a decision memory.** `session-candidates.ts` has promoted `decision`
+session events into decision atoms since the beginning, and a measurement of the live store found
+zero had ever been written — the extractor was built and starving. Only the question header and the
+label of the chosen option are captured.
+
+**The local embedding model is optional.** `@huggingface/transformers` pulls `onnxruntime-node`,
+which downloads a native binary from a postinstall script; an unreachable CDN aborted the whole
+install for reasons unrelated to the package. Retrieval already reported `lexical-only` when no
+vector half was available, which is the same degraded mode a user who never downloaded the model
+was in, so nothing new had to tolerate anything. CI now checks for the rollback explicitly and
+retries once, rather than failing three minutes later with `Cannot find package` — which reads like
+a bug in the change under test rather than a missing dependency.
+
+**Issue #169 is closed, not fixed.** The relevance floor cannot be tuned to separate on-topic from
+technical off-topic queries, and `docs/evals/relative-floor-probe.md` closes the last open
+direction: every page-relative signal scores *worse* than the absolute cosine it was meant to
+replace, and the store-self-similarity family fails for an arithmetic reason rather than an
+empirical one — within one corpus its statistics are constants, so all three variants are monotonic
+transforms of the raw cosine and cannot reorder anything. Nothing about the floor's behaviour
+changes. The measurement is recorded so nobody spends a week retrying it.
+
 ## 5.12.0 — 2026-08-25
 
 Knowl stops claiming more than it can show, and stops silently losing what it can.

--- a/README.md
+++ b/README.md
@@ -574,6 +574,10 @@ knowl doctor                           # setup, retrieval, and registration
 - **Optional transcript search** — off by default, and off means nothing exists on disk. Turn it on
   and past session prose becomes searchable, so a memory miss degrades to a slower lookup instead
   of amnesia.
+- **The recall gap** — how often an agent edited a file this store already knew something about
+  without ever retrieving it. Invisible from inside a session, because an agent that never
+  retrieved an atom cannot notice the atom exists. Counted on every tool call, shown to nobody but
+  you, in `knowl status`.
 
 → [Tasks, sessions, and lifecycle](docs/reference.md#tasks-sessions-and-agent-lifecycle)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -676,6 +676,50 @@ knowl config set search.pathsChanged false
 Worth turning off in a repository whose atoms cite generated or build-time files, where the
 marker would be present on every row forever and stop meaning anything.
 
+### The recall gap — what the store held and nobody asked for
+
+Every gate on the write path decides what gets *in*. `capture.nudge` measures the opposite: what
+a session was given the chance to store and did not. The read path now has the same twin, and it
+answers a question no session can answer about itself — **how often did the agent act on a file
+this store already knew something about, without having retrieved it?**
+
+An agent that never retrieved an atom has no way to notice the atom exists. So the failure is
+invisible from the inside, and worst when the mistake does not fail loudly: wrong approach, tests
+green, shipped, and nobody ever learns the store held the answer the whole time.
+
+On every tool call that reads or writes a file, the touched paths are matched against active
+atoms citing them, and one row records whether the store held anything and whether it had already
+been retrieved. Read it with `knowl status`:
+
+```
+📌 RECALL GAP
+  Tool touches observed: 340
+  Store held something:  91
+  ...already retrieved:  62
+  ...missed:             29 (32%)
+  Lower bound — only knowledge citing a file path can be counted here.
+```
+
+**Nothing is shown to the agent, and there is no configuration key.** It is a measurement, and it
+has no switch for the same reason `capture_outcomes` has none: a count gated behind the feature it
+exists to justify can never justify it. Only what is *done* with a count is ever configurable, and
+today nothing is done with this one.
+
+Three properties worth knowing before quoting the number:
+
+- **It counts touches, not atoms.** Three atoms naming one file is one moment where the agent
+  could have been told something and was not, not three misses.
+- **The share is taken over `held`, never over touches.** Dividing by every tool call reports a
+  figure that falls as the agent works in files the store says nothing about — which is activity,
+  not improvement.
+- **It is a lower bound, printed as one.** Only knowledge carrying `affectedPaths` can be matched
+  to a file, so a decision atom naming no file never counts as a miss. "Already retrieved" is
+  judged on a time window rather than a session join, which errs toward *retrieved* — so the proxy
+  understates the gap and cannot invent one.
+
+The rows are `preserved` across snapshot restore, never refilled: a ratio assembled from two
+different histories is not a floor on anything.
+
 ### What Knowl says mid-turn — `reminders.*`
 
 Separate from what Knowl *stores*: these are the messages it sends the agent between tool

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.12.0",
+  "version": "5.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.12.0",
+      "version": "5.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.12.0",
+  "version": "5.13.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Eleven commits since `v5.12.0`. No `## Unreleased` section existed to write into — the 5.12.0 release commit renamed it in place and nothing recreates it, which is the structural reason changelog entries go missing here.

## Shipped

**The recall gap** (#201) — how often an agent acted on a file the store already knew something about, without ever retrieving it. The one failure a session cannot observe about itself, because an agent that never retrieved an atom has no way to notice the atom exists. Counted on every file-touching tool call, shown to nobody but the operator, in `knowl status`. No configuration key, deliberately.

**Re-derivation protects memory from GC** (#197) — a no-op duplicate write is the only positive capture signal in the system, and it was computed and discarded.

**`knowl_update` can correct a misfiled category** (#199) — previously required storing again and retiring the original, discarding assertion history, access telemetry and re-derivation count to change one enum. Category is the only field GC reads to decide archivability, so the misfiled copy was exactly the one on the collection path.

**A correction flags the item that caused it** (#200) — of 14 items on this repo's store that have ever caused a correction, 6 were still active and still fresh. Weaker evidence earned the flag and direct evidence did not.

**An answered question becomes a decision memory** (#195) — the extractor for this had existed since the beginning with nothing emitting into it.

**The local embedding model is optional** (44f5a8a, #198) — a CDN blip in `onnxruntime-node`'s postinstall aborted the whole install. CI now fails loudly on the rollback instead of three minutes later with `Cannot find package`.

**#169 closed, not fixed** — `docs/evals/relative-floor-probe.md` closes the last open direction. Nothing about the floor's behaviour changes; the measurement is recorded so nobody retries it.

## Docs

Beyond the changelog, since the recall gap is the first thing here a user can actually read:

- `docs/reference.md` — new section under lifecycle, next to the capture posture it is the twin of
- `README.md` — one bullet in the session-lifecycle feature block

## Migration

Level 15, additive. `KNOWL_SCHEMA_VERSION` does not move — an older build ignores the table entirely. Existing stores gain it on next open. No action required on upgrade.

## Verification

- `node scripts/check-version-sync.mjs` — all three version files agree at 5.13.0
- `npm run build` ✓
- `npm test` — **3548 passed, 5 skipped, 0 failed** across 369 files
- `npm run typecheck` ✓
- `npm run docs:check` ✓
- `git diff --check` ✓

Tag after this merges, against the merge commit.