### PR TITLE
feat(status): the write gate's own precision was computed and printed nowhere

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -670,7 +670,38 @@ knowl posture frugal     # reset the same keys -- knowl exactly as it ships
   memory-active session is precisely the one every other reminder goes silent for.
 - **`impact.enabled` + `impact.gate: shadow`** — change-impact detection on, with the write
   gate in shadow: even the maximal stance does not arm a blocking gate ahead of its measured
-  precision bar.
+  precision bar. What that bar currently reads is printed by `knowl status`, below.
+
+#### Whether the write gate is good enough to enforce
+
+Shadow mode runs the real verdict and withholds the refusal, so every refusal an enforcing gate
+*would* have issued is recorded. The bar in front of enforcing it is **≥95% precision over ≥40
+adjudicated findings**, and `knowl status` prints where the store stands against it:
+
+```
+🛡️  WRITE GATE (shadow)
+  Refusals withheld:     60
+  Adjudicated:           48 of 60
+  Precision:             87.5% (6 false positive(s))
+  Bar to enforce:        ≥95% over ≥40 adjudicated — not cleared
+```
+
+The bar is printed beside the number on purpose. A precision figure alone invites "87% sounds
+fine"; against the bar it reads as what it is.
+
+**Unresolved findings count in neither half.** Nothing forces adjudication, so early on the
+unresolved set is the larger one, and treating those withheld refusals as justified is how a
+precision number talks its way past the bar it was meant to clear. Adjudicate with
+`knowl_impact({resolve})`; until something has been, the line reads *not yet measured* rather
+than a percentage, because no evidence is not a perfect score.
+
+Both halves of the bar fail differently and are reported separately: 100% over three findings is
+not evidence, so it shows as **not cleared** with the number of further adjudications that would
+decide it. That prompt is withheld when precision itself is what is failing — telling someone
+below the bar to gather more evidence is advice for a verdict already reached.
+
+The block is absent entirely on a store whose gate has never withheld anything. Such a repo has
+not measured 0%, it has measured nothing.
 
 Query results also annotate staleness whatever the posture says: a row whose `affectedPaths`
 were modified after the row was stored carries `pathsChanged` ("n of m affectedPaths modified

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -20,6 +20,7 @@ import { formatHierarchyToMarkdown } from '../core/format.js';
 import { formatStatusReport } from './status-report.js';
 import { captureHealth } from '../store/capture-outcome.js';
 import { recallGapReport } from '../store/recall-gap.js';
+import { shadowGateReport } from '../store/gate-shadow.js';
 import { unrestatedClaimsReport } from '../store/unrestated.js';
 import { captureNudgeMode } from '../store/capture-config.js';
 import { KNOWLEDGE_CATEGORIES, type KnowledgeCategory } from '../core/types.js';
@@ -467,6 +468,7 @@ program
         capture: await captureHealth(),
         captureNudgeMode: captureNudgeMode(config),
         recall: await recallGapReport(project.id),
+        shadowGate: await shadowGateReport(),
         unrestated: await unrestatedClaimsReport(),
         cloud,
         // Reads config.json a second time rather than threading `config` through: the catalog

--- a/src/cli/status-report.ts
+++ b/src/cli/status-report.ts
@@ -1,6 +1,7 @@
 import { KNOWLEDGE_CATEGORIES, KnowledgeCommit, KnowledgeItem, Project, ProjectConfig } from '../core/types.js';
 import type { ActiveWorkspace } from '../workspace/resolve.js';
 import type { CaptureHealth } from '../store/capture-outcome.js';
+import { SHADOW_GATE_PRECISION_BAR, SHADOW_GATE_SAMPLE_BAR, type ShadowGateReport } from '../store/gate-shadow.js';
 import type { RecallGapReport } from '../store/recall-gap.js';
 import type { UnrestatedReport } from '../store/unrestated.js';
 import type { CloudStatus } from '../cloud/status.js';
@@ -46,6 +47,8 @@ export function formatStatusReport(input: {
   captureNudgeMode?: string;
   /** Absent, or a store that has observed no tool touches, renders no section at all. */
   recall?: RecallGapReport;
+  /** Absent, or a store whose shadow gate has withheld nothing, renders no section at all. */
+  shadowGate?: ShadowGateReport;
   /** Absent, or a store where no active item carries an open assertion, renders no section. */
   unrestated?: UnrestatedReport;
   /** Absent or disconnected renders nothing, so an offline repo gains no noise. */
@@ -93,6 +96,7 @@ export function formatStatusReport(input: {
     }
   }
   lines.push(...formatCaptureHealthBlock(input.capture, input.captureNudgeMode));
+  lines.push(...formatShadowGateBlock(input.shadowGate));
   lines.push(...formatRecallGapBlock(input.recall));
   lines.push(...formatUnrestatedBlock(input.unrestated));
   lines.push(...formatWorkspaceBlock(input.workspace ?? null));
@@ -203,6 +207,53 @@ function formatUnrestatedBlock(unrestated?: UnrestatedReport): string[] {
   lines.push(`  Store history is ${unrestated.storeHistoryDays}d, so ages beyond that cannot be distinguished from absence.`);
   if (unrestated.prosePathOnly > 0) {
     lines.push(`  ${unrestated.prosePathOnly} counted as prose despite citing paths, because every path is a prose file.`);
+  }
+  return lines;
+}
+
+/**
+ * What an enforcing write gate would have refused, and whether that is yet good enough to enforce.
+ *
+ * `shadowGatePrecision` has existed since the gate did, computing exactly the number plan §9's
+ * bar is written against -- and nothing imported it. So shadow mode was recording withheld
+ * refusals into a table whose verdict no command could print, which is the same defect as not
+ * measuring at all: a measurement nobody can read cannot promote or retire the thing it measures.
+ *
+ * THE BAR IS PRINTED BESIDE THE NUMBER, always. A precision figure alone invites the reading
+ * "91% sounds fine"; against ">=95% over >=40 adjudicated" it reads as what it is. Both halves
+ * of the bar are shown because they fail differently -- a store can sit at 100% over three
+ * findings, which is not evidence, and this block has to say so rather than look like a pass.
+ *
+ * Absent until shadow mode has actually withheld something, following every other block here: a
+ * repo whose gate has never run has not measured 0%, it has measured nothing.
+ */
+function formatShadowGateBlock(gate?: ShadowGateReport): string[] {
+  if (!gate || gate.withheld === 0) return [];
+
+  const lines = [
+    STATUS_LINE,
+    '🛡️  WRITE GATE (shadow)',
+    `  Refusals withheld:     ${gate.withheld}`,
+    `  Adjudicated:           ${gate.adjudicated} of ${gate.withheld}`,
+  ];
+
+  if (gate.precision === null) {
+    // Null is not zero and must never render as a percentage. Nothing forces adjudication, so
+    // this is the ordinary early state, and it names the command that moves it.
+    lines.push('  Precision:             not yet measured — resolve findings with `knowl_impact({resolve})`.');
+    return lines;
+  }
+
+  const percent = (gate.precision * 100).toFixed(1);
+  const clears = gate.precision >= SHADOW_GATE_PRECISION_BAR && gate.adjudicated >= SHADOW_GATE_SAMPLE_BAR;
+  lines.push(
+    `  Precision:             ${percent}% (${gate.falsePositives} false positive(s))`,
+    `  Bar to enforce:        ≥${(SHADOW_GATE_PRECISION_BAR * 100).toFixed(0)}% over ≥${SHADOW_GATE_SAMPLE_BAR} adjudicated — ${clears ? 'cleared' : 'not cleared'}`,
+  );
+  // Said only when the sample is the thing standing in the way, so a repo below the precision
+  // bar is not told to go and adjudicate more of something already known to be wrong.
+  if (!clears && gate.adjudicated < SHADOW_GATE_SAMPLE_BAR && gate.precision >= SHADOW_GATE_PRECISION_BAR) {
+    lines.push(`  ${SHADOW_GATE_SAMPLE_BAR - gate.adjudicated} more adjudicated finding(s) would decide it.`);
   }
   return lines;
 }

--- a/src/store/gate-shadow.ts
+++ b/src/store/gate-shadow.ts
@@ -93,17 +93,6 @@ export async function countShadowBlocks(): Promise<number> {
 }
 
 /**
- * `1 − false_positive / adjudicated`, over the findings the shadow rows point at.
- *
- * **Unresolved findings are excluded from both halves rather than counted as correct.** Nothing
- * forces adjudication, so early on the unresolved set is the larger one; treating those blocks as
- * justified is how a precision number talks its way past the bar it was meant to clear. The
- * denominator is deliberately the adjudicated count and not `countShadowBlocks()`.
- *
- * The join is on `impact_findings`, which `sweepReadSets` does not touch -- so this survives the
- * GC that hard-deletes released read-set rows underneath it.
- */
-/**
  * The bar plan §9 puts in front of enforcing the write gate: >=95% precision over >=40 findings.
  *
  * Stated here as constants rather than left in prose, because the report that prints the
@@ -129,6 +118,17 @@ export async function shadowGateReport(): Promise<ShadowGateReport> {
   }
 }
 
+/**
+ * `1 − false_positive / adjudicated`, over the findings the shadow rows point at.
+ *
+ * **Unresolved findings are excluded from both halves rather than counted as correct.** Nothing
+ * forces adjudication, so early on the unresolved set is the larger one; treating those blocks as
+ * justified is how a precision number talks its way past the bar it was meant to clear. The
+ * denominator is deliberately the adjudicated count and not `countShadowBlocks()`.
+ *
+ * The join is on `impact_findings`, which `sweepReadSets` does not touch -- so this survives the
+ * GC that hard-deletes released read-set rows underneath it.
+ */
 export async function shadowGatePrecision(): Promise<ShadowGatePrecision> {
   const rows = await getClient().execute(
     `SELECT COUNT(*) AS adjudicated,

--- a/src/store/gate-shadow.ts
+++ b/src/store/gate-shadow.ts
@@ -103,6 +103,32 @@ export async function countShadowBlocks(): Promise<number> {
  * The join is on `impact_findings`, which `sweepReadSets` does not touch -- so this survives the
  * GC that hard-deletes released read-set rows underneath it.
  */
+/**
+ * The bar plan §9 puts in front of enforcing the write gate: >=95% precision over >=40 findings.
+ *
+ * Stated here as constants rather than left in prose, because the report that prints the
+ * measurement has to print what the measurement is being judged against. A precision figure with
+ * no bar beside it is a number nobody can act on -- which is how this measurement came to be
+ * computed by a function nothing imported.
+ */
+export const SHADOW_GATE_PRECISION_BAR = 0.95;
+export const SHADOW_GATE_SAMPLE_BAR = 40;
+
+/** The precision measurement plus the sample it was taken over, which the bar also names. */
+export type ShadowGateReport = ShadowGatePrecision & { withheld: number };
+
+/** Everything `knowl status` needs to say about the shadow gate, in one round trip each. */
+export async function shadowGateReport(): Promise<ShadowGateReport> {
+  try {
+    const [withheld, precision] = await Promise.all([countShadowBlocks(), shadowGatePrecision()]);
+    return { withheld, ...precision };
+  } catch {
+    // A store on a schema older than `impact_gate_shadow` reports nothing rather than failing
+    // the whole status command over a block that is absent by design on such a store.
+    return { withheld: 0, adjudicated: 0, falsePositives: 0, precision: null };
+  }
+}
+
 export async function shadowGatePrecision(): Promise<ShadowGatePrecision> {
   const rows = await getClient().execute(
     `SELECT COUNT(*) AS adjudicated,

--- a/tests/cli/shadow-gate-status.test.ts
+++ b/tests/cli/shadow-gate-status.test.ts
@@ -1,0 +1,93 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { formatStatusReport } from '../../src/cli/status-report.js';
+import { DEFAULT_CONFIG } from '../../src/core/config.js';
+
+const ROOT = path.resolve('./.knowl-shadow-gate-status-test');
+const base = {
+  project: { id: 'local', name: 'shadow-gate', rootPath: ROOT } as never,
+  config: DEFAULT_CONFIG,
+  activeItems: [], supersededItems: [], deprecatedItems: [], commits: [],
+};
+
+/**
+ * The shadow gate's verdict, in the one place a developer would look for it.
+ *
+ * `shadowGatePrecision` computed exactly the number plan §9's bar is written against, and
+ * nothing imported it -- so shadow mode recorded withheld refusals into a table whose verdict no
+ * command could print. A measurement nobody can read cannot promote or retire the thing it
+ * measures, which makes an unsurfaced precision figure equivalent to not measuring at all.
+ */
+describe('shadow write gate in knowl status', () => {
+  it('renders nothing on a store whose gate has never withheld a refusal', () => {
+    const report = formatStatusReport({
+      ...base,
+      shadowGate: { withheld: 0, adjudicated: 0, falsePositives: 0, precision: null },
+    });
+    // Not a row of zeros: such a repo has not measured 0%, it has measured nothing.
+    expect(report).not.toMatch(/WRITE GATE/);
+  });
+
+  it('never renders a percentage before anything has been adjudicated', () => {
+    const report = formatStatusReport({
+      ...base,
+      shadowGate: { withheld: 12, adjudicated: 0, falsePositives: 0, precision: null },
+    });
+
+    expect(report).toMatch(/WRITE GATE \(shadow\)/);
+    expect(report).toMatch(/Refusals withheld:\s+12/);
+    expect(report).toMatch(/not yet measured/);
+    // Null is not zero. Rendering it as 0.0% or 100% would both be inventions, and the second
+    // would let an untouched install look like it had cleared a bar it never measured against.
+    expect(report).not.toMatch(/%/);
+    expect(report).not.toMatch(/NaN/);
+    // It names the one command that moves the number.
+    expect(report).toMatch(/knowl_impact/);
+  });
+
+  it('prints the bar beside the number, and says it is not cleared', () => {
+    const report = formatStatusReport({
+      ...base,
+      shadowGate: { withheld: 60, adjudicated: 48, falsePositives: 6, precision: 1 - 6 / 48 },
+    });
+
+    expect(report).toMatch(/Precision:\s+87\.5% \(6 false positive\(s\)\)/);
+    // A precision figure alone invites "87% sounds fine"; against the bar it reads as what it is.
+    expect(report).toMatch(/≥95% over ≥40 adjudicated — not cleared/);
+  });
+
+  it('says cleared only when both halves of the bar are met', () => {
+    const report = formatStatusReport({
+      ...base,
+      shadowGate: { withheld: 70, adjudicated: 50, falsePositives: 1, precision: 1 - 1 / 50 },
+    });
+
+    expect(report).toMatch(/98\.0%/);
+    expect(report).toMatch(/— cleared/);
+  });
+
+  it('does not call a small perfect sample cleared, and says what would decide it', () => {
+    // 100% over three findings is not evidence, and this block has to say so rather than look
+    // like a pass. The two halves of the bar fail differently and are reported separately.
+    const report = formatStatusReport({
+      ...base,
+      shadowGate: { withheld: 5, adjudicated: 3, falsePositives: 0, precision: 1 },
+    });
+
+    expect(report).toMatch(/100\.0%/);
+    expect(report).toMatch(/— not cleared/);
+    expect(report).toMatch(/37 more adjudicated finding\(s\) would decide it/);
+  });
+
+  it('does not ask for a bigger sample when precision itself is what is failing', () => {
+    // Telling someone below the precision bar to adjudicate more is advice to gather more
+    // evidence for a verdict already reached.
+    const report = formatStatusReport({
+      ...base,
+      shadowGate: { withheld: 20, adjudicated: 10, falsePositives: 5, precision: 0.5 },
+    });
+
+    expect(report).toMatch(/— not cleared/);
+    expect(report).not.toMatch(/would decide it/);
+  });
+});


### PR DESCRIPTION
`shadowGatePrecision` has existed since the shadow gate did, and it computes exactly the number plan §9's bar is written against — **≥95% precision over ≥40 adjudicated findings**. Nothing imported it. Neither did `countShadowBlocks`, its sample-size half.

So shadow mode was faithfully recording every refusal an enforcing gate *would* have issued, into a table whose verdict no command could print. That is the same defect as not measuring at all: a measurement nobody can read cannot promote the thing it measures, and cannot retire it either. The gate could sit at 99% over 200 findings, or at 40% over six, and a developer running `knowl status` would see the same nothing.

```
🛡️  WRITE GATE (shadow)
  Refusals withheld:     60
  Adjudicated:           48 of 60
  Precision:             87.5% (6 false positive(s))
  Bar to enforce:        ≥95% over ≥40 adjudicated — not cleared
```

## The bar is printed beside the number

A precision figure alone invites "87% sounds fine"; against the bar it reads as what it is. `SHADOW_GATE_PRECISION_BAR` and `SHADOW_GATE_SAMPLE_BAR` move out of prose and into `gate-shadow.ts`, so the report and the module cannot drift about what is being cleared.

## Both halves of the bar fail differently

They are reported separately. **100% over three findings is not evidence**, and this block has to say so rather than look like a pass — it shows `not cleared` plus the number of further adjudications that would decide it.

That prompt is withheld when precision *itself* is what is failing: telling someone below the bar to gather more evidence is advice for a verdict already reached. Both cases have a test.

## Null is never a percentage

`precision` is null until something has been adjudicated, and the line reads *not yet measured* rather than `0.0%` or `100%`. The second would let an untouched install look like it had cleared a bar it never measured against — which is the module's own documented reason for returning null, now honoured at the surface too. A test asserts the block contains no `%` at all in that state.

Unresolved findings still count in neither half, per `shadowGatePrecision`'s existing contract.

## Absences

- No block at all on a store whose gate has never withheld anything, following every other block on this screen: such a repo has not measured 0%, it has measured nothing.
- `shadowGateReport` swallows its own failure, so a store on a schema older than `impact_gate_shadow` loses one block rather than the whole `status` command.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npm run docs:check` | clean |
| `npx vitest run` | **375 files / 3582 passed / 5 skipped / 0 failed** |

Six new tests: both bar halves, the null case, the small-perfect-sample case, the precision-failing case, and the never-withheld absence. `docs/reference.md` gains the block beside the `impact.gate: shadow` posture entry that promises the bar exists.

Note for whoever runs the suite: `npm run build` first, or the integration suites spawn a stale `dist/index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
