### PR TITLE
chore: release 5.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,61 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.15.0 — 2026-08-27
+
+Knowl can see who it is failing, and stops cutting the card that tells them.
+
+**A subagent in a linked workspace received no skills and no knowledge at all.** Both paths that
+build the session card rendered it at full width and let the caller slice the finished string, so
+anything charged against the budget first pushed the cut backwards through a section boundary. On a
+four-repo workspace the repo list alone is 1,034 characters against a subagent's 853-character
+budget: the child got a header, a repo list severed mid-entry, and nothing else. Skills are the half
+that cannot be recovered — recent knowledge can be found by querying, but a peer repo's shared skill
+is findable only by an agent who already knows it exists, which is exactly the agent who does not.
+The card is now **composed** to the budget rather than sliced down to it, so the formatter's own
+clamps apply instead of a blind cut. The parent path had the milder form of the same bug: with all
+three warning producers at their ceiling, 1,310 characters of warning cut the knowledge section off
+entirely.
+
+The cap is no longer optional. An omitted cap used to select the slicing path, which meant three
+further callers — the `knowl agent lifecycle session-start` CLI, session-start on a host that
+shares its binding, and turn-start before a session binding exists — were still cutting cards
+delivered to live agents. There is now no way to ask for a sliced card.
+
+**A subagent's recall is no longer pooled into its parent's.** A subagent shares its parent's
+session id, so every child's recall landed on the parent's row and the one population most worth
+looking at was the one the measurement could not isolate. `knowl status` now splits the ratio:
+
+```
+  Retrieved when held — main thread: 62% (128 held)
+                        subagents:   31% (44 held)
+```
+
+Printed only when both sides have observations, so a comparison is never made against a population
+of one. Additive column, no backfill and none possible — an observation already written cannot be
+re-attributed, because the identity was never on it.
+
+**The knowledge no drift check can reach is now dated.** Drift watches files; roughly half the store
+cites none. A new `knowl status` block reports how long since anyone last restated those claims, by
+category, and names the ones furthest past their own category's cadence. Report only — nothing flips
+`freshness`, because for prose there is no evidence a claim became false, only the absence of anyone
+reaffirming it.
+
+It ranks rather than flags, and that is what makes it shippable today: a cutoff cannot be calibrated
+on a store younger than the cadence it is measuring, but an ordering needs no cutoff and sharpens on
+its own. Ranking on plain age was tried and measured degenerate — a store is seeded in one batch, so
+an age-ranked list is that seed with every row tied at the store's own age. The ratio to a category
+median asks the useful question instead: is this claim unusual *for its kind*.
+
+### Fixed
+
+- The Claude Code plugin registered no MCP server at all.
+
+### Documentation
+
+- `docs/reference.md` covers both new `knowl status` blocks.
+- Parallel agents in git worktrees share the main checkout's store.
+
 
 ## 5.14.0 — 2026-08-26
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -711,7 +711,25 @@ been retrieved. Read it with `knowl status`:
   ...already retrieved:  62
   ...missed:             29 (32%)
   Lower bound — only knowledge citing a file path can be counted here.
