### PR TITLE
fix: the session card was sliced, not composed — subagents lost skills entirely, parents lost knowledge to their own warnings

### DIFF
--- a/docs/evals/subagent-card-composition.md
+++ b/docs/evals/subagent-card-composition.md
@@ -1,0 +1,113 @@
+# The subagent card: what a child actually received, and what the recent-knowledge block was buying
+
+Run 2026-08-27 against this machine's stores and a 12-subagent A/B on Claude Code 2.1.221.
+Companion to `guidance-card-cost.md`, which derived the *ceiling* for the compact card; this
+derives the *composition* of the block that follows it for a subagent.
+
+Two independent findings. The first is a defect and is the more consequential of the two. The
+second is the measurement that decided what replaces the removed block.
+
+---
+
+## 1. A subagent in a linked workspace received no skills and no knowledge
+
+`bootstrapAgentContext` took the parent's rendered card and sliced it:
+
+```ts
+const cap = Math.floor(DEFAULT_CONTEXT_MAX_CHARS / 2);            // 1500
+const recentBudget = Math.max(0, cap - KNOWL_SUBAGENT_BOOTSTRAP_CARD.length - 2);  // 853
+const recent = bootstrap.context ? truncateText(bootstrap.context, recentBudget) : undefined;
+```
+
+Section offsets in the **real** rendered card, counted on this repo's own four-repo `duck`
+workspace:
+
+| cumulative chars | section |
+| ---: | --- |
+| 129 | header + `PROVENANCE` notice |
+| 1,163 | + workspace section (**the repo list alone is 1,034**) |
+| 1,860 | + skills section |
+| 1,888 | `## Recent Active Knowledge` begins |
+
+The cut lands at **853**. It does not reach the skills heading, let alone the knowledge. A
+subagent received the header and a repo list truncated mid-entry, and nothing else.
+
+**Why the skills half is the serious one.** `context-bootstrap.ts` states the reason the skills
+section exists at all, twice: `getRecentContext` "returns only the three most recent items of any
+category, so a skill created last month would never appear", and a peer repo's shared skill "could
+be found only by an agent who already knew to ask for it, which is exactly the agent who does not
+know the tooling exists". Recent knowledge is recoverable by querying. Ambient skill discovery is
+not. The slice dropped precisely the non-recoverable half.
+
+**Why nothing caught it.** `format.ts` already clamps the skills section — `skillBudget` is a
+quarter of the cap — with a comment naming this exact failure shape: "an unclamped quarter is
+unbounded and, since skills render first, would push recent knowledge out of the card entirely."
+Nothing clamps the workspace section, which renders *before* skills and grows with each linked
+repo. Four repos already exceed a subagent's entire budget on the repo list alone.
+
+**Scope.** Unlinked projects are unaffected: `workspaceSection` is absent and produces
+byte-identical output, so the header leaves the skills section room. This is a linked-workspace
+defect, it scales with repo count, and it therefore bites the team configuration hardest.
+
+**Adjacent case, deliberately not changed here.** The parent session-start path at
+`host-lifecycle.ts` has the same blind-slice shape against the full 3,000 budget. It clears 1,888
+on this workspace so it does render knowledge — but when a staleness or drift warning is present,
+`recentBudget` shrinks by the warning's length and the same squeeze applies. Out of scope; noted so
+the next reader does not assume it was considered and dismissed.
+
+---
+
+## 2. Recent-item titles were being answered *from*, not queried against
+
+Three arms, six Claude Code subagents each (sonnet), one task, identical guidance card. The arms
+differ **only** in the block following the card. The task deliberately contained none of the
+retrieval vocabulary, so the agent had to decide for itself to look:
+
+> We want several coding agents working in parallel worktrees to stop building on things a sibling
+> has already invalidated. Propose the mechanism you would build.
+
+| arm | block | called `knowl_query` | subagent tokens |
+| --- | --- | ---: | ---: |
+| A | 853 chars — 5 item titles (the shipped size) | **6 / 6** | ~40k |
+| B | 2,353 chars — 13 item titles (un-halved) | **1 / 6** | ~33k |
+| C | ~120 chars — a bare pointer, no answerable content | **6 / 6** | ~40k |
+
+Fisher exact, one-tailed, B against A: `C(7,6)/C(12,6)` = **p = 0.0076**.
+
+The relationship is monotonic and the direction is the surprise: **the more answerable content the
+card carries, the less the child retrieves.** Arm B is also the *cheapest* arm, because it never
+looks anything up — a cost saving that is entirely the defect.
+
+**What the arms actually produced.** Arms A and C opened atoms and cited body-level detail their
+titles do not contain — Salsa backdating, the ~12%-actionable drift figure, CALM's non-monotonicity
+argument, the out-of-repo worktree blackout. The five non-retrieving arm B agents recombined their
+own injected titles and cited nothing that was not already in front of them; "Canopy", "one join
+away" and "the ledger has no notion of truth" are verbatim title fragments. Arm B's answers read as
+good or better while being assembled entirely from summaries.
+
+**Consequence.** A pointer cannot be answered from. It costs a seventh of arm A's bytes and buys
+the same lookup, which is why the block is now a pointer and no count is printed beside it —
+`getRecentContext` returns at most three items regardless of store size, so any count in scope
+would understate the store and read as a reason not to bother.
+
+---
+
+## What was changed
+
+- `formatRecentContextToMarkdown` gained `compactWorkspace` (names and write-visibility only,
+  dropping the unbounded `role` prose) and `knowledgeAsPointer`.
+- `bootstrapAgentSession` gained `agentCap`, which **composes** the card for a subagent's budget
+  instead of returning the parent's card for a caller to slice.
+- `bootstrapAgentContext` passes the cap and no longer truncates.
+
+## Caveats
+
+1. n = 18 subagents across three arms, one task, one model. Real, and thin.
+2. Every probe agent additionally received the live `SubagentStart` card, so arm A carried a
+   doubled baseline. What the experiment tested is the **contrast** between blocks, not their
+   absolute effect.
+3. A discarded first probe put the retrieval vocabulary in the task text and hit the ceiling —
+   6/6 correct in both arms. That failure is itself a result: a thin card does not hurt when the
+   agent is handed its query. It hurts when the agent must work out that it should look.
+4. Finding 1 makes arm A of finding 2 *more generous than production had been*: on a linked
+   workspace those titles were not reaching the child at all.

