### PR TITLE
chore: release 5.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,62 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+## 5.14.0 — 2026-08-26
+
+Knowl stops charging every turn for work that produced nothing.
+
+One release, four measurements, and the thread joining them is not performance for its own sake:
+each of these was paying a recurring cost for an outcome that never arrived. A guidance card
+repeated into a context window that already held it. An embedding pass that loaded a model and
+then embedded nothing. A pre-tool hook that spawned a process to ask a question only writes can
+answer. A counter that split one conversation across two rows and read the fragment.
+
+**The turn-start card follows the drift schedule now.** It used to print the same 613-character
+paragraph on every prompt, forever — and because turn-start context accumulates in the transcript
+rather than replacing the previous copy, a 40-turn session carried 40 identical copies, ~6k
+tokens. It is also a restatement of `KNOWL.md`/`AGENTS.md`, which every host already carries in
+its system prompt: `CLAUDE.md` → `@KNOWL.md` for Claude Code, the managed block in `AGENTS.md` for
+everyone else. It now lands on the first prompt of a conversation and then follows
+`reminders.driftEvery` / `reminders.driftBackoff` — turn 0, 12, 36, 84, 180 — counted in completed
+turns. `driftEvery 0` silences it. The command also moved onto the entry's fast path, so it costs
+137ms rather than 350ms despite now reading the store.
+
+**Transcript embedding left the hook path, because it was never working there.** `catchUpTranscripts`
+charged the model load to the same 1.5s budget it then enforced before doing any work — and a hook
+is a fresh process per turn, so the model was never warm and the ~1.8s load alone exhausted it.
+The pass found its deadline spent and returned 0, every turn. One real store held **12,598 indexed
+messages and 4 vectors**. The turn-stop hook now runs the lexical pass only, which needs no model,
+and embedding happens where a model stays warm: the search-time top-up inside `knowl serve`, or
+`knowl reindex --transcripts`. The budget also stopped charging setup to the work allowance, which
+is what lets the first call in a warm process do anything at all. Measured: `Stop` went **2595ms →
+492ms**.
+
+**The pre-tool hook only fires for tools that can write.** `runWriteGate` returns on its first line
+when the tool writes no file, so under a `.*` matcher every Read, Grep, Glob, Bash and Task paid a
+process spawn and a store open — ~170ms — to reach an immediate no-op. Host profiles gained
+`writeTools`; Claude Code declares the four names the fallback already used, and the matcher is
+built from that same list, so the gate and the matcher cannot drift apart. Measured over 12 real
+transcripts and 1,060 tool calls: 195 are write tools, so **865 spawns never start — 81.6%**.
+Cursor and Windsurf keep the wildcard deliberately, because their write rule keys off the event
+rather than the tool name.
+
+**One conversation was being counted as two.** `conversationKey` and `turnCaptureKey` built their
+key from the raw project root while the session bindings canonicalised theirs, and hosts do not
+agree on the case of a Windows drive letter. Three live conversations existed under both
+`D:\coding\knowl` and `d:\coding\knowl` at once — one holding 33 turns on one row and 1 on the
+other. Capture health, the `turns >= 3` silence threshold and the new turn-start gate all read a
+fragment. No migration: the key is recomputed from hook input on every call, so old rows fall out
+of the window on their own.
+
+### Upgrading
+
+- **Run `knowl init <host>`.** The pre-tool matcher changed, and `knowl doctor` reports hooks as
+  stale until the config is rewritten. `knowl doctor --fix` does it too.
+- **If transcript search was already on, run `knowl reindex --transcripts --budget 10` once.** This
+  release stops semantic coverage decaying; it does not backfill what never landed.
+
 ## 5.13.0 — 2026-08-26
 
 Knowl starts counting what it never asked for, and stops discarding the evidence that something

--- a/README.md
+++ b/README.md
@@ -573,7 +573,8 @@ knowl doctor                           # setup, retrieval, and registration
   from any directory, any number of times later. `knowl resume <key>`
 - **Optional transcript search** — off by default, and off means nothing exists on disk. Turn it on
   and past session prose becomes searchable, so a memory miss degrades to a slower lookup instead
-  of amnesia.
+  of amnesia. Keyword indexing keeps up on its own; semantic coverage is filled by
+  `knowl reindex --transcripts`, because an embedding model does not belong in a per-turn hook.
 - **The recall gap** — how often an agent edited a file this store already knew something about
   without ever retrieving it. Invisible from inside a session, because an agent that never
   retrieved an atom cannot notice the atom exists. Counted on every tool call, shown to nobody but

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -560,6 +560,19 @@ Ranking fuses BM25 with whole-corpus semantic search over int8 vectors, so a mes
 no word with your query can still win. Semantic ranking follows `search.vector.enabled`; with
 vectors off, transcript search is keyword-only and every result says so.
 
