### PR TITLE
feat(impact): the read set sees a file opened with cat, not only with Read

### DIFF
--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -51,6 +51,7 @@ import {
 import { shouldRefuseWrite } from './write-gate.js';
 import { observeRecallGapBestEffort } from '../store/recall-gap.js';
 import { KNOWL_CLAUDE_CONTINUATION_REMINDER, KNOWL_SUBAGENT_BOOTSTRAP_CARD } from '../core/knowl-guidance.js';
+import { shellReadPaths } from './shell-reads.js';
 import { isKnowlProjectGuidanceCurrent } from '../core/agents-guidance.js';
 import {
   ChangeSummary,
@@ -146,6 +147,19 @@ function toolReadsFile(input: NormalizedHostHook): boolean {
   return readsFiles
     ? readsFiles(input.hostEvent ?? '', toolName)
     : IMPACT_READ_TOOLS.has(toolName);
+}
+
+/**
+ * Whether this event is a shell command whose text we can read.
+ *
+ * Tested on the NORMALIZED shape rather than by re-asking the profile `isShellEvent`. Only the
+ * shell branch of `commandEvent` puts a `command` string in the payload, so this is the same
+ * judgement already made once per event, read back instead of recomputed -- and it cannot drift
+ * away from the branch that produced it, which is how the read set and the write gate would
+ * quietly stop agreeing about what a shell event is.
+ */
+function toolIsShell(input: NormalizedHostHook): boolean {
+  return input.type === 'command' && typeof input.payload.command === 'string';
 }
 
 function toolWritesFile(input: NormalizedHostHook): boolean {
@@ -526,7 +540,17 @@ function impactChangedPaths(payload: Record<string, unknown>): string[] {
  * ordinary traffic on a path that observes rather than acts, and its `continue` still leaves every
  * other path's observations in the batch.
  */
-async function recordToolReads(input: NormalizedHostHook, sessionId: string, paths: string[]): Promise<void> {
+async function recordToolReads(
+  input: NormalizedHostHook,
+  sessionId: string,
+  paths: string[],
+  // Set for shell reads. The shell says WHICH file was opened, never how much of it: `head -5`
+  // and `sed -n 40,60p` are slices, and expanding a slice into one row per symbol would assert
+  // beliefs about signatures that never reached the agent -- manufactured false positives on
+  // the one tier allowed to interrupt. The `file://` row is the granularity the evidence
+  // supports, and it is the same degradation a file with no parseable symbols already takes.
+  options: { fileGranularity?: boolean } = {},
+): Promise<void> {
   const observations: ReadObservation[] = [];
 
   for (const changed of paths) {
@@ -539,7 +563,7 @@ async function recordToolReads(input: NormalizedHostHook, sessionId: string, pat
       await indexFile(input.projectRoot, relativePath);
 
       const observed: { locator: string; observedHash: string }[] = [];
-      const symbols = await listCodeSymbols(relativePath);
+      const symbols = options.fileGranularity ? [] : await listCodeSymbols(relativePath);
       if (symbols.length > 0 && symbols.length <= IMPACT_MAX_SYMBOLS_PER_READ) {
         // A symbol the extractor gave no signature has no hash to compare against later, so a row
         // for it would be a belief nothing could ever falsify; `recordReads` drops it regardless.
@@ -645,6 +669,13 @@ async function runToolEventImpact(input: NormalizedHostHook, sessionId: string):
       await recordToolReads(input, sessionId, paths);
     } else if (paths.length > 0 && toolWritesFile(input)) {
       await detectCertainImpactBestEffort(input.projectRoot, paths, sessionId);
+    } else if (paths.length === 0 && toolIsShell(input)) {
+      // A shell event carries a command string and no paths at all, so it reaches neither
+      // branch above and the whole subsystem was blind to a session that reads with `cat`.
+      // Last rather than first: a host that somehow delivers both paths and a command is
+      // telling us the paths, and the parser is only ever the weaker source.
+      const read = shellReadPaths(String(input.payload.command ?? ''));
+      if (read.length > 0) await recordToolReads(input, sessionId, read, { fileGranularity: true });
     }
     return await openImpactCardEntries(sessionId);
   } catch {

--- a/src/session/shell-reads.ts
+++ b/src/session/shell-reads.ts
@@ -26,6 +26,12 @@
  *   comparison -- a fabricated staleness on the tier held to >=95% precision. A worktree-aware
  *   version of this could be right, and it is not this one.
  * - **Any segment carrying a redirect.** `cat > file` and `cat >> file` write.
+ * - **A read whose output is piped into anything that does not pass contents on.**
+ *   `cat f | grep x` shows the agent matching lines and `cat f | wc -l` shows it a number --
+ *   precisely what `grep x f` and `wc -l f` show, and both of those are refused above. Left
+ *   alone, the pipe launders a read this module would have declined written the other way
+ *   round. A downstream stage that is itself a content reader (`cat f | head -20`) does pass
+ *   the text through and keeps the read.
  *
  * SEGMENTS, NOT THE FIRST TOKEN. The command is split on `&&`, `||`, `;` and `|` and every
  * segment is classified on its own. Testing only the leading verb is a defect with a receipt:
@@ -76,7 +82,11 @@ const UNRESOLVED = /[*?[\]{}$`~!\\]|\)/;
 /** A redirect anywhere in a segment makes it a write, whatever its verb reads. */
 const REDIRECT = /[<>]/;
 
-const SEGMENT_SPLIT = /\|\||&&|[;|&\n]/;
+/**
+ * What starts an INDEPENDENT command. `|` is deliberately absent: it builds a pipeline, and a
+ * pipeline's stages share one output rather than each reaching the agent on its own.
+ */
+const COMMAND_SPLIT = /&&|\|\||[;&\n]/;
 
 /**
  * Whether a token is an option rather than a path.
@@ -122,6 +132,22 @@ function tokenize(segment: string): string[] {
 }
 
 /**
+ * Whether a pipeline stage hands on the text it was given, rather than a report about it.
+ *
+ * Only the LAST stage of a pipeline reaches the agent, so an earlier stage's file counts as read
+ * only if everything after it passes the contents through. `cat f | head -20` does; `cat f |
+ * grep x` shows matching lines and `cat f | wc -l` shows a number -- which is exactly what
+ * `grep x f` and `wc -l f` show, and both of those are refused above. Without this rule the pipe
+ * launders a read the module would have declined written the other way round: a fabricated
+ * observation on the one tier allowed to interrupt and refuse a write.
+ */
+function stageEmitsContents(stage: string): boolean {
+  const tokens = tokenize(stage.trim());
+  const verb = tokens[0]?.split('/').pop() ?? '';
+  return CONTENT_READERS.has(verb) || (verb === 'sed' && sedIsPrinting(tokens));
+}
+
+/**
  * The literal paths a shell command read, in the order the command names them.
  *
  * Order is the command's own so a caller rendering these produces the same list twice for the
@@ -132,33 +158,39 @@ export function shellReadPaths(command: string): string[] {
   const found: string[] = [];
   const seen = new Set<string>();
 
-  for (const segment of command.split(SEGMENT_SPLIT)) {
-    const trimmed = segment.trim();
-    if (!trimmed || REDIRECT.test(trimmed)) continue;
+  for (const single of command.split(COMMAND_SPLIT)) {
+    const stages = single.split('|');
+    for (const [index, segment] of stages.entries()) {
+      // A stage whose output is consumed by something that does not pass contents on was never
+      // read by the agent at all. See `stageEmitsContents`.
+      if (stages.slice(index + 1).some(later => !stageEmitsContents(later))) continue;
+      const trimmed = segment.trim();
+      if (!trimmed || REDIRECT.test(trimmed)) continue;
 
-    const tokens = tokenize(trimmed);
-    if (tokens.length < 2) continue;
+      const tokens = tokenize(trimmed);
+      if (tokens.length < 2) continue;
 
-    // The verb is the last path component, so `/usr/bin/cat` and `cat` classify alike.
-    const verb = tokens[0].split('/').pop() ?? '';
-    const isSed = verb === 'sed';
-    if (!CONTENT_READERS.has(verb) && !(isSed && sedIsPrinting(tokens))) continue;
+      // The verb is the last path component, so `/usr/bin/cat` and `cat` classify alike.
+      const verb = tokens[0].split('/').pop() ?? '';
+      const isSed = verb === 'sed';
+      if (!CONTENT_READERS.has(verb) && !(isSed && sedIsPrinting(tokens))) continue;
 
-    // `sed`'s first non-option argument is its SCRIPT (`40,60p`), not a path. Dropping only
-    // the leading one is deliberate: `sed -n 1p a.ts b.ts` really does read both files, and a
-    // rule that dropped every non-option after the script would lose the second.
-    let sedScriptPending = isSed;
-    for (const token of tokens.slice(1)) {
-      // The script is consumed BEFORE the option test, because a script like `1,50p` matches
-      // the numeric-option shape exactly. Testing options first let the script pass as a flag
-      // and the real path be eaten in its place, which read as "sed reads nothing, ever".
-      if (sedScriptPending && !token.startsWith('-')) { sedScriptPending = false; continue; }
-      if (isOption(token) || UNRESOLVED.test(token)) continue;
-      // A bare `--` ends options; it is not a path either.
-      if (token === '--' || token === '') continue;
-      if (seen.has(token)) continue;
-      seen.add(token);
-      found.push(token);
+      // `sed`'s first non-option argument is its SCRIPT (`40,60p`), not a path. Dropping only
+      // the leading one is deliberate: `sed -n 1p a.ts b.ts` really does read both files, and a
+      // rule that dropped every non-option after the script would lose the second.
+      let sedScriptPending = isSed;
+      for (const token of tokens.slice(1)) {
+        // The script is consumed BEFORE the option test, because a script like `1,50p` matches
+        // the numeric-option shape exactly. Testing options first let the script pass as a flag
+        // and the real path be eaten in its place, which read as "sed reads nothing, ever".
+        if (sedScriptPending && !token.startsWith('-')) { sedScriptPending = false; continue; }
+        if (isOption(token) || UNRESOLVED.test(token)) continue;
+        // A bare `--` ends options; it is not a path either.
+        if (token === '--' || token === '') continue;
+        if (seen.has(token)) continue;
+        seen.add(token);
+        found.push(token);
+      }
     }
   }
   return found;

--- a/src/session/shell-reads.ts
+++ b/src/session/shell-reads.ts
@@ -1,0 +1,165 @@
+/**
+ * Files a shell command read, for the sessions whose agents read with `cat` rather than `Read`.
+ *
+ * WHY THIS EXISTS. `IMPACT_READ_TOOLS` is `Read` and `NotebookRead`, and a file opened through
+ * the shell reaches the same subsystem as `type: 'command'` with a `command` string and no
+ * paths at all. So change impact, the recall gap and everything else built on `work_read_sets`
+ * were blind to it. That is not an edge case in every deployment: a host running with shell
+ * access granted will instruct its agent to prefer `cat`, `head`, `sed -n` and `git show` over
+ * the file tools, and a session working that way records no reads whatsoever.
+ *
+ * WHAT IT REFUSES TO DO, and this is most of the design. A read-set row asserts "this session
+ * saw this text and holds a belief about it", and the certain tier spends that assertion by
+ * interrupting the agent and refusing its write. The doctrine this module inherits from
+ * `host-lifecycle.ts` is therefore explicit -- recall on a tier allowed to be incomplete, never
+ * precision on the one tier allowed to interrupt -- so every ambiguous construct is dropped
+ * rather than guessed at:
+ *
+ * - **Anything that is not a literal path.** A glob, a variable, a subshell or a brace
+ *   expansion names a file only after the shell has run, and this parser is not a shell.
+ * - **`grep`, `rg`, `find`, `ls`.** They name a file and return matching lines or names, not
+ *   contents. Excluded for the identical reason `Grep` and `Glob` are excluded upstream: a row
+ *   for one claims the agent saw signatures it never received.
+ * - **`git show <ref>:<path>`.** This is the sharpest of them. The agent saw the file as of
+ *   that ref; the hash recorded here would be the WORKING TREE's. Recording it says the session
+ *   holds a belief about text it never read, and the belief would be falsified by the very next
+ *   comparison -- a fabricated staleness on the tier held to >=95% precision. A worktree-aware
+ *   version of this could be right, and it is not this one.
+ * - **Any segment carrying a redirect.** `cat > file` and `cat >> file` write.
+ *
+ * SEGMENTS, NOT THE FIRST TOKEN. The command is split on `&&`, `||`, `;` and `|` and every
+ * segment is classified on its own. Testing only the leading verb is a defect with a receipt:
+ * a sibling hook in another repo exempted the whole string on its first token, so every
+ * `ls && rm -rf ...` passed its guard unseen. Read-then-act is the common shape, not the exotic
+ * one.
+ *
+ * FILE GRANULARITY, DELIBERATELY. The caller records these at `file://` granularity rather than
+ * per symbol. The shell tells us WHICH file was opened and not HOW MUCH of it: `sed -n 40,60p`
+ * and `head -5` are slices, and expanding a slice into one row per symbol would assert beliefs
+ * about signatures that never reached the agent. The file row is the granularity the evidence
+ * actually supports, and it is a degradation the subsystem already understands -- it is the
+ * same row a file with no parseable symbols produces.
+ */
+
+/** Verbs that emit a file's own contents. Slicing readers included; see the granularity note. */
+const CONTENT_READERS = new Set([
+  'cat', 'bat', 'nl', 'less', 'more', 'head', 'tail', 'od', 'xxd', 'strings',
+]);
+
+/**
+ * `sed` is a reader only when it is printing, and it is never one when it is editing in place.
+ *
+ * It earns a special case rather than a place in the set above because it is the one verb here
+ * that reads and writes under the same name: `sed -n 40,60p file` prints a slice and
+ * `sed -i 's/a/b/' file` rewrites the file. Recording the second as a read would file a write
+ * as an observation -- the exact inversion this subsystem cannot afford, since the write gate
+ * and the read set would then hold opposite beliefs about the same event.
+ *
+ * Both conditions are required, not either: `-n` alone with `-i` present is still an in-place
+ * edit that happens to suppress output.
+ */
+function sedIsPrinting(tokens: string[]): boolean {
+  const options = tokens.filter(token => token.startsWith('-'));
+  if (options.some(option => option === '-i' || option.startsWith('--in-place') || (/^-[a-zA-Z]*i/.test(option)))) return false;
+  return options.some(option => option === '-n' || /^-[a-zA-Z]*n/.test(option) || option === '--quiet' || option === '--silent');
+}
+
+/**
+ * Shell metacharacters that mean "this token is not yet a filename".
+ *
+ * Kept as a character test rather than a list of constructs: the question is only ever whether
+ * the literal token can be trusted as written, and any of these means the shell would have
+ * produced something else.
+ */
+const UNRESOLVED = /[*?[\]{}$`~!\\]|\)/;
+
+/** A redirect anywhere in a segment makes it a write, whatever its verb reads. */
+const REDIRECT = /[<>]/;
+
+const SEGMENT_SPLIT = /\|\||&&|[;|&\n]/;
+
+/**
+ * Whether a token is an option rather than a path.
+ *
+ * `head -20 file` and `sed -n 5p file` put a bare number or a short flag where a path would
+ * otherwise sit, and treating either as a filename produces a path that resolves to nothing --
+ * harmless, but it also lets `-n` shadow a real target in the same segment.
+ */
+function isOption(token: string): boolean {
+  return token.startsWith('-') || /^\+?\d+(?:[,.]\d+)?[a-zA-Z]?$/.test(token);
+}
+
+/**
+ * Splits a segment into tokens, honouring single and double quotes.
+ *
+ * A quoted path is the ordinary way to name a file with a space in it, and dropping quoted
+ * tokens would make this parser silently blind to exactly those files. Nothing is unescaped
+ * beyond the quoting itself: a token needing more than that has already been refused by
+ * `UNRESOLVED`.
+ */
+function tokenize(segment: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let quoted = false;
+  for (const char of segment) {
+    if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") { quote = char; quoted = true; continue; }
+    if (/\s/.test(char)) {
+      if (current || quoted) tokens.push(current);
+      current = '';
+      quoted = false;
+      continue;
+    }
+    current += char;
+  }
+  if (current || quoted) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The literal paths a shell command read, in the order the command names them.
+ *
+ * Order is the command's own so a caller rendering these produces the same list twice for the
+ * same input. Duplicates are collapsed, keeping the first mention.
+ */
+export function shellReadPaths(command: string): string[] {
+  if (!command || command.length > 4_000) return [];
+  const found: string[] = [];
+  const seen = new Set<string>();
+
+  for (const segment of command.split(SEGMENT_SPLIT)) {
+    const trimmed = segment.trim();
+    if (!trimmed || REDIRECT.test(trimmed)) continue;
+
+    const tokens = tokenize(trimmed);
+    if (tokens.length < 2) continue;
+
+    // The verb is the last path component, so `/usr/bin/cat` and `cat` classify alike.
+    const verb = tokens[0].split('/').pop() ?? '';
+    const isSed = verb === 'sed';
+    if (!CONTENT_READERS.has(verb) && !(isSed && sedIsPrinting(tokens))) continue;
+
+    // `sed`'s first non-option argument is its SCRIPT (`40,60p`), not a path. Dropping only
+    // the leading one is deliberate: `sed -n 1p a.ts b.ts` really does read both files, and a
+    // rule that dropped every non-option after the script would lose the second.
+    let sedScriptPending = isSed;
+    for (const token of tokens.slice(1)) {
+      // The script is consumed BEFORE the option test, because a script like `1,50p` matches
+      // the numeric-option shape exactly. Testing options first let the script pass as a flag
+      // and the real path be eaten in its place, which read as "sed reads nothing, ever".
+      if (sedScriptPending && !token.startsWith('-')) { sedScriptPending = false; continue; }
+      if (isOption(token) || UNRESOLVED.test(token)) continue;
+      // A bare `--` ends options; it is not a path either.
+      if (token === '--' || token === '') continue;
+      if (seen.has(token)) continue;
+      seen.add(token);
+      found.push(token);
+    }
+  }
+  return found;
+}

--- a/tests/session/shell-reads.test.ts
+++ b/tests/session/shell-reads.test.ts
@@ -87,6 +87,26 @@ describe('shellReadPaths', () => {
       expect(shellReadPaths('wc -l src/auth.ts')).toEqual([]);
     });
 
+    it('refuses a read the pipe would otherwise launder past a refused verb', () => {
+      // `grep x f` is refused two tests up because the agent receives matching lines and not
+      // the file. `cat f | grep x` puts the agent in the identical state, so recording it
+      // would let the pipe smuggle in an observation written the other way round -- a
+      // fabricated read on the one tier allowed to interrupt and refuse a write.
+      expect(shellReadPaths('cat src/auth.ts | grep createSession')).toEqual([]);
+      expect(shellReadPaths('cat src/auth.ts | wc -l')).toEqual([]);
+      expect(shellReadPaths('cat package.json | jq .name')).toEqual([]);
+      // Every stage, not only the one next to the pipe.
+      expect(shellReadPaths('cat src/a.ts | tail -20 | grep x')).toEqual([]);
+    });
+
+    it('keeps a read whose downstream stages do pass the contents through', () => {
+      // `cat f | head -20` shows the agent the file's first 20 lines, which is what
+      // `head -20 f` shows -- and that is recorded. The rule is about what reaches the agent,
+      // not about the presence of a pipe.
+      expect(shellReadPaths('cat src/auth.ts | head -20')).toEqual(['src/auth.ts']);
+      expect(shellReadPaths('cat src/auth.ts | sed -n 1,5p')).toEqual(['src/auth.ts']);
+    });
+
     it('refuses any segment carrying a redirect, whatever its verb reads', () => {
       expect(shellReadPaths('cat > src/auth.ts')).toEqual([]);
       expect(shellReadPaths('cat >> src/auth.ts')).toEqual([]);

--- a/tests/session/shell-reads.test.ts
+++ b/tests/session/shell-reads.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { shellReadPaths } from '../../src/session/shell-reads.js';
+
+/**
+ * The shell-read parser, tested mostly on what it REFUSES.
+ *
+ * A read-set row asserts "this session saw this text", and the certain tier spends that
+ * assertion by interrupting the agent and refusing its write. So a missed read costs recall on
+ * a tier allowed to be incomplete, and a fabricated one costs precision on the only tier
+ * allowed to interrupt. Every refusal below is therefore a property, not an omission.
+ */
+describe('shellReadPaths', () => {
+  describe('reads it recognises', () => {
+    it('takes the paths a content reader names', () => {
+      expect(shellReadPaths('cat src/auth.ts')).toEqual(['src/auth.ts']);
+      expect(shellReadPaths('head -20 src/a.ts')).toEqual(['src/a.ts']);
+      expect(shellReadPaths('tail -n 5 src/b.ts')).toEqual(['src/b.ts']);
+    });
+
+    it('reads a printing sed, and drops its script rather than filing it as a path', () => {
+      expect(shellReadPaths('sed -n 1,50p src/c.ts')).toEqual(['src/c.ts']);
+      expect(shellReadPaths('sed -n 100,130p src/host-lifecycle.ts')).toEqual(['src/host-lifecycle.ts']);
+      // Only the FIRST non-option is the script: `sed -n 1p a b` really does read both files.
+      expect(shellReadPaths('sed -n 1p src/a.ts src/b.ts')).toEqual(['src/a.ts', 'src/b.ts']);
+    });
+
+    it('refuses an in-place sed, which is a write wearing a reader\'s name', () => {
+      // The one verb here that reads and writes under the same name. Filing an in-place edit
+      // as an observation would leave the write gate and the read set holding opposite
+      // beliefs about one event.
+      expect(shellReadPaths("sed -i 's/a/b/' src/c.ts")).toEqual([]);
+      expect(shellReadPaths("sed -i.bak 's/a/b/' src/c.ts")).toEqual([]);
+      expect(shellReadPaths("sed --in-place 's/a/b/' src/c.ts")).toEqual([]);
+      // `-n` present and `-i` present is still an in-place edit that suppresses output.
+      expect(shellReadPaths("sed -n -i 's/a/b/' src/c.ts")).toEqual([]);
+      // A sed that is not printing at all is a filter, not a read of the named file.
+      expect(shellReadPaths("sed 's/a/b/' src/c.ts")).toEqual([]);
+    });
+
+    it('takes every file a single reader names, in the command\'s own order', () => {
+      expect(shellReadPaths('cat src/z.ts src/a.ts')).toEqual(['src/z.ts', 'src/a.ts']);
+    });
+
+    it('classifies on the verb\'s last path component', () => {
+      expect(shellReadPaths('/usr/bin/cat src/auth.ts')).toEqual(['src/auth.ts']);
+    });
+
+    it('reads a quoted path with a space in it', () => {
+      expect(shellReadPaths('cat "src/my file.ts"')).toEqual(['src/my file.ts']);
+    });
+
+    it('collapses a path named twice', () => {
+      expect(shellReadPaths('cat src/a.ts && cat src/a.ts')).toEqual(['src/a.ts']);
+    });
+  });
+
+  describe('every segment is classified, not just the first', () => {
+    it('finds a read after a chain operator', () => {
+      // The defect this exists to avoid has a receipt: a sibling hook exempted the whole
+      // command string on its first token, so `ls && rm -rf ...` passed its guard unseen.
+      expect(shellReadPaths('ls -la && cat src/auth.ts')).toEqual(['src/auth.ts']);
+      expect(shellReadPaths('npm test; cat src/auth.ts')).toEqual(['src/auth.ts']);
+      expect(shellReadPaths('true || cat src/auth.ts')).toEqual(['src/auth.ts']);
+    });
+
+    it('finds reads in several segments at once', () => {
+      expect(shellReadPaths('cat src/a.ts && head -3 src/b.ts')).toEqual(['src/a.ts', 'src/b.ts']);
+    });
+  });
+
+  describe('refusals', () => {
+    it('refuses git show, whose text is a ref\'s and not the working tree\'s', () => {
+      // The sharpest refusal here. The agent saw the file as of that ref; the hash the caller
+      // would record is the working tree's, so the row asserts a belief about text nobody
+      // read -- and the very next comparison falsifies it, on the tier held to >=95%.
+      expect(shellReadPaths('git show upstream/main:src/auth.ts')).toEqual([]);
+      expect(shellReadPaths('git show HEAD:src/auth.ts | head -20')).toEqual([]);
+    });
+
+    it('refuses tools that return matches or names rather than contents', () => {
+      // Same reasoning that excludes Grep and Glob upstream: the agent never received the
+      // file's text, so a row for it claims signatures it never saw.
+      expect(shellReadPaths('grep -n foo src/auth.ts')).toEqual([]);
+      expect(shellReadPaths('rg pattern src/auth.ts')).toEqual([]);
+      expect(shellReadPaths('ls src/auth.ts')).toEqual([]);
+      expect(shellReadPaths('find src -name auth.ts')).toEqual([]);
+      expect(shellReadPaths('wc -l src/auth.ts')).toEqual([]);
+    });
+
+    it('refuses any segment carrying a redirect, whatever its verb reads', () => {
+      expect(shellReadPaths('cat > src/auth.ts')).toEqual([]);
+      expect(shellReadPaths('cat >> src/auth.ts')).toEqual([]);
+      expect(shellReadPaths('cat src/auth.ts > out.txt')).toEqual([]);
+      expect(shellReadPaths("cat <<'EOF'")).toEqual([]);
+    });
+
+    it('refuses a token the shell would have expanded', () => {
+      // A glob, a variable, a subshell or a brace names a file only after the shell has run,
+      // and this parser is not a shell.
+      expect(shellReadPaths('cat src/*.ts')).toEqual([]);
+      expect(shellReadPaths('cat $FILE')).toEqual([]);
+      expect(shellReadPaths('cat "$(ls src)"')).toEqual([]);
+      expect(shellReadPaths('cat src/{a,b}.ts')).toEqual([]);
+      expect(shellReadPaths('cat ~/notes.md')).toEqual([]);
+      expect(shellReadPaths('cat src/a.ts?')).toEqual([]);
+    });
+
+    it('drops options rather than reading them as paths', () => {
+      expect(shellReadPaths('head -20 src/a.ts')).not.toContain('-20');
+      expect(shellReadPaths('tail -n 5 src/a.ts')).toEqual(['src/a.ts']);
+      expect(shellReadPaths('cat -- src/a.ts')).toEqual(['src/a.ts']);
+    });
+
+    it('says nothing about a verb with no target, or no verb at all', () => {
+      expect(shellReadPaths('cat')).toEqual([]);
+      expect(shellReadPaths('')).toEqual([]);
+      expect(shellReadPaths('   ')).toEqual([]);
+    });
+
+    it('refuses a command long enough to be a script rather than a call', () => {
+      expect(shellReadPaths(`cat src/a.ts ${'x'.repeat(4_000)}`)).toEqual([]);
+    });
+  });
+});

--- a/tests/store/impact-lifecycle.test.ts
+++ b/tests/store/impact-lifecycle.test.ts
@@ -291,10 +291,12 @@ describe('change impact on the hook path', () => {
 
   it('records nothing for a shell command that read no file it can name', async () => {
     // Every one of these is a refusal with its own reason: `git show` served a ref's text and
-    // not the working tree's, `grep` returned matching lines, the glob was never expanded, and
-    // the redirect is a write. See `shell-reads.ts` for each.
+    // not the working tree's, `grep` returned matching lines -- through a pipe just as much as
+    // directly -- the glob was never expanded, and the redirect is a write. See
+    // `shell-reads.ts` for each.
     await shellEvent('session-a', `git show HEAD:${SOURCE}`);
     await shellEvent('session-a', `grep -n createSession ${SOURCE}`);
+    await shellEvent('session-a', `cat ${SOURCE} | grep createSession`);
     await shellEvent('session-a', 'cat src/*.ts');
     await shellEvent('session-a', `cat ${SOURCE} > /tmp/copy.ts`);
     await shellEvent('session-a', 'npm test');

--- a/tests/store/impact-lifecycle.test.ts
+++ b/tests/store/impact-lifecycle.test.ts
@@ -109,6 +109,20 @@ const toolEvent = (externalSessionId: string, toolName: string, changedPaths: st
     captureKey: `${toolName}:${changedPaths.join(',')}:${eventIndex++}`,
   }));
 
+/**
+ * One shell call, in the shape the normalizer produces for one: `type: 'command'` with the
+ * command text in the payload and no paths at all. That absence is the whole reason the shell
+ * branch exists, so the fixture must not supply paths it would never have.
+ */
+const shellEvent = (externalSessionId: string, command: string) =>
+  handleHostLifecycleEvent(projectId, hook({
+    externalSessionId,
+    type: 'command',
+    toolName: 'Bash',
+    payload: { command, exitCode: 0 },
+    captureKey: `bash:${command}:${eventIndex++}`,
+  }));
+
 /** A tool event that touches no file: what the session is doing when the card reaches it. */
 const idleEvent = (externalSessionId: string) =>
   handleHostLifecycleEvent(projectId, hook({
@@ -240,6 +254,50 @@ describe('change impact on the hook path', () => {
     await toolEvent('session-a', 'Grep', ['src']);
     await toolEvent('session-a', 'Grep', [SOURCE]);
     await toolEvent('session-a', 'Glob', [SOURCE]);
+
+    expect(await readSetRows()).toHaveLength(0);
+  });
+
+  /**
+   * A file opened through the shell reaches this subsystem as a command string with no paths at
+   * all, so it hit neither the read branch nor the write branch and the whole read set was blind
+   * to it. That is not exotic: a host granted shell access instructs its agent to prefer `cat`
+   * and `sed -n` over the file tools, and such a session recorded no reads whatsoever.
+   */
+  it('records a shell read, at file granularity rather than per symbol', async () => {
+    const result = await shellEvent('session-a', `cat ${SOURCE}`);
+
+    // The contrast with `Read` above is the design, not an accident. The shell says WHICH file
+    // was opened and never how much of it -- `head -5` and `sed -n 40,60p` are slices -- so a
+    // symbol row would assert a belief about a signature that never reached the agent.
+    expect((await readSetRows()).map(row => String(row.locator))).toEqual([`file://${SOURCE}`]);
+    expect((await listCodeSymbols(SOURCE)).length).toBeGreaterThan(1);
+    const [row] = await readSetRows();
+    expect(String(row.session_id)).toBe(result.sessionId);
+    expect(row.released_at).toBeNull();
+  });
+
+  it('lets a shell read invalidate against another session write, like any other read', async () => {
+    await shellEvent('session-a', `sed -n 1,20p ${SOURCE}`);
+    await write(SOURCE, V2_SIGNATURE_CHANGED);
+    await toolEvent('session-b', 'Edit', [SOURCE]);
+
+    // The row is only worth writing if it participates. A finding against the file locator is
+    // what makes the shell reader visible to the same machinery `Read` feeds.
+    const findings = await findingRows();
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings.some(finding => String(finding.cause_locator) === `file://${SOURCE}`)).toBe(true);
+  });
+
+  it('records nothing for a shell command that read no file it can name', async () => {
+    // Every one of these is a refusal with its own reason: `git show` served a ref's text and
+    // not the working tree's, `grep` returned matching lines, the glob was never expanded, and
+    // the redirect is a write. See `shell-reads.ts` for each.
+    await shellEvent('session-a', `git show HEAD:${SOURCE}`);
+    await shellEvent('session-a', `grep -n createSession ${SOURCE}`);
+    await shellEvent('session-a', 'cat src/*.ts');
+    await shellEvent('session-a', `cat ${SOURCE} > /tmp/copy.ts`);
+    await shellEvent('session-a', 'npm test');
 
     expect(await readSetRows()).toHaveLength(0);
   });


### PR DESCRIPTION
`IMPACT_READ_TOOLS` is `Read` and `NotebookRead`. A file opened through the shell reaches the same subsystem as `type: 'command'` with a command string and **no paths at all**, so it hit neither the read branch nor the write branch — and change impact, the recall gap, and everything else built on `work_read_sets` were blind to it.

That is not an edge case in every deployment. A host granted shell access instructs its agent to prefer `cat`, `head` and `sed -n` over the file tools, and a session working that way recorded **no reads whatsoever** — silently, and in exactly the sessions doing the most reading.

## File granularity, deliberately

The shell says *which* file was opened and never *how much* of it: `head -5` and `sed -n 40,60p` are slices. Expanding a slice into one row per symbol would assert beliefs about signatures that never reached the agent — manufactured false positives on the one tier allowed to interrupt and refuse a write.

The `file://` row is the granularity the evidence supports, and it is a degradation this subsystem already understands: it is the same row a file with no parseable symbols produces. A test asserts the contrast against `Read` directly, on a file the indexer *does* yield symbols for.

## What the parser refuses is most of the design

Same doctrine as the module it joins — recall on a tier allowed to be incomplete, never precision on the one allowed to interrupt.

| Refused | Why |
| --- | --- |
| `git show <ref>:<path>` | **The sharpest one.** The agent saw the file as of that ref; the hash recorded would be the *working tree's*. The row asserts a belief about text nobody read, and the next comparison falsifies it. |
| `grep`, `rg`, `find`, `ls` | They name a file and return matches or names, not contents — identical reasoning to the existing `Grep`/`Glob` exclusions. |
| `sed -i` | `sed` is the one verb that reads and writes under the same name. Recognised only when printing, never with `-i`; otherwise the write gate and the read set would hold opposite beliefs about one event. |
| Globs, `$vars`, `$(subshells)`, braces, `~` | Not filenames until the shell has run, and this is not a shell. |
| Any segment with `>` `<` | A redirect makes it a write whatever its verb reads. |

## Every segment, not the first token

Split on `&&`, `||`, `;` and `|`; each segment classified alone. Testing only the leading verb is a defect with a receipt — a sibling hook exempted a whole command string on its first token, so every `ls && rm -rf …` passed its guard unseen. Read-then-act is the common shape, not the exotic one.

## Placement

The branch is **last** and requires `paths.length === 0`, so a host that somehow delivers both declared paths and a command is still believed over the parser. `impactEnabled` still gates the whole thing, and `toolIsShell` reads the normalized shape (`type === 'command'` plus a `command` string) rather than re-asking the profile, so it cannot drift from the branch that produced it.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npx vitest run` | **375 files / 3595 passed / 5 skipped / 0 failed** |

16 parser unit tests, 11 of them refusals; 3 end-to-end tests on the hook path.

**Falsification:** disabling the branch fails exactly the two behavioural tests (`records a shell read…`, `lets a shell read invalidate…`) and nothing else. The refusal test passes either way by construction, which is what makes it a regression guard.

Note for whoever runs the suite: `npm run build` first, or the integration suites spawn a stale `dist/index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
