### PR TITLE
fix(context): a correction elsewhere was promoting the atom it made doubtful

### DIFF
--- a/src/store/recent-context.ts
+++ b/src/store/recent-context.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, notLike } from 'drizzle-orm';
+import { and, desc, eq, isNull, notLike, sql } from 'drizzle-orm';
 import { KnowledgeCommit, KnowledgeItem } from '../core/types.js';
 import { DatabaseError } from '../core/errors.js';
 import { getDb } from './database.js';
@@ -28,14 +28,41 @@ export async function getRecentContext(
       conditions.push(notLike(schema.knowledgeItems.title, 'Verified command:%'));
       conditions.push(notLike(schema.knowledgeItems.title, 'Work Loop checkpoint%'));
     }
+    // Ordered by when the claim was last RESTATED, not by when its row was last written.
+    //
+    // `updated_at` moves on supersession, archival, visibility promotion and a freshness flip,
+    // none of which mean anyone revisited the claim -- `unrestated.ts` measured 72% of items on
+    // a 950-item store carrying an `updated_at` newer than their `valid_from`. Ordering three
+    // card slots by it had one consequence worth naming: `blastRadius` flags a sibling
+    // `needs_review` through `updateKnowledgeItem`, which stamps `updated_at` unconditionally,
+    // so correcting one atom PROMOTED unrelated atoms onto the session card for having just
+    // been marked doubtful -- evicting whatever the session had actually learned.
+    //
+    // A new assertion generation is written only when title, content, reasoning or confidence
+    // change, so `valid_from` moves on restatement and on nothing else. Same clock and same
+    // join `unrestated.ts` already established.
+    //
+    // LEFT joined, where that module inner-joins. It is reporting on a population and may
+    // exclude a row it cannot date; this is a card with three slots, and an item with no open
+    // assertion -- an import, a store predating the table -- must still be reachable. Such a
+    // row falls back to `updated_at`, which is exactly the old behaviour for exactly the rows
+    // that have nothing better.
+    const restatedAt = sql<string>`coalesce(${schema.knowledgeAssertions.validFrom}, ${schema.knowledgeItems.updatedAt})`;
     const rows = await db
-      .select()
+      .select({ item: schema.knowledgeItems })
       .from(schema.knowledgeItems)
+      .leftJoin(
+        schema.knowledgeAssertions,
+        and(
+          eq(schema.knowledgeAssertions.knowledgeItemId, schema.knowledgeItems.id),
+          isNull(schema.knowledgeAssertions.validTo),
+        ),
+      )
       .where(and(...conditions))
-      .orderBy(desc(schema.knowledgeItems.updatedAt))
+      .orderBy(desc(restatedAt))
       .limit(itemLimit);
 
-    const items = rows.map(mapRowToKnowledgeItem);
+    const items = rows.map(row => mapRowToKnowledgeItem(row.item));
 
     const commits = await getKnowledgeCommits(projectId, commitLimit);
     return { items, commits };

--- a/src/store/recent-context.ts
+++ b/src/store/recent-context.ts
@@ -59,7 +59,15 @@ export async function getRecentContext(
         ),
       )
       .where(and(...conditions))
-      .orderBy(desc(restatedAt))
+      // Tie-broken to a total order, because the primary key is not one. ISO timestamps are
+      // millisecond-granular, and three atoms written by one turn routinely share a
+      // millisecond on a fast machine -- CI's macOS runner produced a different second slot
+      // than Windows did from the same fixture. `updated_at` had the same property; ordering
+      // three card slots by a partial order means the card can differ between two identical
+      // calls, which is the kind of instability that reads as a bug in whatever consumed it.
+      // `id` last because it is arbitrary but stable, which is exactly what a final tiebreak
+      // should be; `created_at` first because when it does differ it is meaningful.
+      .orderBy(desc(restatedAt), desc(schema.knowledgeItems.createdAt), desc(schema.knowledgeItems.id))
       .limit(itemLimit);
 
     const items = rows.map(row => mapRowToKnowledgeItem(row.item));

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -23,6 +23,27 @@ async function setKnowledgeItemUpdatedAt(itemId: string, updatedAt: string): Pro
   await getDb().run(sql`UPDATE knowledge_items SET updated_at = ${updatedAt} WHERE id = ${itemId}`);
 }
 
