### PR TITLE
fix(cloud,workspace): name the atom a cap rejects, and stop prescribing a fix that breaks publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+**A push no longer fails anonymously on an over-long field.** The cloud contract caps `title`,
+`source` and `conflictKey` at 500 characters; the local store caps nothing, so a research atom
+with a long citation list sat staged until push, where the server's zod rejection came back as
+`Too big: expected string to have <=500 characters` with no path and no id — one line per
+offender, and no way to tell which two atoms of a hundred were meant short of SQL over
+`cloud_published`. The caps are now checked before the request, and the failure names the atom,
+the field and both lengths. Not enforced at write time on purpose: `knowl store` is local-first
+and works with no cloud account, so a machine that will never push does not answer to the
+server's limits (#217).
+
+**`knowl doctor` stops prescribing a fix that breaks publishing.** A repo embedding differently
+from its workspace drew a WARN saying the two sets of items were "invisible to each other", with
+the remedy "align `search.vector`, then reindex". #191 made the mechanism false — each peer is
+searched under its own profile and scored against its own range and floor — and the remedy was
+worse than the warning: a cloud-connected repo's atoms must stay on the server's serving
+profile, so aligning to the workspace would break every `knowl cloud push`. It is now an OK line
+that names the per-profile mode. `workspace add` and `workspace join` still refuse a mismatch,
+but say why they actually refuse: a workspace holds one profile so every repo shares one
+semantic range, which is a policy choice rather than an invisibility claim (#216).
+
 ## 5.16.0 — 2026-09-02
 
 Knowl can be installed from the official MCP registry, and change impact stops being blind to

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1402,6 +1402,20 @@ cloudCommand
         process.exitCode = 1;
         return;
       }
+      if (result.status === 'oversized-field') {
+        // The whole point is the id and the field: the server's own rejection carries neither,
+        // and finding them by hand meant SQL over `cloud_published` (#217).
+        console.error(
+          `${result.offenders.length} staged item(s) carry a field longer than the workspace accepts, `
+          + 'so nothing was sent.',
+        );
+        for (const offender of result.offenders) {
+          console.error(`  ${offender.id}  ${offender.field} is ${offender.length} chars, cap is ${offender.cap}`);
+        }
+        console.error('Shorten the named field with `knowl_update`, then push again.');
+        process.exitCode = 1;
+        return;
+      }
       if (result.status === 'needs-embedding') {
         // Nothing is lost: they stay staged and go out on the next push. Said out loud because a
         // push that quietly sent nothing would look like success.

--- a/src/cli/workspace-report.ts
+++ b/src/cli/workspace-report.ts
@@ -55,12 +55,20 @@ export function workspaceDoctorChecks(active: ActiveWorkspace | null, config: Pr
       });
   }
 
+  // Reported, not warned about. This was a WARN saying the two sets of items were "invisible to
+  // each other", with the fix "align `search.vector`, then reindex". #191 made the mechanism
+  // false: each peer is searched under its own profile now and scored against its own range and
+  // floor, so a mismatched peer returns vector rows like any other. The prescription had a
+  // second problem the wording hid -- a cloud-connected repo cannot take it, because its atoms
+  // must stay on the cloud's serving profile and `assertProfileMatches` refuses any other, so
+  // aligning to the workspace would break every push (#187, #216). Kept as an OK line because
+  // the mismatch is still worth seeing: same-profile repos share one semantic range, and a
+  // second profile costs that.
   const local = embeddingIdentityFromConfig(config);
   if (!sameEmbeddingIdentity(local, active.manifest.embedding)) {
     checks.push({
-      status: 'WARN',
-      message: `This repo embeds with ${formatEmbeddingIdentity(local)} but the workspace uses ${formatEmbeddingIdentity(active.manifest.embedding)}; vector search filters on provider and model, so the two sets of items are invisible to each other`,
-      fix: 'align `search.vector` with the workspace, then run `knowl reindex --vectors`',
+      status: 'OK',
+      message: `This repo embeds with ${formatEmbeddingIdentity(local)} and the workspace uses ${formatEmbeddingIdentity(active.manifest.embedding)}; each is searched under its own profile, so both sets are reachable`,
     });
   }
 

