### PR TITLE
docs: parallel agents in git worktrees share the main checkout's store

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ the agent picks up its guidance, and it will query and write memory on its own.
 Neovim and Kiro work the same way as Zed and JetBrains, through `knowl acp`. Cline needs one
 line pointing it at the shipped plugin. Any other MCP client works with no integration at all.
 
+Running agents in parallel? Every **git worktree** resolves to the main checkout's store —
+[Conductor](https://conductor.build) workspaces, Claude Code's `isolation: "worktree"`, or your
+own scripts all share one memory, with nothing to configure.
+[How that works, and its one limit →](docs/hosts.md#parallel-agents-and-git-worktrees)
+
 → [Every host, and what each one can do](docs/hosts.md) · [How agents use it](#how-agents-use-it) · [MCP tools and resources](docs/reference.md#mcp-tools-and-resources)
 
 ## The idea: memory that retires itself

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -73,6 +73,17 @@ command = "knowl"
 args = ["serve", "--host", "openhands"]
 ```
 
+## Parallel agents and git worktrees
+
+Orchestrators that fan agents out — [Conductor](https://conductor.build), Claude Code's `isolation: "worktree"`, or a plain `git worktree add` script — give each agent its own checkout. Since **5.4.1**, every one of those checkouts resolves to the **main checkout's store**: `.knowl/` is gitignored, so a linked worktree carries no marker of its own, and project discovery falls back to `git rev-parse --git-common-dir`, whose parent is the main checkout. The fallback applies the same project check as the ordinary walk, so a repository that was never initialized still reports no project rather than borrowing a store.
+
+The consequence is the thing parallel agents actually need: **N workspaces share one memory.** What an agent verifies in workspace 1, its siblings can query from workspaces 2 through N — no configuration beyond `knowl init`, run once, in the main checkout. Worktree placement does not matter; inside the repository, a sibling directory, or a temp directory all resolve identically. (Before 5.4.1 a worktree placed outside the repository failed every command with `No Knowl project found` — if that is what you are seeing, upgrade.)
+
+What that does and does not promise:
+
+- **Concurrent writes are safe, not smart.** The store runs WAL with a busy timeout and a retry, so simultaneous writers get bounded waits rather than errors, and same-subject supersession applies no matter which workspace wrote first. Nothing merges two agents' *findings* for you — that is what the conflict surface is for.
+- **A worktree is not a clone.** A hosted sandbox that clones fresh per VM — Conductor Cloud, OpenHands hosted, and their kin — shares no git directory with your checkout, so there is nothing for discovery to resolve to and the local store starts empty every time. That lane needs the [synced store](../README.md#sharing-memory-across-a-team-knowlcloud), not a worktree.
+
 ## Why some hosts get less
 
 **Cursor's mid-turn card.** Emitted, accepted, logged, and never shown to the model — vendor ticket T-C20310, still open. Knowl emits it anyway so it starts working the day that ships, and meanwhile Cursor is notified over MCP.


### PR DESCRIPTION
#123 made every linked worktree resolve to the main checkout's store, and it shipped in 5.4.1 — but the docs never caught up: `README.md` and `docs/hosts.md` both contain zero occurrences of *worktree*, *parallel*, or *Conductor*. Anyone who hears "Knowl works under a parallel-agent runner" and clicks through finds nothing confirming it.

**Re-verified before writing this, on 5.12.0 (2026-08-27):** a worktree created *outside* the repository — the layout Conductor and Claude Code's `isolation: "worktree"` produce — passes `knowl doctor` resolving to the main checkout's store, and `knowl query` returns results, exit 0. The exact reproduction that failed on 5.4.0.

Two changes, docs only:

- **`docs/hosts.md`** — new section *Parallel agents and git worktrees*: the mechanism (`git rev-parse --git-common-dir` fallback, same project check as the ordinary walk), the pre-5.4.1 failure shape so people on old versions recognise it, and the two limits stated honestly — concurrent writes get WAL + busy-timeout bounded waits but nothing merges two agents' findings, and a fresh-clone sandbox (Conductor Cloud, OpenHands hosted) is not a worktree: no shared git directory, empty store, synced-store lane.
- **`README.md`** — four lines at the end of *Connecting an agent* pointing at that section.

No code, no version claims beyond what #123 / 5.4.1 already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