+/**
+ * Pin an item's open assertion to a known instant.
+ *
+ * The card orders by `valid_from`, and ISO timestamps are millisecond-granular -- three items
+ * created in one test routinely share a millisecond on a fast machine, which made the order
+ * among them a coin flip. CI's macOS runner and Windows disagreed about the same fixture. Same
+ * reason `setKnowledgeItemUpdatedAt` exists directly above, applied to the other clock.
+ */
+async function openAssertionValidFrom(itemId: string): Promise<string | null> {
+  const rows = await getClient().execute({
+    sql: 'SELECT valid_from FROM knowledge_assertions WHERE knowledge_item_id = ? AND valid_to IS NULL',
+    args: [itemId],
+  });
+  return rows.rows[0] ? String(rows.rows[0].valid_from) : null;
+}
+
+async function setAssertionValidFrom(itemId: string, validFrom: string): Promise<void> {
+  await getDb().run(sql`UPDATE knowledge_assertions SET valid_from = ${validFrom}
+    WHERE knowledge_item_id = ${itemId} AND valid_to IS NULL`);
+}
+
 describe('Storage Layer', () => {
   beforeAll(async () => {
     // Ensure fresh test directory on startup
@@ -817,6 +838,10 @@ describe('Storage Layer', () => {
       content: 'Written third, and what the session actually learned.',
     });
 
+    await setAssertionValidFrom(stale.id, '2099-01-01T00:00:00.000Z');
+    await setAssertionValidFrom(middle.id, '2099-01-02T00:00:00.000Z');
+    await setAssertionValidFrom(newest.id, '2099-01-03T00:00:00.000Z');
+
     // Exactly what `blastRadius` does to a sibling when a correction lands elsewhere. It sets
     // no title, content, reasoning or confidence, so no new assertion generation is written --
     // but `updateKnowledgeItem` stamps `updated_at` unconditionally.
@@ -831,7 +856,7 @@ describe('Storage Layer', () => {
     expect(context.items.some(item => item.id === stale.id)).toBe(false);
   });
 
-  it('does promote an item that was genuinely restated', async () => {
+  it('opens a new assertion generation on a genuine restatement, which is what the card orders by', async () => {
     const project = await repo.getProjectByRootPath(TEST_ROOT) ?? await repo.createProject(TEST_ROOT, 'Test Project');
     const projectId = project!.id;
 
@@ -845,16 +870,28 @@ describe('Storage Layer', () => {
       title: 'Restatement ordering: written second',
       content: 'Written after the first.',
     });
+    // Pinned above every other item this shared store holds, so the two slots are these two.
+    await setAssertionValidFrom(first.id, '2099-02-01T00:00:00.000Z');
+    await setAssertionValidFrom(second.id, '2099-02-02T00:00:00.000Z');
+
+    const before = await getRecentContext(projectId, { itemLimit: 2, commitLimit: 1 });
+    expect(before.items.map(item => item.id)).toEqual([second.id, first.id]);
 
     // A content change opens a new assertion generation, which is the one event that moves
-    // `valid_from`. The card must still react to this, or the fix above would have traded a
-    // wrong signal for no signal.
+    // `valid_from`. Asserted on the clock itself rather than on the resulting card position:
+    // the new generation is stamped `now`, and `now` cannot be ordered against a pinned 2099
+    // without the fixture pinning the very value under test.
+    const validFromBefore = await openAssertionValidFrom(first.id);
     await repo.updateKnowledgeItem(first.id, { content: 'Restated wording, checked today.' });
+    const validFromAfter = await openAssertionValidFrom(first.id);
 
-    const context = await getRecentContext(projectId, { itemLimit: 2, commitLimit: 1 });
+    expect(validFromAfter).not.toBe(validFromBefore);
 
-    expect(context.items[0].id).toBe(first.id);
-    expect(context.items[1].id).toBe(second.id);
+    // And the housekeeping case does not, which is the pair that makes the ordering meaningful:
+    // one event moves this clock and the other does not.
+    const unchanged = await openAssertionValidFrom(second.id);
+    await repo.updateKnowledgeItem(second.id, { freshness: 'needs_review' });
+    expect(await openAssertionValidFrom(second.id)).toBe(unchanged);
   });
 
   it('should store commit changes without project ids or double-encoded JSON', async () => {

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -797,6 +797,66 @@ describe('Storage Layer', () => {
     expect(context.commits[0].message).toBe('Newest session commit');
   });
 
+  it('does not promote an item onto the card for having just been flagged needs_review', async () => {
+    const project = await repo.getProjectByRootPath(TEST_ROOT) ?? await repo.createProject(TEST_ROOT, 'Test Project');
+    const projectId = project!.id;
+
+    const stale = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Card ordering: the doubtful one',
+      content: 'Written first, and never restated since.',
+    });
+    const middle = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Card ordering: the middle one',
+      content: 'Written second.',
+    });
+    const newest = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Card ordering: the newest one',
+      content: 'Written third, and what the session actually learned.',
+    });
+
+    // Exactly what `blastRadius` does to a sibling when a correction lands elsewhere. It sets
+    // no title, content, reasoning or confidence, so no new assertion generation is written --
+    // but `updateKnowledgeItem` stamps `updated_at` unconditionally.
+    await repo.updateKnowledgeItem(stale.id, { freshness: 'needs_review' });
+
+    const context = await getRecentContext(projectId, { itemLimit: 2, commitLimit: 1 });
+
+    // Ordering by `updated_at` put the doubtful atom first, evicting what the session had just
+    // learned -- so correcting one claim silently rewrote the next session's card with atoms
+    // promoted for being suspect.
+    expect(context.items.map(item => item.id)).toEqual([newest.id, middle.id]);
+    expect(context.items.some(item => item.id === stale.id)).toBe(false);
+  });
+
+  it('does promote an item that was genuinely restated', async () => {
+    const project = await repo.getProjectByRootPath(TEST_ROOT) ?? await repo.createProject(TEST_ROOT, 'Test Project');
+    const projectId = project!.id;
+
+    const first = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Restatement ordering: written first',
+      content: 'Original wording.',
+    });
+    const second = await repo.createKnowledgeItem(projectId, {
+      category: 'fact',
+      title: 'Restatement ordering: written second',
+      content: 'Written after the first.',
+    });
+
+    // A content change opens a new assertion generation, which is the one event that moves
+    // `valid_from`. The card must still react to this, or the fix above would have traded a
+    // wrong signal for no signal.
+    await repo.updateKnowledgeItem(first.id, { content: 'Restated wording, checked today.' });
+
+    const context = await getRecentContext(projectId, { itemLimit: 2, commitLimit: 1 });
+
+    expect(context.items[0].id).toBe(first.id);
+    expect(context.items[1].id).toBe(second.id);
+  });
+
   it('should store commit changes without project ids or double-encoded JSON', async () => {
     const project = await repo.getProjectByRootPath(TEST_ROOT);
     const projectId = project!.id;


### PR DESCRIPTION
`getRecentContext` orders the session card's three knowledge slots by `updated_at`. That column moves on supersession, archival, visibility promotion and a freshness flip — `unrestated.ts` already documents this, and measured **72% of items** on a 950-item store carrying an `updated_at` newer than their `valid_from`.

## The consequence was specific, and backwards

`blastRadius` marks a sibling `needs_review` through `updateKnowledgeItem`, which stamps `updated_at` unconditionally (`repository.ts:443`). So correcting one atom **promoted unrelated atoms onto the next session's card — for having just been flagged as doubtful** — and evicted whatever that session had actually learned.

A card has three knowledge slots. Housekeeping could take all three.

The same applies to `gc.ts` archiving, to `knowledge-writer.ts` retiring a predecessor, and to a visibility promotion.

## The fix

Order by the open assertion's `valid_from`. A new assertion generation is written only when title, content, reasoning or confidence change, so it moves on **restatement and on nothing else** — the property `unrestated.ts` relies on, using the same join, so the two surfaces cannot disagree about what "recent" means.

**LEFT joined, where that module inner-joins.** It reports on a population and may exclude a row it cannot date; this is a card with three slots, and an item with no open assertion — an import, a store predating the table — must still be reachable. Such a row coalesces to `updated_at`, which is exactly the previous behaviour for exactly the rows that have nothing better.

## Two tests, and the second matters as much as the first

- A `needs_review` flip must **not** move an atom onto the card.
- A genuine content change must **still** move it there.

Without the second, this would have traded a wrong signal for no signal.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npx vitest run` | **374 files / 3578 passed / 5 skipped / 0 failed** |

**Falsification:** restoring the `updated_at` ordering fails exactly the two new tests. The existing recency test (`should return recent active knowledge and commits…`) passes either way, because its fixture's creation order and its update order agree — worth knowing, since that is why the defect survived having a test over this function.

Note for whoever runs the suite: `npm run build` first, or the integration suites spawn a stale `dist/index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
