### PR TITLE
feat(query): the staleness marker names what to open

### DIFF
--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -4,6 +4,42 @@ import { renderSkillsSection, selectSurfacedSkills, toPeerSurfacedSkills } from 
 import { fenceUntrusted, inlineUntrusted, UNTRUSTED_NOTICE_BRIEF } from './untrusted.js';
 
 /**
+ * How many moved paths the staleness marker names before it stops counting them out.
+ *
+ * Three, because the marker has to stay one line a reader takes in at a glance -- an atom
+ * citing thirty paths would otherwise turn a marker into a wall, and the reader who skims past
+ * a wall is exactly the reader this marker exists for. The rest are reported as a number,
+ * which is enough to say "there is more here than the three I named".
+ */
+const MAX_NAMED_MOVED_PATHS = 3;
+
+/**
+ * The staleness marker on a query row whose cited files moved after the row was stored.
+ *
+ * WHY IT LEADS WITH AN INSTRUCTION. This used to read `N of M affectedPaths modified since
+ * this was stored -- verify against the files before trusting`, which states a condition and
+ * leaves the reader to work out the action. Measurement on served-but-superseded claims says
+ * that is the shape that does not land: with the source present and reachable, agents opened
+ * it in roughly one turn in five and acted on the stale value in about three quarters of the
+ * rest, and a content-free freshness cue did not move those numbers. What moved them was an
+ * instruction naming what to open, on the path the reader was already on.
+ *
+ * So the sentence opens with the verb and the filenames, and the count -- which is a
+ * description, not an action -- follows it. The count stays because it is the one thing that
+ * separates "one of nine cited files was touched" from "every file this rests on is gone".
+ */
+export function pathsChangedNote(changed: number, checked: number, movedPaths: string[]): string {
+  const named = movedPaths.slice(0, MAX_NAMED_MOVED_PATHS);
+  const rest = movedPaths.length - named.length;
+  // Falls back to the bare count rather than inventing a target. `movedPaths` is empty only if
+  // a caller counted a change it could not name, and "open nothing" is worse than no verb.
+  const targets = named.length === 0
+    ? ''
+    : `Open ${named.join(', ')}${rest > 0 ? ` and ${rest} more` : ''}, then verify this still holds: `;
+  return `${targets}${changed} of ${checked} affectedPaths modified since this was stored${targets ? '.' : ' -- verify against the files before trusting.'}`;
+}
+
+/**
  * Formats a hierarchical knowledge object into clean readable markdown.
  * Shared between MCP server responses and CLI output.
  */

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -15,7 +15,7 @@ import { hasAiConfigured } from '../core/config.js';
 import { initAI } from '../ai/provider.js';
 import { runPipeline } from '../pipeline/pipeline.js';
 import { getHierarchicalKnowledge, queryKnowledgeBase } from '../store/queries.js';
-import { formatHierarchyToMarkdown, formatRecentContextToMarkdown } from '../core/format.js';
+import { formatHierarchyToMarkdown, formatRecentContextToMarkdown, pathsChangedNote } from '../core/format.js';
 import { inlineUntrusted } from '../core/untrusted.js';
 import { compactMcpJson, compactItemResponse, compactAssertionResponse, boundedEvidence } from './response-format.js';
 import { DEFAULT_RESULT_LIMIT, MAX_ITEM_CONTENT_CHARS, MAX_PREVIEW_CHARS, truncateMiddle, truncateText, uncalibratedScore, type UncalibratedScore } from '../core/token-budget.js';
