### PR TITLE
chore: release 5.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,103 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## 5.16.0 — 2026-09-02
+
+Knowl can be installed from the official MCP registry, and change impact stops being blind to
+half of how agents actually read code.
+
+**Knowl is publishable to registry.modelcontextprotocol.io.** `server.json` is the manifest, and
+the part worth reading twice is that the registry does not take a publisher's word for ownership:
+it fetches the npm metadata for exactly the version the manifest names and rejects the publish
+unless that tarball carries an `mcpName` matching the server name. 5.15.0 is on npm without that
+field, so the registry would have refused it — this release is the first that carries it, which is
+what makes the publish possible at all. `mcpName` and the server name now have to stay equal
+across two files forever, so `npm run check:versions` gained `server.json` as a fourth file rather
+than the promise getting a gate of its own.
+
+**The read set sees a file opened with `cat`, not only with `Read`.** The read tools were `Read`
+and `NotebookRead`; a file opened through the shell arrived as a command string with no paths at
+all and hit neither the read branch nor the write branch. That is not an edge case — a host
+granted shell access instructs its agent to prefer `cat`, `head` and `sed -n` over the file tools,
+and a session working that way recorded **no reads whatsoever**, silently, in exactly the sessions
+doing the most reading.
+
+What the parser refuses is most of the design, because a read-set row asserts that a session saw
+some text and the `certain` tier spends that assertion by interrupting the agent and refusing its
+write. So `grep`, `rg`, `find`, `ls` and `wc` are declined — they return matches or names, not
+contents — along with `git show <ref>:<path>` (the agent saw a ref's text; the hash recorded would
+be the working tree's), an in-place `sed -i`, any segment carrying a redirect, and any token the
+shell would still have expanded. A read piped into anything that reports on the text rather than
+passing it on (`cat f | grep x`, `cat f | wc -l`) is declined for the same reason its direct form
+is. Shell reads are recorded at file granularity rather than per symbol: the shell says *which*
+file was opened and never how much of it, and expanding a slice into one row per symbol would
+assert beliefs about signatures that never reached the agent.
+
+**The write gate's own precision is printed somewhere.** The measurement had existed since the
+shadow gate did, computing exactly the number the bar in front of enforcing it is written against
+— and nothing imported it. Shadow mode was faithfully recording every refusal an enforcing gate
+*would* have issued into a table whose verdict no command could read, which is the same defect as
+not measuring at all: a score nobody can see cannot promote the thing it measures, and cannot
+retire it either.
+
+```
+🛡️  WRITE GATE (shadow)
+  Refusals withheld:     60
+  Adjudicated:           48 of 60
+  Precision:             87.5% (6 false positive(s))
+  Bar to enforce:        ≥95% over ≥40 adjudicated — not cleared
+```
+
+The bar is printed beside the number on purpose: a precision figure alone invites "87% sounds
+fine". Both halves fail differently and are reported separately, because 100% over three findings
+is not evidence and this block has to say so rather than look like a pass. Nothing has been
+adjudicated yet reads as *not yet measured*, never `0.0%` or `100%` — no evidence is not a perfect
+score.
+
+**The staleness marker names what to open.** A row whose cited files moved used to report a
+condition and leave the reader to diff `affectedPaths` against the working tree to find the
+target. Measurement on exactly that situation — a served claim whose source had moved, with the
+link present and reachable — found agents opened the source in roughly one turn in five and acted
+on the superseded value in about three quarters of the rest, and a content-free freshness cue did
+not move those numbers. What moved them was an instruction naming the target, on the path the
+reader was already on. So the sentence leads with the verb and the filenames and the count follows
+it, capped at three names plus `and N more` so an atom citing thirty paths still reads as one line.
+
+### Fixed
+
+- **A correction elsewhere was promoting the atom it made doubtful.** The session card's three
+  knowledge slots were ordered by `updated_at`, which moves on supersession, archival, visibility
+  promotion and a freshness flip — 72% of items on a 950-item store carry one newer than their
+  `valid_from`. Marking a sibling `needs_review` stamps that column, so correcting one atom
+  promoted unrelated atoms onto the next session's card *for having just been flagged as
+  doubtful*, evicting whatever that session had actually learned. Housekeeping could take all
+  three slots. The card now orders by the open assertion's `valid_from`, which moves on
+  restatement and on nothing else; an item with no open assertion still falls back to `updated_at`.
+- **A fork was handed a second copy of what it already inherited.** A fork is the one subagent
+  that is not context-poor — it inherits the parent's whole conversation, system prompt and tool
+  definitions, so the parent's own session card and the workflow rules were already in front of it
+  when the subagent bootstrap fired. It now gets neither. Only the context is skipped: a fork's
+  reads, writes and tool events stay attributed exactly as any other subagent's.
+- A conflict-repair test asserted an order it had never established. Both rows were created by
+  back-to-back calls, ISO timestamps are millisecond-granular, and on a fast machine the repair
+  fell through to its own id tiebreak — so "newest wins" was decided by which random hex sorted
+  first. Failed 9 times in 12 under a forced tie. The production sort is unchanged; it is
+  deterministic by construction, which is what its comment always claimed.
+
+### Documentation
+
+- `docs/reference.md` carries the staleness marker's new wording, which its previous text quoted
+  verbatim and would otherwise have contradicted, and documents what the shell-read parser
+  recognises and — at greater length — what it declines.
+- The README feature list gains the shadow write gate's precision surface, alongside the recall
+  gap and the un-restated claims report.
+
+### Chores
+
+- GitHub Actions group bumped (`codeql-action` 4.37.8 → 4.37.9, `ai-plugin-scanner-action`
+  1.2.533 → 1.2.551) and dev dependencies (`eslint` 10.8.0 → 10.9.1, `typescript-eslint`
+  8.66 → 8.68).
+
 ## 5.15.0 — 2026-08-27
 
 Knowl can see who it is failing, and stops cutting the card that tells them.

--- a/README.md
+++ b/README.md
@@ -590,6 +590,12 @@ knowl doctor                           # setup, retrieval, and registration
   you, in `knowl status` — and split between the main thread and subagents, because a subagent
   receives no prompt reminder and no server instructions, so its share is the only read you get on
   whether the bootstrap card alone carries the habit.
+- **The write gate's own score** — with change impact on, the gate that would refuse an edit to
+  code another session changed runs in shadow first, recording every refusal it withheld.
+  `knowl status` prints the precision that produced, next to the bar it has to clear before it is
+  allowed to block anything (≥95% over ≥40 adjudicated findings) — so the decision to arm it is
+  made against a number instead of a hunch. Absent entirely until the gate has withheld something:
+  a repo that never ran it has not scored 0%, it has measured nothing.
 
 → [Tasks, sessions, and lifecycle](docs/reference.md#tasks-sessions-and-agent-lifecycle)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -704,10 +704,20 @@ The block is absent entirely on a store whose gate has never withheld anything. 
 not measured 0%, it has measured nothing.
 
 Query results also annotate staleness whatever the posture says: a row whose `affectedPaths`
-were modified after the row was stored carries `pathsChanged` ("n of m affectedPaths modified
-since this was stored — verify"), absent when clean. The field says *verify*, never *wrong*.
-Paths that cannot be resolved against this checkout — absolute, escaping the root — are skipped
-rather than counted, because an unreadable path is absence of evidence, not evidence.
+were modified after the row was stored carries `pathsChanged`, absent when clean. The marker
+names the files rather than only counting them, because a count leaves the reader to diff
+`affectedPaths` against the working tree to find out where to look:
+
+```
+Open src/auth.ts, src/session.ts, then verify this still holds: 2 of 6 affectedPaths modified
+since this was stored.
+```
+
+Three names at most, then `and N more`, so an atom citing thirty paths still reads as one line.
+The count stays behind them: it is what separates "one of nine cited files was touched" from
+"every file this rests on is gone". The field says *verify*, never *wrong*. Paths that cannot be
+resolved against this checkout — absolute, escaping the root — are skipped rather than counted,
+because an unreadable path is absence of evidence, not evidence.
 
 This one is **on by default**, alone among the keys on this page: it adds a field rather than a
 message, so it spends no mid-turn slot and withholds no stop. It is not free either — every
@@ -981,6 +991,17 @@ true`; the MCP tool below is registered only when it is on.
 While it is on, Knowl records which files a session actually read, and tells a session when
 another one has since changed code underneath it — the case where you are working from something
 that was true when you read it and is not any more.
+
+A read counts whether it came through the agent's file tools or through the shell, so a session
+whose agent prefers `cat`, `head` and `sed -n` is seen. Shell reads are recorded at file
+granularity rather than per symbol: the shell says *which* file was opened and never how much of
+it, and expanding a slice into one row per symbol would assert beliefs about signatures that
+never reached the agent. What the parser declines is the more important half — `grep`, `rg`,
+`find`, `ls` and `wc` return matches or names rather than contents, `git show <ref>:<path>`
+serves a ref's text and not the working tree's, an in-place `sed -i` is a write, a redirect makes
+a segment a write whatever its verb reads, and a glob or a `$variable` is not a filename until
+the shell has run. A read piped into anything that reports on the text instead of passing it on
+(`cat f | grep x`, `cat f | wc -l`) is declined for the same reason the direct form is.
 
 Findings come in three tiers. `certain` and `likely` are returned by default; `possible` is
 unmeasured path matching and is returned only when asked for by name. A `certain` finding also

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.15.0",
+      "version": "5.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.15.0",
+      "version": "5.16.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Nine commits have landed since `v5.15.0` and none of them had a changelog entry. That is structural rather than anyone forgetting: the `## Unreleased` section is renamed in place by each release commit and nothing recreates it, so its absence means the last release consumed it, not that the convention lapsed.

## What is in it

| PR | |
| --- | --- |
| #211 | `server.json` + `mcpName` — the MCP registry manifest |
| #220 | the read set sees a file opened with `cat`, not only with `Read` |
| #221 | the shadow write gate's precision, printed beside its bar |
| #219 | the staleness marker names what to open |
| #222 | a correction elsewhere was promoting the atom it made doubtful |
| #218 | a fork was handed a second copy of what it already inherited |
| #226 | `"newest wins"` was a coin flip when both rows shared a millisecond |
| #215, #212 | actions and dev-dependency bumps |

## This is the release that unblocks the registry

`5.15.0` is on npm **without** `mcpName`, and registry.modelcontextprotocol.io verifies ownership by fetching the npm metadata for exactly the version its manifest names and rejecting the publish unless that tarball carries a matching field. #211 said so at the time — *"the next release carries the field and the publish works then"*. This is that release.

`server.json` carries the version in **two** places (top level and `packages[0]`), both bumped; it joined `check:versions` in #211 as a fourth file, so `npm run check:versions` is the fastest confirmation the bump was complete.

## Docs were corrected, not just extended

Two things in `docs/reference.md` had gone stale under merged PRs, and **`npm run docs:check` was green throughout** — it verifies the two generated regions and tool/command coverage, never that curated prose still matches what the code does:

- It quoted the staleness marker's **old** wording verbatim (`"n of m affectedPaths modified since this was stored — verify"`), which #219 replaced. The document would have contradicted the shipped string.
- Its change-impact section described a read set that stops at the file tools, which #220 is precisely about no longer being true.

The README feature list gains the shadow write gate's precision surface, next to the recall gap and the un-restated claims report — the same gap #210 closed for the previous two status surfaces.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run build` | clean |
| `npm run docs:check` | clean |
| `node scripts/check-version-sync.mjs` | all four files agree at 5.16.0 |
| `npx vitest run` | see below |

No source changes: the diff is the changelog, the four version files, and the README/reference lines this release warrants.

**The tag is not pushed with this PR.** It goes on the merge commit after CI is green on `main`, per the v2.10.0 lesson where a tag pushed ahead of CI had to be deleted and nearly burned a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)