### PR TITLE
test(conflicts): "newest wins" was a coin flip when both rows shared a millisecond

### DIFF
--- a/tests/store/conflicts.test.ts
+++ b/tests/store/conflicts.test.ts
@@ -82,6 +82,16 @@ describe('knowledge conflict keys', () => {
         sql: 'UPDATE knowledge_items SET conflict_key = ? WHERE id = ?',
         args: ['  Search ENGINE  Choice  ', second.id],
       });
+      // Pinned so that "newest" is a fact rather than a coin flip. Both rows are created by
+      // back-to-back calls, ISO timestamps are millisecond-granular, and on a fast machine the
+      // two land in the same millisecond -- at which point the repair falls through to its
+      // documented `a.id.localeCompare(b.id)` tiebreak and the survivor is whichever random
+      // id sorts first. Measured on this fixture with the timestamps forced equal: the
+      // assertion below held 3 times in 12. It is what failed on CI's node 24 runner.
+      await getClient().execute({
+        sql: "UPDATE knowledge_items SET updated_at = '2020-01-01T00:00:00.000Z' WHERE id = ?",
+        args: [first.id],
+      });
 
       const report = await auditKnowledgeStore(undefined, { repair: true });
 


### PR DESCRIPTION
A pre-existing flake, found because it failed on someone else's PR. Not a behaviour change — the production sort is correct and untouched.

## What flakes

`repairs keys already stored raw, and settles the duplicates that exposes` creates two rows with back-to-back `createKnowledgeItem` calls and asserts the **second** survives the repair, because newest wins.

ISO timestamps are millisecond-granular. On a fast machine both rows get the same `updated_at`, and the repair then falls through to its own documented tiebreak (`integrity.ts`):

```ts
.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.id.localeCompare(b.id))
```

Ids are random hex, so under a tie the survivor is **whichever id happens to sort first** — unrelated to which row was created second.

## Measured, not inferred

Driving this exact fixture with the two timestamps forced equal, over 12 fresh stores:

```
under a tie, over 12 fresh stores: test would PASS 3, FAIL 9
```

That is what failed on the **ubuntu node 24** runner on #222, while the identical commit passed on macOS, ubuntu 22 and Windows. The failure message there was `expected '20b4015dc5304e1a' to be 'f73b82c66642461b'` — and `2…` sorts before `f…`, which is the id tiebreak choosing, exactly as predicted.

## The fix

Backdate `first`, so "newest" is a fact rather than a race. **The production sort stays as it is** — it is deterministic by construction, which is precisely what its comment claims; only the fixture was asserting an order it had never established.

Same class as the `tier_since` millisecond note in `tier.ts`, and the third place in this suite where a test has had to pin a clock rather than race it.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npx vitest run` | **374 files / 3576 passed / 5 skipped / 0 failed** |
| `conflicts.test.ts` × 6 | 5 passed, every run |

Independent of #218–#222; merges cleanly with all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
