### PR TITLE
feat(recall): attribute a recall observation to the agent that caused it

### DIFF
--- a/src/cli/status-report.ts
+++ b/src/cli/status-report.ts
@@ -133,6 +133,16 @@ function formatRecallGapBlock(recall?: RecallGapReport): string[] {
     lines.push(`  ...missed:             ${recall.missed} (${Math.round((recall.missed / recall.held) * 100)}%)`);
     lines.push('  Lower bound — only knowledge citing a file path can be counted here.');
   }
+  // Printed only when both populations exist, so the comparison is never against one side.
+  // Subagents are the interesting half: they receive no prompt reminder and no MCP server
+  // instructions, so their share is the closest thing to a controlled read on whether the
+  // bootstrap card alone carries the habit.
+  if (recall.byActor) {
+    const share = (side: { held: number; retrieved: number }) =>
+      side.held === 0 ? 'n/a' : `${Math.round((side.retrieved / side.held) * 100)}%`;
+    lines.push(`  Retrieved when held — main thread: ${share(recall.byActor.main)} (${recall.byActor.main.held} held)`);
+    lines.push(`                        subagents:   ${share(recall.byActor.subagent)} (${recall.byActor.subagent.held} held)`);
+  }
   return lines;
 }
 

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -664,7 +664,10 @@ async function observeToolTouch(input: NormalizedHostHook, projectId: string): P
   if (!toolReadsFile(input) && !toolWritesFile(input)) return;
   const paths = impactChangedPaths(input.payload);
   if (paths.length === 0) return;
-  await observeRecallGapBestEffort(projectId, { conversation: conversationKey(input), paths });
+  // `agentId` rides alongside the conversation key rather than inside it: a subagent shares its
+  // parent's external session id, so the key cannot separate them, and a dozen other counters
+  // read that same key.
+  await observeRecallGapBestEffort(projectId, { conversation: conversationKey(input), agentId: input.agentId, paths });
 }
 
 /**

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -139,9 +139,14 @@ const SCHEMA_STATEMENTS = [
    * Not swept, for the same reason `capture_outcomes` is not: the sessions expire, the question
    * does not. A handful of integers per tool call.
    */