@@ -1010,7 +1010,18 @@ export function registerTools(
             if (!Number.isFinite(storedAt)) return;
             let changed = 0;
             let checked = 0;
-            await Promise.all(item.affectedPaths.map(async raw => {
+            // Which paths moved, not only how many. The count alone leaves the reader to diff
+            // `affectedPaths` against the working tree to find out where to look, and that is
+            // the step measurements say does not happen: served a claim whose source had moved,
+            // with the link present and reachable, agents opened it in about one turn in five
+            // and acted on the superseded value in three quarters of the rest. A content-free
+            // freshness cue did not move that; naming the target on the critical path did.
+            //
+            // Collected positionally rather than pushed: these stats run concurrently, so a
+            // push would order the names by whichever `fs.stat` resolved first and the same
+            // query would name the same paths in a different order on the next run.
+            const moved: Array<string | null> = new Array(item.affectedPaths.length).fill(null);
+            await Promise.all(item.affectedPaths.map(async (raw, index) => {
               // A path that will not resolve against THIS checkout -- absolute, drive-lettered,
               // `./`-prefixed, escaping the root -- is skipped, not counted. A missing FILE is
               // evidence the atom's ground moved; an unreadable PATH is only absence of
@@ -1020,14 +1031,18 @@ export function registerTools(
               checked += 1;
               try {
                 const stat = await fs.stat(path.resolve(projectRoot, contained));
-                if (stat.mtimeMs > storedAt + PATHS_CHANGED_GRACE_MS) changed += 1;
+                if (stat.mtimeMs > storedAt + PATHS_CHANGED_GRACE_MS) {
+                  changed += 1;
+                  moved[index] = contained;
+                }
               } catch {
                 changed += 1;
+                moved[index] = contained;
               }
             }));
             if (changed > 0) {
               pathsChangedNotes.set(item.id,
-                `${changed} of ${checked} affectedPaths modified since this was stored -- verify against the files before trusting.`);
+                pathsChangedNote(changed, checked, moved.filter((p): p is string => p !== null)));
             }
           })).catch(() => {});
         }

--- a/tests/core/format-paths-changed-note.test.ts
+++ b/tests/core/format-paths-changed-note.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { pathsChangedNote } from '../../src/core/format.js';
+
+/**
+ * The staleness marker's wording, tested at the function rather than through a query, because
+ * the properties that matter here are about the sentence and a query cannot cheaply produce an
+ * atom citing thirty files.
+ *
+ * The behaviour under test is that the marker leads with an instruction naming a target. A
+ * marker that only describes a condition is the shape measurement says a reader skips: served a
+ * claim whose source had moved, with the link present and reachable, agents opened it in about
+ * one turn in five and acted on the stale value in three quarters of the rest.
+ */
+describe('pathsChangedNote', () => {
+  it('opens with the verb and the names, and keeps the count behind them', () => {
+    const note = pathsChangedNote(2, 6, ['src/auth.ts', 'src/session.ts']);
+
+    expect(note).toBe('Open src/auth.ts, src/session.ts, then verify this still holds: 2 of 6 affectedPaths modified since this was stored.');
+    expect(note.indexOf('Open')).toBeLessThan(note.indexOf('2 of 6'));
+  });
+
+  it('names three and counts the rest, so a heavily-cited atom stays one line', () => {
+    const note = pathsChangedNote(7, 9, [
+      'src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts', 'src/e.ts', 'src/f.ts', 'src/g.ts',
+    ]);
+
+    expect(note).toContain('Open src/a.ts, src/b.ts, src/c.ts and 4 more,');
+    expect(note).toContain('7 of 9');
+    // The names it dropped are not silently gone -- "and 4 more" says there are others, which
+    // is what stops a reader treating the three as the whole story.
+    expect(note).not.toContain('src/d.ts');
+  });
+
+  it('falls back to the bare condition rather than telling anyone to open nothing', () => {
+    // Reachable only if a caller counts a change it cannot name. An instruction with no target
+    // is worse than the description it replaced, so the old sentence is what survives here.
+    const note = pathsChangedNote(1, 1, []);
+
+    expect(note).toBe('1 of 1 affectedPaths modified since this was stored -- verify against the files before trusting.');
+    expect(note).not.toContain('Open');
+  });
+
+  it('preserves the caller\'s order, which is the atom\'s own citation order', () => {
+    const note = pathsChangedNote(3, 3, ['src/zeta.ts', 'src/alpha.ts', 'src/mid.ts']);
+
+    expect(note).toContain('Open src/zeta.ts, src/alpha.ts, src/mid.ts,');
+  });
+});