--- a/scripts/measure-parent-card-squeeze.ts
+++ b/scripts/measure-parent-card-squeeze.ts
@@ -1,0 +1,106 @@
+/**
+ * Can the parent session-start card's warning block squeeze skills or knowledge out?
+ *
+ * The parent path budgets like this (src/session/host-lifecycle.ts):
+ *   warning      = truncateText([stale, drift, standing].filter(Boolean).join('\n\n'), 3000)
+ *   recentBudget = warning ? 3000 - warning.length - 2 : 3000
+ *   recent       = truncateText(started.context, recentBudget)
+ *
+ * That is the same render-wide-then-slice shape the subagent path had. The question is whether
+ * the warning can grow far enough to push the cut back past a section boundary. All three
+ * producers are bounded, so this is decidable rather than a matter of taste.
+ *
+ * Run: npx tsx scripts/measure-parent-card-squeeze.ts
+ * Reads nothing and writes nothing.
+ */
+import { describeAutoDrift } from '../src/store/drift-auto.js';
+import { describeObservedUsePromotions } from '../src/store/tier.js';
+import { formatRecentContextToMarkdown } from '../src/core/format.js';
+import { DEFAULT_CONTEXT_MAX_CHARS, MAX_TITLE_CHARS } from '../src/core/token-budget.js';
+import type { KnowledgeItem } from '../src/core/types.js';
+
+// The literal from staleGuidanceWarningBestEffort. Copied rather than called because the function
+// is module-private and gated on filesystem state; its return value is a constant.
+const STALE = 'KNOWL GUIDANCE STALE: this project\'s KNOWL.md / AGENTS.md were written by a different '
+  + 'version of Knowl than the one running, so they may contradict the guidance in this block. '
+  + 'Where they disagree, the file is the stale one. Run `knowl init` (or `knowl doctor --fix`) '
+  + 'to refresh them.';
+
+const maxTitle = 'T'.repeat(MAX_TITLE_CHARS);
+// WARNING_TITLE_LIMIT is 3 and titles are capped at MAX_TITLE_CHARS, so this is the largest
+// drift line the producer can emit. candidateCount above the title count adds the ', …'.
+const drift = describeAutoDrift({
+  checked: true, candidateCount: 99, candidateTitles: [maxTitle, maxTitle, maxTitle],
+  sinceCommit: 'a'.repeat(40),
+} as never) ?? '';
+const standing = describeObservedUsePromotions({ promoted: new Array(9).fill({}), deferred: 42 } as never) ?? '';
+
+const worst = [STALE, drift, standing].join('\n\n');
+
+// The same four-repo workspace the subagent defect was measured on.
+const role = (what: string) => `${what}, and a further clause of the kind manifests actually carry describing what stays private, what is shared, and which conventions a reader should not assume transfer`;
+const workspace = {
+  name: 'duck', repo: 'knowl-cloud', selfRole: role('the hosted team-memory service'),
+  peers: [
+    { name: 'duckprep', role: role('the consumer SAT app'), defaultVisibility: 'workspace' as const },
+    { name: 'ducksat', role: role('the private tutoring tool'), defaultVisibility: 'workspace' as const },
+    { name: 'students', role: role('per-student tutoring records'), defaultVisibility: 'workspace' as const },
+  ],
+};
+const item = (t: string, category: 'fact' | 'skill'): KnowledgeItem => ({
+  id: t, title: t, content: 'a body of the ordinary length these carry in a real store, long enough to matter',
+  category, status: 'active', createdAt: '2026-08-27T00:00:00.000Z', updatedAt: '2026-08-27T00:00:00.000Z',
+} as KnowledgeItem);
+
+const card = formatRecentContextToMarkdown({
+  items: [item('one', 'fact'), item('two', 'fact'), item('three', 'fact')],
+  commits: [],
+  // Three skills with titles of the length real ones carry. The live card measured on this
+  // machine rendered its skills section at 697 characters against the 750 the 25% clamp allows,
+  // so a one-skill fixture understates the boundary by ~600 and quietly moves the answer.
+  skills: [
+    item('William\'s work-or-sleep cycle — delete the middle state, ride 70+ down, sleep before the cliff', 'skill'),
+    item('knowl-cloud\'s image generator lives at scripts/design/gen-image.mjs — but ONLY on branch docs/research-and-agent-surface, not on main', 'skill'),
+    item('Website-cloning skill design: the 10-part spine assembled from 6 specimens, none of which has all of it', 'skill'),
+  ],
+}, { maxChars: Number.MAX_SAFE_INTEGER, workspace });
+
+const skillsAt = card.indexOf('## Available skills');
+const knowledgeAt = card.indexOf('## Recent Active Knowledge');
+
+const row = (label: string, n: number) => console.log(`  ${String(n).padStart(6)}  ${label}`);
+console.log('\nWARNING BLOCK, each producer at its maximum:');
+row('stale-guidance (fixed string)', STALE.length);
+row(`drift (${'WARNING_TITLE_LIMIT'} = 3 titles at MAX_TITLE_CHARS ${MAX_TITLE_CHARS})`, drift.length);
+row('standing (fixed + deferred clause)', standing.length);
+row('joined worst case', worst.length);
+
+console.log('\nCARD SECTION BOUNDARIES (four-repo workspace):');
+row('"## Available skills" begins at', skillsAt);
+row('"## Recent Active Knowledge" begins at', knowledgeAt);
+
+const budget = DEFAULT_CONTEXT_MAX_CHARS - worst.length - 2;
+console.log('\nBUDGET LEFT FOR THE CARD:');
+row('with no warning', DEFAULT_CONTEXT_MAX_CHARS);
+row('at worst-case warning', budget);
+console.log(`\n  warning length that costs knowledge under a blind slice: > ${DEFAULT_CONTEXT_MAX_CHARS - knowledgeAt - 2}`);
+console.log(`  warning length that costs skills under a blind slice:    > ${DEFAULT_CONTEXT_MAX_CHARS - skillsAt - 2}`);
+
+// The two paths, side by side. `sliced` is what the parent used to do: render at
+// MAX_SAFE_INTEGER, then cut the finished string. `composed` is what it does now.
+const sliced = card.slice(0, budget);
+const composed = formatRecentContextToMarkdown({
+  items: [item('one', 'fact'), item('two', 'fact'), item('three', 'fact')],
+  commits: [],
+  skills: [item('a skill that cannot be found by querying', 'skill')],
+}, { maxChars: budget, workspace });
+
+const verdict = (label: string, md: string) => {
+  console.log(`\n  ${label}  (${md.length} chars)`);
+  console.log(`    skills:    ${md.includes('## Available skills') ? 'present' : 'LOST'}`);
+  console.log(`    knowledge: ${md.includes('## Recent Active Knowledge') ? 'present' : 'LOST'}`);
+};
+console.log('\nAT THE WORST-CASE WARNING, FOUR-REPO WORKSPACE:');
+verdict('render wide then slice (the old parent path)', sliced);
+verdict('compose to the budget (the current parent path)', composed);
+console.log();

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -124,7 +124,7 @@ export type WorkspaceContext = {
  * not share a nature. A notes repo whose entire content is cross-cutting looks exactly like a
  * code repo with private internals when all you have is a name.
  */
-function workspaceSection(workspace: WorkspaceContext): string {
+function workspaceSection(workspace: WorkspaceContext, compact = false): string {
   // Manifest fields, and manifest fields reach this card unreviewed. `normalizeRepoEntry` is not
   // the defence: it is documented never to reject, because `discoverRepos` reads every manifest
   // on the machine and one bad entry must not take down a machine-wide command. So `name` is
@@ -135,7 +135,9 @@ function workspaceSection(workspace: WorkspaceContext): string {
     const name = inlineUntrusted(repo.name);
     const kin = repo.kin ? inlineUntrusted(repo.kin) : '';
     const parts = [`- ${name}${isSelf ? ' (this repo)' : ''}${kin ? ` [kin: ${kin}]` : ''}`];
-    if (repo.role) parts.push(inlineUntrusted(repo.role));
+    // Dropped first under `compact`, because it is the only unbounded field here: `name` and
+    // `kin` are short identifiers, `role` is free prose from the manifest.
+    if (repo.role && !compact) parts.push(inlineUntrusted(repo.role));
     parts.push(repo.defaultVisibility === 'workspace' ? 'new writes are workspace-visible' : 'new writes stay private');
     return parts.join(' — ');
   };
@@ -162,7 +164,34 @@ export function formatRecentContextToMarkdown(context: {
    * the dependency graph -- `workspace/peer-skills.ts` produces this shape and imports downward.
    */
   peerSkills?: Array<{ repo: string; item: KnowledgeItem }>;
-}, options: { maxChars?: number; maxItemChars?: number; includeTags?: boolean; includeCommitDetails?: boolean; workspace?: WorkspaceContext } = {}): string {
+}, options: {
+  maxChars?: number;
+  maxItemChars?: number;
+  includeTags?: boolean;
+  includeCommitDetails?: boolean;
+  workspace?: WorkspaceContext;
+  /**
+   * Names and write-visibility only, dropping each repo's `role` prose.
+   *
+   * The role lines are the bulk of this section and they scale with the number of linked repos:
+   * on a four-repo workspace the full list measured 1,034 characters, which alone exceeds a
+   * subagent's whole 853-character budget. Nothing clamps this section the way `skillBudget`
+   * clamps skills, so an unclamped workspace pushed BOTH skills and recent knowledge out of a
+   * subagent's card entirely -- and skills are the half that cannot be recovered by querying.
+   */
+  compactWorkspace?: boolean;
+  /**
+   * Replace recent knowledge and commits with a count and an instruction to query.
+   *
+   * Measured, three arms of six subagents each on one task, differing only in this block:
+   * five item titles -> 6/6 called `knowl_query`; thirteen titles -> 1/6; a bare pointer with no
+   * answerable content -> 6/6, at a seventh of the size (Fisher exact p = 0.008 for the middle
+   * arm against either other). Titles long enough to look sufficient are answered FROM rather
+   * than queried against, and the agents that skipped retrieval cited only their own injected
+   * titles back. A pointer cannot be answered from, so it costs bytes and buys the lookup.
+   */
+  knowledgeAsPointer?: boolean;
+} = {}): string {
   const maxChars = options.maxChars ?? DEFAULT_CONTEXT_MAX_CHARS;
   const maxItemChars = options.maxItemChars ?? MAX_SUMMARY_ITEM_CHARS;
   // The notice leads, and must: this card is injected at session bootstrap with no human in
@@ -172,7 +201,7 @@ export function formatRecentContextToMarkdown(context: {
 
   // Absent produces byte-identical output, the same rule formatWorkspaceBlock already holds
   // for an unlinked project.
-  if (options.workspace) md += workspaceSection(options.workspace);
+  if (options.workspace) md += workspaceSection(options.workspace, options.compactWorkspace === true);
 
   // A quarter of the budget at most, and only what fits. An agent that already knows a
   // skill exists needs no mid-turn interrupt, which is why this section earns its space.
@@ -193,6 +222,17 @@ export function formatRecentContextToMarkdown(context: {
     skillBudget,
     toPeerSurfacedSkills(context.peerSkills ?? []),
   ));
+
+  // Pointer mode ends the card here: both remaining sections are recent-activity summaries, and
+  // both are recoverable by querying, which is the whole argument for replacing them. No count is
+  // given because the only one in scope would be a lie -- `getRecentContext` returns at most three
+  // items regardless of how much the store holds, so "3 items" would understate a store of
+  // thousands and read as a reason not to bother.
+  if (options.knowledgeAsPointer) {
+    md += '## Project knowledge\n\nNot reproduced here. Call knowl_query with the words that name '
+      + 'your subject to open what is relevant to your task.\n';
+    return md.length <= maxChars ? md : truncateText(md, maxChars, '[Context truncated]');
+  }
 
   md += '## Recent Active Knowledge\n\n';
   if (context.items.length === 0) {

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -293,24 +293,25 @@ async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook
   };
 }
 
-// Subagent bootstrap deliberately halves the recent-context cap: fan-out multiplies
-// whatever a subagent costs. The guidance card is prepended rather than left to the
-// prompt reminder, because a subagent receives no prompt event and a live probe confirmed
-// MCP server instructions do not reach it either — without the card it gets memory data
-// and nothing telling it to use memory. The card is charged against the cap first so a
-// large recent-context block can never truncate the guidance away.
+// Subagent bootstrap deliberately halves the cap: fan-out multiplies whatever a subagent costs.
+// The guidance card is prepended rather than left to the prompt reminder, because a subagent
+// receives no prompt event and a live probe confirmed MCP server instructions do not reach it
+// either — without the card it gets memory data and nothing telling it to use memory. The card is
+// charged against the cap first so the body can never truncate the guidance away.
+//
+// The remaining budget is COMPOSED for that size rather than sliced down from the parent's card
+// (`agentCap`). Slicing was measured delivering a workspace subagent a half-finished repo list and
+// nothing else, and the replacement pointer is measured buying the lookup the titles it replaced
+// were being answered from instead — both derivations live at the option definitions.
 async function bootstrapAgentContext(projectId: string, input: NormalizedHostHook, sessionId: string) {
   const bootstrap = await bootstrapAgentSession({
     projectId,
     title: input.title ?? 'Agent session (subagent)',
     agent: String(input.host),
     sessionId,
-  }, { includeContext: true });
-  const cap = Math.floor(DEFAULT_CONTEXT_MAX_CHARS / 2);
-  const recentBudget = Math.max(0, cap - KNOWL_SUBAGENT_BOOTSTRAP_CARD.length - 2);
-  const recent = bootstrap.context ? truncateText(bootstrap.context, recentBudget) : undefined;
-  const context = recent ? `${KNOWL_SUBAGENT_BOOTSTRAP_CARD}\n\n${recent}` : KNOWL_SUBAGENT_BOOTSTRAP_CARD;
-  return { context, truncated: Boolean(bootstrap.context && bootstrap.context.length > recentBudget) };
+  }, { includeContext: true, agentCap: Math.max(0, Math.floor(DEFAULT_CONTEXT_MAX_CHARS / 2) - KNOWL_SUBAGENT_BOOTSTRAP_CARD.length - 2) });
+  const context = bootstrap.context ? `${KNOWL_SUBAGENT_BOOTSTRAP_CARD}\n\n${bootstrap.context}` : KNOWL_SUBAGENT_BOOTSTRAP_CARD;
+  return { context, truncated: bootstrap.truncated };
 }
 
 /**

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -243,48 +243,49 @@ function hostContextOutput(input: NormalizedHostHook, context: string | undefine
   return hostProfile(input.host).startContext(input.event, context);
 }
 
-function mergeBootstrapContext(handoffContext: string | undefined, recentContext: string | undefined): { context?: string; truncated: boolean } {
+function mergeBootstrapContext(handoffContext: string | undefined, recentContext: string | undefined, cap: number = DEFAULT_CONTEXT_MAX_CHARS): { context?: string; truncated: boolean } {
   if (!handoffContext && !recentContext) return { context: undefined, truncated: false };
   if (!handoffContext) {
     return {
       context: recentContext,
-      truncated: Boolean(recentContext && recentContext.length > DEFAULT_CONTEXT_MAX_CHARS),
+      truncated: Boolean(recentContext && recentContext.length > cap),
     };
   }
 
-  const handoff = truncateText(handoffContext, DEFAULT_CONTEXT_MAX_CHARS);
+  const handoff = truncateText(handoffContext, cap);
   if (!recentContext) {
     return {
       context: handoff,
-      truncated: handoffContext.length > DEFAULT_CONTEXT_MAX_CHARS,
+      truncated: handoffContext.length > cap,
     };
   }
 
   const separator = '\n\n';
-  const remaining = Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - handoff.length - separator.length);
+  const remaining = Math.max(0, cap - handoff.length - separator.length);
   if (remaining <= 0) return { context: handoff, truncated: true };
   const recent = truncateText(recentContext, remaining, '\n\n[Context truncated]');
   return {
     context: `${handoff}${separator}${recent}`,
-    truncated: handoffContext.length > DEFAULT_CONTEXT_MAX_CHARS || recentContext.length > remaining,
+    truncated: handoffContext.length > cap || recentContext.length > remaining,
   };
 }
 
-async function startBoundSession(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext = false) {
+async function startBoundSession(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext = false, contextCap?: number) {
   return getOrCreateHostSession({
     projectId,
     ...bindingKey(input, scope),
     title: input.title ?? (scope === 'session' ? 'Agent session' : 'Agent turn'),
     includeContext,
+    contextCap,
   });
 }
 
-async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext: boolean) {
-  const started = await startBoundSession(projectId, input, scope, includeContext);
+async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook, scope: 'session' | 'turn', includeContext: boolean, contextCap?: number) {
+  const started = await startBoundSession(projectId, input, scope, includeContext, contextCap);
   if (!includeContext) return { ...started, handoff: null as Awaited<ReturnType<typeof consumePendingSessionHandoff>> };
 
   const handoff = await consumePendingSessionHandoff(projectId, String(input.host));
-  const merged = mergeBootstrapContext(handoff?.context, started.context);
+  const merged = mergeBootstrapContext(handoff?.context, started.context, contextCap ?? DEFAULT_CONTEXT_MAX_CHARS);
   return {
     ...started,
     context: merged.context,
@@ -309,7 +310,11 @@ async function bootstrapAgentContext(projectId: string, input: NormalizedHostHoo
     title: input.title ?? 'Agent session (subagent)',
     agent: String(input.host),
     sessionId,
-  }, { includeContext: true, agentCap: Math.max(0, Math.floor(DEFAULT_CONTEXT_MAX_CHARS / 2) - KNOWL_SUBAGENT_BOOTSTRAP_CARD.length - 2) });
+  }, {
+    includeContext: true,
+    contextCap: Math.max(0, Math.floor(DEFAULT_CONTEXT_MAX_CHARS / 2) - KNOWL_SUBAGENT_BOOTSTRAP_CARD.length - 2),
+    agentCard: true,
+  });
   const context = bootstrap.context ? `${KNOWL_SUBAGENT_BOOTSTRAP_CARD}\n\n${bootstrap.context}` : KNOWL_SUBAGENT_BOOTSTRAP_CARD;
   return { context, truncated: bootstrap.truncated };
 }
@@ -928,11 +933,22 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // A project with no git history therefore never promotes on observed use, which is the
     // same falsifiability rule as `affected_paths`, applied to the repository instead.
     const standing = drift?.checked ? await promoteByObservedUseBestEffort(projectId) : null;
-    const started = await bootstrapWithHandoff(projectId, input, 'session', true);
-    // The warning is charged against the cap first — the same rule the subagent card
-    // follows. Prepending it to an already-budgeted block pushed the session past the size
-    // the host was promised, and the warning is the part that must survive: the watermark
-    // has already advanced, so this line is the only record of the window.
+
+    // Warnings are priced BEFORE the card is rendered, so the card is composed to what is left
+    // rather than rendered wide and sliced. `drift` and `standing` are resolved above and the
+    // stale-guidance check reads only the filesystem, so nothing here needs the session first.
+    //
+    // Measured worst case on a four-repo workspace: the three producers cap at 283 + 777 + 246 =
+    // 1,310 characters joined, against a recent-knowledge heading that begins at 1,777 — so a full
+    // warning block left 1,688 and cut the knowledge section off entirely. Skills were never at
+    // risk here (they would need a 1,888-character warning, above the producers' ceiling), which
+    // is what separates this from the subagent case. scripts/measure-parent-card-squeeze.ts
+    // recomputes every number in this paragraph.
+    //
+    // The warning is charged against the cap first — the same rule the subagent card follows.
+    // Prepending it to an already-budgeted block pushed the session past the size the host was
+    // promised, and the warning is the part that must survive: the watermark has already
+    // advanced, so this line is the only record of the window.
     // Guidance first, then drift. Both are charged against the cap before recent context, and if
     // only one survives truncation it should be the one saying the instructions on disk cannot be
     // trusted -- an agent acting on stale guidance gets the subsequent work wrong, where a missed
@@ -948,14 +964,18 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     const recentBudget = warning
       ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - warning.length - 2)
       : DEFAULT_CONTEXT_MAX_CHARS;
-    const recent = started.context ? truncateText(started.context, recentBudget) : undefined;
-    const context = warning ? (recent ? `${warning}\n\n${recent}` : warning) : recent;
+    const started = await bootstrapWithHandoff(projectId, input, 'session', true, recentBudget);
+    // No second truncation here: `started.context` was already composed to `recentBudget`.
+    const context = warning
+      ? (started.context ? `${warning}\n\n${started.context}` : warning)
+      : started.context;
     return {
       accepted: true,
       sessionId: started.session.id,
       context,
-      contextTruncated: started.truncated
-        || Boolean(started.context && started.context.length > recentBudget),
+      // `started.truncated` alone now: the second clause compared the card against the very
+      // budget it was composed to, so it could only ever be false once the slice went away.
+      contextTruncated: started.truncated,
       recoveredCount: recovered.length,
       purgedEventCount,
       hostOutput: hostContextOutput(input, context),

--- a/src/session/host-session-bindings.ts
+++ b/src/session/host-session-bindings.ts
@@ -19,6 +19,8 @@ export type HostSessionInput = HostSessionKey & {
   title: string;
   query?: string;
   includeContext?: boolean;
+  /** Render the card to this ceiling rather than leaving a caller to slice the finished string. */
+  contextCap?: number;
 };
 
 const normalizedKey = (input: HostSessionKey) => ({
@@ -56,7 +58,7 @@ export async function getOrCreateHostSession(input: HostSessionInput) {
       query: input.query,
       agent: String(input.host),
       sessionId: existing.id,
-    }, { includeContext: input.includeContext });
+    }, { includeContext: input.includeContext, contextCap: input.contextCap });
     return { ...bootstrap, created: false };
   }
 