+  // `agent_id` is null for the main thread. It is a column rather than a change to
+  // `conversation` because a Claude subagent shares its parent's external session id, so the
+  // conversation key cannot separate them -- and a dozen other counters key on that same
+  // function, which splitting it would fragment to answer a question none of them asked.
   `CREATE TABLE IF NOT EXISTS recall_observations (
     id TEXT PRIMARY KEY,
     conversation TEXT NOT NULL,
+    agent_id TEXT,
     paths TEXT NOT NULL,
     held INTEGER NOT NULL,
     retrieved INTEGER NOT NULL,
@@ -972,6 +977,22 @@ async function ensureMemorySessionColumns(client: Client): Promise<void> {
   if (!columns.includes('promotion_error_code')) await client.execute('ALTER TABLE memory_sessions ADD COLUMN promotion_error_code TEXT;');
 }
 
+/**
+ * Which agent a recall observation belonged to. Null is the main thread, and stays null.
+ *
+ * No backfill and none possible: an observation already written cannot be re-attributed,
+ * because the identity was never recorded on it. Rows predating this column read as main-thread
+ * work, which is what the counters assumed before it existed, so nothing silently changes
+ * meaning -- the split simply reports nothing until new observations arrive.
+ */
+async function ensureRecallObservationColumns(client: Client): Promise<void> {
+  if (!(await tableExists(client, 'recall_observations'))) return;
+  const columns = await tableColumns(client, 'recall_observations');
+  if (!columns.includes('agent_id')) {
+    await client.execute('ALTER TABLE recall_observations ADD COLUMN agent_id TEXT;');
+  }
+}
+
 async function ensureHostSessionBindingColumns(client: Client): Promise<void> {
   if (!(await tableExists(client, 'host_session_bindings'))) return;
   const columns = await tableColumns(client, 'host_session_bindings');
@@ -1269,6 +1290,7 @@ export async function bootstrapSchema(
     await ensureOwnershipColumns(client);
     await ensureMemorySessionColumns(client);
     await ensureHostSessionBindingColumns(client);
+    await ensureRecallObservationColumns(client);
     await ensureCodeIndexColumns(client);
     await ensureEmbeddingProfileColumns(client, options.profileFingerprint ?? null);
     await backfillKnowledgeAssertions(client);

--- a/src/store/recall-gap.ts
+++ b/src/store/recall-gap.ts
@@ -66,6 +66,16 @@ export type RecallGapReport = {
   retrieved: number;
   /** `held - retrieved`. The gap this whole thing exists to size. */
   missed: number;
+  /**
+   * The same four numbers, split by who was working: the main thread against subagents.
+   *
+   * Absent until a store has observations on both sides, so a comparison is never printed
+   * against a population of one.
+   */
+  byActor?: {
+    main: Omit<RecallGapReport, 'byActor'>;
+    subagent: Omit<RecallGapReport, 'byActor'>;
+  };
 };
 
 type PathCitingItem = { id: string; source: string | null; affectedPaths: string[] };
@@ -115,6 +125,8 @@ async function retrievedWithin(itemIds: string[], since: string): Promise<Set<st
  */
 export async function observeRecallGap(_projectId: string, input: {
   conversation: string;
+  /** Null or absent is the main thread. A subagent shares its parent's conversation key. */
+  agentId?: string | null;
   paths: string[];
   windowMinutes?: number;
   at?: string;
@@ -130,10 +142,10 @@ export async function observeRecallGap(_projectId: string, input: {
 
   const observation: RecallObservation = { held: matched.length, retrieved: retrieved.size };
   await getClient().execute({
-    sql: `INSERT INTO recall_observations (id, conversation, paths, held, retrieved, observed_at)
-          VALUES (?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO recall_observations (id, conversation, agent_id, paths, held, retrieved, observed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
     args: [
-      crypto.randomUUID(), input.conversation, JSON.stringify(input.paths),
+      crypto.randomUUID(), input.conversation, input.agentId ?? null, JSON.stringify(input.paths),
       observation.held, observation.retrieved, now,
     ],
   });