--- a/tests/mcp/query-paths-changed.test.ts
+++ b/tests/mcp/query-paths-changed.test.ts
@@ -114,6 +114,26 @@ describe('knowl_query pathsChanged marker', () => {
     // strongest form of "moved".
     expect(row.pathsChanged).toContain('2 of 2');
     expect(row.pathsChanged).toContain('verify');
+    // And it says which two. A count leaves the reader to diff `affectedPaths` against the
+    // working tree to find the target; naming it is the whole point of the marker.
+    expect(row.pathsChanged).toContain('src/auth.ts');
+    expect(row.pathsChanged).toContain('src/missing.ts');
+    // The instruction comes before the count, not after it.
+    expect(row.pathsChanged.indexOf('Open')).toBeLessThan(row.pathsChanged.indexOf('2 of 2'));
+  });
+
+  it('names the moved paths in the order the atom cites them, not in stat-resolution order', async () => {
+    const projectId = await seedRepo(A);
+    await fs.mkdir(path.join(A, 'src'), { recursive: true });
+    // Three missing files: every one counts as moved, and none of them touches the disk in a
+    // way that could order the result. Concurrent `fs.stat` settles in an arbitrary order, so
+    // a marker built by pushing as each resolves names the same paths differently run to run.
+    await storeCiting(projectId, 'Ordering probe rotation ttl', ['src/zeta.ts', 'src/alpha.ts', 'src/mid.ts']);
+
+    const result = await callQuery(A, await loadConfig(A), { query: 'ordering probe rotation ttl' });
+    const row = rowsOf(result).find(r => String(r.title).includes('Ordering probe'));
+    expect(row).toBeDefined();
+    expect(row.pathsChanged).toContain('Open src/zeta.ts, src/alpha.ts, src/mid.ts,');
   });
 
   it('says nothing on a row whose files have not moved since it was stored', async () => {


### PR DESCRIPTION
A row whose cited files moved after it was stored has always carried a marker, and the marker read:

> `2 of 6 affectedPaths modified since this was stored -- verify against the files before trusting.`

That states a **condition** and leaves the reader to diff `affectedPaths` against the working tree to find out where to look.

## Why the shape matters

Measurement on exactly this situation — a served claim whose source had moved, provenance link present and reachable — found agents opened the source in roughly **one turn in five**, and acted on the superseded value in about **three quarters** of the rest. A content-free freshness cue did not move those numbers. What moved them was an **instruction naming the target**, placed on the path the reader was already on.

So the sentence now opens with the verb and the filenames, and the count follows:

```
Open src/auth.ts, src/session.ts, then verify this still holds: 2 of 6 affectedPaths modified since this was stored.
```

The count stays: it is the one thing separating "one of nine cited files was touched" from "every file this rests on is gone". Three names, then `and N more`, so an atom citing thirty paths still produces one line a reader takes in at a glance — the reader who skims a wall is the reader the marker exists for.

## Order is the atom's, not the filesystem's

The `fs.stat` calls run concurrently, so collecting names by pushing as each resolves would name the same paths in a different order on every run. They are collected positionally instead. The test pins citation order using three **missing** files — they settle in whatever order they like and touch no disk state that could accidentally impose one.

## What did not change

- **No ranking change, no response-shape change.** One string field already in the response says more than it did.
- `search.pathsChanged` still switches the whole marker off, including the `fs.stat` per cited path.
- A foreign row is still never marked — its paths resolve against another checkout.
- Empty names fall back to the previous sentence **verbatim**: an instruction with no target is worse than the description it replaced. Reachable only if a caller counts a change it cannot name; pinned by a test regardless.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npx vitest run` | **375 files / 3581 passed / 5 skipped / 0 failed** |

Five new tests: four unit tests on the formatter (lead order, the three-name cap, the empty fallback, caller order) and two end-to-end assertions on a real query row.

Note for whoever runs the suite: `npm run build` first, or the integration suites spawn a stale `dist/index.js` and report ~79 unrelated failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
