### PR TITLE
perf(hooks): stop paying per turn for work that produced nothing

### DIFF
--- a/src/cli/agent-hook.ts
+++ b/src/cli/agent-hook.ts
@@ -40,9 +40,14 @@ export async function runAgentHook(host: string, event: string): Promise<void> {
     const result = await handleHostLifecycleEvent(project.id, normalized);
 
     // Best-effort and gated: returns null when transcript search is off, and never throws.
+    //
+    // `embed: false` because this process is fresh every turn and the embedding model is
+    // therefore always cold. See the option's docblock: paying the load here bought nothing --
+    // 0% vector coverage over 12,598 indexed messages -- and cost ~1.8s of every turn stop.
+    // The lexical pass stays; it needs no model.
     if (normalized.event === 'turn-stop' || normalized.event === 'session-stop') {
       const { catchUpTranscripts } = await import('../transcripts/catch-up.js');
-      await catchUpTranscripts(root);
+      await catchUpTranscripts(root, { embed: false });
     }
 
     // **This path must exit 0, including when the output is a refusal.**

--- a/src/cli/agents/hook-config.ts
+++ b/src/cli/agents/hook-config.ts
@@ -91,6 +91,27 @@ function nestedStatusMessage(event: string): string {
   return '';
 }
 
+/**
+ * Which tool names this event's handler needs to see.
+ *
+ * Everything but the pre-tool event needs all of them. The pre-tool handler runs the write gate,
+ * and `runWriteGate` returns on its first line for a tool that does not write a file -- so under
+ * a `.*` matcher every Read, Grep, Glob, Bash and Task in a session paid a process spawn and a
+ * database open (~170ms each) to reach an immediate no-op. A host that declares `writeTools`
+ * gets a matcher naming exactly those, and never starts the process for the rest.
+ *
+ * Anchored, because these are regexes to the host and an unanchored `Edit` also matches
+ * `NotebookEdit` -- harmless here, but not something to leave to the tool names staying
+ * disjoint. A host that declares no `writeTools`, or a wildcard-only schema, keeps the wildcard.
+ */
+function nestedMatcher(host: HookHost, event: string, wildcard: string): string {
+  const profile = hostProfile(host);
+  if (profile.normalizedEvent(event) !== 'tool-precheck') return wildcard;
+  const tools = profile.writeTools;
+  if (!tools || tools.length === 0) return wildcard;
+  return `^(${tools.join('|')})$`;
+}
+
 function nestedEntry(platform: NodeJS.Platform, host: HookHost, event: string): NestedEntry {
   // OpenHands' schema has no `statusMessage`, and its matcher wildcard is `*` rather than the
   // regex `.*` the Anthropic-shaped hosts take. Emitting a field a host does not define is
@@ -98,7 +119,7 @@ function nestedEntry(platform: NodeJS.Platform, host: HookHost, event: string): 
   // other handler in it down too.
   const openHands = hostProfile(host).hookConfigStyle === 'openhands-toplevel';
   return {
-    matcher: openHands ? '*' : '.*',
+    matcher: nestedMatcher(host, event, openHands ? '*' : '.*'),
     hooks: [{
       type: 'command',
       command: knowlHookCommand(platform, host, event),

--- a/src/cli/agents/reminder.ts
+++ b/src/cli/agents/reminder.ts
@@ -1,5 +1,13 @@
 import { promptReminderFor } from '../../core/knowl-guidance.js';
 import { hostProfile, isHookHost, HostOutput } from '../../session/hosts/index.js';
+import { HookHost } from '../../core/host-hook-types.js';
+import {
+  driftReminderEvery, findProjectRoot, isDriftBackoffEnabled, loadConfig, shouldSendDriftReminder,
+} from '../../core/config.js';
+import { closeDb, initDb } from '../../store/database.js';
+import { conversationKey, readCaptureOutcome } from '../../store/capture-outcome.js';
+import { assertKnowledgeDatabasePresent } from '../database-presence.js';
+import { readLifecyclePayload } from './lifecycle.js';
 
 /**
  * Hosts whose key does not title-case into their own name.
@@ -32,4 +40,61 @@ export function createAgentReminderOutput(host: string): HostOutput {
   const output = profile.startContext('turn-start', promptReminderFor(hostLabel(host)));
   if (!output) throw unsupported;
   return output;
+}
+
+/**
+ * Decide whether this prompt earns the card, then emit it or say nothing.
+ *
+ * The card is a static paragraph restating KNOWL.md, and every host already carries that text
+ * in its system prompt -- `CLAUDE.md` -> `@KNOWL.md` for claude (`instruction-files.ts`), the
+ * managed block in `AGENTS.md` for the rest (`agents-guidance.ts`). Sending it on every prompt
+ * spent ~153 tokens a turn and, because turn-start context stays in the transcript rather than
+ * replacing the previous copy, it accumulated: a 40-turn session carried 40 identical copies.
+ *
+ * So it now follows the schedule the mid-turn continuation reminder already uses --
+ * `reminders.driftEvery` with `reminders.driftBackoff`, via `shouldSendDriftReminder` -- read
+ * off `capture_outcomes.turns`.
+ *
+ * Why that counter and not `host_session_bindings.successful_tool_count`, which is what the
+ * mid-turn reminder counts: the binding is keyed on the host session *and turn*, and Claude's
+ * `Stop` closes it, so at `UserPromptSubmit` the row for the turn about to begin does not exist
+ * yet and the previous turn's is already inactive. `capture_outcomes` is keyed on the
+ * conversation for exactly this reason (see `conversationKey`), it survives every turn
+ * boundary, and it is already maintained unconditionally.
+ *
+ * Turn 0 always speaks: a conversation that has never seen the card gets it once. After that
+ * backoff lands deliveries at 12, 36, 84, 180 completed turns.
+ *
+ * Fail-open. Every failure emits the card, because a store that cannot be read must not
+ * silently switch guidance off for the rest of a session -- it degrades to the old behaviour,
+ * which was wasteful but never wrong.
+ */
+export async function runAgentReminder(host: string): Promise<void> {
+  let send = true;
+  try {
+    const payload = await readLifecyclePayload();
+    const identity = hostProfile(host as HookHost).identity(payload);
+    const root = await findProjectRoot(typeof payload.cwd === 'string' ? payload.cwd : process.cwd());
+    assertKnowledgeDatabasePresent(root);
+    await initDb(root);
+    try {
+      const outcome = await readCaptureOutcome(conversationKey({
+        host,
+        projectRoot: root,
+        externalSessionId: identity.externalSessionId,
+      }));
+      const turns = outcome?.turns ?? 0;
+      const config = await loadConfig(root).catch(() => null);
+      send = turns === 0
+        || shouldSendDriftReminder(turns, driftReminderEvery(config), isDriftBackoffEnabled(config));
+    } finally {
+      await closeDb().catch(() => {});
+    }
+  } catch {
+    // Fail open: `send` is already true. See the docblock -- guidance must never switch itself
+    // off for the rest of a session because the store could not be read.
+  }
+  // Silence is an empty stdout, not an empty envelope: a host that reads `hookSpecificOutput`
+  // with a blank `additionalContext` may still spend a line on it.
+  if (send) console.log(JSON.stringify(createAgentReminderOutput(host)));
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -112,7 +112,6 @@ import { startViewer } from '../viewer/server.js';
 import { atomEditUrl, resolveAtomId } from './edit-link.js';
 import { positiveInt } from './parse-options.js';
 import { formatListRows, selectListRows } from './list-report.js';
-import { createAgentReminderOutput } from './agents/reminder.js';
 import { rebuildTranscriptIndex } from '../transcripts/backfill.js';
 import { closeTranscriptDbs, openTranscriptDb } from '../transcripts/database.js';
 import { isTranscriptSearchEnabled } from '../transcripts/config.js';
@@ -3564,12 +3563,16 @@ program
 
 program
   .command('agent-reminder')
-  .description('Emit fixed workflow guidance for an agent host prompt hook')
+  .description('Emit workflow guidance for an agent host prompt hook, on the drift schedule')
   .argument('<host>', 'a host that declares a prompt event: claude, codex, copilot, openhands')
   .option('--json')
-  .action(host => {
+  // Registered so `knowl --help` still describes it, but a real hook invocation never reaches
+  // here: `src/index.ts` dispatches straight to `runAgentReminder`, for the same reason it
+  // does for `agent-hook`. See that module.
+  .action(async host => {
     try {
-      console.log(JSON.stringify(createAgentReminderOutput(host)));
+      const { runAgentReminder } = await import('./agents/reminder.js');
+      await runAgentReminder(host);
     } catch (error: any) {
       console.error(`Error emitting agent reminder: ${error.message}`);
       process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,13 @@ const wantsHelp = process.argv.includes('--help') || process.argv.includes('-h')
 if (command === 'agent-hook' && !wantsHelp) {
   const { runAgentHook } = await import('./cli/agent-hook.js');
   await runAgentHook(process.argv[3], process.argv[4]);
+} else if (command === 'agent-reminder' && !wantsHelp) {
+  // Same fast path, and for the same reason: this is a per-prompt process, and since it
+  // started reading `capture_outcomes` to decide whether to speak it opens the store too.
+  // Routing it through commander loaded the MCP server, the viewer and the code indexer
+  // first, on every single prompt.
+  const { runAgentReminder } = await import('./cli/agents/reminder.js');
+  await runAgentReminder(process.argv[3]);
 } else {
   // Called rather than relying on an import-time side effect: parsing on import meant any test
   // that imported the command tree consumed the test runner's argv and exited.

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -149,11 +149,13 @@ function toolReadsFile(input: NormalizedHostHook): boolean {
 }
 
 function toolWritesFile(input: NormalizedHostHook): boolean {
-  const { writesFiles } = hostProfile(input.host);
+  const { writesFiles, writeTools } = hostProfile(input.host);
   const toolName = input.toolName ?? '';
-  return writesFiles
-    ? writesFiles(input.hostEvent ?? '', toolName)
-    : IMPACT_WRITE_TOOLS.has(toolName);
+  if (writesFiles) return writesFiles(input.hostEvent ?? '', toolName);
+  // Preferred over the fallback set when a host declares it, so the gate and the pre-tool
+  // matcher built from the same list can never disagree about what a write is.
+  if (writeTools) return writeTools.includes(toolName);
+  return IMPACT_WRITE_TOOLS.has(toolName);
 }
 
 

--- a/src/session/hosts/claude.ts
+++ b/src/session/hosts/claude.ts
@@ -99,6 +99,11 @@ export const claudeProfile: HostProfile = {
   nativeOutput: true,
   midTurnDeliveryVerified: true,
   hookConfigStyle: 'claude-nested',
+  // The same four names `IMPACT_WRITE_TOOLS` in `host-lifecycle.ts` falls back to, said here so
+  // the pre-tool matcher can be built from them. Claude Code applies every file write through
+  // one of these; `Bash` is deliberately absent, because the gate needs the paths a tool
+  // declares and a shell command does not declare any.
+  writeTools: ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'],
   identity(raw): HostIdentity {
     return {
       externalSessionId: hostString(raw.session_id) ?? hostString(raw.conversation_id) ?? hostString(raw.thread_id),

--- a/src/session/hosts/profile.ts
+++ b/src/session/hosts/profile.ts
@@ -108,6 +108,25 @@ export interface HostProfile {
   readsFiles?: (hostEvent: string, toolName: string) => boolean;
   writesFiles?: (hostEvent: string, toolName: string) => boolean;
   /**
+   * The write tools by name, when this host's write rule is a plain list.
+   *
+   * Serves two callers that must never disagree: `toolWritesFile`, which decides whether the
+   * write gate has anything to do, and the pre-tool hook entry's `matcher`, which decides
+   * whether the host bothers to *start the process that would ask*.
+   *
+   * That second one is the point. `runWriteGate` returns on its first line for any tool that
+   * does not write a file, so a `.*` matcher spent a process spawn and a database open on every
+   * Read, Grep, Glob, Bash and Task in a session to reach an immediate no-op -- measured at
+   * ~170ms each. A matcher built from this list means the host never starts it.
+   *
+   * Declared here rather than derived from `writesFiles`, because a predicate has no
+   * enumerable domain: nothing can turn `(_e, t) => t === 'apply_patch'` into a regex. A host
+   * whose rule is not a plain name list -- cursor and windsurf key off the *event* -- leaves
+   * this unset and keeps the wildcard, which is correct rather than merely safe: their pre-tool
+   * event only fires on writes already.
+   */
+  writeTools?: readonly string[];
+  /**
    * The top-level keys this host's hooks file must carry beside its events.
    *
    * Copilot rejects a file without `"version": 1`; Cursor requires the same key. Data rather

--- a/src/store/capture-outcome.ts
+++ b/src/store/capture-outcome.ts
@@ -1,3 +1,4 @@
+import { canonicalProjectRoot } from '../core/project-path.js';
 import { getClient } from './database.js';
 
 /**
@@ -87,13 +88,24 @@ const KEY_SEPARATOR = '\u001f';
  *
  * Joined on a separator that cannot appear inside a project path, a host name or a session id,
  * so two different conversations cannot collide on one row.
+ *
+ * The root is canonicalised, for the same reason `normalizedKey` in `host-session-bindings.ts`
+ * canonicalises its own: hosts do not agree on the case of a Windows drive letter, and the raw
+ * value split one conversation across two rows. Measured on a real store, three conversations
+ * were live under both `D:\coding\knowl` and `d:\coding\knowl` at once, one of them holding
+ * 33 turns on one row and 1 on the other. Every counter keyed this way -- capture health, the
+ * `turns >= 3` silence threshold, the prompt reminder's drift gate -- read the fragment rather
+ * than the conversation.
+ *
+ * No migration: this key is recomputed from hook input on every call, so rows written under an
+ * uncanonicalised root are simply never reached again and fall out of the health window.
  */
 export function conversationKey(input: {
   host: string;
   projectRoot: string;
   externalSessionId?: string;
 }): string {
-  return [input.host, input.projectRoot, input.externalSessionId ?? ''].join(KEY_SEPARATOR);
+  return [input.host, canonicalProjectRoot(input.projectRoot), input.externalSessionId ?? ''].join(KEY_SEPARATOR);
 }
 
 /** Every counter starts its row, so neither caller has to know which of them ran first. */
@@ -269,7 +281,7 @@ export function turnCaptureKey(parts: {
   externalSessionId?: string;
   externalTurnId?: string;
 }): string {
-  return [parts.host, parts.projectRoot, parts.externalSessionId ?? '', parts.externalTurnId ?? ''].join(KEY_SEPARATOR);
+  return [parts.host, canonicalProjectRoot(parts.projectRoot), parts.externalSessionId ?? '', parts.externalTurnId ?? ''].join(KEY_SEPARATOR);
 }
 
 /** Count one tool event into the turn, and read the turn's counters back in the same write. */

--- a/src/transcripts/catch-up.ts
+++ b/src/transcripts/catch-up.ts
@@ -38,6 +38,20 @@ export async function catchUpTranscripts(
      * connections this would close.
      */
     closeWhenDone?: boolean;
+    /**
+     * Whether to embed what was indexed. False for the lifecycle hook, and only for it.
+     *
+     * The hook is a fresh process per turn, so the embedding model is never warm and loading it
+     * cost more than the entire budget -- measured at ~1.8s against a 1.5s budget, in a project
+     * with nothing to index. The pass then found the deadline already gone and embedded nothing,
+     * every turn, for months: this repo's own store held 12,598 indexed messages and 4 vectors.
+     *
+     * So the hook pays for the lexical half, which is cheap and needs no model, and the semantic
+     * half happens where a model stays warm -- the long-lived `knowl serve` process, via the
+     * search-time top-up -- or in bulk under a budget a human chose, via
+     * `knowl reindex --transcripts`.
+     */
+    embed?: boolean;
   } = {},
 ): Promise<{ indexed: number; embedded: number } | null> {
   try {
@@ -52,10 +66,17 @@ export async function catchUpTranscripts(
     });
 
     let embedded = 0;
-    if (isVectorSearchEnabled(config)) {
+    if (options.embed !== false && isVectorSearchEnabled(config)) {
       try {
+        // The budget bounds *work*, not setup. Loading the model was charged to it, so a caller
+        // whose model was cold spent the whole budget on the load and then had nothing left to
+        // embed with -- `embedPendingMessages` enforces the deadline before the work, so it
+        // returned 0 rather than overrunning. Giving the load back keeps the budget meaning what
+        // its name says and lets the first call in a warm-model process do real work.
+        const loadStart = Date.now();
         const embedder = options.embedder ?? await createLocalEmbeddingProvider(config, projectRoot);
-        embedded = (await embedPendingMessages({ dbPath, embedder, deadline })).embedded;
+        const embedDeadline = deadline + (Date.now() - loadStart);
+        embedded = (await embedPendingMessages({ dbPath, embedder, deadline: embedDeadline })).embedded;
       } catch {
         // No model on disk yet, or it failed to load. The lexical index still landed; the next
         // turn or an explicit reindex fills the vectors in.

--- a/tests/cli/agent-reminder-gate.test.ts
+++ b/tests/cli/agent-reminder-gate.test.ts
@@ -1,0 +1,51 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const TEST_DIR = path.join(os.tmpdir(), 'knowl-agent-reminder-gate-test');
+const CLI_PATH = path.resolve('./dist/index.js');
+const SESSION = 'gate-session';
+
+function run(args: string[], input?: string): string {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], { cwd: TEST_DIR, encoding: 'utf8', input });
+}
+
+const reminder = () => run(['agent-reminder', 'claude', '--json'], JSON.stringify({
+  session_id: SESSION, cwd: TEST_DIR,
+}));
+
+/** One completed turn: a tool event binds the turn, Stop ends it and bumps `capture_outcomes.turns`. */
+function completeTurn(index: number): void {
+  run(['agent-hook', 'claude', 'PostToolUse', '--json'], JSON.stringify({
+    session_id: SESSION, cwd: TEST_DIR,
+    tool_name: 'Bash', tool_input: { command: `tool-${index}` }, tool_response: { exit_code: 0 },
+  }));
+  run(['agent-hook', 'claude', 'Stop', '--json'], JSON.stringify({ session_id: SESSION, cwd: TEST_DIR }));
+}
+
+describe('prompt reminder drift gate', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+    await fs.mkdir(TEST_DIR, { recursive: true });
+    run(['init', '--yes']);
+    run(['agent-hook', 'claude', 'SessionStart', '--json'], JSON.stringify({ session_id: SESSION, cwd: TEST_DIR }));
+  }, 120_000);
+
+  afterAll(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('speaks on the first prompt of a conversation and goes silent once turns accumulate', () => {
+    // Turn 0: the conversation has never seen the card, so it always gets one.
+    expect(JSON.parse(reminder()).hookSpecificOutput.additionalContext).toContain('KNOWL');
+
+    completeTurn(1);
+    completeTurn(2);
+
+    // The card is a static restatement of KNOWL.md/AGENTS.md, which is already in the system
+    // prompt. Repeating it every turn is what this gate exists to stop.
+    expect(reminder()).toBe('');
+  }, 120_000);
+});

--- a/tests/cli/hosts/profile-conformance.test.ts
+++ b/tests/cli/hosts/profile-conformance.test.ts
@@ -8,6 +8,34 @@ const ALL_HOSTS: HookHost[] = [
 ];
 
 describe('host profile registry', () => {
+  // The matcher on the pre-tool hook entry is built from `writeTools`, and the write gate reads
+  // the same list through `toolWritesFile`. If a host declared both, the two could disagree and
+  // the host would stop starting the process for a tool the gate still wanted to refuse -- a
+  // gate that silently stops firing, which is the failure mode with no symptom.
+  it('never declares both a writesFiles predicate and a writeTools list', () => {
+    for (const host of ALL_HOSTS) {
+      const profile = hostProfile(host);
+      expect(
+        Boolean(profile.writesFiles) && Boolean(profile.writeTools),
+        `${host} declares both writesFiles and writeTools`,
+      ).toBe(false);
+    }
+  });
+
+  it('accepts every one of its writeTools as a write, and nothing outside the list', () => {
+    for (const host of ALL_HOSTS) {
+      const profile = hostProfile(host);
+      if (!profile.writeTools) continue;
+      expect(profile.writeTools.length, `${host} declares an empty writeTools`).toBeGreaterThan(0);
+      // The matcher is anchored, so a name must match itself and nothing must match a name the
+      // list does not carry.
+      const matcher = new RegExp(`^(${profile.writeTools.join('|')})$`);
+      for (const tool of profile.writeTools) expect(matcher.test(tool), `${host}: ${tool}`).toBe(true);
+      expect(matcher.test('Read')).toBe(false);
+      expect(matcher.test('Bash')).toBe(false);
+    }
+  });
+
   it('has exactly one profile per HookHost', () => {
     expect(Object.keys(HOST_PROFILES).sort()).toEqual([...ALL_HOSTS].sort());
     for (const host of ALL_HOSTS) expect(hostProfile(host).host).toBe(host);

--- a/tests/cli/tool-precheck.test.ts
+++ b/tests/cli/tool-precheck.test.ts
@@ -178,8 +178,13 @@ describe('PreToolUse registration', () => {
     expect(await mergeNestedHookConfig(configPath, 'win32', 'claude')).toBe('configured');
 
     const config = JSON.parse(await readFile(configPath, 'utf8'));
+    // Same command shape as every other event, but NOT the same matcher. `runWriteGate` returns
+    // on its first line for a tool that does not write a file, so a wildcard here spent a
+    // process spawn and a database open (~170ms) on every Read, Grep, Glob, Bash and Task to
+    // reach an immediate no-op. The names come from `claudeProfile.writeTools`, which
+    // `toolWritesFile` reads too, so the matcher cannot drift from what the gate acts on.
     expect(config.hooks.PreToolUse).toEqual([{
-      matcher: '.*',
+      matcher: '^(Edit|Write|MultiEdit|NotebookEdit)$',
       hooks: [{ type: 'command', command: 'knowl.cmd agent-hook claude PreToolUse --json', timeout: 30, statusMessage: '' }],
     }]);
     expect(config.hooks.PreToolUse[0].hooks[0]).toEqual({

--- a/tests/store/capture-outcome.test.ts
+++ b/tests/store/capture-outcome.test.ts
@@ -183,17 +183,24 @@ describe('capture outcomes on disk', () => {
     expect(await readCaptureOutcome(stored)).toMatchObject({ turns: 1 });
   });
 
-  it('counts one conversation on one row however the host cased the project root', async () => {
-    // Claude Code sends `cwd` with the drive letter in either case, and the raw root split one
-    // conversation across two rows -- 33 turns on one, 1 on the other, on a real store. Every
-    // counter keyed this way then reads a fragment: capture health, the `turns >= 3` silence
-    // threshold, and the prompt reminder's drift gate.
-    const upper = conversationKey({ host: 'claude', projectRoot: 'D:/coding/knowl', externalSessionId: 's1' });
-    const lower = conversationKey({ host: 'claude', projectRoot: 'd:/coding/knowl', externalSessionId: 's1' });
-    expect(lower).toBe(upper);
+  it('counts one conversation on one row however the host spelled the project root', async () => {
+    // The raw root split one conversation across two rows -- 33 turns on one, 1 on the other, on
+    // a real store -- and every counter keyed this way then read a fragment: capture health, the
+    // `turns >= 3` silence threshold, and the prompt reminder's drift gate.
+    //
+    // Asserted through `canonicalProjectRoot` rather than against a literal, because what counts
+    // as the same root is per-platform and the first version of this test hardcoded Windows: it
+    // compared `D:/...` with `d:/...`, which POSIX resolves to two different directories under
+    // the CWD and case-sensitively, so it failed on ubuntu and macos while passing on windows.
+    const key = (root: string) => conversationKey({ host: 'claude', projectRoot: root, externalSessionId: 's1' });
+    const root = process.cwd();
+    // Unnormalised but equivalent, on every platform: `path.resolve` collapses the round trip.
+    expect(key(path.join(root, 'child', '..'))).toBe(key(root));
+    // Drive-letter case, only where drive letters exist. This is the split that was observed.
+    if (process.platform === 'win32') expect(key(root.toLowerCase())).toBe(key(root.toUpperCase()));
 
-    await recordSessionTurn(upper);
-    await recordSessionTurn(lower);
-    expect(await readCaptureOutcome(upper)).toMatchObject({ turns: 2 });
+    await recordSessionTurn(key(root));
+    await recordSessionTurn(key(path.join(root, 'child', '..')));
+    expect(await readCaptureOutcome(key(root))).toMatchObject({ turns: 2 });
   });
 });

--- a/tests/store/capture-outcome.test.ts
+++ b/tests/store/capture-outcome.test.ts
@@ -182,4 +182,18 @@ describe('capture outcomes on disk', () => {
     expect(stored).toBe(key);
     expect(await readCaptureOutcome(stored)).toMatchObject({ turns: 1 });
   });
+
+  it('counts one conversation on one row however the host cased the project root', async () => {
+    // Claude Code sends `cwd` with the drive letter in either case, and the raw root split one
+    // conversation across two rows -- 33 turns on one, 1 on the other, on a real store. Every
+    // counter keyed this way then reads a fragment: capture health, the `turns >= 3` silence
+    // threshold, and the prompt reminder's drift gate.
+    const upper = conversationKey({ host: 'claude', projectRoot: 'D:/coding/knowl', externalSessionId: 's1' });
+    const lower = conversationKey({ host: 'claude', projectRoot: 'd:/coding/knowl', externalSessionId: 's1' });
+    expect(lower).toBe(upper);
+
+    await recordSessionTurn(upper);
+    await recordSessionTurn(lower);
+    expect(await readCaptureOutcome(upper)).toMatchObject({ turns: 2 });
+  });
 });

--- a/tests/transcripts/catch-up.test.ts
+++ b/tests/transcripts/catch-up.test.ts
@@ -78,6 +78,27 @@ describe('catchUpTranscripts', () => {
     expect(result?.indexed).toBe(1);
   });
 
+  // What the two tests below could not catch, because they inject a stub embedder that costs
+  // nothing to construct. Production resolves a local ONNX model in a process that is fresh
+  // every turn, the load ran inside the budget, and `embedPendingMessages` enforces the deadline
+  // before doing any work -- so the real hook path embedded nothing at all. Measured on this
+  // repo's own store: 12,598 indexed messages, 4 vectors.
+  it('indexes without embedding when the caller says not to, and still indexes', async () => {
+    await writeConfig(true, { vector: true });
+    await seed();
+
+    const embedder = stubEmbedder();
+    const result = await catchUpTranscripts(dir, { projectsDir, embedder, embed: false, closeWhenDone: false });
+
+    const client = await openTranscriptDb(path.join(dir, '.knowl', 'transcripts.db'));
+    const indexed = Number((await client.execute('SELECT COUNT(*) AS n FROM transcript_messages')).rows[0].n);
+    const embedded = Number((await client.execute('SELECT COUNT(*) AS n FROM transcript_vectors')).rows[0].n);
+
+    expect(indexed).toBe(1);
+    expect(embedded).toBe(0);
+    expect(result?.embedded).toBe(0);
+  });
+
   // The regression test for the blocker: catching up lexically but never embedding meant
   // coverage decayed from 100% with every new turn, with no signal that it had.
   it('embeds what it indexes, so coverage stays complete', async () => {


### PR DESCRIPTION
Four cuts to what a hook costs, each measured before and after. They are independent; the thread joining them is that every one was paying per turn for something that produced nothing.

| | Before | After |
|---|---|---|
| Prompt reminder | 153 tokens **every prompt**, 350ms | 0 after turn 0, 137ms |
| `Stop` (transcripts enabled) | 2595ms | **492ms** |
| PreToolUse spawns | every tool call | **81.6% never start** (865 of 1,060 measured) |
| `capture_outcomes` rows | one conversation split across two | one row |

## The prompt reminder repeated itself into the context window

Four hosts declare a `promptEvent`, and `agent-reminder` was a pure function — no store, no counter, no gate. It printed the same 613-character card (~153 tokens) on every prompt forever. Injected turn-start context accumulates in the transcript rather than replacing the previous copy, so a 40-turn session carried 40 identical copies.

It was also redundant on **every** host, not just Claude: `instruction-files.ts` gives claude `CLAUDE.md` → `@KNOWL.md`, and `agents-guidance.ts` writes the managed block into `AGENTS.md` for the rest. Both already carry the card's only unique line — "hooks own the lifecycle, do not call `knowl_task_start`".

So it now follows the same `reminders.driftEvery` / `driftBackoff` schedule the mid-turn continuation reminder uses: turn 0, then 12, 36, 84, 180.

Read off `capture_outcomes.turns` rather than the drift counter, and that choice is the interesting part. `host_session_bindings.successful_tool_count` is keyed on host session **and turn**, and Claude's `Stop` closes it — so at `UserPromptSubmit` the row for the turn about to begin does not exist yet and the previous turn's is already inactive. `capture_outcomes` is keyed on the conversation precisely for this reason.

Fail-open: every failure emits the card. A store that cannot be read must not silently switch guidance off for the rest of a session.

## One conversation was being counted as two

Found while testing the above. `conversationKey` and `turnCaptureKey` built their composite key from the raw `projectRoot`, while `normalizedKey` in `host-session-bindings.ts` canonicalises its own. Hosts do not agree on the case of a Windows drive letter, so one conversation split across two rows. Measured on a real store — three live conversations under both `D:\coding\knowl` and `d:\coding\knowl` at once:

```
claude|3d08c339-...  [["D:\coding\knowl",15,6], ["d:\coding\knowl",3,1]]
claude|d632c023-...  [["D:\coding\knowl",33,13],["d:\coding\knowl",1,2]]
claude|b03a574d-...  [["D:\coding\knowl",9,3],  ["d:\coding\knowl",2,1]]
```

Capture health, the `turns >= 3` silence threshold and the new prompt gate all read a fragment. No migration needed: the key is recomputed from hook input on every call, so old rows fall out of the window on their own.

## The turn-stop hook loaded an embedding model to embed nothing

`catchUpTranscripts` charged `createLocalEmbeddingProvider` to the same 1.5s budget it then enforced *before* doing any work. The hook is a fresh process per turn, so the model is never warm and the ~1.8s load alone exhausted the budget. `embedPendingMessages` found the deadline already gone and returned 0 — every turn, for months.

This repository's own store:

```
messages 12598   vectors 4   coverage 0.0%
```

Isolated it in a fresh empty project, same store, flipping only `search.transcripts.enabled`: **803ms off, 2595ms on**. ~1.8s per turn in a project with nothing to index.

The module's own docblock states the stakes and was falsified by that number: *"Embedding what was just indexed is not optional — skipping it lets coverage decay from 100% with every new turn, silently invalidating the whole-corpus claim that justifies ranking semantically at all."*

So the hook passes `embed: false` and keeps the lexical pass, which needs no model. Embedding happens where a model stays warm — the search-time top-up inside `knowl serve` — or in bulk under `knowl reindex --transcripts`. The budget also now excludes load time, because it bounds work and not setup; that is what lets the first call in a warm-model process do real work instead of finding the deadline spent.

**Why the existing tests could not have caught it.** `catch-up.test.ts` injects a `stubEmbedder()` that costs nothing to construct, so the deadline never blew and coverage read 100%. A test that stubs the expensive part cannot see a bug whose entire cause is that the part is expensive. The new case pins the hook's `embed: false` shape instead.

## Every read spawned a process to ask a question only writes can answer

`runWriteGate` returns on its first line when the tool does not write a file. Under `matcher: '.*'`, every Read, Grep, Glob, Bash and Task paid a process spawn and a store open — ~170ms — to reach an immediate no-op.

`HostProfile` gains `writeTools`. Claude declares the four names `IMPACT_WRITE_TOOLS` was already falling back to; the pre-tool entry's matcher is built from them (`^(Edit|Write|MultiEdit|NotebookEdit)$`), and `toolWritesFile` reads the same list, so gate and matcher cannot drift. `profile-conformance.test.ts` forbids a host declaring both `writesFiles` and `writeTools`.

Measured over 12 real transcripts, 1,060 tool calls: 195 are write tools. **865 spawns avoided, 81.6%.** Top tools were Bash 343, Edit 149, PowerShell 138, Read 103, Grep 74.

Declared as a list rather than derived from `writesFiles` because a predicate has no enumerable domain — nothing turns `(_e, t) => t === 'apply_patch'` into a regex. Cursor and windsurf leave it unset and keep the wildcard on purpose: their write rule keys off the *event*, not the tool name, and their pre-tool event only fires on writes already.

## Upgrade path

`verifyNestedHookConfig` compares whole entries with `equal`, so an existing install still carrying `matcher: ".*"` fails verify, `knowl doctor` reports stale hooks, and `knowl init <host>` or `doctor --fix` rewrites it. Nothing silently keeps the old shape.

Anyone whose transcript vectors are already behind wants one `knowl reindex --transcripts --budget <minutes>`; this PR stops the decay but does not backfill.

## Verification

`npm run typecheck`, `npm run lint`, `npm test` — 370 files, 3553 passed, 5 skipped, 0 failed.