@@ -143,6 +155,7 @@ export async function observeRecallGap(_projectId: string, input: {
 /** Never throws, never blocks the tool call it rides on. */
 export async function observeRecallGapBestEffort(projectId: string, input: {
   conversation: string;
+  agentId?: string | null;
   paths: string[];
 }): Promise<void> {
   try {
@@ -167,5 +180,38 @@ export async function recallGapReport(_projectId: string): Promise<RecallGapRepo
   const touches = Number(row.touches ?? 0);
   const held = Number(row.held ?? 0);
   const retrieved = Number(row.retrieved ?? 0);
-  return { touches, held, retrieved, missed: held - retrieved };
+  return { touches, held, retrieved, missed: held - retrieved, byActor: await recallByActor() };
+}
+
+/**
+ * The same ratio, split into main-thread work and subagent work.
+ *
+ * This is the question `conversation` could never answer: a Claude subagent shares its parent's
+ * external session id, so both sides of the split lived on one row and the child's recall was
+ * indistinguishable from the parent's. `agent_id` is recorded at the hook, which is the only
+ * place the identity exists at all -- the MCP server never learns who called it.
+ *
+ * Returns undefined until a store has observations on BOTH sides. One side alone invites reading
+ * a single population as a comparison, and rows written before the column existed are null, so a
+ * freshly-migrated store would otherwise report "100% main thread" as though it had measured it.
+ */
+async function recallByActor(): Promise<RecallGapReport['byActor']> {
+  const result = await getClient().execute({
+    sql: `SELECT CASE WHEN agent_id IS NULL THEN 'main' ELSE 'subagent' END AS actor,
+                 COUNT(*) AS touches,
+                 SUM(CASE WHEN held > 0 THEN 1 ELSE 0 END) AS held,
+                 SUM(CASE WHEN held > 0 AND retrieved > 0 THEN 1 ELSE 0 END) AS retrieved
+          FROM recall_observations GROUP BY actor`,
+    args: [],
+  });
+  const of = (actor: string) => {
+    const row: any = result.rows.find((candidate: any) => candidate.actor === actor);
+    if (!row) return undefined;
+    const held = Number(row.held ?? 0);
+    const retrieved = Number(row.retrieved ?? 0);
+    return { touches: Number(row.touches ?? 0), held, retrieved, missed: held - retrieved };
+  };
+  const main = of('main');
+  const subagent = of('subagent');
+  return main && subagent ? { main, subagent } : undefined;
 }

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -194,8 +194,22 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * an existing database stamped at 14 would otherwise never gain the table while `knowl status`
  * queries it. `KNOWL_SCHEMA_VERSION` again does not move -- an older build ignores the table
  * entirely and behaves exactly as it does today.
+ *
+ * Level 16 adds `recall_observations.agent_id`: which agent the touch belonged to, null for the
+ * main thread. Additive column, no backfill -- an observation already written cannot be
+ * re-attributed, because the identity was never recorded.
+ *
+ * It exists because `conversation` cannot answer the question. A Claude subagent shares its
+ * parent's `externalSessionId`, and `conversationKey` is host + root + session, so every child's
+ * recall was pooled into the parent's row and the two could not be told apart. Changing
+ * `conversationKey` was the alternative and is the wrong fix: a dozen other counters key on it --
+ * capture health, the `turns >= 3` silence threshold, the prompt reminder's drift gate -- and
+ * splitting it would fragment all of them to answer a question none of them asked.
+ *
+ * `KNOWL_SCHEMA_VERSION` again does not move: an older build selects the columns it knows and is
+ * unaffected by one it never names.
  */
-export const KNOWL_MIGRATION_LEVEL = 15;
+export const KNOWL_MIGRATION_LEVEL = 16;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/tests/store/recall-gap-actor.test.ts
+++ b/tests/store/recall-gap-actor.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
+import { observeRecallGap, recallGapReport } from '../../src/store/recall-gap.js';
+
+const TEST_ROOT = path.resolve('./.knowl-recall-actor-test');
+
+// One conversation key for every observation on purpose: it is exactly what a subagent and its
+// parent share, and the point of the column is that this string cannot tell them apart.
+const observe = async (agentId: string | null, paths: string[]) =>
+  observeRecallGap('p', { conversation: 'claude|/repo|session-1', agentId, paths });
+
+beforeAll(async () => {
+  await fs.rm(TEST_ROOT, { recursive: true, force: true });
+  await fs.mkdir(path.join(TEST_ROOT, '.knowl'), { recursive: true });
+  await initDb(TEST_ROOT);
+});
+
+beforeEach(async () => {
+  await (getDb() as any).run(sql`DELETE FROM recall_observations`);
+});
+
+afterAll(async () => {
+  await closeDb();
+  // Swallowed the same way every other store test swallows it: on Windows the db file can still
+  // be held when the suite ends, and the harness sweeps leftover fixtures on the next run.
+  await fs.rm(TEST_ROOT, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('recall gap, split by actor', () => {
+  it('separates a subagent from its parent even though they share one conversation key', async () => {
+    // The whole reason the column exists. A Claude subagent shares its parent's external session
+    // id, so `conversationKey` — host + root + session — is identical for both, and every child's
+    // recall used to land on the parent's row.
+    await observe(null, ['src/a.ts']);
+    await observe('agent-7', ['src/b.ts']);
+
+    const rows = await getClient().execute('SELECT agent_id FROM recall_observations ORDER BY agent_id');
+    expect(rows.rows.map((row: any) => row.agent_id)).toEqual([null, 'agent-7']);
+  });
+
+  it('reports no split until both populations exist', async () => {
+    // One side alone invites reading a single population as a comparison. It also protects a
+    // freshly-migrated store, whose pre-column rows are all null, from reporting "100% main
+    // thread" as though that had been measured.
+    await observe(null, ['src/a.ts']);
+    expect((await recallGapReport('p')).byActor).toBeUndefined();
+
+    await observe('agent-7', ['src/b.ts']);
+    expect((await recallGapReport('p')).byActor).toBeDefined();
+  });
+
+  it('leaves the pooled totals unchanged by the split', async () => {
+    // The split is additive reporting, not a redefinition. Whatever the top-line numbers said
+    // before this column, they still say.
+    await observe(null, ['src/a.ts']);
+    await observe('agent-7', ['src/b.ts']);
+    const report = await recallGapReport('p');
+
+    expect(report.touches).toBe(2);
+    expect(report.touches).toBe(report.byActor!.main.touches + report.byActor!.subagent.touches);
+    expect(report.held).toBe(report.byActor!.main.held + report.byActor!.subagent.held);
+    expect(report.retrieved).toBe(report.byActor!.main.retrieved + report.byActor!.subagent.retrieved);
+  });
+
+  it('treats an absent agentId as the main thread', async () => {
+    await observeRecallGap('p', { conversation: 'claude|/repo|session-1', paths: ['src/a.ts'] });
+    const rows = await getClient().execute('SELECT agent_id FROM recall_observations');
+    expect(rows.rows[0].agent_id).toBeNull();
+  });
+});

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -85,6 +85,11 @@ const SCHEMA_PINS: Record<number, string> = {
   // touched, and whether the agent had already retrieved it. Additive, so `KNOWL_SCHEMA_VERSION`
   // again does not move.
   15: '5284f58395fafcb6f5649fc5e9d55d99',
+  // 16 adds `recall_observations.agent_id` -- which agent a touch belonged to, null for the main
+  // thread. A column rather than a change to `conversation`, because a subagent shares its
+  // parent's external session id and a dozen other counters key on that same function. Additive,
+  // so `KNOWL_SCHEMA_VERSION` again does not move.
+  16: '232a05446e8fcd4ed32861db0c97b8be',
 };
 
 let root: string;


### PR DESCRIPTION
The recall gap cannot currently tell a subagent from its parent, and the reason is structural: `conversationKey` is host + project root + external session id, and **a Claude subagent shares its parent's external session id**. Every child's recall lands on the parent's row.

That makes the one population most worth looking at the one the measurement cannot isolate. Subagents receive no prompt reminder and no MCP server instructions — the `SubagentStart` card is the only guidance channel that reaches them — so their retrieved-when-held share is the closest thing to a controlled read on whether that card alone carries the habit.

## The change

`agent_id` on `recall_observations`, null for the main thread, written from the hook where `input.agentId` already exists. `knowl status` prints the share for each side:

```
  Retrieved when held — main thread: 62% (128 held)
                        subagents:   31% (44 held)
```

Printed **only when both sides have observations.** Against one population it is not a comparison, and rows predating the column are null — so a freshly migrated store would otherwise report "100% main thread" as though that had been measured.

## A column, not a change to `conversationKey`

That function is read by a dozen other counters — capture health, the `turns >= 3` silence threshold, the prompt reminder's drift gate. Splitting it would fragment all of them to answer a question none of them asked.

## What is deliberately not here

**Filtering subagent writes.** It is the most-requested unbuilt coordination feature across rival memory trackers, and Knowl cannot ship it either: neither `knowledge_items` nor `knowledge_commits` records an author, and no schema change fixes that, because **the MCP server has no caller identity to record**. That is the same constraint the change watermark already works around by matching the caller's own `tool_input` rather than asking who called.

The line worth keeping: **hooks know the agent, MCP calls do not.** Only the hook path can attribute anything, and this sits on the hook path.

## Migration

Level 16, additive, `KNOWL_SCHEMA_VERSION` unmoved. No backfill and none possible — an observation already written cannot be re-attributed because the identity was never on it. Pre-column rows read as main-thread work, which is what the counters assumed before it existed, so nothing silently changes meaning. Pin added; the schema-pin gate caught the missing one, which is it doing its job.

## Verification

`tsc --noEmit` exit 0 at repo scope. Full suite **371 files, 3,557 passed, 5 skipped, 0 failed**, including 4 new tests covering the shared-conversation-key case, the both-sides-required rule, that the split leaves pooled totals unchanged, and that an absent `agentId` reads as main thread.

Independent of #206 and #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