+  Retrieved when held — main thread: 62% (128 held)
+                        subagents:   31% (44 held)
 ```
+
+**The last two lines split the same ratio by who was working**, and subagents are the half worth
+watching. A subagent receives no prompt reminder and no MCP server instructions — the
+`SubagentStart` card is the only guidance channel that reaches it — so its share is the closest
+thing to a controlled read on whether that card alone carries the habit.
+
+They print **only when both sides have observations**. Against one population it is not a
+comparison, and rows written before the attribution existed are unattributed, so a freshly
+upgraded store would otherwise report "100% main thread" as though that had been measured. A host
+that does not identify its subagents therefore shows nothing here rather than something wrong.
+
+The identity is recorded at the hook, which is the only place it exists: **hooks know the agent,
+MCP calls do not.** A subagent shares its parent's session id, so the conversation key cannot
+separate them — the attribution is a column beside it rather than a change to it, because a dozen
+other counters read that same key and splitting it would fragment all of them to answer a question
+none of them asked.
 
 **Nothing is shown to the agent, and there is no configuration key.** It is a measurement, and it
 has no switch for the same reason `capture_outcomes` has none: a count gated behind the feature it
@@ -732,6 +750,63 @@ Three properties worth knowing before quoting the number:
 
 The rows are `preserved` across snapshot restore, never refilled: a ratio assembled from two
 different histories is not a floor on anything.
+
+### The claims no drift check can reach
+
+Drift watches files. An atom that cites a file can be told when that file changes; roughly half
+the store cites none, and nothing can watch those. `knowl status` dates them instead — not by
+whether they went stale, which nothing observed, but by **how long since anyone last restated the
+claim**:
+
+```
+🕰️  UN-RESTATED CLAIMS
+  Prose (cites no code): 573 of 1072
+  Days since anyone restated the claim, by category:
+    goal          n=   7  p50   45.5d
+    skill         n=  12  p50   32.2d
+    state         n= 137  p50     31d
+    constraint    n=  22  p50   24.4d
+    decision      n=  54  p50     24d
+    fact          n= 267  p50   20.2d
+    architecture  n=  74  p50     18d
+  Furthest past its own category's cadence:
+      2.7x p50    54.5d  fact          Use knowl.cmd on Windows PowerShell
+      2.5x p50    45.4d  architecture  Competitor normalized adapter capability matrix
+  Not a staleness signal: nothing here observed a claim becoming false.
+  Store history is 54.5d, so ages beyond that cannot be distinguished from absence.
+  17 counted as prose despite citing paths, because every path is a prose file.
+```
+
+**Report only. Nothing here flips `freshness`, and there is no threshold.** For prose there is no
+evidence a claim became false, only the absence of anyone reaffirming it — flagging would assert a
+defect nothing observed, and losing knowledge nobody can recover is strictly worse than carrying a
+stale atom that ranks slightly lower.
+
+That is also why the list ranks rather than flags. A cutoff ("past N days is stale") cannot pick N
+on a store younger than the cadence it is measuring. An **ordering** needs no cutoff, so it is
+correct at any store age and sharpens on its own as the corpus ages.
+
+Four things worth knowing before quoting it:
+
+- **The clock is `valid_from`, not `updated_at`.** A new assertion generation is written only when
+  title, content, reasoning or confidence change, so it moves on restatement and nothing else.
+  Visibility promotion, supersession and status changes leave it alone — on a measured store 72%
+  of items have an `updated_at` newer than their `valid_from`.
+- **The named list ranks on the ratio to a category median, not on age.** Ranking on age is
+  degenerate: a store is seeded in one batch, and that batch is permanently its oldest cohort, so
+  an age-ranked list is the seed with every row tied at the store's own age. The ratio asks
+  whether a claim is unusual *for its kind* — an architecture note at 54.5d against an 18d cadence
+  is three cadences past due; a goal at 54.5d against a 45.5d cadence is ordinary.
+- **Store history prints beside the ages because it bounds them.** Nothing can be older than the
+  store it lives in, so an empty tail cannot distinguish "nothing rots past 60 days" from "no
+  store is old enough to say".
+- **Citing a path is not citing code.** An atom whose only path is `docs/research/x.md` is exactly
+  the prose this exists for, so it counts as prose and the last line reports how many items that
+  distinction moves.
+
+Retrieval counts are deliberately not an input. A read-count prior is a feedback loop in which an
+atom that ranks high is read more and therefore ranks higher, with nothing in the loop asking
+whether it is true.
 
 ### What Knowl says mid-turn — `reminders.*`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.14.0",
+      "version": "5.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Five commits since `v5.14.0`, two of them features, so a minor bump.

| commit | |
| --- | --- |
| `a198aa3` | fix: the session card was sliced, not composed (#206) |
| `780963e` | feat(recall): attribute a recall observation to the agent that caused it (#208) |
| `e975202` | feat(status): date the two-thirds of knowledge no drift check can reach (#207) |
| `a45387e` | fix(plugin): the Claude Code plugin registered no MCP server at all |
| `8d29888` | docs: parallel agents in git worktrees share the main checkout's store (#205) |

## Contents

- `CHANGELOG.md` — `## Unreleased` renamed in place to `## 5.15.0 — 2026-08-27`, per the convention where the release commit consumes the section.
- Three version files: `package.json`, `package-lock.json` (both occurrences) and `.claude-plugin/plugin.json`. `node scripts/check-version-sync.mjs` agrees at 5.15.0.
- `docs/reference.md` — the two new `knowl status` blocks. **This is the one deviation from the release-PR shape**, which normally touches only the changelog and version files. #207 and #208 both added user-visible output and neither documented it; catching that up here rather than in a separate PR because it documents exactly what is being released.

## Verification

`npm.cmd run build`, then `npm.cmd test` → **374 files, 3576 passed, 5 skipped, 0 failed**. `tsc --noEmit` exit 0. `git diff --check` clean.

The tag is **not** pushed yet — it goes on the merge commit after this is green and merged, per the v2.10.0 lesson where a tag pushed ahead of CI had to be deleted and the version number nearly burned.