@@ -65,7 +67,7 @@ export async function getOrCreateHostSession(input: HostSessionInput) {
     title: input.title,
     query: input.query,
     agent: String(input.host),
-  }, { includeContext: input.includeContext });
+  }, { includeContext: input.includeContext, contextCap: input.contextCap });
   await bindHostSession(input, bootstrap.session.id);
   return { ...bootstrap, created: true };
 }

--- a/src/store/context-bootstrap.ts
+++ b/src/store/context-bootstrap.ts
@@ -51,7 +51,13 @@ async function workspaceContext(): Promise<{ workspace?: WorkspaceContext; peerS
 }
 
 /**
- * `agentCap` composes the card FOR a subagent's budget instead of tail-cutting the parent's.
+ * The card is COMPOSED to `contextCap` -- never rendered wide for a caller to slice afterwards.
+ *
+ * `contextCap` defaults to the full budget rather than being optional, because an omitted cap was
+ * the defect: it fell through to a `MAX_SAFE_INTEGER` render that the caller then tail-cut, and a
+ * tail cut lands wherever the arithmetic puts it rather than on a section boundary. Composing is
+ * not the same operation -- only the formatter knows that skills are clamped to a quarter and that
+ * the workspace section renders first.
  *
  * The blind slice was measured dropping everything that matters: on a four-repo workspace the
  * rendered card reaches the skills heading only at character 1,163 and recent knowledge at 1,888,
@@ -62,6 +68,7 @@ async function workspaceContext(): Promise<{ workspace?: WorkspaceContext; peerS
  * the header alone leaves the skills section room.
  */
 export async function bootstrapAgentSession(input: AgentBootstrapInput, options: { includeContext?: boolean; contextCap?: number; agentCard?: boolean } = {}) {
+  const contextCap = options.contextCap ?? DEFAULT_CONTEXT_MAX_CHARS;
   let session;
   if (input.sessionId) {
     try {
@@ -82,31 +89,18 @@ export async function bootstrapAgentSession(input: AgentBootstrapInput, options:
   // skill could be found only by an agent who already knew to ask for it, which is exactly the
   // agent who does not know the tooling exists. Peers ride the same card, as pointers.
   const { workspace, peerSkills } = await workspaceContext();
-  if (options.contextCap !== undefined) {
-    // Rendered straight to the cap so the formatter's own budgeting applies -- the skills clamp
-    // and the section ordering only mean anything when it knows the real ceiling. Rendering wide
-    // and slicing afterwards is the defect this replaces, and it is not the same operation.
-    //
-    // `agentCard` is the CONTENT policy and is deliberately separate from the cap. A subagent
-    // gets the compact workspace and the knowledge pointer because both were measured on
-    // subagents; a parent gets neither, because nothing measured says that result transfers and
-    // the parent card is charged to every session of every user.
-    const context = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
-      maxChars: options.contextCap,
-      workspace,
-      compactWorkspace: options.agentCard === true,
-      knowledgeAsPointer: options.agentCard === true,
-    });
-    return { session, context, truncated: context.endsWith('[Context truncated]') };
-  }
-  const fallback = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
-    maxChars: Number.MAX_SAFE_INTEGER,
+  // Rendered straight to the cap so the formatter's own budgeting applies -- the skills clamp
+  // and the section ordering only mean anything when it knows the real ceiling.
+  //
+  // `agentCard` is the CONTENT policy and is deliberately separate from the cap. A subagent gets
+  // the compact workspace and the knowledge pointer because both were measured on subagents; a
+  // parent gets neither, because nothing measured says that result transfers and the parent card
+  // is charged to every session of every user.
+  const context = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
+    maxChars: contextCap,
     workspace,
+    compactWorkspace: options.agentCard === true,
+    knowledgeAsPointer: options.agentCard === true,
   });
