### PR TITLE
fix(subagents): a fork was handed a second copy of what it already inherited

### DIFF
--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -294,6 +294,22 @@ async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook
   };
 }
 
+/**
+ * The one subagent type that is not context-poor, and so the one that must not be given a card.
+ *
+ * A fork inherits the parent's entire conversation, its system prompt and its tool definitions.
+ * Everything `bootstrapAgentContext` composes is therefore already in front of it: the parent's
+ * own session card sits in the inherited history, and the workflow rules arrive through the
+ * parent's `CLAUDE.md` -> `@KNOWL.md` import, which a fork shares verbatim. Sending the card
+ * anyway restates both, and it restates them to the agent least in need of them.
+ *
+ * Recognising the case is free rather than heuristic: Claude Code spawns a fork by requesting
+ * the `fork` subagent type through the Agent tool, and `SubagentStart` reports the requested
+ * type in `agent_type` — the same string its matchers filter on. No other subagent type shares
+ * the name, and a session with fork mode off never produces one.
+ */
+const FORK_AGENT_TYPE = 'fork';
+
 // Subagent bootstrap deliberately halves the cap: fan-out multiplies whatever a subagent costs.
 // The guidance card is prepended rather than left to the prompt reminder, because a subagent
 // receives no prompt event and a live probe confirmed MCP server instructions do not reach it
@@ -304,7 +320,12 @@ async function bootstrapWithHandoff(projectId: string, input: NormalizedHostHook
 // (`agentCap`). Slicing was measured delivering a workspace subagent a half-finished repo list and
 // nothing else, and the replacement pointer is measured buying the lookup the titles it replaced
 // were being answered from instead — both derivations live at the option definitions.
+//
+// A fork returns before any of that (see `FORK_AGENT_TYPE`). Only the CONTEXT is skipped: the
+// caller has already bound the fork's turn key by the time it reaches here, so a fork's reads,
+// writes and tool events are attributed exactly as any other subagent's.
 async function bootstrapAgentContext(projectId: string, input: NormalizedHostHook, sessionId: string) {
+  if (input.agentType === FORK_AGENT_TYPE) return { context: undefined, truncated: false };
   const bootstrap = await bootstrapAgentSession({
     projectId,
     title: input.title ?? 'Agent session (subagent)',

--- a/tests/store/host-lifecycle.test.ts
+++ b/tests/store/host-lifecycle.test.ts
@@ -822,6 +822,85 @@ describe('host lifecycle orchestration', () => {
     expect(bare.context).toContain('knowl_query');
   });
 
+  it('sends a fork no card and no context, because it already inherited both', async () => {
+    await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'fork-parent',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+
+    const forked = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'agent-start',
+      externalSessionId: 'fork-parent',
+      externalTurnId: undefined,
+      agentId: 'agent-fork',
+      agentType: 'fork',
+    }));
+
+    // A fork inherits the parent's whole conversation, so the parent's own card and the
+    // KNOWL.md the parent's system prompt carries are already in front of it. Anything sent
+    // here is a second copy delivered to the one subagent that did not need a first.
+    expect(forked.context).toBeUndefined();
+    // No context means no additionalContext envelope at all, rather than an empty one.
+    expect(forked.hostOutput).toBeUndefined();
+  });
+
+  it('binds a fork exactly as it binds any other subagent', async () => {
+    const parent = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'fork-binding',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+
+    const forked = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'agent-start',
+      externalSessionId: 'fork-binding',
+      externalTurnId: undefined,
+      agentId: 'agent-fork-bound',
+      agentType: 'fork',
+    }));
+
+    // Skipping the card must not skip attribution: a fork's reads, writes and tool events
+    // still have to land on the parent's memory session under the fork's own turn key.
+    expect(forked.accepted).toBe(true);
+    expect(forked.sessionId).toBe(parent.sessionId);
+    expect(await findHostSession({
+      host: 'claude',
+      projectRoot: ROOT,
+      externalSessionId: 'fork-binding',
+      externalTurnId: '__agent__:agent-fork-bound',
+    })).not.toBeNull();
+  });
+
+  it('still cards a subagent whose type merely contains the word fork', async () => {
+    await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'session-start',
+      externalSessionId: 'fork-lookalike',
+      externalTurnId: undefined,
+      title: 'Agent session',
+    }));
+
+    // The match is the whole type, not a substring: a custom subagent named `fork-reviewer`
+    // is an ordinary context-poor subagent and must keep its card.
+    const lookalike = await handleHostLifecycleEvent(projectId, hook({
+      host: 'claude',
+      event: 'agent-start',
+      externalSessionId: 'fork-lookalike',
+      externalTurnId: undefined,
+      agentId: 'agent-fork-lookalike',
+      agentType: 'fork-reviewer',
+    }));
+
+    expect(lookalike.context).toContain('knowl_query');
+  });
+
   it('routes subagent tool events to an agent-scoped binding, isolated from the parent', async () => {
     await handleHostLifecycleEvent(projectId, hook({
       host: 'claude',


### PR DESCRIPTION
Fork mode is on by default in interactive sessions since Claude Code 2.1.232, and a fork is the one subagent that is **not** context-poor: it inherits the parent's entire conversation, system prompt and tool definitions.

So both halves of the subagent bootstrap were already in front of it before `SubagentStart` fired — the parent's own session card sits in the inherited history, and the workflow rules arrive through the parent's `CLAUDE.md` → `@KNOWL.md` import, which a fork shares verbatim. The card was being delivered, twice over, to the only subagent that never needed it, and the composed body (recent knowledge, workspace repo list, peer skills) is likewise a second copy of what the parent already read.

## Recognising it is free, not heuristic

> Claude starts a fork by requesting the `fork` subagent type through the Agent tool.
> — sub-agents doc, "Fork the current conversation"

`SubagentStart` reports that requested type in `agent_type`, the same string its matchers filter on. `agentType` was already normalised onto the hook (`agentIdentityFrom`, spread at `hosts/claude.ts:111`) and already reached this branch — its doc comment said "Used only to title the binding."

The match is the **whole type**, not a substring, so a custom subagent named `fork-reviewer` keeps its card. That is pinned by a test, because the substring version is the obvious way to write this and would silently disable the workflow for every agent whose name contains the word.

## Only the context is skipped

The caller binds the fork's turn key before reaching `bootstrapAgentContext`, so a fork's reads, writes and tool events stay attributed exactly as any other subagent's. A second test pins that, because the tempting one-line version of this fix is an early return placed above the binding.

`hostContextOutput` already returns `undefined` for an empty context, so a fork gets no `additionalContext` envelope at all rather than an empty one.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npx vitest run` | **374 files / 3579 passed / 5 skipped / 0 failed** |

**Falsification:** disabling the guard (`if (false && …)`) fails exactly one test — `sends a fork no card and no context` — and nothing else. The binding and `fork-reviewer` tests hold either way by construction, which is what makes them regression guards rather than restatements.

Note for whoever runs the suite: `npm run build` first. Without it the integration suites spawn a stale `dist/index.js` and report ~79 unrelated failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