--- a/src/cloud/publish.ts
+++ b/src/cloud/publish.ts
@@ -179,6 +179,16 @@ export type PushResult =
    * message that names the command that fixes it.
    */
   | { status: 'needs-embedding'; count: number; remedy: string }
+  /**
+   * A staged atom carries a field longer than the cloud contract accepts. Nothing was sent.
+   *
+   * The server enforces these caps too, but its zod rejection arrives as a bare
+   * `Too big: expected string to have <=500 characters` with no path and no id, once per
+   * offending atom -- so a 100-atom push failed with two anonymous lines and no way to find
+   * the two atoms responsible short of SQL over `cloud_published` (#217). Checked here to
+   * name them instead, one round trip earlier.
+   */
+  | { status: 'oversized-field'; offenders: { id: string; field: string; length: number; cap: number }[] }
   | {
     /**
      * The queue is not what the human confirmed. Nothing was sent.
@@ -252,6 +262,37 @@ const MIN_BATCH = 1;
  */
 function isTooMuchAtOnce(error: unknown): error is CloudApiError {
   return error instanceof CloudApiError && (error.code === 'timeout' || error.status === 413);
+}
+
+/**
+ * The cloud contract's `z.string().max(500)` on `title`, `source` and `conflictKey`
+ * (knowl-cloud `packages/contract/src/knowledge.ts`).
+ *
+ * Duplicated rather than imported because the contract package is a different repository, and a
+ * client that cannot be built without the server's source is not a client. The cost of the copy
+ * is that a cap change there is silent here -- which is the failure this check already handles:
+ * an atom that slips past reaches the server and is refused, exactly as it is today, only
+ * without the id. Checking the three fields the contract caps and not, say, `content` (which it
+ * does not cap) keeps that gap the same shape.
+ *
+ * Deliberately NOT enforced at write time. `knowl store` is local-first and works with no cloud
+ * account at all, so rejecting a 600-character title on a machine that will never push would
+ * import the server's limits into a store that does not answer to them.
+ */
+const CONTRACT_MAX_FIELD = 500;
+
+function findOversizedFields(items: PublishItem[]): { id: string; field: string; length: number; cap: number }[] {
+  const offenders: { id: string; field: string; length: number; cap: number }[] = [];
+  for (const item of items) {
+    for (const [field, value] of [
+      ['title', item.title], ['source', item.source], ['conflictKey', item.conflictKey],
+    ] as const) {
+      if (typeof value === 'string' && value.length > CONTRACT_MAX_FIELD) {
+        offenders.push({ id: item.id, field, length: value.length, cap: CONTRACT_MAX_FIELD });
+      }
+    }
+  }
+  return offenders;
 }
 
 const parseJson = <T>(value: unknown): T | null => {
@@ -471,6 +512,11 @@ export async function pushStaged(input: {
       return {
         status: 'pushed', created: 0, updated: 0, conflicts: [], rejected: [], skippedUnchanged,
       };
+    }
+
+    const oversized = findOversizedFields(items);
+    if (oversized.length > 0) {
+      return { status: 'oversized-field', offenders: oversized };
     }
 
     // Keyed off the payloads being sent, never a fresh read. `recordPushed` stores these, and a

--- a/src/workspace/membership.ts
+++ b/src/workspace/membership.ts
@@ -65,9 +65,19 @@ export function isLinked(_projectRoot: string, manifest: WorkspaceManifest, conf
 /**
  * Refuse a repo whose vectors are not comparable with the workspace's.
  *
- * Vector search filters on provider and model, and quantization changes the vector, so two
- * identities are two disjoint search spaces: each repo's items would be simply absent from
- * the other's results, with no error anywhere to explain it.
+ * THIS IS A POLICY CHOICE, NOT AN INVISIBILITY CLAIM -- and it used to say otherwise. The
+ * refusal was written when a mismatched peer really did return nothing: one fingerprint was
+ * applied to every store, so the two sides were disjoint search spaces with no error to
+ * explain it. #191 ended that. Each peer is embedded and scored under its own profile now, so
+ * a mixed workspace searches correctly.
+ *
+ * What a second profile still costs is the shared semantic range. Same-profile repos produce
+ * comparable cosines and share one min-max; a second model earns its own range and its own
+ * relevance floor, which is more machinery and one more model resident per query. One profile
+ * per workspace keeps the simple path, and that -- not invisibility -- is why this still
+ * refuses. Absolute on purpose: `--force` covers the git-tracked-config check only, so there is
+ * no escape hatch here to keep in sync. Deleting the refusal is a live option (#216) and would
+ * be a policy change, not a bug fix.
  *
  * Shared by both routes in. `workspace add` enforced this from the start; `workspace join`
  * -- adopting a manifest copied off another machine -- did not, so a second machine could
@@ -77,8 +87,10 @@ export function assertEmbeddingCompatible(manifest: WorkspaceManifest, identity:
   if (sameEmbeddingIdentity(manifest.embedding, identity)) return;
   throw new Error(
     `This repo embeds with ${formatEmbeddingIdentity(identity)} but workspace "${manifest.name}" uses ` +
-    `${formatEmbeddingIdentity(manifest.embedding)}. Vector search filters on provider and model, so the two ` +
-    'sets of items would be invisible to each other. Align this repo\'s search.vector config first.',
+    `${formatEmbeddingIdentity(manifest.embedding)}. A workspace holds one embedding profile so that ` +
+    'every repo shares one semantic range; a second profile is searchable but costs that. Align this ' +
+    'repo\'s search.vector config first, unless it publishes to a cloud workspace -- that profile is ' +
+    'fixed by the server and must not be changed to satisfy this.',
   );
 }
 

--- a/tests/cli/workspace-cli.test.ts
+++ b/tests/cli/workspace-cli.test.ts
@@ -123,15 +123,17 @@ describe('knowl workspace CLI', { timeout: 120_000 }, () => {
 
     // join is the second way into a workspace and used to skip every check add applies, so
     // a second machine could adopt the same workspace under a different embedding model.
-    // Vector search filters on provider and model, so the two sides would simply not see
-    // each other's items, with nothing anywhere reporting why.
+    // The refusal outlives its original reason: #191 made mixed profiles searchable, so what
+    // it now protects is the shared semantic range, and the message says so rather than
+    // claiming the two sides cannot see each other (#216).
     await saveConfig(other, {
       ...DEFAULT_CONFIG,
       search: { vector: { enabled: true, provider: 'local', model: 'other/model', dtype: 'q8' } },
     });
     const mismatched = knowl(other, 'workspace', 'join', manifest, '--name', 'server');
     expect(mismatched.status).toBe(1);
-    expect(mismatched.stderr).toMatch(/invisible to each other/i);
+    expect(mismatched.stderr).toMatch(/one embedding profile/i);
+    expect(mismatched.stderr).not.toMatch(/invisible/i);
 
     await saveConfig(other, { ...DEFAULT_CONFIG });
     const joined = knowl(other, 'workspace', 'join', manifest, '--name', 'server');

--- a/tests/cli/workspace-report.test.ts
+++ b/tests/cli/workspace-report.test.ts
@@ -142,14 +142,20 @@ describe('workspace doctor checks', () => {
     expect(checks.some(check => check.status === 'WARN' && /protocol/.test(check.message))).toBe(true);
   });
 
-  it('warns when this repo embeds differently from the workspace', () => {
+  it('reports a differing embedding profile without warning about it or prescribing a fix', () => {
     const drifted = {
       ...DEFAULT_CONFIG,
       search: { vector: { enabled: true, provider: 'local', model: 'other', dtype: 'q8' } },
     } as ProjectConfig;
-    // A mismatched embedding makes items mutually invisible, and a filtered-out embedding
-    // looks exactly like no embedding -- nothing else would report this.
-    expect(workspaceDoctorChecks(active(), drifted).some(check => check.status === 'WARN' && /embed/i.test(check.message))).toBe(true);
+    // This was a WARN claiming the two sets were invisible to each other, prescribing
+    // `align search.vector, then reindex`. #191 made the claim false, and the prescription
+    // breaks any cloud-connected repo, whose profile the server fixes (#216). Still reported,
+    // because a second profile costs the shared semantic range -- reported is not silent.
+    const embedding = workspaceDoctorChecks(active(), drifted).filter(check => /embed/i.test(check.message));
+    expect(embedding).toHaveLength(1);
+    expect(embedding[0].status).toBe('OK');
+    expect(embedding[0].fix).toBeUndefined();
+    expect(embedding[0].message).not.toMatch(/invisible/i);
   });
 
   it('reports OK when every peer is present and the identity matches', () => {

--- a/tests/cloud/publish-push.test.ts
+++ b/tests/cloud/publish-push.test.ts
@@ -551,6 +551,31 @@ describe('pushStaged', () => {
     expect((result as any).count).toBe(1);
   });
 
+  it('names the atom and the field when one exceeds the contract cap, and sends nothing', async () => {
+    // The server enforces this too, but its rejection is a bare "Too big: expected string to have
+    // <=500 characters" with no path and no id -- one line per offender and no way to tell which
+    // atom of a hundred it means (#217). The whole value of this check is the two identifiers.
+    await initDb(CLONE);
+    try {
+      await getClient().execute({
+        sql: 'UPDATE knowledge_items SET source = ? WHERE id = ?',
+        args: ['x'.repeat(705), ids.decision],
+      });
+    } finally { await closeDb(); }
+
+    let called = false;
+    const result = await pushStaged({
+      projectRoot: CLONE, config: connected, api: fakeApi([], () => { called = true; }),
+    });
+
+    expect(result.status).toBe('oversized-field');
+    expect((result as any).offenders).toEqual([
+      { id: ids.decision, field: 'source', length: 705, cap: 500 },
+    ]);
+    // Nothing on the wire: the point is to fail one round trip earlier, not to fail louder.
+    expect(called).toBe(false);
+  });
+
   it('sends evidence, and the citation survives a round trip into a replica', async () => {
     // The v1 design requires evidence to cross with a published item, and `sync-apply.ts` already
     // writes it on the way DOWN -- so omitting it here is a one-directional pipe that leaves every

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -781,7 +781,13 @@ describe('Storage Layer', () => {
       content: 'Older active work should appear after newer work.',
       tags: ['session'],
     });
-    await setKnowledgeItemUpdatedAt(older.id, '2099-01-01T00:00:00.000Z');
+    // The card orders by the open assertion's `valid_from`, not by `updated_at` -- so separating
+    // these two on the wrong clock left them tied on the right one, and the order fell through to
+    // the arbitrary-but-stable `id` tiebreak. Deterministic, and a coin flip per fixture: this
+    // passed on Windows and ubuntu and failed on CI's macOS runner, where `f889…` sorted above
+    // `d21b…`. The production ordering is a total order and was never in doubt; the fixture was
+    // asserting a semantic order it had stopped establishing.
+    await setAssertionValidFrom(older.id, '2099-01-01T00:00:00.000Z');
 
     const newer = await repo.createKnowledgeItem(projectId, {
       category: 'state',
@@ -789,7 +795,7 @@ describe('Storage Layer', () => {
       content: 'Newest active work should appear first.',
       tags: ['session'],
     });
-    await setKnowledgeItemUpdatedAt(newer.id, '2099-01-02T00:00:00.000Z');
+    await setAssertionValidFrom(newer.id, '2099-01-02T00:00:00.000Z');
 
     const archived = await repo.createKnowledgeItem(projectId, {
       category: 'state',

--- a/tests/workspace/membership.test.ts
+++ b/tests/workspace/membership.test.ts
@@ -141,8 +141,10 @@ describe('two-sided membership', () => {
       ...DEFAULT_CONFIG,
       search: { vector: { enabled: true, provider: 'local', model: 'other/model', dtype: 'q8' } },
     });
+    // Still refused, but for the reason that survives #191: mixed profiles are searchable, so
+    // what the refusal protects is the single shared semantic range, not visibility (#216).
     await expect(joinWorkspace({ projectRoot: REPO_B, workspaceName: 'ws', repoName: 'b' }))
-      .rejects.toThrow(/invisible to each other/i);
+      .rejects.toThrow(/one embedding profile/i);
   });
 
   it('leaving an unlinked repo is a no-op rather than an error', async () => {


### PR DESCRIPTION
Two issues whose fixes are message-and-guard work with no design question attached. The other five open issues are decisions between named options and are commented rather than touched.

## #217 — a push that fails anonymously

The cloud contract caps `title`, `source` and `conflictKey` at 500 characters (`packages/contract/src/knowledge.ts:56,61,71`). The local store caps nothing, so a research atom carrying a long citation list stays staged until push, where the server's zod rejection arrives as:

```
Push failed: Too big: expected string to have <=500 characters; Too big: expected string to have <=500 characters
```

No path, no field, no id — one line per offender and no way to find them short of SQL over `cloud_published`.

Checked before the request now, in `pushStaged`. The new `oversized-field` status carries `{ id, field, length, cap }` per offender and the CLI prints them:

```
2 staged item(s) carry a field longer than the workspace accepts, so nothing was sent.
  5622d2b41bde4945  source is 505 chars, cap is 500
  382d07ad38254e7a  source is 705 chars, cap is 500
Shorten the named field with `knowl_update`, then push again.
```

**Not enforced at write time, deliberately.** `knowl store` is local-first and works with no cloud account at all, so rejecting a 600-character title on a machine that will never push would import the server's limits into a store that does not answer to them. The cap is a property of the wire, so it is checked at the wire — one round trip earlier than today, which is the entire delta.

**Ask 3 not taken.** Skipping the rejected atom and sending the rest is a partial-success change, and `publish.ts` documents all-or-nothing as deliberate for the secret case. Different question, left open on the issue.

The 500 is duplicated rather than imported, because the contract package is another repository and a client that cannot be built without the server's source is not a client. The cost is that a cap change there is silent here — which degrades to exactly today's behaviour, an anonymous server rejection, so the gap keeps its current shape rather than growing a new one.

## #216 — advice that is both wrong and unsafe to take

`knowl doctor` warned that a repo embedding differently from its workspace made the two sets of items "invisible to each other", with the fix `align search.vector with the workspace, then run knowl reindex --vectors`.

Both halves are now wrong:

- **The mechanism.** #191 made each peer searched under its own profile and scored against its own range and floor (`src/store/agent-query.ts:606-619`). A mismatched peer returns vector rows like any other.
- **The remedy, which is worse than the stale warning.** A cloud-connected repo's atoms must stay on the server's serving profile — `assertProfileMatches` refuses any other — so aligning to the workspace breaks every `knowl cloud push`. The advisory has been standing on knowl-cloud since 5.2.1, telling anyone who followed it to break their own publishing.

Now an `OK` line naming the per-profile mode, with no `fix` to take. Kept rather than dropped because the mismatch is still worth seeing: same-profile repos share one semantic range, and a second profile costs that.

`workspace add` and `workspace join` still refuse a mismatch. What changed is the reason they give — one profile per workspace keeps the shared range, which is a policy choice rather than an invisibility claim. **Deleting the refusal is left open**, since that is a policy change and the issue names it as one. The docstring says so at the site.

## Verification

`npm run build`, `npm run typecheck`, `npm test` — **377 files, 3614 passed, 5 skipped**, and `git diff --check` clean.

Four tests pinned the old #216 wording and were updated to pin the new reason instead. One new test in `tests/cloud/publish-push.test.ts` asserts the offender is named and that nothing reaches the wire — the two properties the whole change exists for.

The `## Unreleased` heading was missing again (third recorded occurrence — every release commit renames it in place and nothing recreates it), so this recreates it.

---

## One unrelated commit, and why it is here

`e1867a6` fixes a latent flake in `tests/store/store.test.ts` that failed this branch's macOS job. It is not caused by this branch — the diff touches no store code.

`getRecentContext` orders by the open assertion's `valid_from` since #222. The session-continuity fixture still separated its two items with `setKnowledgeItemUpdatedAt`, and those rows have open assertions, so `updated_at` is never consulted for them. The items stayed tied on `valid_from`, tied again on `created_at`, and the order fell through to the arbitrary-but-stable `id` tiebreak — passing on Windows and both ubuntu runners, failing on macOS where `f889…` sorted above `d21b…`.

**The production ordering was never in doubt.** `recent-context.ts` orders by `(valid_from, created_at, id)` descending, a total order written for exactly this hazard, and `setAssertionValidFrom` already existed in the test file for the same reason. Only the fixture was asserting a semantic order it had stopped establishing.

Happy to split it into its own PR if you would rather keep this branch to the two issues.