-  const truncated = fallback.length > DEFAULT_CONTEXT_MAX_CHARS;
-  return {
-    session,
-    context: truncated ? `${fallback.slice(0, DEFAULT_CONTEXT_MAX_CHARS - 24)}\n\n[Context truncated]` : fallback,
-    truncated,
-  };
+  return { session, context, truncated: context.endsWith('[Context truncated]') };
 }

--- a/src/store/context-bootstrap.ts
+++ b/src/store/context-bootstrap.ts
@@ -50,7 +50,18 @@ async function workspaceContext(): Promise<{ workspace?: WorkspaceContext; peerS
   }
 }
 
-export async function bootstrapAgentSession(input: AgentBootstrapInput, options: { includeContext?: boolean } = {}) {
+/**
+ * `agentCap` composes the card FOR a subagent's budget instead of tail-cutting the parent's.
+ *
+ * The blind slice was measured dropping everything that matters: on a four-repo workspace the
+ * rendered card reaches the skills heading only at character 1,163 and recent knowledge at 1,888,
+ * while a subagent is cut at 853 -- so it received a half-finished repo list and nothing else. No
+ * skills, no knowledge. Skills are the half that cannot be recovered, since `getRecentContext`
+ * returns three items of any category and a peer repo's shared skill is findable only by an agent
+ * who already knows it exists. Unlinked projects never hit this: `workspaceSection` is absent and
+ * the header alone leaves the skills section room.
+ */
+export async function bootstrapAgentSession(input: AgentBootstrapInput, options: { includeContext?: boolean; agentCap?: number } = {}) {
   let session;
   if (input.sessionId) {
     try {
@@ -71,6 +82,17 @@ export async function bootstrapAgentSession(input: AgentBootstrapInput, options:
   // skill could be found only by an agent who already knew to ask for it, which is exactly the
   // agent who does not know the tooling exists. Peers ride the same card, as pointers.
   const { workspace, peerSkills } = await workspaceContext();
+  if (options.agentCap !== undefined) {
+    // Rendered straight to the cap: the formatter's own budgeting keeps the skills section whole
+    // and the pointer is a fixed two lines, so there is nothing left for a post-hoc slice to cut.
+    const context = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
+      maxChars: options.agentCap,
+      workspace,
+      compactWorkspace: true,
+      knowledgeAsPointer: true,
+    });
+    return { session, context, truncated: context.endsWith('[Context truncated]') };
+  }
   const fallback = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
     maxChars: Number.MAX_SAFE_INTEGER,
     workspace,

--- a/src/store/context-bootstrap.ts
+++ b/src/store/context-bootstrap.ts
@@ -61,7 +61,7 @@ async function workspaceContext(): Promise<{ workspace?: WorkspaceContext; peerS
  * who already knows it exists. Unlinked projects never hit this: `workspaceSection` is absent and
  * the header alone leaves the skills section room.
  */
-export async function bootstrapAgentSession(input: AgentBootstrapInput, options: { includeContext?: boolean; agentCap?: number } = {}) {
+export async function bootstrapAgentSession(input: AgentBootstrapInput, options: { includeContext?: boolean; contextCap?: number; agentCard?: boolean } = {}) {
   let session;
   if (input.sessionId) {
     try {
@@ -82,14 +82,20 @@ export async function bootstrapAgentSession(input: AgentBootstrapInput, options:
   // skill could be found only by an agent who already knew to ask for it, which is exactly the
   // agent who does not know the tooling exists. Peers ride the same card, as pointers.
   const { workspace, peerSkills } = await workspaceContext();
-  if (options.agentCap !== undefined) {
-    // Rendered straight to the cap: the formatter's own budgeting keeps the skills section whole
-    // and the pointer is a fixed two lines, so there is nothing left for a post-hoc slice to cut.
+  if (options.contextCap !== undefined) {
+    // Rendered straight to the cap so the formatter's own budgeting applies -- the skills clamp
+    // and the section ordering only mean anything when it knows the real ceiling. Rendering wide
+    // and slicing afterwards is the defect this replaces, and it is not the same operation.
+    //
+    // `agentCard` is the CONTENT policy and is deliberately separate from the cap. A subagent
+    // gets the compact workspace and the knowledge pointer because both were measured on
+    // subagents; a parent gets neither, because nothing measured says that result transfers and
+    // the parent card is charged to every session of every user.
     const context = formatRecentContextToMarkdown({ ...recent, skills, peerSkills }, {
-      maxChars: options.agentCap,
+      maxChars: options.contextCap,
       workspace,
-      compactWorkspace: true,
-      knowledgeAsPointer: true,
+      compactWorkspace: options.agentCard === true,
+      knowledgeAsPointer: options.agentCard === true,
     });
     return { session, context, truncated: context.endsWith('[Context truncated]') };
   }

--- a/tests/core/format-agent-card.test.ts
+++ b/tests/core/format-agent-card.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { formatRecentContextToMarkdown } from '../../src/core/format.js';
+import type { KnowledgeItem } from '../../src/core/types.js';
+
+const item = (title: string, category: 'fact' | 'skill' = 'fact'): KnowledgeItem => ({
+  id: title, title, content: 'body', category, status: 'active',
+  createdAt: '2026-08-27T00:00:00.000Z', updatedAt: '2026-08-27T00:00:00.000Z',
+} as KnowledgeItem);
+
+// `toSurfacedSkills` keeps only active items of category 'skill'; a 'fact' renders no row at
+// all, which is what made the first draft of these tests pass an empty section as a pass.
+const skill = (title: string): KnowledgeItem => item(title, 'skill');
+
+// A four-repo workspace with prose roles, which is what the defect was measured on: the repo
+// list alone rendered 1,034 characters against a subagent's 853-character budget.
+// Roles are the length real manifests carry -- the measured four-repo list was 1,034 characters,
+// about 258 per repo. A fixture with short roles does not reproduce the defect, and the guard
+// test below fails rather than passing quietly if this drifts back under the cap.
+const role = (what: string) => `${what}, and a further clause of the kind manifests actually carry describing what stays private, what is shared, and which conventions a reader should not assume transfer`;
+const WIDE_WORKSPACE = {
+  name: 'duck', repo: 'knowl-cloud',
+  selfRole: role('the hosted team-memory service, Node engine in src/ plus the Next.js client in web/'),
+  peers: [
+    { name: 'duckprep', role: role('the consumer SAT app, React 19 and Postgres'), defaultVisibility: 'workspace' as const },
+    { name: 'ducksat', role: role('the private tutoring tool, vanilla TS and SQLite'), defaultVisibility: 'workspace' as const },
+    { name: 'students', role: role('per-student tutoring records, roster and pedagogy'), defaultVisibility: 'workspace' as const },
+  ],
+};
+
+const AGENT_CAP = 853;
+
+describe('the card composed for a subagent', () => {
+  it('uses a fixture whose repo list alone exceeds a subagent budget, as the real one does', () => {
+    // The precondition every other test here depends on. Stated as an assertion because a
+    // shortened fixture would make the regression tests pass for the wrong reason.
+    const md = formatRecentContextToMarkdown({ items: [], commits: [] }, {
+      maxChars: Number.MAX_SAFE_INTEGER, workspace: WIDE_WORKSPACE,
+    });
+    expect(md.length).toBeGreaterThan(AGENT_CAP);
+  });
+
+  it('reaches the skills section on a workspace whose repo list alone exceeds the budget', () => {
+    // The regression this exists for. Slicing the parent's card at 853 stopped inside the repo
+    // list, so a subagent got no skills at all -- and skills are the part it cannot query for,
+    // because getRecentContext returns three items of any category and a peer's shared skill is
+    // findable only by an agent who already knows it exists.
+    const md = formatRecentContextToMarkdown(
+      { items: [item('a')], commits: [], skills: [skill('a skill worth surfacing')] },
+      { maxChars: AGENT_CAP, workspace: WIDE_WORKSPACE, compactWorkspace: true, knowledgeAsPointer: true },
+    );
+    expect(md).toContain('a skill worth surfacing');
+    expect(md).not.toContain('[Context truncated]');
+    expect(md.length).toBeLessThanOrEqual(AGENT_CAP);
+  });
+
+  it('loses the skills section under the old render-wide-then-slice path', () => {
+    // Pins the CAUSE, and the cause is the two-step: bootstrapAgentSession rendered at
+    // MAX_SAFE_INTEGER and the caller sliced the finished string to 853. Rendering AT 853
+    // instead is not the same operation and does not reproduce the loss -- the formatter's own
+    // skillBudget clamp and section ordering only apply when it knows the real cap, which under
+    // the old path it never did. Written the wrong way round first, and this comment is why.
+    const wide = formatRecentContextToMarkdown(
+      { items: [item('a')], commits: [], skills: [skill('a skill worth surfacing')] },
+      { maxChars: Number.MAX_SAFE_INTEGER, workspace: WIDE_WORKSPACE },
+    );
+    expect(wide).toContain('a skill worth surfacing');
+    expect(wide.slice(0, AGENT_CAP)).not.toContain('a skill worth surfacing');
+  });
+
+  it('drops role prose but keeps repo names and write visibility', () => {
+    const md = formatRecentContextToMarkdown({ items: [], commits: [] }, {
+      maxChars: AGENT_CAP, workspace: WIDE_WORKSPACE, compactWorkspace: true,
+    });
+    expect(md).toContain('- duckprep — new writes are workspace-visible');
+    expect(md).not.toContain('the consumer SAT app');
+  });
+
+  it('replaces recent knowledge with a pointer carrying no answerable content', () => {
+    // Measured: 5 titles -> 6/6 subagents queried, 13 titles -> 1/6, a bare pointer -> 6/6 at a
+    // seventh of the size. Content long enough to look sufficient is answered FROM.
+    const md = formatRecentContextToMarkdown(
+      { items: [item('a title an agent could answer from')], commits: [{ createdAt: 'x', message: 'a commit message', changes: [] } as never] },
+      { maxChars: AGENT_CAP, knowledgeAsPointer: true },
+    );
+    expect(md).toContain('Call knowl_query');
+    expect(md).not.toContain('a title an agent could answer from');
+    expect(md).not.toContain('a commit message');
+    expect(md).not.toMatch(/## Recent Active Knowledge/);
+  });
+
+  it('prints no item count beside the pointer', () => {
+    // getRecentContext returns at most three items whatever the store holds, so any count in
+    // scope understates it and reads as a reason not to bother looking.
+    const md = formatRecentContextToMarkdown(
+      { items: [item('one'), item('two'), item('three')], commits: [] },
+      { maxChars: AGENT_CAP, knowledgeAsPointer: true },
+    );
+    expect(md).not.toMatch(/\b3\b/);
+  });
+
+  it('leaves the parent card unchanged when neither option is set', () => {
+    const md = formatRecentContextToMarkdown({ items: [item('kept')], commits: [] }, { workspace: WIDE_WORKSPACE });
+    expect(md).toContain('kept');
+    expect(md).toContain('the consumer SAT app');
+    expect(md).toContain('## Recent Active Knowledge');
+  });
+});

--- a/tests/core/format-agent-card.test.ts
+++ b/tests/core/format-agent-card.test.ts
@@ -98,6 +98,23 @@ describe('the card composed for a subagent', () => {
     expect(md).not.toMatch(/\b3\b/);
   });
 
+  it('keeps recent knowledge for a parent squeezed by a worst-case warning block', () => {
+    // The parent path prices its warnings first and composes the card into what is left. Its
+    // three producers cap at 283 + 777 + 246 = 1,310 joined; under the old render-wide-then-slice
+    // that cut the knowledge section off entirely on a four-repo workspace. Composing at the same
+    // budget keeps it, because the formatter can drop item BODIES to fit rather than losing a
+    // whole trailing section to a blind cut.
+    const parentBudget = 3000 - 1310 - 2;
+    const md = formatRecentContextToMarkdown(
+      { items: [item('a knowledge item the parent must still see')], commits: [], skills: [skill('a skill')] },
+      { maxChars: parentBudget, workspace: WIDE_WORKSPACE },
+    );
+    expect(md).toContain('## Recent Active Knowledge');
+    expect(md).toContain('a knowledge item the parent must still see');
+    expect(md).toContain('a skill');
+    expect(md.length).toBeLessThanOrEqual(parentBudget);
+  });
+
   it('leaves the parent card unchanged when neither option is set', () => {
     const md = formatRecentContextToMarkdown({ items: [item('kept')], commits: [] }, { workspace: WIDE_WORKSPACE });
     expect(md).toContain('kept');


### PR DESCRIPTION
Two bugs, one root cause, on the two paths that build the session card. Both were rendering the card at `MAX_SAFE_INTEGER` and letting the caller slice the finished string, so anything charged against the budget first pushed the cut backwards into a section boundary.

## 1. A subagent in a linked workspace got no skills and no knowledge

Section offsets in the real rendered card, counted on a four-repo workspace:

| cumulative | section |
| ---: | --- |
| 129 | header + provenance notice |
| 1,163 | + workspace section (**repo list alone = 1,034**) |
| 1,860 | + skills |
| 1,888 | recent knowledge begins |

A subagent is cut at **853**. It received the header and a repo list severed mid-entry, and nothing else.

The skills half is the serious one, and `context-bootstrap.ts` already says why twice: `getRecentContext` "returns only the three most recent items of any category, so a skill created last month would never appear", and a peer repo's shared skill "could be found only by an agent who already knew to ask for it, which is exactly the agent who does not know the tooling exists". Recent knowledge is recoverable by querying. Ambient skill discovery is not.

`format.ts` already clamps skills to a quarter of the cap, with a comment naming this exact failure shape. Nothing clamps the workspace section, which renders *before* skills and grows with every linked repo. Unlinked projects were never affected.

## 2. The parent card lost its knowledge section to its own warnings

Measured with all three warning producers at their ceiling: 283 (stale guidance, fixed) + 777 (drift: `WARNING_TITLE_LIMIT` 3 × `MAX_TITLE_CHARS` 200) + 246 (standing) = **1,310** joined, against a recent-knowledge heading at 1,777. That leaves 1,688 and the blind slice cut knowledge off entirely.

Skills were never at risk here — they would need a 1,888-character warning, above what the producers can emit. So this is the milder bug: a tail case needing all three warnings at once, and the loss is the recoverable half.

## The fix

Price what comes first, then **compose** the card into what is left, so the formatter's own budgeting applies instead of a blind cut.

- `bootstrapAgentSession`'s cap splits into `contextCap` (budget) and `agentCard` (subagent content policy).
- `mergeBootstrapContext` honours the cap, so a handoff cannot reintroduce the overrun.
- The parent takes the cap and **not** the policy — see below.

## The subagent knowledge block is now a pointer, and that part is measured

Three arms of six Claude Code subagents, one task, identical guidance card, differing only in this block. The task deliberately contained none of the retrieval vocabulary, so the agent had to decide for itself to look.

| arm | block | called `knowl_query` |
| --- | --- | ---: |
| A | 853 chars — 5 item titles (the shipped size) | **6 / 6** |
| B | 2,353 chars — 13 titles | **1 / 6** |
| C | ~120 chars — a bare pointer | **6 / 6** |

Fisher exact, one-tailed, B against A: **p = 0.0076**. Monotonic, and the direction is the surprise — content long enough to look sufficient gets answered *from* rather than queried against. The five non-retrieving arm B agents cited only their own injected titles back. Arm B is also the cheapest arm, because it never looks anything up.

No count is printed beside the pointer: `getRecentContext` returns at most three items however much is held, so any count in scope understates the store and reads as a reason not to bother.

**This is applied to subagents only.** The experiment measured subagents; it is not evidence about parents, and the parent card is charged to every session of every user.

## Verification

`tsc --noEmit` exit 0 at repo scope. Full suite **371 files, 3,561 passed, 5 skipped, 0 failed**.

Derivation in `docs/evals/subagent-card-composition.md`, following `guidance-card-cost.md`. `scripts/measure-parent-card-squeeze.ts` recomputes the parent numbers and prints both paths at the same budget — slice loses knowledge, compose keeps both. `tests/core/format-agent-card.test.ts` adds 8 tests, including one asserting its own precondition so a shrunken fixture fails loudly rather than passing for the wrong reason.

## Caveats worth your scrutiny

- n = 18 subagents, one task, one model. Real, and thin.
- Every probe agent also received the live `SubagentStart` card, so arm A carried a doubled baseline; what was tested is the **contrast** between blocks.
- A first probe was discarded at ceiling (6/6 in both arms) because its task text contained the search terms. That failure is itself a result: a thin card does not hurt when the agent is handed its query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
