### PR TITLE
feat(status): date the two-thirds of knowledge no drift check can reach (#98, point 4 only)

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -20,6 +20,7 @@ import { formatHierarchyToMarkdown } from '../core/format.js';
 import { formatStatusReport } from './status-report.js';
 import { captureHealth } from '../store/capture-outcome.js';
 import { recallGapReport } from '../store/recall-gap.js';
+import { unrestatedClaimsReport } from '../store/unrestated.js';
 import { captureNudgeMode } from '../store/capture-config.js';
 import { KNOWLEDGE_CATEGORIES, type KnowledgeCategory } from '../core/types.js';
 import { createManifest, isValidRepoName, readManifest, writeManifest } from '../workspace/manifest.js';
@@ -466,6 +467,7 @@ program
         capture: await captureHealth(),
         captureNudgeMode: captureNudgeMode(config),
         recall: await recallGapReport(project.id),
+        unrestated: await unrestatedClaimsReport(),
         cloud,
         // Reads config.json a second time rather than threading `config` through: the catalog
         // resolves preset-owned values through `resolveVectorProfile`, and duplicating that

--- a/src/cli/status-report.ts
+++ b/src/cli/status-report.ts
@@ -2,6 +2,7 @@ import { KNOWLEDGE_CATEGORIES, KnowledgeCommit, KnowledgeItem, Project, ProjectC
 import type { ActiveWorkspace } from '../workspace/resolve.js';
 import type { CaptureHealth } from '../store/capture-outcome.js';
 import type { RecallGapReport } from '../store/recall-gap.js';
+import type { UnrestatedReport } from '../store/unrestated.js';
 import type { CloudStatus } from '../cloud/status.js';
 import { formatWorkspaceBlock } from './workspace-report.js';
 
@@ -41,6 +42,8 @@ export function formatStatusReport(input: {
   captureNudgeMode?: string;
   /** Absent, or a store that has observed no tool touches, renders no section at all. */
   recall?: RecallGapReport;
+  /** Absent, or a store where no active item carries an open assertion, renders no section. */
+  unrestated?: UnrestatedReport;
   /** Absent or disconnected renders nothing, so an offline repo gains no noise. */
   cloud?: CloudStatus | null;
   /**
@@ -87,6 +90,7 @@ export function formatStatusReport(input: {
   }
   lines.push(...formatCaptureHealthBlock(input.capture, input.captureNudgeMode));
   lines.push(...formatRecallGapBlock(input.recall));
+  lines.push(...formatUnrestatedBlock(input.unrestated));
   lines.push(...formatWorkspaceBlock(input.workspace ?? null));
   lines.push(...formatCloudBlock(input.cloud ?? null));
   lines.push(STATUS_LINE);
@@ -132,6 +136,42 @@ function formatRecallGapBlock(recall?: RecallGapReport): string[] {
     lines.push(`  ...already retrieved:  ${recall.retrieved}`);
     lines.push(`  ...missed:             ${recall.missed} (${Math.round((recall.missed / recall.held) * 100)}%)`);
     lines.push('  Lower bound — only knowledge citing a file path can be counted here.');
+  }
+  return lines;
+}
+
+/**
+ * The knowledge no drift check can reach, dated by when anyone last restated it.
+ *
+ * Report only, and that is the whole of it. For prose there is no evidence a claim became false,
+ * only the absence of anyone reaffirming it -- flagging would assert a defect nothing observed,
+ * and the failure mode of over-eager staleness here is losing knowledge nobody can recover.
+ *
+ * Categories are printed in measured order rather than a fixed one. On a real 962-item store the
+ * longest un-restated were goal, skill, constraint and decision, and `state` was among the
+ * best-maintained -- the opposite of the intuition that state rots fastest, because a state atom
+ * gets rewritten as the state changes, which is the one case where the write path already forces
+ * a restatement.
+ */
+function formatUnrestatedBlock(unrestated?: UnrestatedReport): string[] {
+  if (!unrestated || unrestated.rows.length === 0) return [];
+
+  const width = Math.max(...unrestated.rows.map(row => row.category.length));
+  const lines = [
+    STATUS_LINE,
+    '🕰️  UN-RESTATED CLAIMS',
+    `  Prose (cites no code): ${unrestated.proseCount} of ${unrestated.proseCount + unrestated.codeCount}`,
+    '  Days since anyone restated the claim, by category:',
+  ];
+  for (const row of unrestated.rows) {
+    lines.push(`    ${row.category.padEnd(width)}  n=${String(row.count).padStart(4)}  p50 ${String(row.medianDays).padStart(6)}d  oldest ${String(row.oldestDays).padStart(6)}d`);
+  }
+  // Both caveats are printed, not filed. The first is why the table is not a staleness verdict;
+  // the second is why its tail cannot be read as one either.
+  lines.push('  Not a staleness signal: nothing here observed a claim becoming false.');
+  lines.push(`  Store history is ${unrestated.storyDays}d, so ages beyond that cannot be distinguished from absence.`);
+  if (unrestated.prosePathOnly > 0) {
+    lines.push(`  ${unrestated.prosePathOnly} counted as prose despite citing paths, because every path is a prose file.`);
   }
   return lines;
 }

--- a/src/cli/status-report.ts
+++ b/src/cli/status-report.ts
@@ -4,7 +4,11 @@ import type { CaptureHealth } from '../store/capture-outcome.js';
 import type { RecallGapReport } from '../store/recall-gap.js';
 import type { UnrestatedReport } from '../store/unrestated.js';
 import type { CloudStatus } from '../cloud/status.js';
+import { truncateText } from '../core/token-budget.js';
 import { formatWorkspaceBlock } from './workspace-report.js';
+
+/** Titles run to MAX_TITLE_CHARS (200); a status block is read at a glance, not studied. */
+const TITLE_CHARS = 64;
 
 const STATUS_LINE = '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━';
 
@@ -147,6 +151,11 @@ function formatRecallGapBlock(recall?: RecallGapReport): string[] {
  * only the absence of anyone reaffirming it -- flagging would assert a defect nothing observed,
  * and the failure mode of over-eager staleness here is losing knowledge nobody can recover.
  *
+ * The named list is what makes this worth printing before the corpus is old enough to flag
+ * anything: ranking needs no threshold, so it is correct at any store age and sharpens on its own.
+ * It ranks on the ratio to a category median, not on age -- see `UnrestatedItem`, where the
+ * measurement that ruled out plain age is recorded.
+ *
  * Categories are printed in measured order rather than a fixed one. On a real 962-item store the
  * longest un-restated were goal, skill, constraint and decision, and `state` was among the
  * best-maintained -- the opposite of the intuition that state rots fastest, because a state atom
@@ -164,12 +173,24 @@ function formatUnrestatedBlock(unrestated?: UnrestatedReport): string[] {
     '  Days since anyone restated the claim, by category:',
   ];
   for (const row of unrestated.rows) {
-    lines.push(`    ${row.category.padEnd(width)}  n=${String(row.count).padStart(4)}  p50 ${String(row.medianDays).padStart(6)}d  oldest ${String(row.oldestDays).padStart(6)}d`);
+    lines.push(`    ${row.category.padEnd(width)}  n=${String(row.count).padStart(4)}  p50 ${String(row.medianDays).padStart(6)}d`);
+  }
+  // No per-category `oldest` column, and the list below is not ranked on age either. Both were
+  // measured printing the same non-finding: the store's own age, seven times in the column's
+  // case, five times in an age-ranked list's, because a store is seeded in one batch and that
+  // batch stays its oldest cohort forever. Ranking each claim against its own category's median
+  // asks the question the column was reaching for -- is this one unusual for its kind.
+  if (unrestated.outliers.length > 0) {
+    lines.push("  Furthest past its own category's cadence:");
+    const categoryWidth = Math.max(...unrestated.outliers.map(entry => entry.category.length));
+    for (const entry of unrestated.outliers) {
+      lines.push(`    ${String(entry.ratio).padStart(5)}x p50  ${String(entry.days).padStart(6)}d  ${entry.category.padEnd(categoryWidth)}  ${truncateText(entry.title, TITLE_CHARS, '...')}`);
+    }
   }
   // Both caveats are printed, not filed. The first is why the table is not a staleness verdict;
   // the second is why its tail cannot be read as one either.
   lines.push('  Not a staleness signal: nothing here observed a claim becoming false.');
-  lines.push(`  Store history is ${unrestated.storyDays}d, so ages beyond that cannot be distinguished from absence.`);
+  lines.push(`  Store history is ${unrestated.storeHistoryDays}d, so ages beyond that cannot be distinguished from absence.`);
   if (unrestated.prosePathOnly > 0) {
     lines.push(`  ${unrestated.prosePathOnly} counted as prose despite citing paths, because every path is a prose file.`);
   }

--- a/src/store/unrestated.ts
+++ b/src/store/unrestated.ts
@@ -52,13 +52,41 @@ export type UnrestatedCategoryRow = {
   count: number;
   /** Days since restatement at the 50th percentile, one decimal. */
   medianDays: number;
-  /** Days since restatement for the single oldest item in this category. */
-  oldestDays: number;
-  oldestTitle: string;
 };
+
+/**
+ * One claim, named rather than merely counted, and ranked against its OWN category's cadence.
+ *
+ * **A ranked list is why this reports something today and a threshold would not.** Flagging needs
+ * a cutoff -- "past N days is stale" -- and N cannot be chosen on a store younger than the cadence
+ * it is trying to measure, which is what deferred the flagging half of #98 to roughly 2027-02.
+ * Ordering needs no cutoff, so it is correct at any store age and sharpens on its own.
+ *
+ * **But ranking on raw age is degenerate, and measurement caught it.** Rendered against this
+ * repo's own 1,072-item store, the five oldest claims all came back at 54.5d -- the store's exact
+ * age -- because a store is seeded in one batch and that batch is permanently its oldest cohort.
+ * The list said "the day you created the store is the oldest day in it", which is the same
+ * non-finding as the per-category `oldest` column it replaced, and every future store repeats it.
+ *
+ * `ratio` is days divided by the median for that category, so a claim is measured against how
+ * often claims of its KIND actually get restated. An architecture note at 54.5d against an 18d
+ * median is three cadences past due and worth opening; a goal at 54.5d against a 45.5d median is
+ * ordinary. Both are the same age, and only one is interesting. This also breaks the seed-cohort
+ * tie on a real signal rather than on row order.
+ */
+export type UnrestatedItem = { title: string; category: KnowledgeCategory; days: number; ratio: number };
+
+/** How many claims to name. Enough to act on, short enough to live in a status block. */
+const OLDEST_NAMED = 5;
 
 export type UnrestatedReport = {
   rows: UnrestatedCategoryRow[];
+  /**
+   * The claims furthest past their own category's cadence, named. The per-category medians say
+   * the corpus is maintained unevenly; only these say what to go and look at, and a title can be
+   * opened where a distribution can only be nodded at.
+   */
+  outliers: UnrestatedItem[];
   proseCount: number;
   codeCount: number;
   /**
@@ -74,8 +102,11 @@ export type UnrestatedReport = {
    * found an empty `>60d` bucket while the oldest store was itself under 60 days old, which cannot
    * distinguish "nothing rots past 60 days" from "no store is old enough to say". A reader who
    * cannot see this number will read the first when the data only supports the second.
+   *
+   * It also bounds every age here: nothing can be older than the store it lives in, which is why
+   * `outliers` ranks on the ratio to a category median rather than on age directly.
    */
-  storyDays: number;
+  storeHistoryDays: number;
 };
 
 const daysBetween = (fromIso: string, now: number): number => {
@@ -120,43 +151,61 @@ export async function unrestatedClaimsReport(now: number = Date.now()): Promise<
 
   let codeCount = 0;
   let prosePathOnly = 0;
-  let storyDays = 0;
-  const byCategory = new Map<string, { ages: number[]; oldest: { days: number; title: string } }>();
+  let storeHistoryDays = 0;
+  const prose: UnrestatedItem[] = [];
+  const byCategory = new Map<KnowledgeCategory, number[]>();
 
   for (const row of rows) {
     const age = daysBetween(String(row.validFrom), now);
-    storyDays = Math.max(storyDays, age);
+    // Every row, prose or not: this bounds what the whole report can mean, and a code-coupled
+    // item is still part of the store's history.
+    storeHistoryDays = Math.max(storeHistoryDays, age);
     if (citesCode(row as never)) { codeCount += 1; continue; }
 
     const paths = [...(normalizeAffectedPaths(row.affectedPaths as string[] | null) ?? []), ...sourcePaths(row.source)];
     if (paths.length > 0) prosePathOnly += 1;
 
-    const bucket = byCategory.get(String(row.category)) ?? { ages: [], oldest: { days: -1, title: '' } };
-    bucket.ages.push(age);
-    if (age > bucket.oldest.days) bucket.oldest = { days: age, title: String(row.title) };
-    byCategory.set(String(row.category), bucket);
+    const category = String(row.category) as KnowledgeCategory;
+    prose.push({ title: String(row.title), category, days: round1(age), ratio: 0 });
+    const ages = byCategory.get(category) ?? [];
+    ages.push(age);
+    byCategory.set(category, ages);
   }
 
-  const report: UnrestatedReport = {
-    rows: [...byCategory.entries()].map(([category, bucket]) => {
-      const sorted = [...bucket.ages].sort((a, b) => a - b);
-      return {
-        category: category as KnowledgeCategory,
-        count: bucket.ages.length,
-        medianDays: round1(percentile(sorted, 0.5)),
-        oldestDays: round1(bucket.oldest.days),
-        oldestTitle: bucket.oldest.title,
-      };
+  const rowsByAge = [...byCategory.entries()].map(([category, ages]) => {
+    const sorted = [...ages].sort((a, b) => a - b);
+    return { category, count: ages.length, medianDays: round1(percentile(sorted, 0.5)) };
     // Longest-un-restated first. Measured ordering on a real store put constraint, skill and
     // decision at the top and `state` among the best maintained, which inverts the intuition that
     // state rots fastest -- a state atom gets rewritten as the state changes, which is the one
     // case where the write path already forces a restatement. Sorting rather than hard-coding a
     // category order means the report keeps telling the truth if that ordering changes.
-    }).sort((a, b) => b.medianDays - a.medianDays),
+  }).sort((a, b) => b.medianDays - a.medianDays);
+
+  // A median can legitimately be 0 -- a category whose every claim was restated today -- and that
+  // is a real state, not a guard to skip. Flooring at a tenth of a day keeps the division finite,
+  // and such a category cannot crowd the list anyway: its items have a `days` near zero, so their
+  // ratio is near zero too.
+  const medians = new Map(rowsByAge.map(row => [row.category, Math.max(row.medianDays, 0.1)]));
+
+  const report: UnrestatedReport = {
+    rows: rowsByAge,
+    // Ties on the ratio fall back to age, so the seed cohort still orders deterministically
+    // rather than by whatever order the rows came back in.
+    //
+    // ponytail: no per-category cap, so one category can take most of the five. Rendered against
+    // this repo it does -- four of five are `fact`, which holds the seed cohort AND has the
+    // lowest median, so its items score highest on both terms. That is the correct answer rather
+    // than a bug (those claims really are furthest past their kind's cadence) and it spreads out
+    // as the store ages. Cap at two per category if the list is still repeating itself by then.
+    outliers: prose
+      .map(item => ({ ...item, ratio: round1(item.days / (medians.get(item.category) ?? 0.1)) }))
+      .sort((a, b) => b.ratio - a.ratio || b.days - a.days)
+      .slice(0, OLDEST_NAMED),
     proseCount: rows.length - codeCount,
     codeCount,
     prosePathOnly,
-    storyDays: round1(storyDays),
+    storeHistoryDays: round1(storeHistoryDays),
   };
   return report.rows.length === 0 ? undefined : report;
 }

--- a/src/store/unrestated.ts
+++ b/src/store/unrestated.ts
@@ -1,0 +1,162 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { getDb } from './database.js';
+import * as schema from './schema.js';
+import { normalizeAffectedPaths, sourcePaths } from './freshness.js';
+import type { KnowledgeCategory } from '../core/types.js';
+
+/**
+ * How long has it been since anyone RESTATED each claim, for the knowledge no drift check can
+ * reach.
+ *
+ * Report only. Nothing here flips `freshness`, and that is the design rather than a first step
+ * towards it: for prose there is no evidence a claim became false, only the absence of anyone
+ * reaffirming it, and flagging asserts a defect nothing observed. dat999zx/knowl#98 states the
+ * out-of-scope line in the same terms -- losing knowledge nobody can recover is strictly worse
+ * than carrying a stale atom that ranks 6% lower.
+ *
+ * **`valid_from` is the clock, and it is the only honest one available.** `updated_at` moves on
+ * visibility promotion, supersession and status changes, none of which mean anyone revisited the
+ * claim; measured on a 950-item store, 72% of items have `updated_at` newer than `valid_from`.
+ * A new assertion generation is written only when title, content, reasoning or confidence change
+ * (`repository.ts`), so `valid_from` moves on restatement and on nothing else.
+ *
+ * Retrieval counts are deliberately not an input. A read-count prior is a feedback loop in which
+ * an atom that ranks high is read more and therefore ranks higher, with nothing in the loop asking
+ * whether it is true -- the trap Mem0's audit hit at 808 stored copies of one hallucinated
+ * preference.
+ */
+
+/** File extensions that make a cited path prose rather than code. */
+const PROSE_EXTENSIONS = ['.md', '.mdx', '.txt', '.rst', '.adoc'];
+
+const isProsePath = (path: string): boolean =>
+  PROSE_EXTENSIONS.some(extension => path.toLowerCase().endsWith(extension));
+
+/**
+ * Whether an item cites code, which is what decides a drift check can speak to it at all.
+ *
+ * **Citing a path is not the same as citing code**, and the distinction is not cosmetic: an atom
+ * whose only path is `docs/research/competitor-teardown.md` has a non-empty `affectedPaths` and
+ * is still exactly the prose this report exists for. A census keyed on "has any path" counts it
+ * on the wrong side. Reviewed on #98 and confirmed small, but small in degree is not the same as
+ * right, and `prosePathOnly` below reports how many items the distinction actually moves so the
+ * number can be argued with rather than trusted.
+ */
+export function citesCode(item: { affectedPaths?: string[] | null; source?: string | null }): boolean {
+  const paths = [...(normalizeAffectedPaths(item.affectedPaths) ?? []), ...sourcePaths(item.source)];
+  return paths.some(path => !isProsePath(path));
+}
+
+export type UnrestatedCategoryRow = {
+  category: KnowledgeCategory;
+  count: number;
+  /** Days since restatement at the 50th percentile, one decimal. */
+  medianDays: number;
+  /** Days since restatement for the single oldest item in this category. */
+  oldestDays: number;
+  oldestTitle: string;
+};
+
+export type UnrestatedReport = {
+  rows: UnrestatedCategoryRow[];
+  proseCount: number;
+  codeCount: number;
+  /**
+   * Items counted as prose ONLY because every path they cite is a prose file. This is the size of
+   * the disagreement between "has no paths" and "cites no code" -- the reconciliation #98 asked
+   * for, published rather than resolved silently.
+   */
+  prosePathOnly: number;
+  /**
+   * Age of the oldest open assertion anywhere in the store, prose or not.
+   *
+   * Printed beside the buckets because it bounds what they can mean. Every measurement so far has
+   * found an empty `>60d` bucket while the oldest store was itself under 60 days old, which cannot
+   * distinguish "nothing rots past 60 days" from "no store is old enough to say". A reader who
+   * cannot see this number will read the first when the data only supports the second.
+   */
+  storyDays: number;
+};
+
+const daysBetween = (fromIso: string, now: number): number => {
+  const from = Date.parse(fromIso);
+  if (Number.isNaN(from)) return 0;
+  return Math.max(0, (now - from) / 86_400_000);
+};
+
+const percentile = (sorted: number[], fraction: number): number =>
+  sorted.length === 0 ? 0 : sorted[Math.min(sorted.length - 1, Math.floor(fraction * sorted.length))];
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+/**
+ * Returns undefined when there is nothing to say -- no active item carries an open assertion --
+ * so a caller renders no section rather than an empty one.
+ */
+export async function unrestatedClaimsReport(now: number = Date.now()): Promise<UnrestatedReport | undefined> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      category: schema.knowledgeItems.category,
+      title: schema.knowledgeItems.title,
+      affectedPaths: schema.knowledgeItems.affectedPaths,
+      source: schema.knowledgeItems.source,
+      validFrom: schema.knowledgeAssertions.validFrom,
+    })
+    .from(schema.knowledgeItems)
+    .innerJoin(
+      schema.knowledgeAssertions,
+      eq(schema.knowledgeAssertions.knowledgeItemId, schema.knowledgeItems.id),
+    )
+    // The OPEN assertion only. A replaced generation is the record of a claim that has already
+    // been restated, so counting it would date an item by a restatement that happened.
+    .where(and(
+      eq(schema.knowledgeItems.status, 'active'),
+      isNull(schema.knowledgeAssertions.replacedAt),
+      isNull(schema.knowledgeAssertions.validTo),
+    ));
+
+  if (rows.length === 0) return undefined;
+
+  let codeCount = 0;
+  let prosePathOnly = 0;
+  let storyDays = 0;
+  const byCategory = new Map<string, { ages: number[]; oldest: { days: number; title: string } }>();
+
+  for (const row of rows) {
+    const age = daysBetween(String(row.validFrom), now);
+    storyDays = Math.max(storyDays, age);
+    if (citesCode(row as never)) { codeCount += 1; continue; }
+
+    const paths = [...(normalizeAffectedPaths(row.affectedPaths as string[] | null) ?? []), ...sourcePaths(row.source)];
+    if (paths.length > 0) prosePathOnly += 1;
+
+    const bucket = byCategory.get(String(row.category)) ?? { ages: [], oldest: { days: -1, title: '' } };
+    bucket.ages.push(age);
+    if (age > bucket.oldest.days) bucket.oldest = { days: age, title: String(row.title) };
+    byCategory.set(String(row.category), bucket);
+  }
+
+  const report: UnrestatedReport = {
+    rows: [...byCategory.entries()].map(([category, bucket]) => {
+      const sorted = [...bucket.ages].sort((a, b) => a - b);
+      return {
+        category: category as KnowledgeCategory,
+        count: bucket.ages.length,
+        medianDays: round1(percentile(sorted, 0.5)),
+        oldestDays: round1(bucket.oldest.days),
+        oldestTitle: bucket.oldest.title,
+      };
+    // Longest-un-restated first. Measured ordering on a real store put constraint, skill and
+    // decision at the top and `state` among the best maintained, which inverts the intuition that
+    // state rots fastest -- a state atom gets rewritten as the state changes, which is the one
+    // case where the write path already forces a restatement. Sorting rather than hard-coding a
+    // category order means the report keeps telling the truth if that ordering changes.
+    }).sort((a, b) => b.medianDays - a.medianDays),
+    proseCount: rows.length - codeCount,
+    codeCount,
+    prosePathOnly,
+    storyDays: round1(storyDays),
+  };
+  return report.rows.length === 0 ? undefined : report;
+}

--- a/tests/cli/unrestated-status.test.ts
+++ b/tests/cli/unrestated-status.test.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { formatStatusReport } from '../../src/cli/status-report.js';
+import { DEFAULT_CONFIG } from '../../src/core/config.js';
+import type { UnrestatedReport } from '../../src/store/unrestated.js';
+
+const ROOT = path.resolve('./.knowl-unrestated-status-test');
+const base = {
+  project: { id: 'local', name: 'unrestated', rootPath: ROOT } as never,
+  config: DEFAULT_CONFIG,
+  activeItems: [], supersededItems: [], deprecatedItems: [], commits: [],
+};
+
+const report = (overrides: Partial<UnrestatedReport> = {}): UnrestatedReport => ({
+  rows: [
+    { category: 'constraint', count: 41, medianDays: 36.3 },
+    { category: 'fact', count: 281, medianDays: 21.7 },
+  ],
+  outliers: [
+    { title: 'Secrets never leave the machine', category: 'constraint', days: 53.4, ratio: 3.4 },
+    { title: 'Ranking beats flagging on a young store', category: 'decision', days: 51.2, ratio: 1.5 },
+  ],
+  proseCount: 520, codeCount: 442, prosePathOnly: 34, storeHistoryDays: 53.4,
+  ...overrides,
+});
+
+describe('un-restated claims in knowl status', () => {
+  it('renders nothing when no active item carries an open assertion', () => {
+    expect(formatStatusReport({ ...base, unrestated: undefined })).not.toMatch(/UN-RESTATED/);
+    expect(formatStatusReport({ ...base, unrestated: report({ rows: [] }) })).not.toMatch(/UN-RESTATED/);
+  });
+
+  it("names the claims furthest past their own category's cadence, worst first", () => {
+    const out = formatStatusReport({ ...base, unrestated: report() });
+    expect(out).toMatch(/Furthest past its own category's cadence:/);
+    expect(out).toMatch(/3\.4x p50\s+53\.4d\s+constraint\s+Secrets never leave the machine/);
+    expect(out.indexOf('Secrets never leave')).toBeLessThan(out.indexOf('Ranking beats flagging'));
+  });
+
+  it('ranks on the cadence ratio, not on age, so a seed cohort does not fill the list', () => {
+    // The defect the ratio exists for: every claim in a seeded store shares one age. Ranked on
+    // age these tie and the list is an arbitrary slice of the seed; ranked on the ratio the
+    // architecture note at three times its category's median sorts above the ordinary goal.
+    const out = formatStatusReport({ ...base, unrestated: report({ outliers: [
+      { title: 'three cadences past due', category: 'architecture', days: 54.5, ratio: 3 },
+      { title: 'ordinary for a goal', category: 'goal', days: 54.5, ratio: 1.2 },
+    ] }) });
+    expect(out.indexOf('three cadences past due')).toBeLessThan(out.indexOf('ordinary for a goal'));
+  });
+
+  it('prints no per-category oldest column, which was the store age repeated', () => {
+    // The reshape this file guards. `oldest` per category is `storeHistoryDays` in whichever
+    // category happens to hold the corpus's oldest item, and a duplicate of the p50 row's own
+    // ceiling in the rest -- seven copies of one number reading as seven findings. A category
+    // row carries exactly one day figure now.
+    const line = formatStatusReport({ ...base, unrestated: report() })
+      .split('\n').find(row => row.includes('constraint  n='));
+    expect(line).toBeDefined();
+    expect(line!.match(/\d+\.\d+d/g)).toHaveLength(1);
+  });
+
+  it('truncates a title rather than letting a 200-char claim wrap the block', () => {
+    const long = 'x'.repeat(200);
+    const out = formatStatusReport({
+      ...base,
+      unrestated: report({ outliers: [{ title: long, category: 'decision', days: 53.4, ratio: 1.5 }] }),
+    });
+    expect(out).not.toMatch(new RegExp(long));
+    expect(out).toMatch(/x{40,}\.\.\./);
+  });
+
+  it('prints the store history beside the list, because it bounds every age in it', () => {
+    // 53.4d is the store's age. Without the bound printed, a reader takes an age for a measured
+    // tail rather than the ceiling it is pinned to.
+    expect(formatStatusReport({ ...base, unrestated: report() })).toMatch(/Store history is 53\.4d/);
+  });
+});

--- a/tests/store/unrestated.test.ts
+++ b/tests/store/unrestated.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { citesCode } from '../../src/store/unrestated.js';
+
+describe('citesCode — what separates prose from code-coupled knowledge', () => {
+  it('counts an item with no paths at all as prose', () => {
+    expect(citesCode({ affectedPaths: null, source: null })).toBe(false);
+    expect(citesCode({ affectedPaths: [], source: 'verified in this workspace' })).toBe(false);
+  });
+
+  it('counts a source that is a path list, not just affectedPaths', () => {
+    // 58 of 71 items flagged with no affectedPaths in the measured store carried a
+    // semicolon-separated path list in `source`. Reading only affectedPaths calls those prose.
+    expect(citesCode({ source: 'src/store/database.ts; src/store/bootstrap.ts; package.json' })).toBe(true);
+  });
+
+  it('counts an item whose ONLY paths are prose files as prose', () => {
+    // The caution raised on #98: citing a path is not the same as citing code. An atom whose
+    // only path is a research write-up has non-empty affectedPaths and is exactly the prose this
+    // report exists for. A census keyed on "has any path" puts it on the wrong side.
+    expect(citesCode({ affectedPaths: ['docs/research/competitor-teardown.md'] })).toBe(false);
+    expect(citesCode({ source: 'docs/evals/floor-sweep.md; README.md' })).toBe(false);
+  });
+
+  it('counts an item citing one code path among prose as code-coupled', () => {
+    // One real file is enough for a drift check to have something to watch, which is the only
+    // question this predicate is answering.
+    expect(citesCode({ affectedPaths: ['docs/notes.md', 'src/store/drift.ts'] })).toBe(true);
+  });
+
+  it('does not mistake prose containing a full stop for a path', () => {
+    // sourcePaths requires no whitespace and at least one `/` or `.`, so a sentence cannot
+    // qualify -- but a single unspaced token with a dot could, and that is the edge worth pinning.
+    expect(citesCode({ source: 'measured on the real store, twice' })).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements **point 4 of the sketch in #98 and nothing else**: report the oldest un-restated claims by category, flag nothing. You concluded the cheap first cut was justified now and enforcement still waits; this is that cut.

## What it reports

Live output, `DuckPrep-server`, 962 items:

```
🕰️  UN-RESTATED CLAIMS
  Prose (cites no code): 573 of 1072
  Days since anyone restated the claim, by category:
    goal          n=   7  p50   45.5d
    skill         n=  12  p50   32.2d
    state         n= 137  p50     31d
    constraint    n=  22  p50   24.4d
    decision      n=  54  p50     24d
    fact          n= 267  p50   20.2d
    architecture  n=  74  p50     18d
  Furthest past its own category's cadence:
      2.7x p50    54.5d  fact          Knowl is a local-first knowledge operating system for agents
      2.7x p50    54.5d  fact          Use knowl.cmd on Windows PowerShell
      2.7x p50    54.5d  fact          Knowl tests are organized by subsystem
      2.7x p50    54.5d  fact          Doctor verification result in this repo
      2.5x p50    45.4d  architecture  Competitor normalized adapter capability matrix
  Not a staleness signal: nothing here observed a claim becoming false.
  Store history is 54.5d, so ages beyond that cannot be distinguished from absence.
  17 counted as prose despite citing paths, because every path is a prose file.
```

Renders no section on a store where no active item carries an open assertion.

## It reproduces your ordering independently

| category | your p50 | this | your n | this |
| --- | ---: | ---: | ---: | ---: |
| constraint | 42.8 | 36.3 | 34 | 41 |
| skill | 35.9 | 36.8 | 32 | 35 |
| decision | 35.1 | 33.1 | 46 | 53 |
| state | 24.4 | 25.6 | 47 | 52 |
| architecture | 22.6 | 23.8 | 49 | 51 |
| fact | 20.5 | 21.7 | 232 | 281 |

Same ordering, magnitudes within a day or two, and `state` again among the best-maintained rather than the worst. `goal` (p50 41.3d, n=7) tops the table; your listing did not include it.

**Prose share comes out 54.1% here against your 46.7%.** 34 of that gap is the prose-path rule below. The rest is a genuine filter difference and I have not reconciled it — worth a look before anyone quotes either number.

## Three decisions worth arguing with

**`valid_from` as the clock.** Confirmed the way you did: a new generation is written only when title, content, reasoning or confidence change, so promotion, supersession and status changes leave it alone.

**Not a flag.** For prose there is no evidence a claim became false, only the absence of anyone reaffirming it. Flagging asserts a defect nothing observed, and the issue's own out-of-scope line applies — losing knowledge nobody can recover is strictly worse than carrying a stale atom that ranks 6% lower. Retrieval counts are not an input either, for the feedback-loop reason `hygiene.ts` already gives.

**Both caveats are printed, not filed.** The store's own history prints beside the ages, because an empty `>60d` bucket on a 53-day-old store cannot distinguish "nothing rots past 60 days" from "no store is old enough to say" — a reader who cannot see that number will read the first. And the prose-path count prints because citing a path is not citing code: an atom whose only path is `docs/research/x.md` is exactly the prose this exists for. That was @William-Sommers' caution on the issue; it moves 34 items here.

Categories sort by measured age rather than a fixed order, so the report keeps telling the truth if the ordering changes.

## Verification

`tsc --noEmit` exit 0 at repo scope. Full suite **371 files, 3,558 passed, 5 skipped, 0 failed**. Output above is the built CLI against a real store, not a fixture.

Independent of #206, which is on the card-composition path.

---

## Amended before merge (`2b7fe58`)

Two framings were tried and both printed the store's own age dressed as a finding. Recording them
because each looks obviously right and the next reader will otherwise re-derive one.

**The per-category `oldest` column is gone.** It printed one number, identically, in every row: the
store's age. The corpus's oldest item sits in some category and nothing can be older than the store
it lives in, so the ceiling lands in every row that reaches it. Seven copies of `storeHistoryDays`
read as seven findings.

**Ranking the replacement list on plain age failed the same way.** Against this repo's 1,072-item
store the five oldest all came back at 54.5d — a store is seeded in one batch, and that batch is
permanently its oldest cohort. Every store reproduces this. Caught only by running the built CLI
against a real store; the fixture tests were green throughout.

**What shipped is the ratio to the category's own median.** `days / max(categoryMedian, 0.1)`, ties
broken by age. An architecture note at 54.5d against an 18d cadence is three cadences past due; a
goal at 54.5d against a 45.5d cadence is ordinary. Same age, and only the ratio separates them.
`oldestTitle` was already being computed and discarded, so this cost about ten lines.

**On the deferral in #98.** The gate there is calibration — a threshold ("past N days is stale")
cannot pick N on a store younger than the cadence it is measuring. An *ordering* needs no cutoff and
is correct at any corpus age, so the reporting half does not have to wait for the flagging half.
That distinction is what makes this mergeable now; #98 stays open for the flagging half.

Known ceiling, marked `ponytail:` in the source: no per-category cap, so one category can take most
of the five slots — and here four of five are `fact`, which holds the seed cohort *and* has the
lowest median. That is the correct answer rather than a defect, and it spreads out as the store
ages.

`tests/cli/unrestated-status.test.ts` guards both dead ends: one test asserts a category row carries
exactly one day figure, so the column cannot come back; another asserts the ratio outranks age, so a
seed cohort cannot refill the list.

Verified on merged main: build clean, `tsc --noEmit` exit 0, **374 files, 3576 passed, 5 skipped, 0
failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

