### PR TITLE
feat(registry): publish to the official MCP registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@dat999zx/knowl",
+  "mcpName": "io.github.dat999zx/knowl",
   "version": "5.15.0",
-  "description": "Governed project memory for AI coding agents. Local-first, typed knowledge atoms over MCP, with stale decisions retired instead of accumulated.",
+  "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",
   "repository": {

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -9,6 +9,11 @@
 //                              5.6.0 with the version written by hand and nothing keeping it in
 //                              step, which is the same shape as the demo Dockerfile that sat
 //                              pinned to 3.2.2 while users installed 5.5.0.
+//   server.json                is what the official MCP registry reads, and it fails CLOSED in a
+//                              way the others do not: the registry fetches the npm metadata for
+//                              exactly the version named here and rejects the publish unless that
+//                              tarball carries a matching `mcpName`. A stale number here is not a
+//                              cosmetic drift, it is a publish that cannot succeed.
 //
 // A number that must be hand-maintained to stay honest eventually is not, so this checks instead
 // of asking.
@@ -18,6 +23,7 @@ const read = (rel) => JSON.parse(readFileSync(new URL(rel, import.meta.url), 'ut
 const pkg = read('../package.json');
 const lock = read('../package-lock.json');
 const plugin = read('../.claude-plugin/plugin.json');
+const server = read('../server.json');
 
 const problems = [];
 if (lock.version !== pkg.version) problems.push(`package-lock.json version is ${lock.version}, expected ${pkg.version}`);
@@ -28,8 +34,22 @@ if (plugin.version !== pkg.version) {
   problems.push(`.claude-plugin/plugin.json version is ${plugin.version}, expected ${pkg.version}`);
 }
 
+if (server.version !== pkg.version) {
+  problems.push(`server.json version is ${server.version}, expected ${pkg.version}`);
+}
+const npmPackage = server.packages?.find((entry) => entry.registryType === 'npm');
+if (npmPackage?.version !== pkg.version) {
+  problems.push(`server.json npm package version is ${npmPackage?.version}, expected ${pkg.version}`);
+}
+// Two halves of one proof: the registry only accepts the publish when the name asserted here is
+// the same string the published package carries. They are in different files, so nothing but this
+// keeps them equal.
+if (pkg.mcpName !== server.name) {
+  problems.push(`package.json mcpName is ${pkg.mcpName}, expected ${server.name} (the name in server.json)`);
+}
+
 if (problems.length > 0) {
-  console.error(`Version drift:\n  ${problems.join('\n  ')}\nRun: npm install --package-lock-only, and update .claude-plugin/plugin.json`);
+  console.error(`Version drift:\n  ${problems.join('\n  ')}\nRun: npm install --package-lock-only, and update .claude-plugin/plugin.json and server.json`);
   process.exit(1);
 }
-console.log(`package-lock.json and .claude-plugin/plugin.json both match package.json (${pkg.version}).`);
+console.log(`package-lock.json, .claude-plugin/plugin.json and server.json all match package.json (${pkg.version}).`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.dat999zx/knowl",
+  "title": "Knowl",
+  "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
+  "version": "5.15.0",
+  "websiteUrl": "https://knowl.cloud",
+  "repository": {
+    "url": "https://github.com/dat999zx/knowl",
+    "source": "github",
+    "id": "1279171235"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@dat999zx/knowl",
+      "version": "5.15.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -26,5 +26,11 @@
         }
       ]
     }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.knowl.cloud/mcp/"
+    }
   ]
 }


### PR DESCRIPTION
Knowl is not in `registry.modelcontextprotocol.io`. Searched four namespaces on 2026-08-30 (`knowl`, `cloud.knowl`, `dat999zx`, `io.github.dat999zx`) — zero exact matches, and `server.json` 404'd on the repo root, so it was never published.

## What is here

- **`server.json`** — the registry manifest, `io.github.dat999zx/knowl`, validated against the official `2025-12-11` schema. Lists both the npm package and the hosted endpoint.
- **`mcpName` in `package.json`** — the ownership proof for the *package* half. The registry fetches the npm metadata for exactly the version in `server.json` and rejects it unless that tarball carries a matching `mcpName`.
- **`check-version-sync.mjs` extended** — `server.json`'s two version fields and the `mcpName` ↔ `server.json.name` pair. That script already existed for this class of promise, so this joins it rather than adding a second gate. Both new assertions were confirmed to fail before being trusted.
- **npm description fixed** — it was still `Governed project memory for AI coding agents…`, the wording the 2026-08-17 sweep measured as dead (`governance` returns a bare echo; `team memory for` completes to RAM hardware). The GitHub description was updated then and `package.json` was missed, so npm has shown the old pitch since.

## Two ways to publish, and one of them works today

`remotes` carries **no** ownership check — that applies only to package entries. So:

- **Today, remotes-only.** Drop the `packages` block temporarily and publish; the hosted endpoint is listed immediately.
- **At the next release, both.** `5.15.0` is already on npm without `mcpName`, so the package half cannot validate until a release carries it. The version checker is what stops `server.json` being left behind at that moment.

Either way the publish itself is an interactive device flow:

```
mcp-publisher login github   # as dat999zx
mcp-publisher publish
```

The hosted endpoint was verified spec-compliant before being listed, not assumed: `POST /mcp` returns 401 with `www-authenticate: Bearer resource_metadata="https://api.knowl.cloud/.well-known/oauth-protected-resource"`, and that metadata URL answers 200 — the same shape mem0, Zep and Supermemory are listed with. The validator does not require the namespace to match the remote's domain (only streamable-http/sse, non-localhost, no templating), so `io.github.dat999zx/knowl` can carry `api.knowl.cloud`.

`packages` is ordered first on purpose: the local install needs no account and is the artifact that actually spreads, so a reader should meet it before the hosted option.

## Why bother, given the shelf is crowded

100+ memory servers are already there, so this is table stakes rather than a win — but PulseMCP paused its own submissions and now redirects to this registry, so one publish covers two surfaces.

## Not verified here

`npm run docs:check` and the test suite need `node_modules`, which this worktree does not have; the change is one new JSON file plus two `package.json` fields, and `check:versions` — the gate that covers them — passes.