+**The two halves are indexed on different schedules, and only one of them is automatic.** The
+lexical half rides the turn-stop hook, which needs no model and costs little. The semantic half
+does not: a hook is a fresh process per turn, so the embedding model would be cold every time, and
+loading it cost more than the whole catch-up budget — measured at ~1.8s against a 1.5s budget, in
+a repository with nothing to index. The pass then found its deadline already spent and embedded
+nothing, every turn. Before 5.14.0 that was the shipped behaviour and it was silent: one real
+store held 12,598 indexed messages and 4 vectors.
+
+So embedding now happens where a model stays warm — inside the long-lived `knowl serve` process,
+as a short top-up when you actually run `knowl_transcript_search` — or in bulk, under a budget you
+chose, with `knowl reindex --transcripts`. **If you enabled transcript search before 5.14.0, run
+that once**; the change stops coverage decaying but does not backfill what never landed.
+
 Three tools appear only when the feature is enabled, which is why they are absent from the
 canonical tool table below:
 
@@ -726,6 +739,14 @@ Separate from what Knowl *stores*: these are the messages it sends the agent bet
 calls. Both are **on by default**, and both share the single mid-turn slot with the change card
 and the capture prompts — turning one off does not give the others more room, it gives the turn
 back.
+
+Since 5.14.0 the same two keys also govern the **turn-start card**, the one a host's prompt hook
+delivers. It used to be unconditional: the same paragraph on every prompt, and because turn-start
+context accumulates in the transcript rather than replacing the previous copy, a 40-turn session
+carried 40 identical copies. It is also a restatement of `KNOWL.md`/`AGENTS.md`, which every host
+already carries in its system prompt. It now lands on the first prompt of a conversation and then
+follows the schedule below, counted in completed turns rather than tool calls — so `driftEvery 0`
+silences it too.
 
 ```bash
 knowl config set reminders.driftEvery 24        # remind half as often; 0 turns it off

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.13.0",
+      "version": "5.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts 5.14.0 for #203. Version bumped across `package.json`, `package-lock.json` and `.claude-plugin/plugin.json`; `npm run check:versions` agrees.

## Why minor and not patch

Three reasons, any one of which would be enough:

1. **`knowl doctor` will report a problem on every existing install.** `verifyNestedHookConfig` compares whole entries, so a config still carrying `matcher: ".*"` on the pre-tool event reads as stale until `knowl init` runs. A patch that makes doctor complain everywhere is a surprise; a minor with an upgrade section is not.
2. **A documented capability moved off the automatic path.** Semantic transcript coverage used to be described as riding the turn-stop hook. It never actually worked there — one real store held 12,598 indexed messages and 4 vectors — but the contract said it did, and now it needs `knowl reindex --transcripts`.
3. **`HostProfile.writeTools` is a new field on an exported type.** Additive, backwards compatible, minor by the letter of semver.

## Docs, not only the changelog

Two claims in `docs/reference.md` were falsified by what #203 fixed, so both are rewritten rather than appended to:

- **The transcript section** described one index on one schedule. It is two halves on two schedules and only the lexical one is automatic. The new paragraph says why an embedding model cannot live in a per-turn hook (fresh process, cold model, ~1.8s load against a 1.5s budget, deadline enforced before the work), and where embedding happens instead. Anyone who turned transcript search on before this release will look here for the one `knowl reindex --transcripts` they need.
- **`reminders.*`** was introduced as "the messages it sends the agent between tool calls". Those two keys now govern the turn-start card as well, and someone setting `driftEvery 0` should know it silences both.

The README's transcript bullet gains one clause on where semantic coverage comes from now — the level of detail a feature list carries, not more.

## Also

Recreates the `## Unreleased` heading. The 5.12.0 and 5.13.0 release commits each consumed it in place and nothing put it back, which `07652bb` had to work around; this stops the third repeat.

## Upgrade notes, as shipped in the changelog

- Run `knowl init <host>` — or `knowl doctor --fix` — so the pre-tool matcher is rewritten.
- If transcript search was already on, run `knowl reindex --transcripts --budget 10` once. This release stops semantic coverage decaying; it does not backfill what never landed.

## Verification

`npm run typecheck`, `npm run docs:check`, `npm run check:versions`, `npm run lint` all clean. No source changes in this PR — the code shipped in #203, which merged green on Windows, macOS and Linux across Node 22 and 24.
