### PR TITLE
feat(fleet): the sessions on one machine can see each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,20 +25,23 @@ that names the per-profile mode. `workspace add` and `workspace join` still refu
 but say why they actually refuse: a workspace holds one profile so every repo shares one
 semantic range, which is a policy choice rather than an invisibility claim (#216).
 
-**The sessions on one machine can see each other.** Claude Code keeps a registry of
+**The sessions on one machine can see each other, on every host.** Claude Code keeps a registry of
 its live sessions and lets one message another, but records nothing about what each is doing —
-so two sessions hit the same failure and both start fixing it, and a third changes the hook every
-one of them is standing on. Knowl now keeps the other half in one machine-level file,
-`~/.knowl/fleet.db`: what each session was asked, what it wrote this turn, its last error, and
-which problem it has claimed by editing files after seeing it. `knowl fleet` lists it from any
-terminal, inside a project or not, and the `knowl_fleet` MCP tool lists it to an agent — registered
-unless `fleet.enabled` is `false`, the one switch here that ships on, because the roster prints
-nothing when a session is alone and nobody opts into it until after the collision. The rest
-follows the capture ladder and ships quiet: `fleet.digest` (`off`), `fleet.cards` (`enforce`, since
-a card is advice and never a refusal) and `fleet.nudge` (`shadow`, since it withholds a stop).
-`knowl posture maximal` now also turns the digest on and arms the nudge, and every card shown or
-shadowed lands in a ledger whose precision `knowl fleet --cards` prints — nothing here may graduate
-from advising to refusing without that number.
+and every other host records nothing at all — so two sessions hit the same failure and both start
+fixing it, and a third changes the hook every one of them is standing on. Knowl now keeps the
+other half in one machine-level file, `~/.knowl/fleet.db`: what each session was asked, what it
+wrote this turn, its last error, and which problem it has claimed by editing files after seeing
+it. Every host with Knowl hooks is in the fleet and they see each other — a Codex session appears
+on a Claude session's roster and the reverse — with liveness read from the host's own registry
+where it publishes one and from recency where it does not. Only the sessions the host's messaging
+can actually reach are offered as something to `SendMessage`; the rest are listed, marked, and
+raised with the user instead. `knowl fleet` lists it from any terminal, inside a project or not,
+and the `knowl_fleet` MCP tool lists it to an agent — registered unless `fleet.enabled` is
+`false`, the one switch here that ships on, because the roster prints nothing when a session is
+alone and nobody opts into it until after the collision. The rest follows the capture ladder and
+ships quiet: `fleet.digest` (`off`), `fleet.cards` (`enforce`, since a card is advice and never a
+refusal) and `fleet.nudge` (`shadow`, since it withholds a stop). `knowl posture maximal` now also
+turns the digest on and arms the nudge.
 
 ## 5.16.0 — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ that names the per-profile mode. `workspace add` and `workspace join` still refu
 but say why they actually refuse: a workspace holds one profile so every repo shares one
 semantic range, which is a policy choice rather than an invisibility claim (#216).
 
+**The sessions on one machine can see each other.** Claude Code keeps a registry of
+its live sessions and lets one message another, but records nothing about what each is doing —
+so two sessions hit the same failure and both start fixing it, and a third changes the hook every
+one of them is standing on. Knowl now keeps the other half in one machine-level file,
+`~/.knowl/fleet.db`: what each session was asked, what it wrote this turn, its last error, and
+which problem it has claimed by editing files after seeing it. `knowl fleet` lists it from any
+terminal, inside a project or not, and the `knowl_fleet` MCP tool lists it to an agent — registered
+unless `fleet.enabled` is `false`, the one switch here that ships on, because the roster prints
+nothing when a session is alone and nobody opts into it until after the collision. The rest
+follows the capture ladder and ships quiet: `fleet.digest` (`off`), `fleet.cards` (`enforce`, since
+a card is advice and never a refusal) and `fleet.nudge` (`shadow`, since it withholds a stop).
+`knowl posture maximal` now also turns the digest on and arms the nudge, and every card shown or
+shadowed lands in a ledger whose precision `knowl fleet --cards` prints — nothing here may graduate
+from advising to refusing without that number.
+
 ## 5.16.0 — 2026-09-02
 
 Knowl can be installed from the official MCP registry, and change impact stops being blind to

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ privacy boundary: do not put it behind a public proxy or tunnel.
 ### Everything else
 
 <!-- generated:tool-count -->
-**27 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 1 when linked into a local workspace, and 1 when change impact is on)
+**27 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 1 when linked into a local workspace, 1 when change impact is on, and 1 for fleet awareness unless it is switched off)
 <!-- /generated:tool-count -->
 and two resource URIs · the
 **complete CLI**, from `knowl status` to `knowl audit` · a **read-only integrity audit** ·

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,7 +29,7 @@ which parts of a restore are deliberately not restored.
 | [Overview](#overview) · [Quick start](#quick-start) | What Knowl is and how to install it |
 | [Core knowledge model](#core-knowledge-model) | [Atom categories](#atom-categories) · [Metadata, history, ownership](#metadata-history-and-ownership) · [Governed writes](#governed-writes-and-current-truth) |
 | [Retrieval and context](#retrieval-and-context) | [Current retrieval](#current-retrieval) · [What a result carries](#what-a-result-carries) · [Embedding models](#choosing-an-embedding-model) · [Historical queries](#historical-retrieval-and-assertions) · [Context packs](#bounded-context-packs) |
-| [Tasks, sessions, lifecycle](#tasks-sessions-and-agent-lifecycle) | [Work loops](#manual-work-loops) · [Retention and promotion](#session-retention-recovery-and-promotion) · [Handoffs and resume keys](#leaving-work-for-later) · [Transcript search](#searchable-session-transcripts-optional-off-by-default) · [What exists and what is on](#seeing-what-exists-and-what-is-on--knowl-config-list) · [Host behavior](#host-and-subagent-behavior) |
+| [Tasks, sessions, lifecycle](#tasks-sessions-and-agent-lifecycle) | [Work loops](#manual-work-loops) · [Retention and promotion](#session-retention-recovery-and-promotion) · [Handoffs and resume keys](#leaving-work-for-later) · [Transcript search](#searchable-session-transcripts-optional-off-by-default) · [What exists and what is on](#seeing-what-exists-and-what-is-on--knowl-config-list) · [Host behavior](#host-and-subagent-behavior) · [The fleet](#who-else-is-running--the-fleet) |
 | [Evidence, code, drift](#evidence-code-intelligence-and-drift) | [Evidence and symbols](#evidence-and-symbols) · [PR drift and feedback](#pull-request-drift-and-retrieval-feedback) |
 | [Workspaces](#workspaces) | [Federation and ownership](#federation-and-ownership) · [Reading a peer's atom by id](#reading-a-linked-repos-atom-by-id) · [Doing a peer's work](#doing-a-linked-repos-work-from-here) · [Ownership stamping](#ownership) |
 | [Knowl Cloud](#knowl-cloud) | [Identity and connection](#identity-and-connection) · [Publishing and drift](#publishing-works-from-any-branch-reporting-drift-does-not) · [Staying current](#staying-current) |
@@ -671,6 +671,11 @@ knowl posture frugal     # reset the same keys -- knowl exactly as it ships
 - **`impact.enabled` + `impact.gate: shadow`** — change-impact detection on, with the write
   gate in shadow: even the maximal stance does not arm a blocking gate ahead of its measured
   precision bar. What that bar currently reads is printed by `knowl status`, below.
+- **`fleet.digest: on` + `fleet.nudge: enforce`** — the fleet's two quiet-by-default surfaces
+  (see [the fleet](#who-else-is-running--the-fleet)): the per-turn delta of what the other
+  sessions on this machine moved on to, and the stop-time nudge when this turn's writes changed
+  code another live session had read. The nudge withholds a stop rather than refusing a tool
+  call, which is the line maximal draws — the same one that keeps `impact.gate` in shadow.
 
 #### Whether the write gate is good enough to enforce
 
@@ -956,6 +961,70 @@ consecutive events, a mid-turn card reminds the agent to re-query. A Knowl call 
 change card resets the counter. Change cards report new knowledge commits since that agent's
 watermark; matched writes made through that agent's own MCP call are suppressed so the caller is
 not notified about its own change.
+
+### Who else is running — the fleet
+
+Several Claude Code sessions on one machine do not know about each other. The host keeps a
+registry of its live sessions and lets one message another, but records nothing about what each
+is doing — so two sessions hit the same `SQLITE_BUSY`, both start fixing it, and a third upgrades
+the hook every one of them is standing on. Knowl keeps the half the registry does not: what each
+session was asked, what it wrote this turn, the last error it saw, and which problem it has
+claimed by editing files after seeing that error. One machine-level file, `~/.knowl/fleet.db`,
+beside the resume keys — not a project table, because the collision that matters most crosses
+repositories. A session whose process is gone is never listed, whatever the file still says.
+
+**On by default**, and the only feature in this document that is: the roster costs a directory
+listing and prints nothing when a session is alone, and nobody opts into "tell me other sessions
+exist" until after the collision.
+
+```bash
+knowl fleet                 # every live session: repo, state, what it is on, what it is editing
+knowl fleet --repo web      # one repo's sessions
+knowl fleet --json --cards  # the report as JSON, plus the card ledger
+```
+
+`knowl fleet` needs no Knowl project: the fleet is machine-level, and the terminal you ask from is
+often outside every repo. Run from inside a Claude Code session, the listing marks that session
+`(you)`.
+
+- **`knowl_fleet`** — the same listing as an MCP tool, registered unless `fleet.enabled` is
+  `false`. Use it before fixing an error that may be shared, before changing hooks, config,
+  migrations or the knowl install, or when the user asks who else is running. `inRepo` narrows
+  to one repo (not `repo`, which on every Knowl tool means *act as that linked repo*); `cards`
+  appends the ledger. Messaging a session is the host's own
+  `SendMessage(to:name)`, and `notify_when_idle:true` waits for it to finish. It is absent from
+  the canonical tool table below for the reason the transcript tools are: a gated tool is not a
+  promise every session can rely on.
+
+```jsonc
+// .knowl/config.json
+"fleet": {
+  "enabled": true,      // absent means on; false silences every fleet surface at once
+  "digest": "off",      // "on": a per-turn delta of what the other sessions moved on to
+  "cards": "enforce",   // same-problem and shared-surface cards; "shadow" records, "off" never
+  "nudge": "shadow"     // stop-time stale-read nudge; "enforce" withholds one stop
+}
+```
+
+- **`fleet.enabled`** (default on) — the roster at session start, the tool, the command, and the
+  three switches below. `false` turns all of it off.
+- **`fleet.digest`** (default `off`) — at each turn start, a few lines on what the other sessions
+  moved on to since this one last looked. Off because it costs lines on every turn of a busy
+  fleet; `knowl posture maximal` turns it on.
+- **`fleet.cards`** (default `enforce`) — a *same-problem* card when another live session has
+  claimed the failure this one just hit, and a *shared-surface* card before a change to
+  something every session stands on: hooks, config, migrations, the knowl install. Advice on the
+  mid-turn channel the agent already gets, never a refusal, which is why it ships armed;
+  `shadow` records what would have been said and says nothing.
+- **`fleet.nudge`** (default `shadow`) — at stop, when this turn's writes changed code another
+  live session had read: `enforce` withholds the stop once and asks the agent to tell that
+  session, which costs a turn. Shadow by default on the same ladder as `capture.nudge`, for the
+  same reason: how often it would fire is measured before it is allowed to.
+
+Every card shown or shadowed is a row in a ledger with a resolution column, and `--cards` prints
+it: shown, shadowed, adjudicated, false positives, precision. Nothing adjudicated reads as *not
+yet measured* rather than as a percentage. Nothing here graduates from advising to refusing
+without that number — the contract the write gate set.
 
 ## Evidence, code intelligence, and drift
 
@@ -2283,6 +2352,7 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl doctor` | Check project, vector coverage, agent, and workspace readiness |
 | `knowl state` | Print the active hierarchical project memory |
 | `knowl audit` | Run a read-only, limited integrity audit |
+| `knowl fleet [--repo <name>] [--json] [--cards]` | List the other Claude Code sessions live on this machine and what each is doing. Needs no Knowl project; `--cards` adds the fleet card ledger |
 
 ### Workspaces
 
@@ -2399,7 +2469,8 @@ The recommended agent flow is:
 ### Tools
 
 Knowl exposes the core tools below. Two transcript search tools and a session listing tool are
-registered in addition when transcript indexing is enabled for the repository.
+registered in addition when transcript indexing is enabled for the repository, and `knowl_fleet`
+unless fleet awareness is switched off.
 
 | Tool | Purpose |
 | --- | --- |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -964,37 +964,45 @@ not notified about its own change.
 
 ### Who else is running — the fleet
 
-Several Claude Code sessions on one machine do not know about each other. The host keeps a
-registry of its live sessions and lets one message another, but records nothing about what each
-is doing — so two sessions hit the same `SQLITE_BUSY`, both start fixing it, and a third upgrades
-the hook every one of them is standing on. Knowl keeps the half the registry does not: what each
-session was asked, what it wrote this turn, the last error it saw, and which problem it has
-claimed by editing files after seeing that error. One machine-level file, `~/.knowl/fleet.db`,
-beside the resume keys — not a project table, because the collision that matters most crosses
-repositories. A session whose process is gone is never listed, whatever the file still says.
+Several agent sessions on one machine do not know about each other. Claude Code keeps a registry
+of its live sessions and lets one message another, but records nothing about what each is doing —
+and every other host records nothing at all — so two sessions hit the same `SQLITE_BUSY`, both
+start fixing it, and a third upgrades the hook every one of them is standing on. Knowl keeps the
+half no host has: what each session was asked, what it wrote this turn, the last error it saw,
+and which problem it has claimed by editing files after seeing that error. One machine-level
+file, `~/.knowl/fleet.db`, beside the resume keys — not a project table, because the collision
+that matters most crosses repositories.
+
+**Every host with Knowl hooks is in the fleet**, and they see each other: a Codex session appears
+on a Claude session's roster and the reverse. Liveness is answered exactly where a host publishes
+a session registry (Claude Code does; a row its registry does not list is a dead process and is
+dropped) and by recency where none does — a session with no registry drops off the roster two
+hours after its last event, and a clean exit closes its row immediately. Only sessions the
+host's own messaging can actually reach are offered as something to `SendMessage`; the rest are
+listed, marked, and raised with the user instead.
 
 **On by default**, and the only feature in this document that is: the roster costs a directory
 listing and prints nothing when a session is alone, and nobody opts into "tell me other sessions
 exist" until after the collision.
 
 ```bash
-knowl fleet                 # every live session: repo, state, what it is on, what it is editing
+knowl fleet                 # every live session: host, repo, state, what it is on, what it is editing
 knowl fleet --repo web      # one repo's sessions
-knowl fleet --json --cards  # the report as JSON, plus the card ledger
+knowl fleet --json          # the report as JSON
 ```
 
 `knowl fleet` needs no Knowl project: the fleet is machine-level, and the terminal you ask from is
 often outside every repo. Run from inside a Claude Code session, the listing marks that session
-`(you)`.
+`(you)`; other hosts publish no session id to read, so there the label is simply absent.
 
 - **`knowl_fleet`** — the same listing as an MCP tool, registered unless `fleet.enabled` is
   `false`. Use it before fixing an error that may be shared, before changing hooks, config,
   migrations or the knowl install, or when the user asks who else is running. `inRepo` narrows
-  to one repo (not `repo`, which on every Knowl tool means *act as that linked repo*); `cards`
-  appends the ledger. Messaging a session is the host's own
-  `SendMessage(to:name)`, and `notify_when_idle:true` waits for it to finish. It is absent from
-  the canonical tool table below for the reason the transcript tools are: a gated tool is not a
-  promise every session can rely on.
+  to one repo (not `repo`, which on every Knowl tool means *act as that linked repo*). Messaging
+  a session is the host's own `SendMessage(to:name)`, and `notify_when_idle:true` waits for it to
+  finish — offered only for the sessions it can reach. It is absent from the canonical tool table
+  below for the reason the transcript tools are: a gated tool is not a promise every session can
+  rely on.
 
 ```jsonc
 // .knowl/config.json
@@ -1020,11 +1028,6 @@ often outside every repo. Run from inside a Claude Code session, the listing mar
   live session had read: `enforce` withholds the stop once and asks the agent to tell that
   session, which costs a turn. Shadow by default on the same ladder as `capture.nudge`, for the
   same reason: how often it would fire is measured before it is allowed to.
-
-Every card shown or shadowed is a row in a ledger with a resolution column, and `--cards` prints
-it: shown, shadowed, adjudicated, false positives, precision. Nothing adjudicated reads as *not
-yet measured* rather than as a percentage. Nothing here graduates from advising to refusing
-without that number — the contract the write gate set.
 
 ## Evidence, code intelligence, and drift
 
@@ -2352,7 +2355,7 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl doctor` | Check project, vector coverage, agent, and workspace readiness |
 | `knowl state` | Print the active hierarchical project memory |
 | `knowl audit` | Run a read-only, limited integrity audit |
-| `knowl fleet [--repo <name>] [--json] [--cards]` | List the other Claude Code sessions live on this machine and what each is doing. Needs no Knowl project; `--cards` adds the fleet card ledger |
+| `knowl fleet [--repo <name>] [--json]` | List the agent sessions live on this machine and what each is doing. Needs no Knowl project |
 
 ### Workspaces
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -20,7 +20,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
 import { DEFAULT_PRESET_ID, VECTOR_PRESETS } from '../src/core/vector-profile.js';
 import { stripManagedKnowlGuidance } from '../src/core/agents-guidance.js';
 import { renderManagedKnowlGuidanceSection } from '../src/core/knowl-guidance.js';
@@ -38,7 +38,7 @@ function contextLabel(tokens: number): string {
 /** Region id -> [file, body]. */
 const regions: Record<string, [string, string]> = {
   'tool-count': [README, [
-    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace, ${WORKSPACE_TOOL_DEFINITIONS.length} when linked into a local workspace, and ${IMPACT_TOOL_DEFINITIONS.length} when change impact is on)`,
+    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace, ${WORKSPACE_TOOL_DEFINITIONS.length} when linked into a local workspace, ${IMPACT_TOOL_DEFINITIONS.length} when change impact is on, and ${FLEET_TOOL_DEFINITIONS.length} for fleet awareness unless it is switched off)`,
   ].join('\n')],
 
   'embedding-presets': [REFERENCE, [
@@ -80,7 +80,7 @@ const referenceText = fs.readFileSync(REFERENCE, 'utf8');
 // nothing about it. Adding a set to `tool-definitions.ts` means adding it here.
 for (const tool of [
   ...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ...CLOUD_TOOL_DEFINITIONS,
-  ...WORKSPACE_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS,
+  ...WORKSPACE_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS, ...FLEET_TOOL_DEFINITIONS,
 ]) {
   if (!referenceText.includes(`\`${tool.name}\``)) {
     failures.push(`docs/reference.md documents no tool named ${tool.name}`);

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -207,7 +207,17 @@ function questionDecision(input: Record<string, unknown>, raw: Record<string, un
   return decided.length > 0 ? decided.join('; ').slice(0, MAX_STRING) : undefined;
 }
 
-function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: Record<string, unknown>): Pick<NormalizedHostHook, 'type' | 'payload' | 'status' | 'toolName' | 'knowlTool' | 'knowlToolName' | 'knowlChangeKeys' | 'captureKey'> {
+/**
+ * The tail of what a failed command printed, joined stderr-then-stdout, for the fleet's error
+ * signature. Both halves arrive tail-bounded from the stdin filter; this bounds the join.
+ */
+function failedCommandOutput(raw: Record<string, unknown>): string | undefined {
+  const response = recordValue(raw.tool_response) ?? recordValue(raw.toolResponse);
+  const text = [stringValue(response?.stderr), stringValue(response?.stdout)].filter(Boolean).join('\n');
+  return text ? text.slice(-MAX_STRING) : undefined;
+}
+
+function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: Record<string, unknown>): Pick<NormalizedHostHook, 'type' | 'payload' | 'status' | 'toolName' | 'knowlTool' | 'knowlToolName' | 'knowlChangeKeys' | 'captureKey' | 'errorText'> {
   const input = toolInput(raw);
   const toolName = stringValue(raw.tool_name) ?? stringValue(raw.toolName) ?? '';
   const knowlTool = /knowl/i.test(toolName);
@@ -220,7 +230,16 @@ function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: 
   const named = toolName ? { toolName } : {};
   const isShell = hostProfile(host).isShellEvent(eventName, toolName);
   // Shell events already fingerprint on the command itself, so they were never affected.
-  if (isShell) return { ...commandEvent(projectRoot, raw), status: typeof raw.exit_code === 'number' && raw.exit_code !== 0 ? 'failed' : undefined, ...named, knowlTool, ...changeKeys };
+  if (isShell) {
+    const command = commandEvent(projectRoot, raw);
+    const failed = typeof raw.exit_code === 'number' && raw.exit_code !== 0;
+    // A non-zero exit is a problem this session hit, and the text is the only way to tell
+    // whether another session hit the same one. Attached only on failure, so a passing
+    // command's output never leaves the hook process at all.
+    const exitedNonZero = failed || (typeof command.payload.exitCode === 'number' && command.payload.exitCode !== 0);
+    const errorText = exitedNonZero ? failedCommandOutput(raw) : undefined;
+    return { ...command, status: failed ? 'failed' : undefined, ...named, knowlTool, ...changeKeys, ...(errorText ? { errorText } : {}) };
+  }
 
   const captureKey = toolCaptureKey(toolName, input);
   const decision = questionDecision(input, raw);
@@ -394,6 +413,10 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
   }
   if (event === 'turn-stop' || event === 'session-stop') {
     const failed = eventName === 'StopFailure' || stringValue(raw.status) === 'failed' || Boolean(stringValue(raw.error) || recordValue(raw.error));
+    // Claude's `Stop` carries the turn's final assistant text. Kept beside the payload, never
+    // in it -- see `assistantMessage` on the type -- and only on a clean stop, since a failed
+    // one has no answer to summarise.
+    const assistantMessage = event === 'turn-stop' && !failed ? stringValue(raw.last_assistant_message) : undefined;
     return {
       host: normalizedHost,
       event,
@@ -401,10 +424,17 @@ function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record
       projectRoot,
       status: failed ? 'failed' : 'finished',
       payload: failurePayload(raw, failed),
+      ...(assistantMessage ? { assistantMessage } : {}),
     };
   }
   if (eventName === 'PostToolUseFailure' || eventName === 'postToolUseFailure') {
-    return { host: normalizedHost, event, ...ids, projectRoot, type: 'error', status: 'failed', payload: { message: stringValue(raw.error) ?? 'Tool failed' } };
+    const nestedError = recordValue(raw.error);
+    const errorText = stringValue(raw.error) ?? stringValue(nestedError?.message) ?? stringValue(nestedError?.error);
+    return {
+      host: normalizedHost, event, ...ids, ...agent, projectRoot, type: 'error', status: 'failed',
+      payload: { message: stringValue(raw.error) ?? 'Tool failed' },
+      ...(errorText ? { errorText } : {}),
+    };
   }
   return { host: normalizedHost, event, ...ids, ...agent, projectRoot, ...toolEvent(normalizedHost, eventName, projectRoot, raw) };
 }

--- a/src/cli/agents/lifecycle.ts
+++ b/src/cli/agents/lifecycle.ts
@@ -19,7 +19,22 @@ const ROOT_FIELDS = new Set([
   // Claude subagent identity: without these the agent-scoped binding degrades to the
   // shared main-thread row and SubagentStart/Stop cannot resolve an agent at all.
   'agent_id', 'agentId', 'agent_type', 'agentType',
+  // The turn's ask and the turn's answer, for the fleet's one-line "what is this session on".
+  // `prompt` was already read by the correction-signal classifier in `host-hook.ts`, which
+  // could never fire in production because this list dropped the field before it arrived --
+  // a hook that computes from a field it never receives passes every test that bypasses stdin.
+  // Neither reaches `payload`; see `errorText` / `assistantMessage` on NormalizedHostHook.
+  'prompt', 'last_assistant_message',
 ]);
+/**
+ * Keys whose LAST characters matter more than their first.
+ *
+ * Every retained string keeps its head, which is right for a prompt or a path and wrong for
+ * command output: a failing test run prints its banner first and its failure last, so the
+ * head of `stdout` is the list of files that passed. These keep the tail instead, at the same
+ * bound, so the line that names the failure survives.
+ */
+const TAIL_FIELDS = new Set(['error', 'stdout', 'stderr']);
 // Knowl write-tool arguments are retained so a new commit can be recognised as the
 // caller's own work. They are compared in memory and never persisted: only summary,
 // command, and changedPaths reach the stored event payload.
@@ -33,8 +48,11 @@ const TOOL_DISCRIMINATORS = ['pattern', 'glob', 'query', 'url'];
 const NESTED_FIELDS: Record<string, Set<string>> = {
   tool_input: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path', 'notebook_path', ...TOOL_DISCRIMINATORS, ...KNOWL_WRITE_ARGS]),
   toolInput: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path', 'notebook_path', ...TOOL_DISCRIMINATORS, ...KNOWL_WRITE_ARGS]),
-  tool_response: new Set(['exit_code', 'exitCode']),
-  toolResponse: new Set(['exit_code', 'exitCode']),
+  // `stdout`/`stderr` are kept here, tail-bounded, for the fleet's error signature and never
+  // persisted: `appendMemorySessionEvent` strips both keys, and the fleet reduces them to one
+  // line before it writes anything.
+  tool_response: new Set(['exit_code', 'exitCode', 'stdout', 'stderr']),
+  toolResponse: new Set(['exit_code', 'exitCode', 'stdout', 'stderr']),
   error: new Set(['code', 'type', 'message', 'error']),
 };
 // Fields kept inside an allowlisted array of objects, e.g. tool_input.atoms[i].
@@ -65,23 +83,37 @@ function shouldDiscardPath(stack: Array<string | number | null>): boolean {
 
 function retainOnlyBoundedStrings() {
   let chunks: string[] | undefined;
+  // The key the next string value belongs to. Keys arrive packed (`packKeys: true`) as one
+  // `keyValue` token ahead of their value, so this is exact rather than inferred.
+  let currentKey: string | undefined;
+  let keepTail = false;
   return new Transform({
     objectMode: true,
     transform(token, _encoding, callback) {
+      if (token.name === 'keyValue') currentKey = String(token.value);
       if (token.name === 'startString') {
         chunks = [];
+        keepTail = currentKey !== undefined && TAIL_FIELDS.has(currentKey);
         callback();
         return;
       }
       if (chunks) {
         if (token.name === 'stringChunk') {
-          const retained = chunks.join('').length;
-          if (retained < MAX_RETAINED_STRING) chunks.push(String(token.value).slice(0, MAX_RETAINED_STRING - retained));
+          if (keepTail) {
+            // Rolling window: never hold more than twice the bound, never lose the end.
+            chunks.push(String(token.value));
+            const joined = chunks.join('');
+            if (joined.length > 2 * MAX_RETAINED_STRING) chunks = [joined.slice(-MAX_RETAINED_STRING)];
+          } else {
+            const retained = chunks.join('').length;
+            if (retained < MAX_RETAINED_STRING) chunks.push(String(token.value).slice(0, MAX_RETAINED_STRING - retained));
+          }
           callback();
           return;
         }
         if (token.name === 'endString') {
-          const value = chunks.join('').slice(0, MAX_RETAINED_STRING);
+          const joined = chunks.join('');
+          const value = keepTail ? joined.slice(-MAX_RETAINED_STRING) : joined.slice(0, MAX_RETAINED_STRING);
           chunks = undefined;
           callback(null, { name: 'stringValue', value });
           return;

--- a/src/cli/agents/reminder.ts
+++ b/src/cli/agents/reminder.ts
@@ -7,6 +7,7 @@ import {
 import { closeDb, initDb } from '../../store/database.js';
 import { conversationKey, readCaptureOutcome } from '../../store/capture-outcome.js';
 import { assertKnowledgeDatabasePresent } from '../database-presence.js';
+import { fleetTurnStartBestEffort } from '../../session/fleet-lifecycle.js';
 import { readLifecyclePayload } from './lifecycle.js';
 
 /**
@@ -32,12 +33,12 @@ const hostLabel = (host: string): string =>
  * tells the agent not to open a manual task loop, and a Codex session told that *Claude's*
  * hooks own the lifecycle can reasonably read the sentence as being about a different session.
  */
-export function createAgentReminderOutput(host: string): HostOutput {
+export function createAgentReminderOutput(host: string, text: string = promptReminderFor(hostLabel(host))): HostOutput {
   const unsupported = new Error(`Unsupported reminder host: ${host}`);
   if (!isHookHost(host)) throw unsupported;
   const profile = hostProfile(host);
   if (!profile.promptEvent) throw unsupported;
-  const output = profile.startContext('turn-start', promptReminderFor(hostLabel(host)));
+  const output = profile.startContext('turn-start', text);
   if (!output) throw unsupported;
   return output;
 }
@@ -71,6 +72,11 @@ export function createAgentReminderOutput(host: string): HostOutput {
  */
 export async function runAgentReminder(host: string): Promise<void> {
   let send = true;
+  // The fleet's half of the prompt event: this turn's ask goes into the fleet store, and in
+  // maximal posture the digest of what other sessions moved on to comes back. It shares the
+  // one envelope with the card rather than printing a second, since a host reads one JSON
+  // object from a hook.
+  let digest: string | undefined;
   try {
     const payload = await readLifecyclePayload();
     const identity = hostProfile(host as HookHost).identity(payload);
@@ -87,6 +93,14 @@ export async function runAgentReminder(host: string): Promise<void> {
       const config = await loadConfig(root).catch(() => null);
       send = turns === 0
         || shouldSendDriftReminder(turns, driftReminderEvery(config), isDriftBackoffEnabled(config));
+      if (identity.externalSessionId) {
+        digest = await fleetTurnStartBestEffort({
+          host,
+          externalSessionId: identity.externalSessionId,
+          projectRoot: root,
+          prompt: typeof payload.prompt === 'string' ? payload.prompt : undefined,
+        }, config);
+      }
     } finally {
       await closeDb().catch(() => {});
     }
@@ -96,5 +110,6 @@ export async function runAgentReminder(host: string): Promise<void> {
   }
   // Silence is an empty stdout, not an empty envelope: a host that reads `hookSpecificOutput`
   // with a blank `additionalContext` may still spend a line on it.
-  if (send) console.log(JSON.stringify(createAgentReminderOutput(host)));
+  const parts = [send ? promptReminderFor(hostLabel(host)) : undefined, digest].filter((part): part is string => Boolean(part));
+  if (parts.length > 0) console.log(JSON.stringify(createAgentReminderOutput(host, parts.join('\n\n'))));
 }

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -317,7 +317,7 @@ export const CONFIG_FIELDS: ConfigField[] = [
     key: 'fleet.enabled', category: 'Fleet', type: 'boolean',
     parse: booleanValue, defaultValue: true,
     label: 'Fleet awareness',
-    description: 'Know about the other Claude Code sessions on this machine: who is running, what each is on, what it is editing, which failure it has claimed. Powers the session-start roster, knowl_fleet and `knowl fleet`, and the three switches below. Costs a directory listing per event and says nothing when this session is alone. Off silences every fleet surface at once.',
+    description: 'Know about the other agent sessions on this machine, whatever host each runs under: who is running, what each is on, what it is editing, which failure it has claimed. Powers the session-start roster, knowl_fleet and `knowl fleet`, and the three switches below. Costs a directory listing per event and says nothing when this session is alone. Off silences every fleet surface at once.',
   },
   {
     key: 'fleet.digest', category: 'Fleet', type: 'enum', values: FLEET_DIGEST_MODES,

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -33,12 +33,16 @@ export type ConfigKey =
   | 'capture.events'
   | 'capture.scope'
   | 'capture.checkpoint'
+  | 'fleet.enabled'
+  | 'fleet.digest'
+  | 'fleet.cards'
+  | 'fleet.nudge'
   | 'cloud.autoStage'
   | 'updateCheck.enabled';
 
 export type ConfigCategory =
   | 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact' | 'Capture'
-  | 'Reminders' | 'Cloud' | 'Updates';
+  | 'Fleet' | 'Reminders' | 'Cloud' | 'Updates';
 
 /**
  * How a value should be asked for. Without this the UI had only `parse`, so every field
@@ -111,6 +115,11 @@ const IMPACT_GATE_MODES = ['off', 'shadow', 'enforce'] as const;
 const CAPTURE_NUDGE_MODES = ['off', 'shadow', 'enforce'] as const;
 const CHECKPOINT_MODES = ['off', 'ask'] as const;
 const CAPTURE_SCOPES = ['conversation', 'turn'] as const;
+// The capture ladder again, and its own constant for the reason CAPTURE_NUDGE_MODES is: a card
+// is advice on a channel the agent already reads, a nudge withholds a stop, and a mode added
+// to either must not become settable on the other.
+const FLEET_CARD_MODES = ['off', 'shadow', 'enforce'] as const;
+const FLEET_DIGEST_MODES = ['off', 'on'] as const;
 
 export const CONFIG_FIELDS: ConfigField[] = [
   // The preset leads the Search list: it is the one setting most people should touch,
@@ -299,6 +308,40 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(CAPTURE_SCOPES), defaultValue: 'conversation',
     label: 'Capture scope',
     description: 'Granularity of the stored-nothing question. conversation is the one-shot end-of-session verdict; turn additionally prompts once, through the free mid-turn channel, when a turn does substantial work and stores nothing -- and a query does not quiet it, only a write does.',
+  },
+  {
+    // ON when unset, as `search.pathsChanged` is: the reader is `!== false` and the key stays
+    // out of DEFAULT_CONFIG so an upgrade does not stamp it into every config on the machine.
+    // The default is on because the collision this prevents is one nobody opts into avoiding
+    // until after it has happened, and a lone session pays a directory listing for nothing.
+    key: 'fleet.enabled', category: 'Fleet', type: 'boolean',
+    parse: booleanValue, defaultValue: true,
+    label: 'Fleet awareness',
+    description: 'Know about the other Claude Code sessions on this machine: who is running, what each is on, what it is editing, which failure it has claimed. Powers the session-start roster, knowl_fleet and `knowl fleet`, and the three switches below. Costs a directory listing per event and says nothing when this session is alone. Off silences every fleet surface at once.',
+  },
+  {
+    key: 'fleet.digest', category: 'Fleet', type: 'enum', values: FLEET_DIGEST_MODES,
+    parse: enumValue(FLEET_DIGEST_MODES), defaultValue: 'off',
+    label: 'Per-turn fleet digest',
+    description: 'At each turn start, a few lines on what the other sessions moved on to since this one last looked. Off because it costs lines on every turn of a busy fleet; on when seeing the delta is worth more than pulling it with knowl_fleet.',
+  },
+  {
+    // `enforce` by default, the one ladder here that ships armed: a card is advice on the
+    // mid-turn channel the agent already receives, never a refusal, so the measured bar the
+    // write gate waits behind does not apply to it. Absent from DEFAULT_CONFIG all the same.
+    key: 'fleet.cards', category: 'Fleet', type: 'enum', values: FLEET_CARD_MODES,
+    parse: enumValue(FLEET_CARD_MODES), defaultValue: 'enforce',
+    label: 'Same-problem and shared-surface cards',
+    description: 'When another live session has claimed the failure this one just hit, or this one is about to change hooks, config, migrations or the knowl install every session stands on: enforce says so mid-turn, shadow records what it would have said and says nothing. Advice only, never a refusal; every card lands in the ledger `knowl fleet --cards` prints.',
+  },
+  {
+    // `defaultValue: 'shadow'` here and nowhere else, for the reason `capture.nudge` gives:
+    // written into DEFAULT_CONFIG it would start withholding stops in every repository on the
+    // machine, and this key withholds one -- the turn it costs is the reason it is measured first.
+    key: 'fleet.nudge', category: 'Fleet', type: 'enum', values: FLEET_CARD_MODES,
+    parse: enumValue(FLEET_CARD_MODES), defaultValue: 'shadow',
+    label: 'Stale-read nudge at stop',
+    description: 'When this turn\'s writes changed code another live session had read: enforce withholds the stop once and asks the agent to tell that session, which costs a turn; shadow records what it would have asked. Off skips the check. Same ladder as capture.nudge, for the same reason: how often it would fire is measured before it is allowed to.',
   },
   // Both default ON and both stay out of DEFAULT_CONFIG, for the reason the Capture keys
   // above give: merged in, they are written into every config on the machine at the next

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -36,8 +36,8 @@ import { runCliQuery } from './query-command.js';
 import { runCliResume } from './resume-command.js';
 import { closeResumeDb } from '../session/resume-store.js';
 import { createResumePoint } from '../session/resume-points.js';
-import { describeFleet, renderFleetCardLedger, renderFleetReport } from '../fleet/report.js';
-import { closeFleetDb, fleetCardReport } from '../fleet/store.js';
+import { describeFleet, renderFleetReport } from '../fleet/report.js';
+import { closeFleetDb } from '../fleet/store.js';
 import { formatPendingHandoffContext, recordDeliberateHandoff } from '../session/session-handoff.js';
 import { formatCrossRepoNotice } from './cross-repo-notice.js';
 import { formatWorkspaceBlock } from './workspace-report.js';
@@ -2955,23 +2955,23 @@ program
   });
 
 /**
- * Machine-level, so it asks for no Knowl project: the fleet is every Claude Code session on the
- * box, and the terminal a user asks from is often outside all of their repos. The project is
- * looked up only to name this repo as its workspace does; not finding one costs nothing.
+ * Machine-level, so it asks for no Knowl project: the fleet is every agent session on the box,
+ * whatever host each runs under, and the terminal a user asks from is often outside all of
+ * their repos. The project is looked up only to name this repo as its workspace does; not
+ * finding one costs nothing.
  *
  * `CLAUDE_CODE_SESSION_ID` is what Claude Code sets in the environment of the shell it runs
  * commands in, and it matches the `sessionId` in that session's own registry record (checked
  * against `<config dir>/sessions/<pid>.json`, from inside a subagent too), so a session asking
- * about the fleet sees itself marked `(you)`. A terminal outside any session has no such
- * variable and marks nobody.
+ * about the fleet sees itself marked `(you)`. A terminal outside any session -- or inside a
+ * host that publishes no such variable -- marks nobody, which costs one label and no rows.
  */
 program
   .command('fleet')
-  .description('List the other Claude Code sessions live on this machine and what each is doing')
+  .description('List the agent sessions live on this machine and what each is doing')
   .option('--repo <name>', 'Only sessions in this repo (workspace repo name or folder name)')
   .option('--json', 'Print machine-readable JSON')
-  .option('--cards', 'Also print the fleet card ledger: shown, shadowed, adjudicated, precision')
-  .action(async (options: { repo?: string; json?: boolean; cards?: boolean }) => {
+  .action(async (options: { repo?: string; json?: boolean }) => {
     try {
       const root = await findProjectRoot(process.cwd()).catch(() => null);
       const config = root ? await loadConfig(root).catch(() => null) : null;
@@ -2979,7 +2979,6 @@ program
         selfSessionId: process.env.CLAUDE_CODE_SESSION_ID || undefined,
         selfRepo: config?.workspace?.repo ?? (root ? path.basename(root) : undefined),
       });
-      const cards = options.cards ? await fleetCardReport() : undefined;
       await closeFleetDb();
       if (options.json) {
         const sessions = options.repo ? report.sessions.filter(session => session.repo === options.repo) : report.sessions;
@@ -2988,12 +2987,10 @@ program
           ...report,
           sessions,
           claims: report.claims.filter(claim => listed.has(claim.sessionId)),
-          ...(cards ? { cards } : {}),
         }, null, 2));
         return;
       }
       console.log(renderFleetReport(report, { repo: options.repo }));
-      if (cards) console.log(`\n${renderFleetCardLedger(cards)}`);
     } catch (error: any) {
       console.error(`❌ Fleet error: ${error.message}`);
       process.exitCode = 1;

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -36,6 +36,8 @@ import { runCliQuery } from './query-command.js';
 import { runCliResume } from './resume-command.js';
 import { closeResumeDb } from '../session/resume-store.js';
 import { createResumePoint } from '../session/resume-points.js';
+import { describeFleet, renderFleetCardLedger, renderFleetReport } from '../fleet/report.js';
+import { closeFleetDb, fleetCardReport } from '../fleet/store.js';
 import { formatPendingHandoffContext, recordDeliberateHandoff } from '../session/session-handoff.js';
 import { formatCrossRepoNotice } from './cross-repo-notice.js';
 import { formatWorkspaceBlock } from './workspace-report.js';
@@ -2889,13 +2891,15 @@ configCommand.on('command:*', () => {
  * the user whose answer to "how much should memory do" is a stance rather than a matrix.
  * `maximal` is the all-knowing posture: the recall chain runs the transcript fallback inside a
  * missed query, capture asks per turn and per event and may withhold a stop, impact detection
- * runs with the gate in shadow. `frugal` resets the same keys to their defaults -- which is
- * knowl exactly as it ships.
+ * runs with the gate in shadow, and the fleet reports every turn's delta and may withhold a
+ * stop over a stale read. `frugal` resets the same keys to their defaults -- which is knowl
+ * exactly as it ships.
  */
 const POSTURE_KEYS = [
   'search.transcripts.enabled', 'search.transcripts.fallback',
   'capture.nudge', 'capture.events', 'capture.scope', 'capture.checkpoint',
   'impact.enabled', 'impact.gate',
+  'fleet.digest', 'fleet.nudge',
 ] as const;
 const MAXIMAL_POSTURE: Array<{ key: (typeof POSTURE_KEYS)[number]; raw: string }> = [
   { key: 'search.transcripts.enabled', raw: 'true' },
@@ -2910,6 +2914,11 @@ const MAXIMAL_POSTURE: Array<{ key: (typeof POSTURE_KEYS)[number]; raw: string }
   // Shadow, not enforce, even here: the write gate refuses tool calls, and its own contract
   // requires the measured precision bar before anything is permitted to block.
   { key: 'impact.gate', raw: 'shadow' },
+  // The fleet's two quiet-by-default surfaces. The digest costs lines per turn, which is what
+  // maximal is for. The nudge is armed on the same footing as `capture.nudge` above: it withholds
+  // a stop, which is a turn, and never refuses a tool call -- the line the write gate sits behind.
+  { key: 'fleet.digest', raw: 'on' },
+  { key: 'fleet.nudge', raw: 'enforce' },
 ];
 
 program
@@ -2941,6 +2950,52 @@ program
       if (teardown) console.log(teardown);
     } catch (error: any) {
       console.error(`❌ Posture error: ${error.message}`);
+      process.exitCode = 1;
+    }
+  });
+
+/**
+ * Machine-level, so it asks for no Knowl project: the fleet is every Claude Code session on the
+ * box, and the terminal a user asks from is often outside all of their repos. The project is
+ * looked up only to name this repo as its workspace does; not finding one costs nothing.
+ *
+ * `CLAUDE_CODE_SESSION_ID` is what Claude Code sets in the environment of the shell it runs
+ * commands in, and it matches the `sessionId` in that session's own registry record (checked
+ * against `<config dir>/sessions/<pid>.json`, from inside a subagent too), so a session asking
+ * about the fleet sees itself marked `(you)`. A terminal outside any session has no such
+ * variable and marks nobody.
+ */
+program
+  .command('fleet')
+  .description('List the other Claude Code sessions live on this machine and what each is doing')
+  .option('--repo <name>', 'Only sessions in this repo (workspace repo name or folder name)')
+  .option('--json', 'Print machine-readable JSON')
+  .option('--cards', 'Also print the fleet card ledger: shown, shadowed, adjudicated, precision')
+  .action(async (options: { repo?: string; json?: boolean; cards?: boolean }) => {
+    try {
+      const root = await findProjectRoot(process.cwd()).catch(() => null);
+      const config = root ? await loadConfig(root).catch(() => null) : null;
+      const report = await describeFleet({
+        selfSessionId: process.env.CLAUDE_CODE_SESSION_ID || undefined,
+        selfRepo: config?.workspace?.repo ?? (root ? path.basename(root) : undefined),
+      });
+      const cards = options.cards ? await fleetCardReport() : undefined;
+      await closeFleetDb();
+      if (options.json) {
+        const sessions = options.repo ? report.sessions.filter(session => session.repo === options.repo) : report.sessions;
+        const listed = new Set(sessions.map(session => session.sessionId));
+        console.log(JSON.stringify({
+          ...report,
+          sessions,
+          claims: report.claims.filter(claim => listed.has(claim.sessionId)),
+          ...(cards ? { cards } : {}),
+        }, null, 2));
+        return;
+      }
+      console.log(renderFleetReport(report, { repo: options.repo }));
+      if (cards) console.log(`\n${renderFleetCardLedger(cards)}`);
+    } catch (error: any) {
+      console.error(`❌ Fleet error: ${error.message}`);
       process.exitCode = 1;
     }
   });

--- a/src/core/host-hook-types.ts
+++ b/src/core/host-hook-types.ts
@@ -99,4 +99,21 @@ export interface NormalizedHostHook {
    * never persisted, so no attribution column is needed.
    */
   knowlChangeKeys?: { ids: string[]; titles: string[] };
+  /**
+   * The tail of what a failed tool printed, for the fleet's same-problem match.
+   *
+   * Beside `payload` rather than inside it, deliberately: `payload` is what
+   * `memory_session_events` persists, and raw command output is what that table strips
+   * (`stdout`/`stderr` never reach a row). This is reduced to a signature and a one-line
+   * head before anything stores it, and the reduction happens where the text still exists.
+   */
+  errorText?: string;
+  /**
+   * The head of the assistant's final message for the turn, on `turn-stop` only.
+   *
+   * Same rule as `errorText`: in memory for the fleet's one-line focus, never in `payload`.
+   * Knowl does not store conversations, and a 240-character summary of what a turn did is the
+   * most of one that ever reaches disk.
+   */
+  assistantMessage?: string;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -513,6 +513,30 @@ export interface ProjectConfig {
     checkpoint?: 'off' | 'ask';
   };
   /**
+   * Awareness of the other agent sessions running on this machine.
+   *
+   * The host already keeps a registry of its live sessions and already lets one message
+   * another; what it does not record is what each session is working on, which problem it has
+   * claimed, or what it wrote this turn. These switches govern what Knowl does with that: a
+   * roster at session start, a same-problem card when two sessions hit one failure, a
+   * pre-flight card before a change to something every session stands on, and a stop-time
+   * nudge when a turn's writes invalidated what another session read.
+   *
+   * `enabled` defaults ON and is the only key here that does: the roster prints nothing when a
+   * session is alone, and the collision it prevents is one nobody opts into avoiding until
+   * after it has happened. Everything else follows the `capture` ladder and is absent from
+   * DEFAULT_CONFIG for the reason `impact` and `capture` are.
+   */
+  fleet?: {
+    enabled?: boolean;
+    /** The per-turn delta of what other sessions moved on to. Costs lines every turn of a busy fleet. */
+    digest?: 'off' | 'on';
+    /** The same-problem and shared-surface cards: advice on a channel the agent already gets. */
+    cards?: 'off' | 'shadow' | 'enforce';
+    /** The stop-time "a session read what you just changed" nudge, which withholds a stop and costs a turn. */
+    nudge?: 'off' | 'shadow' | 'enforce';
+  };
+  /**
    * This repo's half of workspace membership. The other half is the workspace manifest
    * listing this repo; either alone is not membership, which is what makes linkage
    * un-forgeable by a cloned repository.

--- a/src/fleet/cards.ts
+++ b/src/fleet/cards.ts
@@ -1,0 +1,228 @@
+import { inlineUntrusted } from '../core/untrusted.js';
+import type { SurfaceHit } from './surfaces.js';
+
+/**
+ * Everything the cards know about one live session, flattened.
+ *
+ * `name` is what the host answers to -- the `to:` of a `SendMessage` -- and it is the only field
+ * an agent can act on, which is why every card leads with it. `messageable` is false for a
+ * session under another config directory: the roster can see it because the fleet store is
+ * shared, but the host's own messaging cannot reach it, and a card that told the agent to
+ * message it would send the agent chasing a refusal.
+ */
+export interface SessionView {
+  name: string;
+  sessionId: string;
+  repo: string;
+  cwd: string;
+  messageable: boolean;
+  /** Minutes since the session started. */
+  ageMinutes: number;
+  /** Minutes since its last recorded turn ended; undefined when it has recorded none. */
+  idleMinutes?: number;
+  /** True while a turn is in flight as far as the store knows. */
+  working: boolean;
+  ask?: string;
+  summary?: string;
+  /** Repo-relative paths written in the turn in flight. */
+  writes: string[];
+  lastError?: string;
+  /** Whether Knowl recorded any activity from it at all. */
+  known: boolean;
+  /** The store row's last change, for the per-turn delta; absent when unknown to Knowl. */
+  updatedAt?: string;
+}
+
+const MAX_ROSTER_REPOS = 8;
+const MAX_NAMES_PER_REPO = 12;
+const MAX_FOCUS_CHARS = 110;
+const MAX_DIGEST_SESSIONS = 6;
+
+/** `duckprep-server-1e` -> `1e`, since the repo column already says `duckprep-server`. */
+export function shortName(name: string, repo: string): string {
+  const stem = repo.toLowerCase();
+  const lowered = name.toLowerCase();
+  if (lowered.startsWith(stem + '-') && name.length > stem.length + 1) return name.slice(stem.length + 1);
+  return name;
+}
+
+/** One line of what a session is on: what it was asked, or failing that what it last said. */
+export function focusOf(view: Pick<SessionView, 'ask' | 'summary'>): string | undefined {
+  const text = view.ask ?? view.summary;
+  return text ? inlineUntrusted(text).slice(0, MAX_FOCUS_CHARS) : undefined;
+}
+
+/**
+ * The SessionStart section: who else is running, grouped by repo. Sixty-odd tokens for a
+ * fleet of twenty, and no focus lines -- those are a pull (`knowl_fleet`) or a per-turn delta,
+ * because a start card that carried every session's current task would be stale by the second
+ * tool call and would cost the same again on every resume. Empty when the session is alone, so
+ * a single-session user never sees a line about it.
+ */
+export function renderFleetRoster(self: { sessionId: string; repo: string }, sessions: SessionView[]): string {
+  const others = sessions.filter(session => session.sessionId !== self.sessionId);
+  if (others.length === 0) return '';
+  const byRepo = new Map<string, SessionView[]>();
+  for (const session of others) {
+    const list = byRepo.get(session.repo) ?? [];
+    list.push(session);
+    byRepo.set(session.repo, list);
+  }
+  const repos = [...byRepo.entries()].sort((a, b) => {
+    if (a[0] === self.repo) return -1;
+    if (b[0] === self.repo) return 1;
+    return b[1].length - a[1].length;
+  });
+  const lines = [`LIVE SESSIONS (${others.length} other Claude Code session${others.length === 1 ? '' : 's'} on this machine)`];
+  for (const [repo, list] of repos.slice(0, MAX_ROSTER_REPOS)) {
+    const names = list.slice(0, MAX_NAMES_PER_REPO).map(session => {
+      const short = inlineUntrusted(shortName(session.name, repo));
+      return session.messageable ? short : `${short}†`;
+    });
+    const more = list.length > MAX_NAMES_PER_REPO ? ` +${list.length - MAX_NAMES_PER_REPO}` : '';
+    const tag = repo === self.repo ? '  ← same repo as you' : '';
+    lines.push(`${inlineUntrusted(repo).padEnd(14)} ${names.join(' · ')}${more}${tag}`);
+  }
+  if (others.some(session => !session.messageable)) lines.push('† runs under another Claude config dir: visible here, not reachable with SendMessage.');
+  lines.push('knowl_fleet tells you what each is doing. Message one with SendMessage(to:"<full name>").');
+  return lines.join('\n');
+}
+
+/**
+ * The per-turn delta: only sessions whose focus changed since this session last saw it. Empty
+ * output means "say nothing", and the caller must treat it that way -- a card that repeats the
+ * same six lines every turn is exactly the interruption tax the whole design is built to avoid.
+ */
+export function renderFleetDigest(changed: SessionView[]): string {
+  if (changed.length === 0) return '';
+  const lines = [`SESSIONS MOVED (${changed.length}):`];
+  for (const session of changed.slice(0, MAX_DIGEST_SESSIONS)) {
+    const writes = session.writes.length > 0
+      ? ` — editing ${session.writes.slice(0, 3).map(inlineUntrusted).join(', ')}${session.writes.length > 3 ? ` +${session.writes.length - 3}` : ''}`
+      : '';
+    const state = session.working ? 'working' : 'idle';
+    lines.push(`- ${inlineUntrusted(session.name)} [${inlineUntrusted(session.repo)}, ${state}]: ${focusOf(session) ?? '(no focus recorded)'}${writes}`);
+  }
+  if (changed.length > MAX_DIGEST_SESSIONS) lines.push(`+${changed.length - MAX_DIGEST_SESSIONS} more — knowl_fleet for the full list.`);
+  return lines.join('\n');
+}
+
+export interface ClaimView {
+  session: SessionView;
+  head: string;
+  minutesAgo: number;
+  files: string[];
+}
+
+/**
+ * The same-problem card. Everything in it is what SWE-Touch found the bare announcement
+ * lacks: the exact files the other session is editing, what it is trying to do, and the two
+ * concrete calls that resolve it. The instruction is "do not fix in parallel", not "stop" --
+ * the agent may still be the right one to fix it, but only after the other has been asked.
+ */
+export function renderSameProblemCard(claim: ClaimView): string {
+  const { session } = claim;
+  const when = claim.minutesAgo < 1 ? 'just now' : `${claim.minutesAgo} min ago`;
+  const lines = [
+    'ANOTHER SESSION IS ALREADY ON THIS PROBLEM',
+    `${inlineUntrusted(session.name)} hit the same error ${when} and is working on it right now:`,
+    `  error: ${inlineUntrusted(claim.head)}`,
+  ];
+  if (claim.files.length > 0) lines.push(`  editing: ${claim.files.slice(0, 4).map(inlineUntrusted).join(', ')}${claim.files.length > 4 ? ` +${claim.files.length - 4}` : ''}`);
+  const focus = focusOf(session);
+  if (focus) lines.push(`  its focus: ${focus}`);
+  lines.push('Do not fix this in parallel. Either:');
+  if (session.messageable) {
+    lines.push(`  · SendMessage(to:"${inlineUntrusted(session.name)}", message:"…") to split the work, or`);
+    lines.push(`  · SendMessage(to:"${inlineUntrusted(session.name)}", notify_when_idle:true) and pick it up after, or`);
+  } else {
+    lines.push('  · that session runs under another Claude config dir and cannot be messaged, so');
+  }
+  lines.push('  · tell the user both sessions hit it and let them decide.');
+  return lines.join('\n');
+}
+
+export interface SurfaceView {
+  hit: SurfaceHit;
+  /** Live sessions that would feel the change, most recently active first. */
+  affected: SessionView[];
+  /** Sessions that read the exact file and have not re-read it since. */
+  readers: SessionView[];
+  /** One stored incident line, when the store has one for this kind of surface. */
+  incident?: string;
+  /** True when the change has already happened and the card can only ask for repair. */
+  after?: boolean;
+}
+
+/**
+ * The pre-flight card for a shared surface. Advisory by design: it names who is standing on
+ * the thing about to move and the two polite ways to move it, then gets out of the way. It
+ * never says "blocked" -- a card that claims to have stopped something it did not stop teaches
+ * the agent to ignore the next one.
+ */
+export function renderSharedSurfaceCard(view: SurfaceView): string {
+  const { hit } = view;
+  const scope = hit.machineWide ? 'every live session on this machine' : 'every live session in this repo';
+  const lines = [
+    `SHARED SURFACE · ${hit.kind} · ${inlineUntrusted(hit.target)}`,
+    `${hit.reason.charAt(0).toUpperCase()}${hit.reason.slice(1)} — reaches ${scope}.`,
+  ];
+  if (view.incident) lines.push(`Known incident: ${inlineUntrusted(view.incident)}`);
+  const editing = view.affected.filter(session => session.working || session.writes.length > 0);
+  const idle = view.affected.filter(session => !editing.includes(session));
+  if (view.affected.length > 0) {
+    const describe = (session: SessionView) => {
+      const state = editing.includes(session) ? 'working' : session.idleMinutes !== undefined ? `idle ${session.idleMinutes} min` : 'no activity recorded';
+      return `${inlineUntrusted(session.name)} (${state})`;
+    };
+    lines.push(`Sessions that would feel it: ${[...editing, ...idle].slice(0, 6).map(describe).join(', ')}${view.affected.length > 6 ? ` +${view.affected.length - 6}` : ''}.`);
+  }
+  if (view.readers.length > 0) {
+    lines.push(`Read this exact file and not since: ${view.readers.slice(0, 4).map(session => inlineUntrusted(session.name)).join(', ')}.`);
+  }
+  const busy = editing.filter(session => session.messageable);
+  if (view.after) {
+    lines.push('This already ran. Verify the sessions above still work, and message the working ones so they know.');
+    return lines.join('\n');
+  }
+  lines.push('Options:');
+  if (busy.length > 0) {
+    lines.push(`  (a) wait — SendMessage(to:"${inlineUntrusted(busy[0].name)}", notify_when_idle:true)${busy.length > 1 ? ` (and the other ${busy.length - 1})` : ''}, then proceed;`);
+    lines.push('  (b) proceed now, and message the working sessions first so they re-read;');
+  } else {
+    lines.push('  (a) proceed, and message any session that would need to re-read;');
+  }
+  lines.push('  (c) ask the user which.');
+  return lines.join('\n');
+}
+
+export interface StaleReadView {
+  session: SessionView;
+  /** Repo-relative paths this session wrote that the other read and has not re-read. */
+  paths: string[];
+}
+
+/**
+ * The stop-time push. This one costs a turn -- it rides the only channel that reaches a model
+ * at stop, which withholds the stop -- so it asks for one specific thing and accepts a reason
+ * instead. The specificity is the point: file, symbol, what changed. CooperBench's agents spent
+ * a fifth of their budget on messages that said nothing; this card exists to make the one
+ * message that matters, once.
+ */
+export function renderStaleReadNudge(views: StaleReadView[]): string {
+  if (views.length === 0) return '';
+  const lines = ['ANOTHER SESSION READ WHAT YOU JUST CHANGED'];
+  for (const view of views.slice(0, 3)) {
+    const state = view.session.working || (view.session.idleMinutes !== undefined && view.session.idleMinutes <= 30) ? 'still working' : 'idle';
+    const focus = focusOf(view.session);
+    const paths = view.paths.slice(0, 3).map(inlineUntrusted).join(', ') + (view.paths.length > 3 ? ` +${view.paths.length - 3}` : '');
+    lines.push(`- ${inlineUntrusted(view.session.name)} (${state}${focus ? `, on: ${focus}` : ''}) read ${paths} before your edit.`);
+  }
+  const first = views[0].session;
+  if (first.messageable) {
+    lines.push(`Send one SendMessage(to:"${inlineUntrusted(first.name)}") naming the file, the symbol, and what changed — or say in one line why it does not affect them. Then stop.`);
+  } else {
+    lines.push('That session cannot be messaged from here (another Claude config dir). Tell the user in one line, then stop.');
+  }
+  return lines.join('\n');
+}

--- a/src/fleet/cards.ts
+++ b/src/fleet/cards.ts
@@ -5,14 +5,17 @@ import type { SurfaceHit } from './surfaces.js';
  * Everything the cards know about one live session, flattened.
  *
  * `name` is what the host answers to -- the `to:` of a `SendMessage` -- and it is the only field
- * an agent can act on, which is why every card leads with it. `messageable` is false for a
- * session under another config directory: the roster can see it because the fleet store is
- * shared, but the host's own messaging cannot reach it, and a card that told the agent to
- * message it would send the agent chasing a refusal.
+ * an agent can act on, which is why every card leads with it. `messageable` is false whenever
+ * that call cannot reach the session: it runs on another host, under another config directory,
+ * or the reader's own host has no messaging at all. The roster still sees it, because the fleet
+ * store is shared by every host; a card that offered the call anyway would send the agent
+ * chasing a refusal.
  */
 export interface SessionView {
   name: string;
   sessionId: string;
+  /** The agent host this session runs under: `claude`, `codex`, `cursor`, and so on. */
+  host: string;
   repo: string;
   cwd: string;
   messageable: boolean;
@@ -73,7 +76,7 @@ export function renderFleetRoster(self: { sessionId: string; repo: string }, ses
     if (b[0] === self.repo) return 1;
     return b[1].length - a[1].length;
   });
-  const lines = [`LIVE SESSIONS (${others.length} other Claude Code session${others.length === 1 ? '' : 's'} on this machine)`];
+  const lines = [`LIVE SESSIONS (${others.length} other agent session${others.length === 1 ? '' : 's'} on this machine)`];
   for (const [repo, list] of repos.slice(0, MAX_ROSTER_REPOS)) {
     const names = list.slice(0, MAX_NAMES_PER_REPO).map(session => {
       const short = inlineUntrusted(shortName(session.name, repo));
@@ -83,8 +86,13 @@ export function renderFleetRoster(self: { sessionId: string; repo: string }, ses
     const tag = repo === self.repo ? '  ← same repo as you' : '';
     lines.push(`${inlineUntrusted(repo).padEnd(14)} ${names.join(' · ')}${more}${tag}`);
   }
-  if (others.some(session => !session.messageable)) lines.push('† runs under another Claude config dir: visible here, not reachable with SendMessage.');
-  lines.push('knowl_fleet tells you what each is doing. Message one with SendMessage(to:"<full name>").');
+  // The hosts of the unreachable ones, named: "another host" is a fact the agent can act on
+  // only if it knows which, and it is what tells a person their Codex tab is in the fleet too.
+  const unreachable = [...new Set(others.filter(session => !session.messageable).map(session => session.host))].sort();
+  if (unreachable.length > 0) lines.push(`† visible here, not reachable with SendMessage (${unreachable.join(', ')} — another host or config directory).`);
+  lines.push(others.some(session => session.messageable)
+    ? 'knowl_fleet tells you what each is doing. Message one with SendMessage(to:"<full name>").'
+    : 'knowl_fleet tells you what each is doing. None can be messaged from here — raise anything that matters with the user.');
   return lines.join('\n');
 }
 
@@ -136,7 +144,7 @@ export function renderSameProblemCard(claim: ClaimView): string {
     lines.push(`  · SendMessage(to:"${inlineUntrusted(session.name)}", message:"…") to split the work, or`);
     lines.push(`  · SendMessage(to:"${inlineUntrusted(session.name)}", notify_when_idle:true) and pick it up after, or`);
   } else {
-    lines.push('  · that session runs under another Claude config dir and cannot be messaged, so');
+    lines.push(`  · that session (${inlineUntrusted(session.host)}) cannot be messaged from here, so`);
   }
   lines.push('  · tell the user both sessions hit it and let them decide.');
   return lines.join('\n');
@@ -180,9 +188,13 @@ export function renderSharedSurfaceCard(view: SurfaceView): string {
   if (view.readers.length > 0) {
     lines.push(`Read this exact file and not since: ${view.readers.slice(0, 4).map(session => inlineUntrusted(session.name)).join(', ')}.`);
   }
+  // Only the sessions this one can actually reach may be offered as something to message; the
+  // rest fall back to the user, who can reach every terminal on the machine.
   const busy = editing.filter(session => session.messageable);
   if (view.after) {
-    lines.push('This already ran. Verify the sessions above still work, and message the working ones so they know.');
+    lines.push(busy.length > 0
+      ? 'This already ran. Verify the sessions above still work, and message the working ones so they know.'
+      : 'This already ran. Verify the sessions above still work, and tell the user which ones may need a restart.');
     return lines.join('\n');
   }
   lines.push('Options:');
@@ -190,7 +202,8 @@ export function renderSharedSurfaceCard(view: SurfaceView): string {
     lines.push(`  (a) wait — SendMessage(to:"${inlineUntrusted(busy[0].name)}", notify_when_idle:true)${busy.length > 1 ? ` (and the other ${busy.length - 1})` : ''}, then proceed;`);
     lines.push('  (b) proceed now, and message the working sessions first so they re-read;');
   } else {
-    lines.push('  (a) proceed, and message any session that would need to re-read;');
+    lines.push('  (a) proceed, and tell the user which sessions will need to re-read;');
+    lines.push('  (b) hold until they are idle;');
   }
   lines.push('  (c) ask the user which.');
   return lines.join('\n');
@@ -222,7 +235,7 @@ export function renderStaleReadNudge(views: StaleReadView[]): string {
   if (first.messageable) {
     lines.push(`Send one SendMessage(to:"${inlineUntrusted(first.name)}") naming the file, the symbol, and what changed — or say in one line why it does not affect them. Then stop.`);
   } else {
-    lines.push('That session cannot be messaged from here (another Claude config dir). Tell the user in one line, then stop.');
+    lines.push(`That session cannot be messaged from here (${inlineUntrusted(first.host)}). Tell the user in one line, then stop.`);
   }
   return lines.join('\n');
 }

--- a/src/fleet/config.ts
+++ b/src/fleet/config.ts
@@ -1,0 +1,45 @@
+import type { ProjectConfig } from '../core/types.js';
+
+/**
+ * The fleet's switches, read the way `capture-config.ts` reads its own: an optional argument,
+ * and anything unrecognised falls to the quietest value. A typo in a config file must fail
+ * toward silence, never toward a card.
+ */
+export type FleetCardMode = 'off' | 'shadow' | 'enforce';
+const CARD_MODES: readonly FleetCardMode[] = ['off', 'shadow', 'enforce'];
+
+/**
+ * ON unless explicitly off. The roster costs a directory listing and prints nothing when the
+ * session is alone, so the default that ships is the default that helps; an opt-in switch for
+ * "tell me other sessions exist" is one nobody discovers until after the collision.
+ */
+export function isFleetEnabled(config?: ProjectConfig | null): boolean {
+  return config?.fleet?.enabled !== false;
+}
+
+/** The per-turn delta digest. Off by default: it costs lines on every turn of a busy fleet. */
+export function isFleetDigestEnabled(config?: ProjectConfig | null): boolean {
+  return isFleetEnabled(config) && config?.fleet?.digest === 'on';
+}
+
+/**
+ * The same-problem and shared-surface cards. `enforce` by default -- they are advice riding a
+ * channel the agent already gets, never a refusal -- and `shadow` records what would have
+ * been said for anyone measuring before trusting.
+ */
+export function fleetCardsMode(config?: ProjectConfig | null): FleetCardMode {
+  if (!isFleetEnabled(config)) return 'off';
+  const mode = config?.fleet?.cards;
+  return CARD_MODES.includes(mode as FleetCardMode) ? mode as FleetCardMode : 'enforce';
+}
+
+/**
+ * The stop-time nudge, which withholds a stop and so costs a turn. Shadow by default, on the
+ * same ladder `capture.nudge` climbs: the measurement of how often it would fire is what any
+ * decision to enforce it has to be made on.
+ */
+export function fleetNudgeMode(config?: ProjectConfig | null): FleetCardMode {
+  if (!isFleetEnabled(config)) return 'off';
+  const mode = config?.fleet?.nudge;
+  return CARD_MODES.includes(mode as FleetCardMode) ? mode as FleetCardMode : 'shadow';
+}

--- a/src/fleet/report.ts
+++ b/src/fleet/report.ts
@@ -1,0 +1,146 @@
+import path from 'node:path';
+import { inlineUntrusted } from '../core/untrusted.js';
+import { focusOf, type SessionView } from './cards.js';
+import { claudeConfigDirs, readHostSessionRegistry, sameDir, type HostSessionRecord } from './roster.js';
+import { listFleetSessions, openFleetClaimsForSession, type FleetCardReport, type FleetClaim, type FleetSessionRow } from './store.js';
+
+/** A turn still counts as in flight for this long after its last event; after that the session is idle. */
+const WORKING_WINDOW_MS = 10 * 60 * 1000;
+
+export interface FleetReport {
+  self: { sessionId: string; repo: string } | null;
+  sessions: SessionView[];
+  claims: FleetClaim[];
+  generatedAt: string;
+}
+
+export interface DescribeFleetInput {
+  /** The asking session's host session id; its own row is included and marked. */
+  selfSessionId?: string;
+  selfRepo?: string;
+  /** Overrides for tests. */
+  registry?: HostSessionRecord[];
+  rows?: FleetSessionRow[];
+  claims?: FleetClaim[];
+  now?: Date;
+}
+
+/**
+ * The live sessions on this machine, as the cards see them.
+ *
+ * The host's registry is the truth about liveness -- a process that is gone is not a session,
+ * whatever the store still says -- and the store is the truth about activity. A registry entry
+ * with no store row is a session Knowl has never heard from (no hooks installed there, or a
+ * repo with no `.knowl`): listed, named by its folder, and marked unknown. A store row with no
+ * registry entry is a dead session and is dropped.
+ */
+export async function describeFleet(input: DescribeFleetInput = {}): Promise<FleetReport> {
+  const now = input.now ?? new Date();
+  const registry = input.registry ?? readHostSessionRegistry(claudeConfigDirs());
+  const rows = input.rows ?? await listFleetSessions();
+  const byId = new Map(rows.map(row => [row.sessionId, row]));
+  const selfRecord = input.selfSessionId ? registry.find(record => record.sessionId === input.selfSessionId) : undefined;
+  const selfDir = selfRecord?.configDir ?? process.env.CLAUDE_CONFIG_DIR ?? '';
+
+  const sessions: SessionView[] = registry.map(record => {
+    const row = byId.get(record.sessionId);
+    const turnEnded = row?.turnEndedAt ? Date.parse(row.turnEndedAt) : NaN;
+    const updated = row ? Date.parse(row.updatedAt) : NaN;
+    const working = Boolean(row?.turnStartedAt) && !row?.turnEndedAt && Number.isFinite(updated) && now.getTime() - updated < WORKING_WINDOW_MS;
+    return {
+      name: record.name,
+      sessionId: record.sessionId,
+      repo: row?.repo ?? path.basename(record.cwd),
+      cwd: record.cwd,
+      messageable: selfDir ? sameDir(record.configDir, selfDir) : true,
+      ageMinutes: Math.max(0, Math.round((now.getTime() - record.startedAt) / 60_000)),
+      idleMinutes: Number.isFinite(turnEnded) ? Math.max(0, Math.round((now.getTime() - turnEnded) / 60_000)) : undefined,
+      working,
+      ask: row?.ask ?? undefined,
+      summary: row?.summary ?? undefined,
+      writes: row?.writes ?? [],
+      lastError: row?.lastError ?? undefined,
+      known: Boolean(row),
+      updatedAt: row?.updatedAt,
+    };
+  });
+
+  const live = new Set(sessions.map(session => session.sessionId));
+  let claims = input.claims;
+  if (!claims) {
+    claims = [];
+    for (const session of sessions) {
+      if (!session.known) continue;
+      const row = byId.get(session.sessionId)!;
+      claims.push(...await openFleetClaimsForSession({ host: row.host, sessionId: row.sessionId }));
+    }
+  }
+  claims = claims.filter(claim => live.has(claim.sessionId));
+
+  const selfRepo = input.selfRepo ?? (input.selfSessionId ? sessions.find(session => session.sessionId === input.selfSessionId)?.repo : undefined);
+  return {
+    self: input.selfSessionId ? { sessionId: input.selfSessionId, repo: selfRepo ?? '' } : null,
+    sessions,
+    claims,
+    generatedAt: now.toISOString(),
+  };
+}
+
+/** The whole picture as text, for the MCP tool and the CLI. */
+export function renderFleetReport(report: FleetReport, options: { repo?: string } = {}): string {
+  const sessions = options.repo ? report.sessions.filter(session => session.repo === options.repo) : report.sessions;
+  if (sessions.length === 0) {
+    return options.repo
+      ? `No live Claude Code sessions in repo "${inlineUntrusted(options.repo)}".`
+      : 'No live Claude Code sessions on this machine.';
+  }
+  const claimsBySession = new Map<string, FleetClaim[]>();
+  for (const claim of report.claims) {
+    const list = claimsBySession.get(claim.sessionId) ?? [];
+    list.push(claim);
+    claimsBySession.set(claim.sessionId, list);
+  }
+  const lines = [`${sessions.length} live Claude Code session${sessions.length === 1 ? '' : 's'}${options.repo ? ` in ${inlineUntrusted(options.repo)}` : ' on this machine'} (${report.generatedAt.slice(11, 16)} UTC):`];
+  const ordered = [...sessions].sort((a, b) => a.repo.localeCompare(b.repo) || a.name.localeCompare(b.name));
+  for (const session of ordered) {
+    const you = report.self && session.sessionId === report.self.sessionId ? ' (you)' : '';
+    const state = session.working ? 'working' : session.idleMinutes !== undefined ? `idle ${session.idleMinutes}m` : session.known ? 'idle' : 'unknown to knowl';
+    const reach = session.messageable ? '' : ' · not messageable (other config dir)';
+    lines.push(`- ${inlineUntrusted(session.name)}${you} [${inlineUntrusted(session.repo)} · ${state} · up ${formatAge(session.ageMinutes)}${reach}]`);
+    const focus = focusOf(session);
+    if (focus) lines.push(`    on: ${focus}`);
+    if (session.summary && session.ask) lines.push(`    last said: ${inlineUntrusted(session.summary).slice(0, 110)}`);
+    if (session.writes.length > 0) lines.push(`    editing: ${session.writes.slice(0, 4).map(inlineUntrusted).join(', ')}${session.writes.length > 4 ? ` +${session.writes.length - 4}` : ''}`);
+    if (session.lastError) lines.push(`    last error: ${inlineUntrusted(session.lastError).slice(0, 110)}`);
+    for (const claim of (claimsBySession.get(session.sessionId) ?? []).slice(0, 2)) {
+      lines.push(`    claims: ${inlineUntrusted(claim.head)}${claim.files.length > 0 ? ` → ${claim.files.slice(0, 3).map(inlineUntrusted).join(', ')}` : ''}${claim.machineWide ? ' (machine-wide)' : ''}`);
+    }
+  }
+  lines.push('Message one with SendMessage(to:"<name>"); SendMessage(to:"<name>", notify_when_idle:true) waits for it to finish.');
+  return lines.join('\n');
+}
+
+/**
+ * The precision ledger as text, in the shape `knowl status` gives the write gate and for the
+ * same reason: a count of cards alone invites "it fired a lot, it must be useful", and a
+ * ledger nobody adjudicated reads as *not yet measured* rather than as a perfect score.
+ */
+export function renderFleetCardLedger(report: FleetCardReport): string {
+  const precision = report.precision === null
+    ? 'not yet measured'
+    : `${(report.precision * 100).toFixed(1)}%`;
+  return [
+    'Fleet cards:',
+    `  shown:            ${report.shown}`,
+    `  shadowed:         ${report.shadowed}`,
+    `  adjudicated:      ${report.adjudicated} of ${report.shown + report.shadowed}`,
+    `  false positives:  ${report.falsePositives}`,
+    `  precision:        ${precision}`,
+  ].join('\n');
+}
+
+function formatAge(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return hours < 48 ? `${hours}h${minutes % 60 ? ` ${minutes % 60}m` : ''}` : `${Math.floor(hours / 24)}d`;
+}

--- a/src/fleet/report.ts
+++ b/src/fleet/report.ts
@@ -1,11 +1,24 @@
 import path from 'node:path';
 import { inlineUntrusted } from '../core/untrusted.js';
 import { focusOf, type SessionView } from './cards.js';
-import { claudeConfigDirs, readHostSessionRegistry, sameDir, type HostSessionRecord } from './roster.js';
-import { listFleetSessions, openFleetClaimsForSession, type FleetCardReport, type FleetClaim, type FleetSessionRow } from './store.js';
+import { claudeConfigDirs, derivedSessionName, readHostSessionRegistry, REGISTRY_HOSTS, sameDir, type HostSessionRecord } from './roster.js';
+import { listFleetSessions, openFleetClaimsForSession, type FleetClaim, type FleetSessionRow } from './store.js';
 
 /** A turn still counts as in flight for this long after its last event; after that the session is idle. */
 const WORKING_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * How long a session on a host with no registry still counts as live after its last event.
+ *
+ * The registry hosts get an exact answer -- the process is there or it is not. Every other host
+ * leaves only its hook events, so liveness is inferred from recency, and the number is the
+ * whole precision of that inference. Two hours is chosen against what being wrong costs in each
+ * direction: too long lists a session that has gone, and the roster tells the agent to
+ * coordinate with nobody; too short drops a session parked mid-task, which is the exact one
+ * worth knowing about. A session-end hook closes the row outright on every clean exit, so this
+ * only decides how long a *crashed* session lingers.
+ */
+const UNREGISTERED_LIVE_WINDOW_MS = 2 * 60 * 60 * 1000;
 
 export interface FleetReport {
   self: { sessionId: string; repo: string } | null;
@@ -18,6 +31,12 @@ export interface DescribeFleetInput {
   /** The asking session's host session id; its own row is included and marked. */
   selfSessionId?: string;
   selfRepo?: string;
+  /**
+   * The asking session's host. Decides whether any peer can be messaged at all: the messaging
+   * channel the cards name belongs to the registry hosts, so a Codex session reading a roster
+   * is told to tell the user rather than to make a call it does not have.
+   */
+  selfHost?: string;
   /** Overrides for tests. */
   registry?: HostSessionRecord[];
   rows?: FleetSessionRow[];
@@ -28,34 +47,46 @@ export interface DescribeFleetInput {
 /**
  * The live sessions on this machine, as the cards see them.
  *
- * The host's registry is the truth about liveness -- a process that is gone is not a session,
- * whatever the store still says -- and the store is the truth about activity. A registry entry
- * with no store row is a session Knowl has never heard from (no hooks installed there, or a
- * repo with no `.knowl`): listed, named by its folder, and marked unknown. A store row with no
- * registry entry is a dead session and is dropped.
+ * Two sources, and which one is authoritative depends on the host. A registry host answers for
+ * its own sessions exactly -- the process is there or it is not -- so one of its store rows
+ * that the registry does not list is dead and is dropped. Every other host publishes no such
+ * file, and its sessions exist here only as the rows its hooks wrote; those are judged by
+ * recency instead, which is what makes a Codex or Windsurf session visible to the Claude
+ * session in the next terminal, and vice versa.
+ *
+ * A registry entry with no store row is a session Knowl has never heard from (no hooks
+ * installed there, or a repo with no `.knowl`): listed, named by its folder, marked unknown.
  */
 export async function describeFleet(input: DescribeFleetInput = {}): Promise<FleetReport> {
   const now = input.now ?? new Date();
   const registry = input.registry ?? readHostSessionRegistry(claudeConfigDirs());
   const rows = input.rows ?? await listFleetSessions();
   const byId = new Map(rows.map(row => [row.sessionId, row]));
-  const selfRecord = input.selfSessionId ? registry.find(record => record.sessionId === input.selfSessionId) : undefined;
+  const registered = new Map(registry.map(record => [record.sessionId, record]));
+  const selfRecord = input.selfSessionId ? registered.get(input.selfSessionId) : undefined;
   const selfDir = selfRecord?.configDir ?? process.env.CLAUDE_CONFIG_DIR ?? '';
+  // A host outside the registry set has no way to address a peer; one inside it, or one we
+  // were not told, is assumed able to and still has to share the peer's config directory.
+  const selfCanMessage = input.selfHost === undefined || REGISTRY_HOSTS.has(input.selfHost);
 
-  const sessions: SessionView[] = registry.map(record => {
-    const row = byId.get(record.sessionId);
+  const view = (row: FleetSessionRow | undefined, record: HostSessionRecord | undefined): SessionView => {
     const turnEnded = row?.turnEndedAt ? Date.parse(row.turnEndedAt) : NaN;
     const updated = row ? Date.parse(row.updatedAt) : NaN;
-    const working = Boolean(row?.turnStartedAt) && !row?.turnEndedAt && Number.isFinite(updated) && now.getTime() - updated < WORKING_WINDOW_MS;
+    const cwd = record?.cwd ?? row!.projectRoot;
+    const sessionId = record?.sessionId ?? row!.sessionId;
+    const startedAt = record ? record.startedAt : Date.parse(row!.startedAt);
     return {
-      name: record.name,
-      sessionId: record.sessionId,
-      repo: row?.repo ?? path.basename(record.cwd),
-      cwd: record.cwd,
-      messageable: selfDir ? sameDir(record.configDir, selfDir) : true,
-      ageMinutes: Math.max(0, Math.round((now.getTime() - record.startedAt) / 60_000)),
+      name: record?.name ?? derivedSessionName(cwd, sessionId),
+      sessionId,
+      host: record?.host ?? row!.host,
+      repo: row?.repo ?? path.basename(cwd),
+      cwd,
+      // Only a registry-backed peer can be reached, and only from a session under the same
+      // config directory. Everything else the roster can see but not address.
+      messageable: Boolean(record) && selfCanMessage && (selfDir ? sameDir(record!.configDir, selfDir) : true),
+      ageMinutes: Number.isFinite(startedAt) ? Math.max(0, Math.round((now.getTime() - startedAt) / 60_000)) : 0,
       idleMinutes: Number.isFinite(turnEnded) ? Math.max(0, Math.round((now.getTime() - turnEnded) / 60_000)) : undefined,
-      working,
+      working: Boolean(row?.turnStartedAt) && !row?.turnEndedAt && Number.isFinite(updated) && now.getTime() - updated < WORKING_WINDOW_MS,
       ask: row?.ask ?? undefined,
       summary: row?.summary ?? undefined,
       writes: row?.writes ?? [],
@@ -63,7 +94,17 @@ export async function describeFleet(input: DescribeFleetInput = {}): Promise<Fle
       known: Boolean(row),
       updatedAt: row?.updatedAt,
     };
-  });
+  };
+
+  const sessions: SessionView[] = registry.map(record => view(byId.get(record.sessionId), record));
+  for (const row of rows) {
+    if (registered.has(row.sessionId)) continue;
+    // Its host answered for it and did not list it, so the process is gone.
+    if (REGISTRY_HOSTS.has(row.host)) continue;
+    const updated = Date.parse(row.updatedAt);
+    if (!Number.isFinite(updated) || now.getTime() - updated > UNREGISTERED_LIVE_WINDOW_MS) continue;
+    sessions.push(view(row, undefined));
+  }
 
   const live = new Set(sessions.map(session => session.sessionId));
   let claims = input.claims;
@@ -91,8 +132,8 @@ export function renderFleetReport(report: FleetReport, options: { repo?: string 
   const sessions = options.repo ? report.sessions.filter(session => session.repo === options.repo) : report.sessions;
   if (sessions.length === 0) {
     return options.repo
-      ? `No live Claude Code sessions in repo "${inlineUntrusted(options.repo)}".`
-      : 'No live Claude Code sessions on this machine.';
+      ? `No live agent sessions in repo "${inlineUntrusted(options.repo)}".`
+      : 'No live agent sessions on this machine.';
   }
   const claimsBySession = new Map<string, FleetClaim[]>();
   for (const claim of report.claims) {
@@ -100,13 +141,13 @@ export function renderFleetReport(report: FleetReport, options: { repo?: string 
     list.push(claim);
     claimsBySession.set(claim.sessionId, list);
   }
-  const lines = [`${sessions.length} live Claude Code session${sessions.length === 1 ? '' : 's'}${options.repo ? ` in ${inlineUntrusted(options.repo)}` : ' on this machine'} (${report.generatedAt.slice(11, 16)} UTC):`];
+  const lines = [`${sessions.length} live agent session${sessions.length === 1 ? '' : 's'}${options.repo ? ` in ${inlineUntrusted(options.repo)}` : ' on this machine'} (${report.generatedAt.slice(11, 16)} UTC):`];
   const ordered = [...sessions].sort((a, b) => a.repo.localeCompare(b.repo) || a.name.localeCompare(b.name));
   for (const session of ordered) {
     const you = report.self && session.sessionId === report.self.sessionId ? ' (you)' : '';
     const state = session.working ? 'working' : session.idleMinutes !== undefined ? `idle ${session.idleMinutes}m` : session.known ? 'idle' : 'unknown to knowl';
-    const reach = session.messageable ? '' : ' · not messageable (other config dir)';
-    lines.push(`- ${inlineUntrusted(session.name)}${you} [${inlineUntrusted(session.repo)} · ${state} · up ${formatAge(session.ageMinutes)}${reach}]`);
+    const reach = session.messageable ? '' : ' · not messageable';
+    lines.push(`- ${inlineUntrusted(session.name)}${you} [${inlineUntrusted(session.host)} · ${inlineUntrusted(session.repo)} · ${state} · up ${formatAge(session.ageMinutes)}${reach}]`);
     const focus = focusOf(session);
     if (focus) lines.push(`    on: ${focus}`);
     if (session.summary && session.ask) lines.push(`    last said: ${inlineUntrusted(session.summary).slice(0, 110)}`);
@@ -116,27 +157,10 @@ export function renderFleetReport(report: FleetReport, options: { repo?: string 
       lines.push(`    claims: ${inlineUntrusted(claim.head)}${claim.files.length > 0 ? ` → ${claim.files.slice(0, 3).map(inlineUntrusted).join(', ')}` : ''}${claim.machineWide ? ' (machine-wide)' : ''}`);
     }
   }
-  lines.push('Message one with SendMessage(to:"<name>"); SendMessage(to:"<name>", notify_when_idle:true) waits for it to finish.');
+  if (sessions.some(session => session.messageable)) {
+    lines.push('Message one with SendMessage(to:"<name>"); SendMessage(to:"<name>", notify_when_idle:true) waits for it to finish.');
+  }
   return lines.join('\n');
-}
-
-/**
- * The precision ledger as text, in the shape `knowl status` gives the write gate and for the
- * same reason: a count of cards alone invites "it fired a lot, it must be useful", and a
- * ledger nobody adjudicated reads as *not yet measured* rather than as a perfect score.
- */
-export function renderFleetCardLedger(report: FleetCardReport): string {
-  const precision = report.precision === null
-    ? 'not yet measured'
-    : `${(report.precision * 100).toFixed(1)}%`;
-  return [
-    'Fleet cards:',
-    `  shown:            ${report.shown}`,
-    `  shadowed:         ${report.shadowed}`,
-    `  adjudicated:      ${report.adjudicated} of ${report.shown + report.shadowed}`,
-    `  false positives:  ${report.falsePositives}`,
-    `  precision:        ${precision}`,
-  ].join('\n');
 }
 
 function formatAge(minutes: number): string {

--- a/src/fleet/roster.ts
+++ b/src/fleet/roster.ts
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * One live host session on this machine, as Claude Code itself records it.
+ *
+ * Claude Code writes one JSON file per running session under `<config dir>/sessions/<pid>.json`
+ * -- the same files its own `ListAgents` reads -- and removes it when the session exits. That
+ * file is the whole reason this module can exist without a daemon: the host already maintains
+ * the roster, validates it against the process table, and exports the directory to every hook
+ * through `CLAUDE_CONFIG_DIR`. Reading it costs a directory listing, not a tool call.
+ *
+ * What the file does NOT carry is as important as what it does: there is no status and no
+ * "current task". Those come from Knowl's own `session_focus` rows, joined on `sessionId`.
+ */
+export interface HostSessionRecord {
+  pid: number;
+  sessionId: string;
+  cwd: string;
+  name: string;
+  startedAt: number;
+  kind: string;
+  /** Which config directory the record was read from -- sessions in different ones cannot message each other. */
+  configDir: string;
+  messagingSocketPath?: string;
+  version?: string;
+}
+
+/**
+ * Whether a process id names a running process.
+ *
+ * Signal 0 is the portable existence check: Node maps it to `OpenProcess` on Windows and to
+ * `kill(pid, 0)` elsewhere. `EPERM` means the process exists but belongs to someone else, which
+ * for a session registry under our own home directory is still "alive". Anything else --
+ * `ESRCH` above all -- means the record outlived its process, which happens on every crash and
+ * every force-closed terminal, and is exactly the case a roster must not report as a peer.
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Every Claude Code config directory this user might be running sessions from.
+ *
+ * `CLAUDE_CONFIG_DIR` is the one the current session runs under and is always first. The
+ * others exist because one person can run two accounts side by side (`~/.claude` and
+ * `~/.claude-account-b` is a real layout), and sessions under different directories register
+ * in different `sessions/` folders. Claude Code's own listing therefore cannot see across them
+ * -- "two sessions can reach each other only when they can see the same files" -- but Knowl's
+ * store is shared by both, so a roster built here can. Only directories that actually hold a
+ * `sessions` folder count; a `.claude-launchers` or `.claude.json` sibling is not a config dir.
+ */
+export function claudeConfigDirs(env: NodeJS.ProcessEnv = process.env, home: string = os.homedir()): string[] {
+  const dirs: string[] = [];
+  const push = (dir: string | undefined) => {
+    if (!dir) return;
+    const resolved = path.resolve(dir);
+    if (dirs.some(existing => sameDir(existing, resolved))) return;
+    if (!isDirectory(path.join(resolved, 'sessions'))) return;
+    dirs.push(resolved);
+  };
+  // An explicit list wins outright: a machine whose config dirs live somewhere the discovery
+  // below would never look, or a test that must not see the developer's real fleet.
+  if (env.KNOWL_CLAUDE_CONFIG_DIRS) {
+    for (const dir of env.KNOWL_CLAUDE_CONFIG_DIRS.split(path.delimiter)) push(dir.trim());
+    return dirs;
+  }
+  push(env.CLAUDE_CONFIG_DIR);
+  push(path.join(home, '.claude'));
+  for (const name of listDir(home).filter(name => name.startsWith('.claude') && name !== '.claude').sort()) {
+    push(path.join(home, name));
+  }
+  return dirs;
+}
+
+function listDir(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The live sessions registered under the given config directories, dead records dropped.
+ *
+ * Parsing is deliberately forgiving of shape and strict about liveness. A record missing a
+ * field is skipped rather than thrown on -- Claude Code owns that file format and may add or
+ * rename keys -- but a record whose pid is gone is never returned, because a dead session
+ * reported as a peer would be told about, waited on and messaged, and none of that can succeed.
+ * The caller's own session is included; filtering it out is the caller's decision, since the
+ * MCP tool and the SessionStart card want opposite things.
+ */
+export function readHostSessionRegistry(
+  configDirs: string[] = claudeConfigDirs(),
+  alive: (pid: number) => boolean = isPidAlive,
+): HostSessionRecord[] {
+  const records: HostSessionRecord[] = [];
+  for (const configDir of configDirs) {
+    const dir = path.join(configDir, 'sessions');
+    for (const name of listDir(dir).filter(name => name.endsWith('.json'))) {
+      const record = parseRecord(readJson(path.join(dir, name)), configDir);
+      if (!record) continue;
+      if (!alive(record.pid)) continue;
+      records.push(record);
+    }
+  }
+  records.sort((a, b) => a.startedAt - b.startedAt);
+  return records;
+}
+
+function parseRecord(raw: unknown, configDir: string): HostSessionRecord | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const value = raw as Record<string, unknown>;
+  const pid = typeof value.pid === 'number' ? value.pid : Number(value.pid);
+  const sessionId = typeof value.sessionId === 'string' ? value.sessionId : undefined;
+  const cwd = typeof value.cwd === 'string' ? value.cwd : undefined;
+  if (!Number.isInteger(pid) || pid <= 0 || !sessionId || !cwd) return undefined;
+  const startedAt = typeof value.startedAt === 'number' ? value.startedAt : Number(value.startedAt);
+  return {
+    pid,
+    sessionId,
+    cwd,
+    // A record without a name is still a session; the derived form is what the host would show.
+    name: typeof value.name === 'string' && value.name.length > 0 ? value.name : `${path.basename(cwd).toLowerCase()}-${sessionId.slice(0, 2)}`,
+    startedAt: Number.isFinite(startedAt) ? startedAt : 0,
+    kind: typeof value.kind === 'string' ? value.kind : 'interactive',
+    configDir,
+    messagingSocketPath: typeof value.messagingSocketPath === 'string' ? value.messagingSocketPath : undefined,
+    version: typeof value.version === 'string' ? value.version : undefined,
+  };
+}
+
+function readJson(file: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function isDirectory(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Case-insensitive on Windows, where `C:\Code` and `c:\Code` are one directory and the two
+ * spellings both occur in real hook payloads (`cwd` arrives lowercase-drive from VS Code).
+ */
+export function sameDir(a: string, b: string): boolean {
+  const left = path.resolve(a);
+  const right = path.resolve(b);
+  return process.platform === 'win32' ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+/**
+ * Whether `child` is `parent` or lies inside it. `path.relative` already compares
+ * case-insensitively on win32, so the casing rule of `sameDir` holds here without a second
+ * check.
+ */
+export function withinDir(parent: string, child: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  if (relative === '') return true;
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/src/fleet/roster.ts
+++ b/src/fleet/roster.ts
@@ -3,6 +3,18 @@ import os from 'node:os';
 import path from 'node:path';
 
 /**
+ * Hosts that publish a live-session registry of their own, so an absent record is proof of
+ * death rather than of silence.
+ *
+ * Claude Code is the only one today, and this exists so the rest of the fleet does not assume
+ * it is the only host that ever runs: a `codex` or `windsurf` row has no registry to be missing
+ * from, so it is judged by recency instead (see `describeFleet`). Adding a host here without a
+ * reader for its registry would delete its sessions from every roster, so the two change
+ * together.
+ */
+export const REGISTRY_HOSTS: ReadonlySet<string> = new Set(['claude']);
+
+/**
  * One live host session on this machine, as Claude Code itself records it.
  *
  * Claude Code writes one JSON file per running session under `<config dir>/sessions/<pid>.json`
@@ -12,9 +24,13 @@ import path from 'node:path';
  * through `CLAUDE_CONFIG_DIR`. Reading it costs a directory listing, not a tool call.
  *
  * What the file does NOT carry is as important as what it does: there is no status and no
- * "current task". Those come from Knowl's own `session_focus` rows, joined on `sessionId`.
+ * "current task". Those come from Knowl's own `fleet_sessions` rows, joined on `sessionId` --
+ * and those rows are written by every host's hooks, which is how a session with no registry at
+ * all still appears on the roster.
  */
 export interface HostSessionRecord {
+  /** The host that published this record. Only `claude` does, which is why it is stamped here. */
+  host: string;
   pid: number;
   sessionId: string;
   cwd: string;
@@ -125,17 +141,29 @@ function parseRecord(raw: unknown, configDir: string): HostSessionRecord | undef
   if (!Number.isInteger(pid) || pid <= 0 || !sessionId || !cwd) return undefined;
   const startedAt = typeof value.startedAt === 'number' ? value.startedAt : Number(value.startedAt);
   return {
+    host: 'claude',
     pid,
     sessionId,
     cwd,
     // A record without a name is still a session; the derived form is what the host would show.
-    name: typeof value.name === 'string' && value.name.length > 0 ? value.name : `${path.basename(cwd).toLowerCase()}-${sessionId.slice(0, 2)}`,
+    name: typeof value.name === 'string' && value.name.length > 0 ? value.name : derivedSessionName(cwd, sessionId),
     startedAt: Number.isFinite(startedAt) ? startedAt : 0,
     kind: typeof value.kind === 'string' ? value.kind : 'interactive',
     configDir,
     messagingSocketPath: typeof value.messagingSocketPath === 'string' ? value.messagingSocketPath : undefined,
     version: typeof value.version === 'string' ? value.version : undefined,
   };
+}
+
+/**
+ * The name a session gets when nothing named it: its folder and two characters of its id.
+ *
+ * Claude Code's own fallback, reused for hosts that keep no registry -- so a Codex session and
+ * a nameless Claude one read the same way in a roster, and `shortName` can strip the repo
+ * prefix from either.
+ */
+export function derivedSessionName(cwd: string, sessionId: string): string {
+  return `${path.basename(cwd).toLowerCase()}-${sessionId.slice(0, 2)}`;
 }
 
 function readJson(file: string): unknown {
@@ -162,15 +190,4 @@ export function sameDir(a: string, b: string): boolean {
   const left = path.resolve(a);
   const right = path.resolve(b);
   return process.platform === 'win32' ? left.toLowerCase() === right.toLowerCase() : left === right;
-}
-
-/**
- * Whether `child` is `parent` or lies inside it. `path.relative` already compares
- * case-insensitively on win32, so the casing rule of `sameDir` holds here without a second
- * check.
- */
-export function withinDir(parent: string, child: string): boolean {
-  const relative = path.relative(path.resolve(parent), path.resolve(child));
-  if (relative === '') return true;
-  return !relative.startsWith('..') && !path.isAbsolute(relative);
 }

--- a/src/fleet/signature.ts
+++ b/src/fleet/signature.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * A failure reduced to the part two sessions would share.
+ *
+ * Two sessions that hit "the same problem" never see byte-identical text: the path is their
+ * own worktree's, the line number moved, the timestamp and the pid differ, the test runner
+ * prefixed a different elapsed time. Matching on raw text therefore never fires, and the
+ * whole feature would be a table nobody's rows ever join. What survives across sessions is the
+ * error's *kind* and the first line that names it, so that is what is hashed.
+ *
+ * `head` is kept beside the hash for the card: an agent told "a peer hit signature 3f9a…" has
+ * nothing to act on, while "a peer hit `SQLITE_BUSY: database is locked`" is a sentence it can
+ * recognise from its own screen.
+ */
+export interface ErrorSignature {
+  /** Stable across sessions: sha1 of the normalised head. */
+  sig: string;
+  /** The normalised first meaningful line, for display. */
+  head: string;
+}
+
+const MAX_HEAD_CHARS = 160;
+
+/** ANSI colour sequences, built from the escape's code point so the pattern holds no control character. */
+const ANSI_SEQUENCE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+/** Lines that name a runner, a shell prompt or a frame rather than the error itself. */
+const NOISE_LINE = /^(\s*$|\s*at\s|\s*\d+\s*\||>|\$|npm (ERR|warn)|\s*(FAIL|PASS|RUNS)\s|.*node:internal|\s*-{3,}|\s*={3,})/i;
+
+/**
+ * Runner totals and per-file tallies. They contain the word "failed" and say nothing about
+ * what failed, so they must lose to any line that does.
+ */
+const SUMMARY_LINE = /^\s*(test files|tests|snapshots|duration|start at|errors)\s*[:|]?\s*\d|\(\d+\s+tests?\b|\b\d+\s+(passed|failed|skipped)\b.*\b\d+\s+(passed|failed|skipped)\b/i;
+
+/**
+ * Lines that name the failure itself: an exception class, an errno-style code, a shouted
+ * constant, or a runner's own "this is the error" marker. The LAST such line in the tail wins,
+ * because both Node and vitest print the cause after the context -- a `caused by:` chain ends
+ * at the root, and vitest's `→ message` follows its `× test name`.
+ */
+const STRONG_ERROR = /^\s*[→×✖✗]|\b\w+(Error|Exception)\b|\bE[A-Z]{3,}\b|\b[A-Z]{2,}_[A-Z_]{2,}\b|\berror:/;
+
+/** Weaker evidence, used only when nothing strong appears. The FIRST such line wins. */
+const ERROR_LINE = /\b(error|exception|failed|failure|cannot|could not|unable|not found|denied|refused|timeout|timed out|assert|expected|unexpected|invalid|missing|undefined|null|busy|locked|conflict)\b/i;
+
+/**
+ * Lowercase, one space, and every token that is unique to one session replaced by a
+ * placeholder: absolute and relative paths, line:column pairs, hex ids and hashes, numbers,
+ * quoted strings longer than a word, ISO timestamps and durations.
+ */
+export function normalizeErrorLine(line: string): string {
+  return line
+    .replace(ANSI_SEQUENCE, '')
+    .replace(/\b[A-Za-z]:[\\/][^\s'"`:)]+/g, '<path>')
+    .replace(/(^|[\s'"`(])(?:\.{1,2}[\\/]|~[\\/]|[\\/])[^\s'"`:)]+/g, '$1<path>')
+    .replace(/\b[\w.-]+\.(ts|tsx|js|mjs|cjs|json|py|rs|go|java|sql|md|css|html)\b/g, '<file>')
+    .replace(/\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}[:\d.]*Z?\b/g, '<time>')
+    .replace(/\b[0-9a-f]{7,64}\b/gi, '<hex>')
+    .replace(/:\d+\b/g, ':<n>')
+    .replace(/\b\d+(\.\d+)?\s?(ms|s|m|h|kb|mb|gb|%)\b/gi, '<n>')
+    .replace(/\b\d+\b/g, '<n>')
+    .replace(/(["'`])(?:(?!\1).){24,}\1/g, '$1<str>$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * The line that names the failure, chosen from the tail of the output.
+ *
+ * The tail, because a failing command prints its build log first and its error last, and the
+ * head of a 400-line vitest run is a list of files that passed. Among the last lines the last
+ * `STRONG_ERROR` match wins; failing that, the first `ERROR_LINE` match; failing that, the last
+ * non-noise line; failing that, the last line at all -- an empty signature would silently
+ * match every other empty signature.
+ */
+export function errorHeadLine(text: string): string {
+  const lines = text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  if (lines.length === 0) return '';
+  const tail = lines.slice(-40).filter(line => !NOISE_LINE.test(line) && !SUMMARY_LINE.test(line));
+  const strong = [...tail].reverse().find(line => STRONG_ERROR.test(line));
+  if (strong) return strong;
+  const weak = tail.find(line => ERROR_LINE.test(line));
+  if (weak) return weak;
+  return tail[tail.length - 1] ?? lines[lines.length - 1];
+}
+
+export function errorSignature(text: string): ErrorSignature | undefined {
+  const head = normalizeErrorLine(errorHeadLine(text)).slice(0, MAX_HEAD_CHARS);
+  if (head.length < 8) return undefined;
+  return { sig: createHash('sha1').update(head).digest('hex').slice(0, 16), head };
+}
+
+/**
+ * Whether two normalised heads describe the same failure without being byte-equal.
+ *
+ * Token Jaccard over the placeholder-normalised heads. The threshold is deliberately high:
+ * this decides whether one session is told to stop and coordinate, and a false "same problem"
+ * costs a real interruption, while a missed one costs nothing that was not already the status
+ * quo. 0.8 keeps `expected 3 to be 4` apart from `expected undefined to be defined` (shared
+ * tokens 2 of 5) and joins `sqlite_busy: database is locked (<path>)` with
+ * `error: sqlite_busy: database is locked` (5 of 6).
+ */
+export function sameErrorHead(a: string, b: string, threshold = 0.8): boolean {
+  if (a === b) return true;
+  const left = new Set(a.split(' ').filter(Boolean));
+  const right = new Set(b.split(' ').filter(Boolean));
+  if (left.size === 0 || right.size === 0) return false;
+  let shared = 0;
+  for (const token of left) if (right.has(token)) shared += 1;
+  const union = left.size + right.size - shared;
+  return shared / union >= threshold;
+}

--- a/src/fleet/store.ts
+++ b/src/fleet/store.ts
@@ -1,0 +1,561 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createClient, type Client } from '@libsql/client';
+import { knowlHome } from '../core/paths.js';
+import { synchronousPragma } from '../core/sqlite-sync.js';
+import { sameErrorHead } from './signature.js';
+
+/**
+ * Where the fleet lives: one database under the Knowl home, not inside any repo.
+ *
+ * The thing being recorded is "the Claude Code sessions running on this machine", and that is
+ * a machine-level fact in the same way a resume key is. Filed per repo it would be invisible
+ * across the boundary that matters most: a session in `~/work/api` upgrading the engine every
+ * session in `~/work/web` is standing on. Claude Code keeps its own registry at the same level
+ * (`<config dir>/sessions/`), and this file is the half of the picture that registry does not
+ * carry -- what each session is doing, which problem it has claimed, what it wrote this turn.
+ *
+ * Deliberately not a set of project-store tables. That would have meant a migration level, a
+ * schema pin, a snapshot policy and a federated read across every linked repo on every hook
+ * event; here it is one small file every hook already knows how to find.
+ */
+export function fleetDbPath(): string {
+  return path.join(knowlHome(), 'fleet.db');
+}
+
+const MAX_WRITES_PER_TURN = 20;
+const MAX_ASK_CHARS = 240;
+const MAX_SUMMARY_CHARS = 240;
+const MAX_ERROR_CHARS = 200;
+const MAX_CLAIM_FILES = 12;
+
+/** How long a session row without an end mark still counts as one worth listing. */
+export const FLEET_SESSION_RETENTION_HOURS = 7 * 24;
+
+function schemaStatements(): string[] {
+  return [
+    // Twenty sessions may open this file at once, and each writes a few rows per tool event.
+    // A concurrent writer waits rather than fails, as the resume and transcript stores do.
+    'PRAGMA busy_timeout = 10000;',
+    'PRAGMA journal_mode = WAL;',
+    // See `synchronousPragma`. Everything here is re-derivable from the next event, so the
+    // durability this trades away is worth less than in the knowledge store.
+    synchronousPragma(),
+    `CREATE TABLE IF NOT EXISTS fleet_sessions (
+      host TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      project_root TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      ask TEXT,
+      summary TEXT,
+      writes_json TEXT NOT NULL DEFAULT '[]',
+      last_error TEXT,
+      last_error_sig TEXT,
+      last_error_at TEXT,
+      turns INTEGER NOT NULL DEFAULT 0,
+      turn_started_at TEXT,
+      turn_ended_at TEXT,
+      started_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      ended_at TEXT,
+      PRIMARY KEY (host, session_id)
+    );`,
+    'CREATE INDEX IF NOT EXISTS idx_fleet_sessions_updated ON fleet_sessions(updated_at);',
+    `CREATE TABLE IF NOT EXISTS fleet_claims (
+      id TEXT PRIMARY KEY,
+      host TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      project_root TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      sig TEXT NOT NULL,
+      head TEXT NOT NULL,
+      machine_wide INTEGER NOT NULL DEFAULT 0,
+      files_json TEXT NOT NULL DEFAULT '[]',
+      started_at TEXT NOT NULL,
+      touched_at TEXT NOT NULL,
+      released_at TEXT
+    );`,
+    'CREATE INDEX IF NOT EXISTS idx_fleet_claims_open ON fleet_claims(released_at, sig);',
+    'CREATE INDEX IF NOT EXISTS idx_fleet_claims_session ON fleet_claims(host, session_id, released_at);',
+    // The precision ledger. Every card shown or shadowed is a row, and `resolution` is the
+    // column the table exists for: without a denominator no false-positive rate exists, and
+    // without that rate nothing here may ever graduate from advising to refusing.
+    `CREATE TABLE IF NOT EXISTS fleet_cards (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      host TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      shown_at TEXT NOT NULL,
+      resolution TEXT,
+      resolved_at TEXT
+    );`,
+    'CREATE INDEX IF NOT EXISTS idx_fleet_cards_subject ON fleet_cards(host, session_id, kind, subject);',
+    `CREATE TABLE IF NOT EXISTS fleet_seen (
+      host TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      other_session_id TEXT NOT NULL,
+      seen_updated_at TEXT NOT NULL,
+      PRIMARY KEY (host, session_id, other_session_id)
+    );`,
+  ];
+}
+
+const clients = new Map<string, Client>();
+
+/** The shared fleet database, created on first use. */
+export async function openFleetDb(): Promise<Client> {
+  const resolved = fleetDbPath();
+  const existing = clients.get(resolved);
+  if (existing) return existing;
+
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  const client = createClient({ url: `file:${resolved}` });
+  try {
+    for (const statement of schemaStatements()) await client.execute(statement);
+  } catch (error) {
+    await client.close();
+    throw error;
+  }
+  clients.set(resolved, client);
+  return client;
+}
+
+/** Drop the cached client so the next open reconnects. Tests need this on Windows. */
+export async function closeFleetDb(): Promise<void> {
+  const entries = [...clients.entries()];
+  clients.clear();
+  for (const [, client] of entries) {
+    await client.execute('PRAGMA wal_checkpoint(TRUNCATE)').catch(() => {});
+    client.close();
+  }
+}
+
+const newId = (): string => crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+const now = (): string => new Date().toISOString();
+const clip = (value: string | undefined | null, max: number): string | null =>
+  value ? value.replace(/\s+/g, ' ').trim().slice(0, max) || null : null;
+
+function parseList(raw: unknown): string[] {
+  try {
+    const parsed = JSON.parse(String(raw ?? '[]'));
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export interface FleetSessionKey {
+  host: string;
+  sessionId: string;
+}
+
+export interface FleetSessionRow extends FleetSessionKey {
+  projectRoot: string;
+  repo: string;
+  ask: string | null;
+  summary: string | null;
+  writes: string[];
+  lastError: string | null;
+  lastErrorSig: string | null;
+  lastErrorAt: string | null;
+  turns: number;
+  turnStartedAt: string | null;
+  turnEndedAt: string | null;
+  startedAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+}
+
+function toSessionRow(row: Record<string, unknown>): FleetSessionRow {
+  return {
+    host: String(row.host),
+    sessionId: String(row.session_id),
+    projectRoot: String(row.project_root),
+    repo: String(row.repo),
+    ask: row.ask ? String(row.ask) : null,
+    summary: row.summary ? String(row.summary) : null,
+    writes: parseList(row.writes_json),
+    lastError: row.last_error ? String(row.last_error) : null,
+    lastErrorSig: row.last_error_sig ? String(row.last_error_sig) : null,
+    lastErrorAt: row.last_error_at ? String(row.last_error_at) : null,
+    turns: Number(row.turns ?? 0),
+    turnStartedAt: row.turn_started_at ? String(row.turn_started_at) : null,
+    turnEndedAt: row.turn_ended_at ? String(row.turn_ended_at) : null,
+    startedAt: String(row.started_at),
+    updatedAt: String(row.updated_at),
+    endedAt: row.ended_at ? String(row.ended_at) : null,
+  };
+}
+
+/**
+ * Make sure a session has a row, and mark it live.
+ *
+ * An upsert keyed on the host's own session id, so a session whose SessionStart was lost still
+ * appears the moment any later event arrives -- the same recovery the host bindings do. A
+ * resumed session gets its `ended_at` cleared rather than a second row: it is the same
+ * conversation, and the host reuses the id.
+ */
+export async function touchFleetSession(input: FleetSessionKey & { projectRoot: string; repo: string }): Promise<void> {
+  const stamp = now();
+  await (await openFleetDb()).execute({
+    sql: `INSERT INTO fleet_sessions (host, session_id, project_root, repo, started_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(host, session_id) DO UPDATE SET
+            project_root = excluded.project_root, repo = excluded.repo, updated_at = excluded.updated_at, ended_at = NULL`,
+    args: [input.host, input.sessionId, input.projectRoot, input.repo, stamp, stamp],
+  });
+}
+
+export async function recordFleetTurnStart(input: FleetSessionKey & { ask?: string | null }): Promise<void> {
+  const stamp = now();
+  await (await openFleetDb()).execute({
+    sql: `UPDATE fleet_sessions
+          SET ask = COALESCE(?, ask), turns = turns + 1, turn_started_at = ?, turn_ended_at = NULL, updated_at = ?
+          WHERE host = ? AND session_id = ?`,
+    args: [clip(input.ask, MAX_ASK_CHARS), stamp, stamp, input.host, input.sessionId],
+  });
+}
+
+/** Append a repo-relative path to this turn's writes. Bounded and deduplicated; the newest stays. */
+export async function recordFleetWrite(input: FleetSessionKey & { paths: string[] }): Promise<string[]> {
+  const db = await openFleetDb();
+  const current = await db.execute({
+    sql: 'SELECT writes_json FROM fleet_sessions WHERE host = ? AND session_id = ?',
+    args: [input.host, input.sessionId],
+  });
+  if (current.rows.length === 0) return [];
+  const merged = [...parseList(current.rows[0].writes_json)];
+  for (const candidate of input.paths) {
+    const index = merged.indexOf(candidate);
+    if (index >= 0) merged.splice(index, 1);
+    merged.push(candidate);
+  }
+  const writes = merged.slice(-MAX_WRITES_PER_TURN);
+  await db.execute({
+    sql: 'UPDATE fleet_sessions SET writes_json = ?, updated_at = ? WHERE host = ? AND session_id = ?',
+    args: [JSON.stringify(writes), now(), input.host, input.sessionId],
+  });
+  return writes;
+}
+
+export async function recordFleetError(input: FleetSessionKey & { head: string; sig: string }): Promise<void> {
+  const stamp = now();
+  await (await openFleetDb()).execute({
+    sql: `UPDATE fleet_sessions SET last_error = ?, last_error_sig = ?, last_error_at = ?, updated_at = ?
+          WHERE host = ? AND session_id = ?`,
+    args: [clip(input.head, MAX_ERROR_CHARS), input.sig, stamp, stamp, input.host, input.sessionId],
+  });
+}
+
+/**
+ * Close the turn: keep what the assistant said it did, and hand back the writes so the caller
+ * can check them against other sessions' reads before they are cleared.
+ */
+export async function recordFleetTurnStop(input: FleetSessionKey & { summary?: string | null }): Promise<{ writes: string[] }> {
+  const db = await openFleetDb();
+  const current = await db.execute({
+    sql: 'SELECT writes_json FROM fleet_sessions WHERE host = ? AND session_id = ?',
+    args: [input.host, input.sessionId],
+  });
+  const writes = current.rows.length > 0 ? parseList(current.rows[0].writes_json) : [];
+  const stamp = now();
+  await db.execute({
+    sql: `UPDATE fleet_sessions SET summary = COALESCE(?, summary), turn_ended_at = ?, writes_json = '[]', updated_at = ?
+          WHERE host = ? AND session_id = ?`,
+    args: [clip(input.summary, MAX_SUMMARY_CHARS), stamp, stamp, input.host, input.sessionId],
+  });
+  return { writes };
+}
+
+export async function endFleetSession(input: FleetSessionKey): Promise<void> {
+  const stamp = now();
+  const db = await openFleetDb();
+  await db.execute({
+    sql: 'UPDATE fleet_sessions SET ended_at = ?, updated_at = ? WHERE host = ? AND session_id = ?',
+    args: [stamp, stamp, input.host, input.sessionId],
+  });
+  await db.execute({
+    sql: 'UPDATE fleet_claims SET released_at = ? WHERE host = ? AND session_id = ? AND released_at IS NULL',
+    args: [stamp, input.host, input.sessionId],
+  });
+}
+
+export async function getFleetSession(input: FleetSessionKey): Promise<FleetSessionRow | null> {
+  const rows = await (await openFleetDb()).execute({
+    sql: 'SELECT * FROM fleet_sessions WHERE host = ? AND session_id = ?',
+    args: [input.host, input.sessionId],
+  });
+  return rows.rows.length > 0 ? toSessionRow(rows.rows[0] as Record<string, unknown>) : null;
+}
+
+/**
+ * Every session row that has not ended and was touched inside the retention window. The
+ * caller joins these to the host's live registry; a row here is a claim of activity, not
+ * proof of a process.
+ */
+export async function listFleetSessions(options: { sinceIso?: string } = {}): Promise<FleetSessionRow[]> {
+  const since = options.sinceIso ?? new Date(Date.now() - FLEET_SESSION_RETENTION_HOURS * 3_600_000).toISOString();
+  const rows = await (await openFleetDb()).execute({
+    sql: 'SELECT * FROM fleet_sessions WHERE ended_at IS NULL AND updated_at >= ? ORDER BY updated_at DESC',
+    args: [since],
+  });
+  return rows.rows.map(row => toSessionRow(row as Record<string, unknown>));
+}
+
+export interface FleetClaim {
+  id: string;
+  host: string;
+  sessionId: string;
+  projectRoot: string;
+  repo: string;
+  sig: string;
+  head: string;
+  machineWide: boolean;
+  files: string[];
+  startedAt: string;
+  touchedAt: string;
+  releasedAt: string | null;
+}
+
+function toClaim(row: Record<string, unknown>): FleetClaim {
+  return {
+    id: String(row.id),
+    host: String(row.host),
+    sessionId: String(row.session_id),
+    projectRoot: String(row.project_root),
+    repo: String(row.repo),
+    sig: String(row.sig),
+    head: String(row.head),
+    machineWide: Number(row.machine_wide) === 1,
+    files: parseList(row.files_json),
+    startedAt: String(row.started_at),
+    touchedAt: String(row.touched_at),
+    releasedAt: row.released_at ? String(row.released_at) : null,
+  };
+}
+
+/**
+ * Record that a session is working on a problem: it saw this failure and then edited these
+ * files. One open claim per (session, signature); a second sighting extends it rather than
+ * duplicating it, and the files accumulate.
+ */
+export async function openFleetClaim(input: {
+  host: string;
+  sessionId: string;
+  projectRoot: string;
+  repo: string;
+  sig: string;
+  head: string;
+  machineWide: boolean;
+  files: string[];
+}): Promise<FleetClaim> {
+  const db = await openFleetDb();
+  const stamp = now();
+  const existing = await db.execute({
+    sql: 'SELECT * FROM fleet_claims WHERE host = ? AND session_id = ? AND sig = ? AND released_at IS NULL LIMIT 1',
+    args: [input.host, input.sessionId, input.sig],
+  });
+  if (existing.rows.length > 0) {
+    const claim = toClaim(existing.rows[0] as Record<string, unknown>);
+    const files = [...new Set([...claim.files, ...input.files])].slice(-MAX_CLAIM_FILES);
+    await db.execute({
+      sql: 'UPDATE fleet_claims SET files_json = ?, touched_at = ? WHERE id = ?',
+      args: [JSON.stringify(files), stamp, claim.id],
+    });
+    return { ...claim, files, touchedAt: stamp };
+  }
+  const id = newId();
+  const files = [...new Set(input.files)].slice(-MAX_CLAIM_FILES);
+  await db.execute({
+    sql: `INSERT INTO fleet_claims (id, host, session_id, project_root, repo, sig, head, machine_wide, files_json, started_at, touched_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [id, input.host, input.sessionId, input.projectRoot, input.repo, input.sig, clip(input.head, MAX_ERROR_CHARS) ?? input.sig, input.machineWide ? 1 : 0, JSON.stringify(files), stamp, stamp],
+  });
+  return {
+    id, host: input.host, sessionId: input.sessionId, projectRoot: input.projectRoot, repo: input.repo,
+    sig: input.sig, head: input.head, machineWide: input.machineWide, files, startedAt: stamp, touchedAt: stamp, releasedAt: null,
+  };
+}
+
+export async function openFleetClaimsForSession(input: FleetSessionKey): Promise<FleetClaim[]> {
+  const rows = await (await openFleetDb()).execute({
+    sql: 'SELECT * FROM fleet_claims WHERE host = ? AND session_id = ? AND released_at IS NULL ORDER BY touched_at DESC',
+    args: [input.host, input.sessionId],
+  });
+  return rows.rows.map(row => toClaim(row as Record<string, unknown>));
+}
+
+/**
+ * Release claims a session is no longer working: every open one, or only those whose files
+ * saw no edit this turn. The second form is what a turn boundary uses -- a session that edited
+ * the claimed files this turn is still on the problem; one that moved on has let it go.
+ */
+export async function releaseFleetClaims(input: FleetSessionKey & { untouchedBy?: string[] }): Promise<number> {
+  const db = await openFleetDb();
+  const stamp = now();
+  if (!input.untouchedBy) {
+    const result = await db.execute({
+      sql: 'UPDATE fleet_claims SET released_at = ? WHERE host = ? AND session_id = ? AND released_at IS NULL',
+      args: [stamp, input.host, input.sessionId],
+    });
+    return Number(result.rowsAffected ?? 0);
+  }
+  const open = await openFleetClaimsForSession(input);
+  const touched = new Set(input.untouchedBy);
+  let released = 0;
+  for (const claim of open) {
+    if (claim.files.some(file => touched.has(file))) continue;
+    await db.execute({ sql: 'UPDATE fleet_claims SET released_at = ? WHERE id = ?', args: [stamp, claim.id] });
+    released += 1;
+  }
+  return released;
+}
+
+/**
+ * Other sessions' open claims on the same problem.
+ *
+ * Exact signature first; failing that, a fuzzy match on the normalised head, which is what
+ * catches the same failure phrased two ways. Scope is the repo unless the claim was marked
+ * machine-wide -- an engine or hook failure hits every session on the box, a repo's own test
+ * failure does not. The caller still has to check the claiming session is alive; this table
+ * cannot know.
+ */
+export async function matchingFleetClaims(input: {
+  sig: string;
+  head: string;
+  projectRoot: string;
+  excludeSessionId: string;
+}): Promise<FleetClaim[]> {
+  const rows = await (await openFleetDb()).execute({
+    sql: 'SELECT * FROM fleet_claims WHERE released_at IS NULL AND session_id != ? ORDER BY touched_at DESC LIMIT 200',
+    args: [input.excludeSessionId],
+  });
+  const root = input.projectRoot.toLowerCase();
+  return rows.rows
+    .map(row => toClaim(row as Record<string, unknown>))
+    .filter(claim => claim.machineWide || claim.projectRoot.toLowerCase() === root)
+    .filter(claim => claim.sig === input.sig || sameErrorHead(claim.head, input.head));
+}
+
+export type FleetCardKind = 'same-problem' | 'shared-surface' | 'stale-read' | 'digest';
+
+/**
+ * Record a card, and say whether it is the first of its kind on this subject for this session.
+ *
+ * "First" is the claim-once rule every card here follows: the same problem, the same surface
+ * or the same stale read is announced once per session, because a card that repeats is the
+ * fatigue that teaches an agent to skip the channel. A shadowed card is recorded exactly like a
+ * shown one, so the ledger measures what enforce would have said.
+ */
+export async function recordFleetCard(input: {
+  kind: FleetCardKind;
+  host: string;
+  sessionId: string;
+  subject: string;
+  mode: 'shadow' | 'enforce';
+}): Promise<{ id: string; first: boolean }> {
+  const db = await openFleetDb();
+  const existing = await db.execute({
+    sql: 'SELECT id FROM fleet_cards WHERE host = ? AND session_id = ? AND kind = ? AND subject = ? LIMIT 1',
+    args: [input.host, input.sessionId, input.kind, input.subject],
+  });
+  if (existing.rows.length > 0) return { id: String(existing.rows[0].id), first: false };
+  const id = newId();
+  await db.execute({
+    sql: 'INSERT INTO fleet_cards (id, kind, host, session_id, subject, mode, shown_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    args: [id, input.kind, input.host, input.sessionId, input.subject, input.mode, now()],
+  });
+  return { id, first: true };
+}
+
+export type FleetCardResolution = 'acted' | 'dismissed' | 'false_positive';
+
+/** The first verdict is final, as `resolveFinding` in the project store. */
+export async function resolveFleetCard(id: string, resolution: FleetCardResolution): Promise<boolean> {
+  const result = await (await openFleetDb()).execute({
+    sql: 'UPDATE fleet_cards SET resolution = ?, resolved_at = ? WHERE id = ? AND resolution IS NULL',
+    args: [resolution, now(), id],
+  });
+  return Number(result.rowsAffected ?? 0) > 0;
+}
+
+export interface FleetCardReport {
+  shown: number;
+  shadowed: number;
+  adjudicated: number;
+  falsePositives: number;
+  /** null until anything has been adjudicated. */
+  precision: number | null;
+}
+
+export async function fleetCardReport(kind?: FleetCardKind): Promise<FleetCardReport> {
+  const rows = await (await openFleetDb()).execute({
+    sql: `SELECT mode, resolution, COUNT(*) AS n FROM fleet_cards ${kind ? 'WHERE kind = ?' : ''} GROUP BY mode, resolution`,
+    args: kind ? [kind] : [],
+  });
+  const report: FleetCardReport = { shown: 0, shadowed: 0, adjudicated: 0, falsePositives: 0, precision: null };
+  for (const row of rows.rows) {
+    const n = Number(row.n ?? 0);
+    if (String(row.mode) === 'shadow') report.shadowed += n; else report.shown += n;
+    if (row.resolution) {
+      report.adjudicated += n;
+      if (String(row.resolution) === 'false_positive') report.falsePositives += n;
+    }
+  }
+  if (report.adjudicated > 0) report.precision = 1 - report.falsePositives / report.adjudicated;
+  return report;
+}
+
+export async function listFleetCards(input: FleetSessionKey & { limit?: number }): Promise<Array<{ id: string; kind: FleetCardKind; subject: string; mode: string; shownAt: string; resolution: string | null }>> {
+  const rows = await (await openFleetDb()).execute({
+    sql: 'SELECT id, kind, subject, mode, shown_at, resolution FROM fleet_cards WHERE host = ? AND session_id = ? ORDER BY shown_at DESC LIMIT ?',
+    args: [input.host, input.sessionId, input.limit ?? 20],
+  });
+  return rows.rows.map(row => ({
+    id: String(row.id), kind: String(row.kind) as FleetCardKind, subject: String(row.subject), mode: String(row.mode),
+    shownAt: String(row.shown_at), resolution: row.resolution ? String(row.resolution) : null,
+  }));
+}
+
+/** What this session last saw of each other session, for the per-turn delta digest. */
+export async function readFleetSeen(input: FleetSessionKey): Promise<Map<string, string>> {
+  const rows = await (await openFleetDb()).execute({
+    sql: 'SELECT other_session_id, seen_updated_at FROM fleet_seen WHERE host = ? AND session_id = ?',
+    args: [input.host, input.sessionId],
+  });
+  return new Map(rows.rows.map(row => [String(row.other_session_id), String(row.seen_updated_at)]));
+}
+
+export async function markFleetSeen(input: FleetSessionKey & { seen: Array<{ otherSessionId: string; updatedAt: string }> }): Promise<void> {
+  if (input.seen.length === 0) return;
+  const db = await openFleetDb();
+  for (const entry of input.seen) {
+    await db.execute({
+      sql: `INSERT INTO fleet_seen (host, session_id, other_session_id, seen_updated_at) VALUES (?, ?, ?, ?)
+            ON CONFLICT(host, session_id, other_session_id) DO UPDATE SET seen_updated_at = excluded.seen_updated_at`,
+      args: [input.host, input.sessionId, entry.otherSessionId, entry.updatedAt],
+    });
+  }
+}
+
+/** Drop rows nobody will read again: ended or silent sessions past retention, and their claims, cards and watermarks. */
+export async function sweepFleet(olderThanIso: string): Promise<number> {
+  const db = await openFleetDb();
+  const stale = await db.execute({
+    sql: 'SELECT host, session_id FROM fleet_sessions WHERE updated_at < ?',
+    args: [olderThanIso],
+  });
+  let removed = 0;
+  for (const row of stale.rows) {
+    const args = [String(row.host), String(row.session_id)];
+    await db.execute({ sql: 'DELETE FROM fleet_claims WHERE host = ? AND session_id = ?', args });
+    await db.execute({ sql: 'DELETE FROM fleet_cards WHERE host = ? AND session_id = ?', args });
+    await db.execute({ sql: 'DELETE FROM fleet_seen WHERE host = ? AND session_id = ?', args });
+    await db.execute({ sql: 'DELETE FROM fleet_sessions WHERE host = ? AND session_id = ?', args });
+    removed += 1;
+  }
+  return removed;
+}

--- a/src/fleet/store.ts
+++ b/src/fleet/store.ts
@@ -9,12 +9,14 @@ import { sameErrorHead } from './signature.js';
 /**
  * Where the fleet lives: one database under the Knowl home, not inside any repo.
  *
- * The thing being recorded is "the Claude Code sessions running on this machine", and that is
- * a machine-level fact in the same way a resume key is. Filed per repo it would be invisible
- * across the boundary that matters most: a session in `~/work/api` upgrading the engine every
- * session in `~/work/web` is standing on. Claude Code keeps its own registry at the same level
- * (`<config dir>/sessions/`), and this file is the half of the picture that registry does not
- * carry -- what each session is doing, which problem it has claimed, what it wrote this turn.
+ * The thing being recorded is "the agent sessions running on this machine", whatever host each
+ * one runs under, and that is a machine-level fact in the same way a resume key is. Filed per
+ * repo it would be invisible across the boundary that matters most: a session in `~/work/api`
+ * upgrading the engine every session in `~/work/web` is standing on. Claude Code keeps its own
+ * registry at the same level (`<config dir>/sessions/`) and no other host does, so this file is
+ * both the half of the picture that registry does not carry -- what each session is doing,
+ * which problem it has claimed, what it wrote this turn -- and the only record at all that a
+ * Codex or Windsurf session exists.
  *
  * Deliberately not a set of project-store tables. That would have meant a migration level, a
  * schema pin, a snapshot policy and a federated read across every linked repo on every hook
@@ -78,19 +80,15 @@ function schemaStatements(): string[] {
     );`,
     'CREATE INDEX IF NOT EXISTS idx_fleet_claims_open ON fleet_claims(released_at, sig);',
     'CREATE INDEX IF NOT EXISTS idx_fleet_claims_session ON fleet_claims(host, session_id, released_at);',
-    // The precision ledger. Every card shown or shadowed is a row, and `resolution` is the
-    // column the table exists for: without a denominator no false-positive rate exists, and
-    // without that rate nothing here may ever graduate from advising to refusing.
+    // What has already been said, so it is not said twice. One row per (session, kind,
+    // subject); `recordFleetCard` reads it as a claim-once latch and nothing else does.
     `CREATE TABLE IF NOT EXISTS fleet_cards (
       id TEXT PRIMARY KEY,
       kind TEXT NOT NULL,
       host TEXT NOT NULL,
       session_id TEXT NOT NULL,
       subject TEXT NOT NULL,
-      mode TEXT NOT NULL,
-      shown_at TEXT NOT NULL,
-      resolution TEXT,
-      resolved_at TEXT
+      shown_at TEXT NOT NULL
     );`,
     'CREATE INDEX IF NOT EXISTS idx_fleet_cards_subject ON fleet_cards(host, session_id, kind, subject);',
     `CREATE TABLE IF NOT EXISTS fleet_seen (
@@ -447,76 +445,36 @@ export type FleetCardKind = 'same-problem' | 'shared-surface' | 'stale-read' | '
  *
  * "First" is the claim-once rule every card here follows: the same problem, the same surface
  * or the same stale read is announced once per session, because a card that repeats is the
- * fatigue that teaches an agent to skip the channel. A shadowed card is recorded exactly like a
- * shown one, so the ledger measures what enforce would have said.
+ * fatigue that teaches an agent to skip the channel. A shadowed card claims its subject exactly
+ * like a shown one, so switching a repo from shadow to enforce does not replay what shadow
+ * already decided.
  */
 export async function recordFleetCard(input: {
   kind: FleetCardKind;
   host: string;
   sessionId: string;
   subject: string;
-  mode: 'shadow' | 'enforce';
-}): Promise<{ id: string; first: boolean }> {
+}): Promise<boolean> {
   const db = await openFleetDb();
   const existing = await db.execute({
     sql: 'SELECT id FROM fleet_cards WHERE host = ? AND session_id = ? AND kind = ? AND subject = ? LIMIT 1',
     args: [input.host, input.sessionId, input.kind, input.subject],
   });
-  if (existing.rows.length > 0) return { id: String(existing.rows[0].id), first: false };
-  const id = newId();
+  if (existing.rows.length > 0) return false;
   await db.execute({
-    sql: 'INSERT INTO fleet_cards (id, kind, host, session_id, subject, mode, shown_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
-    args: [id, input.kind, input.host, input.sessionId, input.subject, input.mode, now()],
+    sql: 'INSERT INTO fleet_cards (id, kind, host, session_id, subject, shown_at) VALUES (?, ?, ?, ?, ?, ?)',
+    args: [newId(), input.kind, input.host, input.sessionId, input.subject, now()],
   });
-  return { id, first: true };
+  return true;
 }
 
-export type FleetCardResolution = 'acted' | 'dismissed' | 'false_positive';
-
-/** The first verdict is final, as `resolveFinding` in the project store. */
-export async function resolveFleetCard(id: string, resolution: FleetCardResolution): Promise<boolean> {
-  const result = await (await openFleetDb()).execute({
-    sql: 'UPDATE fleet_cards SET resolution = ?, resolved_at = ? WHERE id = ? AND resolution IS NULL',
-    args: [resolution, now(), id],
-  });
-  return Number(result.rowsAffected ?? 0) > 0;
-}
-
-export interface FleetCardReport {
-  shown: number;
-  shadowed: number;
-  adjudicated: number;
-  falsePositives: number;
-  /** null until anything has been adjudicated. */
-  precision: number | null;
-}
-
-export async function fleetCardReport(kind?: FleetCardKind): Promise<FleetCardReport> {
+export async function listFleetCards(input: FleetSessionKey & { limit?: number }): Promise<Array<{ kind: FleetCardKind; subject: string; shownAt: string }>> {
   const rows = await (await openFleetDb()).execute({
-    sql: `SELECT mode, resolution, COUNT(*) AS n FROM fleet_cards ${kind ? 'WHERE kind = ?' : ''} GROUP BY mode, resolution`,
-    args: kind ? [kind] : [],
-  });
-  const report: FleetCardReport = { shown: 0, shadowed: 0, adjudicated: 0, falsePositives: 0, precision: null };
-  for (const row of rows.rows) {
-    const n = Number(row.n ?? 0);
-    if (String(row.mode) === 'shadow') report.shadowed += n; else report.shown += n;
-    if (row.resolution) {
-      report.adjudicated += n;
-      if (String(row.resolution) === 'false_positive') report.falsePositives += n;
-    }
-  }
-  if (report.adjudicated > 0) report.precision = 1 - report.falsePositives / report.adjudicated;
-  return report;
-}
-
-export async function listFleetCards(input: FleetSessionKey & { limit?: number }): Promise<Array<{ id: string; kind: FleetCardKind; subject: string; mode: string; shownAt: string; resolution: string | null }>> {
-  const rows = await (await openFleetDb()).execute({
-    sql: 'SELECT id, kind, subject, mode, shown_at, resolution FROM fleet_cards WHERE host = ? AND session_id = ? ORDER BY shown_at DESC LIMIT ?',
+    sql: 'SELECT kind, subject, shown_at FROM fleet_cards WHERE host = ? AND session_id = ? ORDER BY shown_at DESC LIMIT ?',
     args: [input.host, input.sessionId, input.limit ?? 20],
   });
   return rows.rows.map(row => ({
-    id: String(row.id), kind: String(row.kind) as FleetCardKind, subject: String(row.subject), mode: String(row.mode),
-    shownAt: String(row.shown_at), resolution: row.resolution ? String(row.resolution) : null,
+    kind: String(row.kind) as FleetCardKind, subject: String(row.subject), shownAt: String(row.shown_at),
   }));
 }
 

--- a/src/fleet/surfaces.ts
+++ b/src/fleet/surfaces.ts
@@ -41,6 +41,22 @@ const MANIFEST_NAMES = new Set([
 const MIGRATION_DIRS = new Set(['migrations', 'migrate', 'migration']);
 
 /**
+ * The directories each agent host keeps its hooks, MCP list and settings in.
+ *
+ * Every path `hookHostSpecs` and the project adapters write, plus the two user-level ones.
+ * Listing only `.claude` was the same mistake the rest of this feature made: the file a Codex
+ * or Windsurf session's hooks are loaded from is exactly as shared as Claude Code's, and one
+ * agent rewriting it while four others run is the change this card exists to announce.
+ *
+ * `.github` earns its place through Copilot (`.github/hooks/knowl.json`, `.github/mcp.json`)
+ * and costs nothing else: the check below still requires a hooks path or a settings-shaped
+ * file name, so a workflow or an issue template does not match.
+ */
+const HOST_CONFIG_DIRS = new Set([
+  '.claude', '.codex', '.cursor', '.windsurf', '.openhands', '.agents', '.github', '.gemini', '.codeium',
+]);
+
+/**
  * Commands that replace the Knowl engine under every running hook and serve process.
  *
  * The specific incident this guards is recorded in the store: an `npm install -g` while
@@ -59,14 +75,14 @@ export function classifySharedSurfacePath(filePath: string, projectRoot?: string
   if (segments.includes('.knowl') && base === 'config.json') {
     return { kind: 'knowl-config', target: display, reason: 'every hook and serve in this repo reads it on the next event', machineWide: false };
   }
-  const claudeIndex = segments.findIndex(segment => segment === '.claude' || /^\.claude-[\w-]+$/.test(segment));
-  if (claudeIndex >= 0) {
-    const rest = segments.slice(claudeIndex + 1);
-    if (rest[0] === 'hooks') {
-      return { kind: 'host-hooks', target: display, reason: 'hook scripts run inside every live session on the next matching event', machineWide: isHomeLevel(segments, claudeIndex) };
+  const hostIndex = segments.findIndex(segment => HOST_CONFIG_DIRS.has(segment) || /^\.claude-[\w-]+$/.test(segment));
+  if (hostIndex >= 0) {
+    const rest = segments.slice(hostIndex + 1);
+    if (rest[0] === 'hooks' || /^hooks(\.[\w-]+)?\.json$/.test(base)) {
+      return { kind: 'host-hooks', target: display, reason: 'hook scripts run inside every live session on the next matching event', machineWide: isHomeLevel(segments, hostIndex) };
     }
-    if (/^settings(\.[\w-]+)?\.json$/.test(base)) {
-      return { kind: 'host-settings', target: display, reason: 'Claude Code re-reads settings live; hook and permission changes reach every session using this file', machineWide: isHomeLevel(segments, claudeIndex) };
+    if (/^(settings|config|mcp|mcp_config)(\.[\w-]+)?\.(json|toml)$/.test(base)) {
+      return { kind: 'host-settings', target: display, reason: 'the host re-reads its settings live; hook, MCP and permission changes reach every session using this file', machineWide: isHomeLevel(segments, hostIndex) };
     }
   }
   if (segments.some(segment => MIGRATION_DIRS.has(segment)) && /\.(sql|ts|js|mjs|cjs|py|rb)$/.test(base)) {
@@ -96,9 +112,9 @@ export function classifySharedSurfaceCommand(command: string): SurfaceHit | unde
   return undefined;
 }
 
-/** A `.claude` directory directly under a home directory is the user-level one every session reads. */
-function isHomeLevel(segments: string[], claudeIndex: number): boolean {
-  const before = segments.slice(0, claudeIndex);
+/** A host config directory directly under a home directory is the user-level one every session reads. */
+function isHomeLevel(segments: string[], hostIndex: number): boolean {
+  const before = segments.slice(0, hostIndex);
   return before.length <= 3 && (before.includes('users') || before.includes('home') || before.length <= 1);
 }
 

--- a/src/fleet/surfaces.ts
+++ b/src/fleet/surfaces.ts
@@ -1,0 +1,109 @@
+import path from 'node:path';
+
+/**
+ * A "shared surface": something one session can change that every other live session is
+ * standing on. The list is a hand-written heuristic, in the tradition of Canopy's
+ * `SharedSurface` enum, and it is honest about that: it names the places where a textual
+ * change has fleet-wide effect *by construction* -- the engine every hook runs, the hook
+ * registrations themselves, the settings the host reads, the schema every process opens --
+ * rather than trying to infer blast radius from content. The inference half lives in the
+ * read-set overlap check beside this; this half fires even when no peer has read the file,
+ * because a hook config is read by processes, not by agents.
+ */
+export type SurfaceKind =
+  | 'knowl-engine'
+  | 'host-settings'
+  | 'host-hooks'
+  | 'knowl-config'
+  | 'migrations'
+  | 'manifest'
+  | 'env'
+  | 'generated'
+  /** Not on the hand list: another live session read this exact file and still holds a current copy. */
+  | 'live-read';
+
+export interface SurfaceHit {
+  kind: SurfaceKind;
+  /** What the agent is about to touch, as a human reads it. */
+  target: string;
+  /** Why every live session cares, in one sentence. */
+  reason: string;
+  /** True when the effect reaches every session on the machine, not only those in this repo. */
+  machineWide: boolean;
+}
+
+const MANIFEST_NAMES = new Set([
+  'package.json', 'package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lockb',
+  'cargo.toml', 'cargo.lock', 'go.mod', 'go.sum', 'pyproject.toml', 'poetry.lock',
+  'requirements.txt', 'gemfile', 'gemfile.lock', 'composer.json', 'composer.lock',
+]);
+
+const MIGRATION_DIRS = new Set(['migrations', 'migrate', 'migration']);
+
+/**
+ * Commands that replace the Knowl engine under every running hook and serve process.
+ *
+ * The specific incident this guards is recorded in the store: an `npm install -g` while
+ * seventeen `knowl serve` processes held the SQLite binary mapped left a half-installed tree,
+ * `EBUSY` on the repair, and every open tab reporting the MCP server red. That is the most
+ * expensive thing one session can do to the others, and it looks like a routine upgrade.
+ */
+const ENGINE_COMMAND = /\b(npm|pnpm|yarn|bun)\s+(i|install|add|up|upgrade|update|link|rm|remove|uninstall)\b[^\n|;&]*(-g|--global|\bglobal\b)[^\n|;&]*\bknowl\b|\bknowl(-sync|\.cmd)?\s+(upgrade|self-update)\b|\bknowl-sync\b/i;
+
+export function classifySharedSurfacePath(filePath: string, projectRoot?: string): SurfaceHit | undefined {
+  const normalised = filePath.replace(/\\/g, '/');
+  const base = path.posix.basename(normalised).toLowerCase();
+  const segments = normalised.toLowerCase().split('/').filter(Boolean);
+  const display = projectRoot ? relativeDisplay(filePath, projectRoot) : filePath;
+
+  if (segments.includes('.knowl') && base === 'config.json') {
+    return { kind: 'knowl-config', target: display, reason: 'every hook and serve in this repo reads it on the next event', machineWide: false };
+  }
+  const claudeIndex = segments.findIndex(segment => segment === '.claude' || /^\.claude-[\w-]+$/.test(segment));
+  if (claudeIndex >= 0) {
+    const rest = segments.slice(claudeIndex + 1);
+    if (rest[0] === 'hooks') {
+      return { kind: 'host-hooks', target: display, reason: 'hook scripts run inside every live session on the next matching event', machineWide: isHomeLevel(segments, claudeIndex) };
+    }
+    if (/^settings(\.[\w-]+)?\.json$/.test(base)) {
+      return { kind: 'host-settings', target: display, reason: 'Claude Code re-reads settings live; hook and permission changes reach every session using this file', machineWide: isHomeLevel(segments, claudeIndex) };
+    }
+  }
+  if (segments.some(segment => MIGRATION_DIRS.has(segment)) && /\.(sql|ts|js|mjs|cjs|py|rb)$/.test(base)) {
+    return { kind: 'migrations', target: display, reason: 'a schema change lands under every session sharing this database', machineWide: false };
+  }
+  if (MANIFEST_NAMES.has(base)) {
+    return { kind: 'manifest', target: display, reason: 'dependency and script changes affect every session building or testing this repo', machineWide: false };
+  }
+  if (/^\.env(\.[\w-]+)?$/.test(base)) {
+    return { kind: 'env', target: display, reason: 'every process in this repo reads it at start', machineWide: false };
+  }
+  if (/\.generated\.|\.gen\.|^schema\.d\.ts$/.test(base) || segments.includes('generated')) {
+    return { kind: 'generated', target: display, reason: 'generated output is usually rebuilt by more than one session', machineWide: false };
+  }
+  return undefined;
+}
+
+export function classifySharedSurfaceCommand(command: string): SurfaceHit | undefined {
+  if (ENGINE_COMMAND.test(command)) {
+    return {
+      kind: 'knowl-engine',
+      target: command.trim().split(/\r?\n/)[0].slice(0, 120),
+      reason: 'replaces the Knowl engine under every live session\'s hooks and serve processes; installing while serves run has half-installed and hit EBUSY before',
+      machineWide: true,
+    };
+  }
+  return undefined;
+}
+
+/** A `.claude` directory directly under a home directory is the user-level one every session reads. */
+function isHomeLevel(segments: string[], claudeIndex: number): boolean {
+  const before = segments.slice(0, claudeIndex);
+  return before.length <= 3 && (before.includes('users') || before.includes('home') || before.length <= 1);
+}
+
+function relativeDisplay(filePath: string, projectRoot: string): string {
+  const relative = path.relative(projectRoot, filePath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return filePath;
+  return relative.replace(/\\/g, '/');
+}

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -235,7 +235,7 @@ export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
 ];
 
 /**
- * The other Claude Code sessions on this machine, read-only.
+ * The other agent sessions on this machine, whatever host each runs under, read-only.
  *
  * Registered unless the repo turned fleet awareness OFF -- the opposite default from every set
  * above, for the reason `isFleetEnabled` gives: a session that is alone gets a short answer
@@ -244,12 +244,13 @@ export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
  *
  * It lists and never messages. Messaging is the host's own `SendMessage`, which the description
  * names by its real arguments rather than wrapping, so the agent reaches the session through
- * the channel that can actually deliver.
+ * the channel that can actually deliver -- and the listing marks the sessions that channel
+ * cannot reach, because a peer on another host is visible here and addressable nowhere.
  */
 export const FLEET_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_fleet',
-          description: 'The other live Claude Code sessions on this machine: what each is working on, the files it is editing this turn, the problem it has claimed, and whether it can be messaged. Use before fixing an error that may be shared, before changing hooks, config, migrations or the knowl install, or when the user asks who else is running. Message a session with SendMessage(to:name); SendMessage(to:name, notify_when_idle:true) waits for it to finish.',
+          description: 'The other live agent sessions on this machine (Claude Code, Codex, Cursor and any other host with Knowl hooks): what each is working on, the files it is editing this turn, the problem it has claimed, and whether it can be messaged. Use before fixing an error that may be shared, before changing hooks, config, migrations or the knowl install, or when the user asks who else is running. A session marked messageable is reachable with SendMessage(to:name); SendMessage(to:name, notify_when_idle:true) waits for it to finish. Raise the rest with the user instead.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -260,10 +261,6 @@ export const FLEET_TOOL_DEFINITIONS: ToolDefinition[] = [
               inRepo: {
                 type: 'string', maxLength: 200,
                 description: 'Only sessions in this repo (workspace repo name or folder name). Omit for every session.',
-              },
-              cards: {
-                type: 'boolean',
-                description: 'Also report the fleet card ledger: how many cards were shown or shadowed on this machine, how many were adjudicated, and the precision that decides whether a card may ever become more than advice.',
               },
             },
           },

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -234,6 +234,42 @@ export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
 ];
 
+/**
+ * The other Claude Code sessions on this machine, read-only.
+ *
+ * Registered unless the repo turned fleet awareness OFF -- the opposite default from every set
+ * above, for the reason `isFleetEnabled` gives: a session that is alone gets a short answer
+ * from a tool it never needed, and a session that is not alone is the one about to fix an
+ * error a neighbour already claimed. One tool on the budget rule `knowl_impact` cites.
+ *
+ * It lists and never messages. Messaging is the host's own `SendMessage`, which the description
+ * names by its real arguments rather than wrapping, so the agent reaches the session through
+ * the channel that can actually deliver.
+ */
+export const FLEET_TOOL_DEFINITIONS: ToolDefinition[] = [
+        {
+          name: 'knowl_fleet',
+          description: 'The other live Claude Code sessions on this machine: what each is working on, the files it is editing this turn, the problem it has claimed, and whether it can be messaged. Use before fixing an error that may be shared, before changing hooks, config, migrations or the knowl install, or when the user asks who else is running. Message a session with SendMessage(to:name); SendMessage(to:name, notify_when_idle:true) waits for it to finish.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              // Not `repo`: on this surface a property of that name is the act-as rebind
+              // (`callToolAsRepo` reads it off the raw arguments and runs the call as that linked
+              // repo), and a filter spelled the same way was intercepted before the handler saw
+              // it -- refused with "not in a workspace" on every call that named a repo.
+              inRepo: {
+                type: 'string', maxLength: 200,
+                description: 'Only sessions in this repo (workspace repo name or folder name). Omit for every session.',
+              },
+              cards: {
+                type: 'boolean',
+                description: 'Also report the fleet card ledger: how many cards were shown or shadowed on this machine, how many were adjudicated, and the precision that decides whether a card may ever become more than advice.',
+              },
+            },
+          },
+        },
+];
+
 /** Every tool the server always offers, in listing order. */
 export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -48,7 +48,10 @@ import { isTranscriptFallbackEnabled, isTranscriptSearchEnabled } from '../trans
 import { hasIndexableArchive } from '../transcripts/paths.js';
 import { handleSessionList, handleTranscriptRead, handleTranscriptSearch, NO_TRANSCRIPT_MATCHES_PREFIX } from '../transcripts/mcp-handlers.js';
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
-import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
+import { isFleetEnabled } from '../fleet/config.js';
+import { describeFleet, renderFleetCardLedger, renderFleetReport } from '../fleet/report.js';
+import { fleetCardReport } from '../fleet/store.js';
 import { teamUpdateNotice } from '../cloud/team-update.js';
 import { maybeAutoSync } from '../cloud/auto-sync.js';
 import { cloudStatusInRequest } from '../cloud/status.js';
@@ -167,6 +170,7 @@ const MAX_IMPACT_SIGNATURE_CHARS = 200;
 
 const IMPACT_DISABLED_MESSAGE =
   'Change-impact detection is not enabled for this repository. Enable impact.enabled with `knowl config`.';
+const FLEET_DISABLED_MESSAGE = 'Fleet awareness is off in this repository (fleet.enabled=false).';
 
 
 /**
@@ -224,6 +228,13 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
     tools.push(...IMPACT_TOOL_DEFINITIONS);
   }
 
+  // On unless the repo said otherwise -- the reverse of every gate here, for the reasons in
+  // `isFleetEnabled`. Still conditional on a config existing, so an unconfigured server offers
+  // the core set alone.
+  if (config && isFleetEnabled(config)) {
+    tools.push(...FLEET_TOOL_DEFINITIONS);
+  }
+
   if (config?.cloud) {
     tools.push(...CLOUD_TOOL_DEFINITIONS);
   }
@@ -247,7 +258,7 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
 const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
   [
     ...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS,
-    ...CLOUD_TOOL_DEFINITIONS, ...WORKSPACE_TOOL_DEFINITIONS,
+    ...CLOUD_TOOL_DEFINITIONS, ...WORKSPACE_TOOL_DEFINITIONS, ...FLEET_TOOL_DEFINITIONS,
   ]
     .map(tool => [tool.name, tool.inputSchema]),
 );
@@ -1765,6 +1776,26 @@ export function registerTools(
           locator: String(locator ?? ''),
           context: typeof context === 'number' ? context : undefined,
         });
+        return { content: [{ type: 'text', text }] };
+      }
+
+      // Re-checks its own gate for the reason the transcript handlers do: a cached tool list
+      // keeps this callable after `fleet.enabled` goes false.
+      else if (name === 'knowl_fleet') {
+        if (!isFleetEnabled(config)) {
+          return { isError: true, content: [{ type: 'text', text: FLEET_DISABLED_MESSAGE }] };
+        }
+        const { inRepo, cards } = args as any;
+        // The protocol names no caller (see `openImpactFindings`), so "(you)" comes from the
+        // environment instead: Claude Code sets CLAUDE_CODE_SESSION_ID on what it spawns, and
+        // the value matches that session's registry record. A server started without it marks
+        // nobody, which is a listing with one label missing rather than a wrong one.
+        const report = await describeFleet({
+          selfSessionId: process.env.CLAUDE_CODE_SESSION_ID || undefined,
+          selfRepo: config?.workspace?.repo ?? (projectRoot ? path.basename(projectRoot) : undefined),
+        });
+        let text = renderFleetReport(report, { repo: inRepo ? String(inRepo) : undefined });
+        if (cards) text += `\n\n${renderFleetCardLedger(await fleetCardReport())}`;
         return { content: [{ type: 'text', text }] };
       }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -50,8 +50,7 @@ import { handleSessionList, handleTranscriptRead, handleTranscriptSearch, NO_TRA
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
 import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
 import { isFleetEnabled } from '../fleet/config.js';
-import { describeFleet, renderFleetCardLedger, renderFleetReport } from '../fleet/report.js';
-import { fleetCardReport } from '../fleet/store.js';
+import { describeFleet, renderFleetReport } from '../fleet/report.js';
 import { teamUpdateNotice } from '../cloud/team-update.js';
 import { maybeAutoSync } from '../cloud/auto-sync.js';
 import { cloudStatusInRequest } from '../cloud/status.js';
@@ -1785,17 +1784,17 @@ export function registerTools(
         if (!isFleetEnabled(config)) {
           return { isError: true, content: [{ type: 'text', text: FLEET_DISABLED_MESSAGE }] };
         }
-        const { inRepo, cards } = args as any;
+        const { inRepo } = args as any;
         // The protocol names no caller (see `openImpactFindings`), so "(you)" comes from the
         // environment instead: Claude Code sets CLAUDE_CODE_SESSION_ID on what it spawns, and
         // the value matches that session's registry record. A server started without it marks
-        // nobody, which is a listing with one label missing rather than a wrong one.
+        // nobody, which is a listing with one label missing rather than a wrong one -- and that
+        // is the state on every host that publishes no such variable of its own.
         const report = await describeFleet({
           selfSessionId: process.env.CLAUDE_CODE_SESSION_ID || undefined,
           selfRepo: config?.workspace?.repo ?? (projectRoot ? path.basename(projectRoot) : undefined),
         });
-        let text = renderFleetReport(report, { repo: inRepo ? String(inRepo) : undefined });
-        if (cards) text += `\n\n${renderFleetCardLedger(await fleetCardReport())}`;
+        const text = renderFleetReport(report, { repo: inRepo ? String(inRepo) : undefined });
         return { content: [{ type: 'text', text }] };
       }
 

--- a/src/session/fleet-lifecycle.ts
+++ b/src/session/fleet-lifecycle.ts
@@ -19,6 +19,7 @@ import {
   touchFleetSession, FLEET_SESSION_RETENTION_HOURS,
 } from '../fleet/store.js';
 import { classifySharedSurfaceCommand, classifySharedSurfacePath, type SurfaceHit } from '../fleet/surfaces.js';
+import { toolWritesFile } from './hosts/index.js';
 
 /**
  * The fleet's hooks into the lifecycle, each best-effort.
@@ -33,8 +34,15 @@ import { classifySharedSurfaceCommand, classifySharedSurfacePath, type SurfaceHi
 /** A failure this session saw is still "the problem it is on" for this long after it was seen. */
 const PENDING_ERROR_WINDOW_MS = 15 * 60 * 1000;
 
-/** Errors from the engine, its hooks or its store hit every session on the machine, not one repo. */
-const MACHINE_WIDE_ERROR = /\bknowl\b|agent-hook|agent-reminder|\.knowl[\\/]|hooks?[\\/]|\.claude[\\/]/i;
+/**
+ * Errors from the engine, its hooks or its store hit every session on the machine, not one repo.
+ *
+ * The host directories are listed rather than just Claude's: a hook that crashes under
+ * `.codex/` or `.windsurf/` is the same machine-wide failure as one under `.claude/`, and a
+ * pattern that names only one host reports the others as a local problem in one repo.
+ */
+const MACHINE_WIDE_ERROR =
+  /\bknowl\b|agent-hook|agent-reminder|\.knowl[\\/]|hooks?[\\/]|\.(claude|codex|cursor|windsurf|openhands|agents)[\\/]/i;
 
 const fleetKey = (input: { host: string; externalSessionId: string }) =>
   ({ host: String(input.host), sessionId: input.externalSessionId });
@@ -87,19 +95,27 @@ async function fileHash(root: string, relativePath: string): Promise<string | nu
 }
 
 /**
- * Which live host sessions are still standing on these repo-relative paths, from the project
- * store's read set. Rows are keyed by memory session id; the host session id is what the fleet
- * knows, so the two are joined through the active bindings. A `file://` row whose hash still
- * matches the file is a copy that is current now and stale after the write; a `symbol://` row
- * says the session read the file at symbol granularity and is counted as a reader outright.
+ * Which live host sessions read these repo-relative paths, from the project store's read set.
+ *
+ * Rows are keyed by memory session id; the host session id is what the fleet knows, so the two
+ * are joined through the active bindings. `holding` selects which half is wanted: `current`
+ * before a write, for the sessions whose copy the write is about to invalidate, and `stale`
+ * after one, for the sessions whose copy it did. A `symbol://` row satisfies both, because a
+ * session that read at symbol granularity is a reader either way and there is no file hash to
+ * compare it against.
  */
-async function readersOf(root: string, relative: string[], excludeSessionId: string): Promise<Map<string, string[]>> {
+async function readersOf(
+  root: string,
+  relative: string[],
+  excludeSessionId: string,
+  holding: 'current' | 'stale',
+): Promise<Map<string, string[]>> {
   const readers = new Map<string, string[]>();
   if (relative.length === 0) return readers;
   const client = getClient();
   for (const file of relative) {
     const rows = await client.execute({
-      sql: `SELECT r.session_id, r.locator, r.observed_hash, b.external_session_id
+      sql: `SELECT r.locator, r.observed_hash, b.external_session_id
             FROM work_read_sets r
             JOIN host_session_bindings b ON b.memory_session_id = r.session_id AND b.active = 1
             WHERE r.released_at IS NULL AND (r.locator = ? OR r.locator LIKE ?)`,
@@ -110,9 +126,11 @@ async function readersOf(root: string, relative: string[], excludeSessionId: str
     for (const row of rows.rows) {
       const external = String(row.external_session_id);
       if (external === excludeSessionId) continue;
-      const locator = String(row.locator);
-      const holdsCurrent = locator.startsWith('symbol://') || (current !== null && String(row.observed_hash) === current);
-      if (!holdsCurrent) continue;
+      const matches = String(row.locator).startsWith('symbol://')
+        || (holding === 'current'
+          ? current !== null && String(row.observed_hash) === current
+          : current === null || String(row.observed_hash) !== current);
+      if (!matches) continue;
       const list = readers.get(external) ?? [];
       if (!list.includes(file)) list.push(file);
       readers.set(external, list);
@@ -121,8 +139,8 @@ async function readersOf(root: string, relative: string[], excludeSessionId: str
   return readers;
 }
 
-async function liveFleet(input: Pick<NormalizedHostHook, 'externalSessionId'>, repo: string): Promise<FleetReport> {
-  return describeFleet({ selfSessionId: input.externalSessionId, selfRepo: repo });
+async function liveFleet(input: { externalSessionId: string; host: string }, repo: string): Promise<FleetReport> {
+  return describeFleet({ selfSessionId: input.externalSessionId, selfRepo: repo, selfHost: input.host });
 }
 
 const sessionsById = (report: FleetReport): Map<string, SessionView> =>
@@ -170,7 +188,7 @@ export async function fleetTurnStartBestEffort(
     });
     await markFleetSeen({ ...key, seen: others.map(session => ({ otherSessionId: session.sessionId, updatedAt: session.updatedAt! })) });
     const digest = renderFleetDigest(changed);
-    if (digest) await recordFleetCard({ kind: 'digest', ...key, subject: new Date().toISOString().slice(0, 16), mode: 'enforce' });
+    if (digest) await recordFleetCard({ kind: 'digest', ...key, subject: new Date().toISOString().slice(0, 16) });
     return digest || undefined;
   } catch {
     return undefined;
@@ -197,8 +215,13 @@ export async function fleetObserveToolEventBestEffort(input: NormalizedHostHook,
       if (signature && storable(signature.head)) await recordFleetError({ ...key, head: signature.head, sig: signature.sig });
     }
 
+    // The same predicate the write gate and the impact detector use, rather than a second
+    // guess at it. The regex this replaces read the tool NAME, so it recognised Claude Code's
+    // `Edit`/`Write` and Codex's `apply_patch` by luck and nothing else: Cursor and Windsurf
+    // name the event and carry no tool name at all, so no write of theirs was ever recorded and
+    // no claim of theirs could ever open.
     const writes = relativePaths(input.projectRoot, changedPathsOf(input));
-    const wroteFiles = writes.length > 0 && !failed && /edit|write|patch/i.test(input.toolName ?? '');
+    const wroteFiles = writes.length > 0 && !failed && toolWritesFile(input);
     if (!wroteFiles) return;
     await recordFleetWrite({ ...key, paths: writes });
     const row = await getFleetSession(key);
@@ -239,8 +262,8 @@ export async function fleetToolCardBestEffort(input: NormalizedHostHook, config:
         const live = sessionsById(report);
         const match = matches.find(claim => live.has(claim.sessionId));
         if (match) {
-          const card = await recordFleetCard({ kind: 'same-problem', ...key, subject: match.sig, mode });
-          if (card.first && mode === 'enforce') {
+          const first = await recordFleetCard({ kind: 'same-problem', ...key, subject: match.sig });
+          if (first && mode === 'enforce') {
             return renderSameProblemCard({
               session: live.get(match.sessionId)!,
               head: match.head,
@@ -259,8 +282,8 @@ export async function fleetToolCardBestEffort(input: NormalizedHostHook, config:
       const report = await liveFleet(input, repo);
       const affected = report.sessions.filter(session => session.sessionId !== input.externalSessionId && (hit.machineWide || session.repo === repo));
       if (affected.length > 0) {
-        const card = await recordFleetCard({ kind: 'shared-surface', ...key, subject: hit.target, mode });
-        if (card.first && mode === 'enforce') {
+        const first = await recordFleetCard({ kind: 'shared-surface', ...key, subject: hit.target });
+        if (first && mode === 'enforce') {
           return renderSharedSurfaceCard({ hit, affected, readers: [], after: true, incident: engineIncident(hit) });
         }
       }
@@ -299,7 +322,7 @@ export async function fleetPrecheckBestEffort(input: NormalizedHostHook, config:
       hit = classifySharedSurfacePath(path.resolve(input.projectRoot, file), input.projectRoot);
       if (hit) break;
     }
-    const readers = await readersOf(input.projectRoot, relative, input.externalSessionId);
+    const readers = await readersOf(input.projectRoot, relative, input.externalSessionId, 'current');
     if (!hit && readers.size === 0) return undefined;
 
     const report = await liveFleet(input, repo);
@@ -318,8 +341,8 @@ export async function fleetPrecheckBestEffort(input: NormalizedHostHook, config:
       : readerViews;
     if (affected.length === 0 && readerViews.length === 0) return undefined;
 
-    const card = await recordFleetCard({ kind: 'shared-surface', ...key, subject: surface.target, mode });
-    if (!card.first || mode !== 'enforce') return undefined;
+    const first = await recordFleetCard({ kind: 'shared-surface', ...key, subject: surface.target });
+    if (!first || mode !== 'enforce') return undefined;
     return renderSharedSurfaceCard({ hit: surface, affected, readers: readerViews, incident: engineIncident(surface) });
   } catch {
     return undefined;
@@ -350,7 +373,7 @@ export async function fleetTurnStopBestEffort(
 
     // After the write, "holds a current copy" means the reader re-read since; those are fine.
     // A reader whose copy no longer matches is the one to tell.
-    const stale = await staleReadersOf(input.projectRoot, writes, input.externalSessionId);
+    const stale = await readersOf(input.projectRoot, writes, input.externalSessionId, 'stale');
     if (stale.size === 0) return undefined;
     const report = await liveFleet(input, repo);
     const live = sessionsById(report);
@@ -360,8 +383,8 @@ export async function fleetTurnStopBestEffort(
       if (!session) continue;
       const fresh: string[] = [];
       for (const file of paths) {
-        const card = await recordFleetCard({ kind: 'stale-read', ...key, subject: `${sessionId}:${file}`, mode });
-        if (card.first) fresh.push(file);
+        const first = await recordFleetCard({ kind: 'stale-read', ...key, subject: `${sessionId}:${file}` });
+        if (first) fresh.push(file);
       }
       if (fresh.length > 0) views.push({ session, paths: fresh });
     }
@@ -370,34 +393,6 @@ export async function fleetTurnStopBestEffort(
   } catch {
     return undefined;
   }
-}
-
-/** Readers whose recorded copy of a path no longer matches the file on disk. */
-async function staleReadersOf(root: string, relative: string[], excludeSessionId: string): Promise<Map<string, string[]>> {
-  const stale = new Map<string, string[]>();
-  const client = getClient();
-  for (const file of relative) {
-    const rows = await client.execute({
-      sql: `SELECT r.locator, r.observed_hash, b.external_session_id
-            FROM work_read_sets r
-            JOIN host_session_bindings b ON b.memory_session_id = r.session_id AND b.active = 1
-            WHERE r.released_at IS NULL AND (r.locator = ? OR r.locator LIKE ?)`,
-      args: [`file://${file}`, `symbol://${file}#%`],
-    });
-    if (rows.rows.length === 0) continue;
-    const current = await fileHash(root, file);
-    for (const row of rows.rows) {
-      const external = String(row.external_session_id);
-      if (external === excludeSessionId) continue;
-      const locator = String(row.locator);
-      const isStale = locator.startsWith('symbol://') || current === null || String(row.observed_hash) !== current;
-      if (!isStale) continue;
-      const list = stale.get(external) ?? [];
-      if (!list.includes(file)) list.push(file);
-      stale.set(external, list);
-    }
-  }
-  return stale;
 }
 
 export async function fleetSessionStopBestEffort(input: NormalizedHostHook, config: ProjectConfig | null): Promise<void> {

--- a/src/session/fleet-lifecycle.ts
+++ b/src/session/fleet-lifecycle.ts
@@ -1,0 +1,410 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { NormalizedHostHook } from '../core/host-hook-types.js';
+import { validateKnowledgeWrite } from '../core/knowledge-validation.js';
+import type { ProjectConfig } from '../core/types.js';
+import { getClient } from '../store/database.js';
+import { repoRelativePath } from '../store/read-set.js';
+import {
+  renderFleetDigest, renderFleetRoster, renderSameProblemCard, renderSharedSurfaceCard, renderStaleReadNudge,
+  type SessionView, type StaleReadView,
+} from '../fleet/cards.js';
+import { fleetCardsMode, fleetNudgeMode, isFleetDigestEnabled, isFleetEnabled } from '../fleet/config.js';
+import { describeFleet, type FleetReport } from '../fleet/report.js';
+import { errorSignature } from '../fleet/signature.js';
+import {
+  endFleetSession, getFleetSession, markFleetSeen, matchingFleetClaims, openFleetClaim, readFleetSeen, recordFleetCard,
+  recordFleetError, recordFleetTurnStart, recordFleetTurnStop, recordFleetWrite, releaseFleetClaims, sweepFleet,
+  touchFleetSession, FLEET_SESSION_RETENTION_HOURS,
+} from '../fleet/store.js';
+import { classifySharedSurfaceCommand, classifySharedSurfacePath, type SurfaceHit } from '../fleet/surfaces.js';
+
+/**
+ * The fleet's hooks into the lifecycle, each best-effort.
+ *
+ * Every function here runs inside a hook the host is waiting on, beside capture paths that
+ * already have their own work to do. None of them may fail that hook: a fleet that cannot be
+ * read is a session that is simply alone for one event, which is exactly what it was before
+ * this file existed. So every entry point swallows and returns nothing, and the caller treats
+ * "nothing" as "say nothing".
+ */
+
+/** A failure this session saw is still "the problem it is on" for this long after it was seen. */
+const PENDING_ERROR_WINDOW_MS = 15 * 60 * 1000;
+
+/** Errors from the engine, its hooks or its store hit every session on the machine, not one repo. */
+const MACHINE_WIDE_ERROR = /\bknowl\b|agent-hook|agent-reminder|\.knowl[\\/]|hooks?[\\/]|\.claude[\\/]/i;
+
+const fleetKey = (input: { host: string; externalSessionId: string }) =>
+  ({ host: String(input.host), sessionId: input.externalSessionId });
+
+/**
+ * A line of host text that is allowed to reach the fleet store, or nothing.
+ *
+ * The fleet keeps the first 240 characters of what a turn was asked and what it answered, and
+ * one normalised error line -- the only place in Knowl that stores any of the conversation, and
+ * a deliberate, bounded exception: a roster that cannot say what a session is *on* answers the
+ * question nobody asked. The exception buys no exemption from the write gate every knowledge
+ * item passes. A line the secret validator refuses is dropped whole, not trimmed, because a
+ * secret is not made safe by being shorter.
+ */
+function storable(text: string | undefined | null): string | undefined {
+  if (!text) return undefined;
+  try {
+    validateKnowledgeWrite({ title: 'fleet', content: text });
+    return text;
+  } catch {
+    return undefined;
+  }
+}
+
+export function fleetRepoName(config: ProjectConfig | null | undefined, projectRoot: string): string {
+  return config?.workspace?.repo ?? path.basename(projectRoot);
+}
+
+function changedPathsOf(input: NormalizedHostHook): string[] {
+  const raw = input.payload.changedPaths;
+  return Array.isArray(raw) ? raw.filter((value): value is string => typeof value === 'string') : [];
+}
+
+/** Repo-relative, forward-slashed, or dropped: a path outside the repo is not one a peer read. */
+function relativePaths(root: string, paths: string[]): string[] {
+  const out: string[] = [];
+  for (const candidate of paths) {
+    const relative = repoRelativePath(root, path.isAbsolute(candidate) ? candidate : path.resolve(root, candidate));
+    if (relative && !out.includes(relative)) out.push(relative);
+  }
+  return out;
+}
+
+async function fileHash(root: string, relativePath: string): Promise<string | null> {
+  try {
+    return crypto.createHash('sha256').update(await fs.readFile(path.resolve(root, relativePath))).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which live host sessions are still standing on these repo-relative paths, from the project
+ * store's read set. Rows are keyed by memory session id; the host session id is what the fleet
+ * knows, so the two are joined through the active bindings. A `file://` row whose hash still
+ * matches the file is a copy that is current now and stale after the write; a `symbol://` row
+ * says the session read the file at symbol granularity and is counted as a reader outright.
+ */
+async function readersOf(root: string, relative: string[], excludeSessionId: string): Promise<Map<string, string[]>> {
+  const readers = new Map<string, string[]>();
+  if (relative.length === 0) return readers;
+  const client = getClient();
+  for (const file of relative) {
+    const rows = await client.execute({
+      sql: `SELECT r.session_id, r.locator, r.observed_hash, b.external_session_id
+            FROM work_read_sets r
+            JOIN host_session_bindings b ON b.memory_session_id = r.session_id AND b.active = 1
+            WHERE r.released_at IS NULL AND (r.locator = ? OR r.locator LIKE ?)`,
+      args: [`file://${file}`, `symbol://${file}#%`],
+    });
+    if (rows.rows.length === 0) continue;
+    const current = await fileHash(root, file);
+    for (const row of rows.rows) {
+      const external = String(row.external_session_id);
+      if (external === excludeSessionId) continue;
+      const locator = String(row.locator);
+      const holdsCurrent = locator.startsWith('symbol://') || (current !== null && String(row.observed_hash) === current);
+      if (!holdsCurrent) continue;
+      const list = readers.get(external) ?? [];
+      if (!list.includes(file)) list.push(file);
+      readers.set(external, list);
+    }
+  }
+  return readers;
+}
+
+async function liveFleet(input: Pick<NormalizedHostHook, 'externalSessionId'>, repo: string): Promise<FleetReport> {
+  return describeFleet({ selfSessionId: input.externalSessionId, selfRepo: repo });
+}
+
+const sessionsById = (report: FleetReport): Map<string, SessionView> =>
+  new Map(report.sessions.map(session => [session.sessionId, session]));
+
+/**
+ * SessionStart: register this session, sweep what nobody will read again, and hand back the
+ * roster section for the card. Empty when the session is alone or the feature is off.
+ */
+export async function fleetSessionStartBestEffort(input: NormalizedHostHook, config: ProjectConfig | null): Promise<string> {
+  try {
+    if (!isFleetEnabled(config)) return '';
+    const repo = fleetRepoName(config, input.projectRoot);
+    await touchFleetSession({ ...fleetKey(input), projectRoot: input.projectRoot, repo });
+    await sweepFleet(new Date(Date.now() - FLEET_SESSION_RETENTION_HOURS * 3_600_000).toISOString()).catch(() => 0);
+    const report = await liveFleet(input, repo);
+    return renderFleetRoster({ sessionId: input.externalSessionId, repo }, report.sessions);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * The prompt hook: record what this turn was asked, and in maximal posture say which other
+ * sessions moved since this session last looked. Returns the digest text, or nothing.
+ */
+export async function fleetTurnStartBestEffort(
+  input: { host: string; externalSessionId: string; projectRoot: string; prompt?: string },
+  config: ProjectConfig | null,
+): Promise<string | undefined> {
+  try {
+    if (!isFleetEnabled(config)) return undefined;
+    const repo = fleetRepoName(config, input.projectRoot);
+    const key = fleetKey(input);
+    await touchFleetSession({ ...key, projectRoot: input.projectRoot, repo });
+    await recordFleetTurnStart({ ...key, ask: storable(input.prompt) ?? null });
+    if (!isFleetDigestEnabled(config)) return undefined;
+
+    const report = await liveFleet(input, repo);
+    const seen = await readFleetSeen(key);
+    const others = report.sessions.filter(session => session.sessionId !== input.externalSessionId && session.known && session.updatedAt);
+    const changed = others.filter(session => {
+      const last = seen.get(session.sessionId);
+      return !last || session.updatedAt! > last;
+    });
+    await markFleetSeen({ ...key, seen: others.map(session => ({ otherSessionId: session.sessionId, updatedAt: session.updatedAt! })) });
+    const digest = renderFleetDigest(changed);
+    if (digest) await recordFleetCard({ kind: 'digest', ...key, subject: new Date().toISOString().slice(0, 16), mode: 'enforce' });
+    return digest || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Every tool event, before anything is said: record writes and failures, and open or extend
+ * this session's claim on the problem it is fixing. Split from the card below because this
+ * half must run on every event -- failed ones included, and ones whose slot the change card
+ * has already taken -- while the card may only be computed when it will be shown.
+ */
+export async function fleetObserveToolEventBestEffort(input: NormalizedHostHook, config: ProjectConfig | null): Promise<void> {
+  try {
+    if (!isFleetEnabled(config)) return;
+    const repo = fleetRepoName(config, input.projectRoot);
+    const key = fleetKey(input);
+    await touchFleetSession({ ...key, projectRoot: input.projectRoot, repo });
+
+    const failed = input.status === 'failed';
+    const errorText = input.errorText ?? (failed && typeof input.payload.message === 'string' ? input.payload.message : undefined);
+    if (errorText) {
+      const signature = errorSignature(errorText);
+      if (signature && storable(signature.head)) await recordFleetError({ ...key, head: signature.head, sig: signature.sig });
+    }
+
+    const writes = relativePaths(input.projectRoot, changedPathsOf(input));
+    const wroteFiles = writes.length > 0 && !failed && /edit|write|patch/i.test(input.toolName ?? '');
+    if (!wroteFiles) return;
+    await recordFleetWrite({ ...key, paths: writes });
+    const row = await getFleetSession(key);
+    const pendingSince = row?.lastErrorAt ? Date.parse(row.lastErrorAt) : NaN;
+    if (row?.lastErrorSig && row.lastError && Number.isFinite(pendingSince) && Date.now() - pendingSince < PENDING_ERROR_WINDOW_MS) {
+      await openFleetClaim({
+        ...key, projectRoot: input.projectRoot, repo, sig: row.lastErrorSig, head: row.lastError,
+        machineWide: MACHINE_WIDE_ERROR.test(row.lastError) || writes.some(file => MACHINE_WIDE_ERROR.test(file)),
+        files: writes,
+      });
+    }
+  } catch {
+    // Nothing: an unrecorded write is one the fleet does not know about, which is the prior state.
+  }
+}
+
+/**
+ * The card for a tool event, at most one: another session already on the same problem first,
+ * a shared surface that just moved second. Only called when the host's mid-turn slot is open
+ * and free -- a card recorded as shown that was never shown would spend its one appearance on
+ * nothing, so the ledger is written here and nowhere earlier.
+ */
+export async function fleetToolCardBestEffort(input: NormalizedHostHook, config: ProjectConfig | null): Promise<string | undefined> {
+  try {
+    const mode = fleetCardsMode(config);
+    if (mode === 'off') return undefined;
+    const repo = fleetRepoName(config, input.projectRoot);
+    const key = fleetKey(input);
+    const failed = input.status === 'failed';
+
+    // Same problem, someone else already on it.
+    const row = await getFleetSession(key);
+    const pendingSince = row?.lastErrorAt ? Date.parse(row.lastErrorAt) : NaN;
+    if (row?.lastErrorSig && row.lastError && Number.isFinite(pendingSince) && Date.now() - pendingSince < PENDING_ERROR_WINDOW_MS) {
+      const matches = await matchingFleetClaims({ sig: row.lastErrorSig, head: row.lastError, projectRoot: input.projectRoot, excludeSessionId: input.externalSessionId });
+      if (matches.length > 0) {
+        const report = await liveFleet(input, repo);
+        const live = sessionsById(report);
+        const match = matches.find(claim => live.has(claim.sessionId));
+        if (match) {
+          const card = await recordFleetCard({ kind: 'same-problem', ...key, subject: match.sig, mode });
+          if (card.first && mode === 'enforce') {
+            return renderSameProblemCard({
+              session: live.get(match.sessionId)!,
+              head: match.head,
+              minutesAgo: Math.max(0, Math.round((Date.now() - Date.parse(match.startedAt)) / 60_000)),
+              files: match.files,
+            });
+          }
+        }
+      }
+    }
+
+    // A shared surface that already moved: the engine install, run from a shell.
+    const command = typeof input.payload.command === 'string' ? input.payload.command : '';
+    const hit = command && !failed ? classifySharedSurfaceCommand(command) : undefined;
+    if (hit) {
+      const report = await liveFleet(input, repo);
+      const affected = report.sessions.filter(session => session.sessionId !== input.externalSessionId && (hit.machineWide || session.repo === repo));
+      if (affected.length > 0) {
+        const card = await recordFleetCard({ kind: 'shared-surface', ...key, subject: hit.target, mode });
+        if (card.first && mode === 'enforce') {
+          return renderSharedSurfaceCard({ hit, affected, readers: [], after: true, incident: engineIncident(hit) });
+        }
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The one stored incident worth repeating verbatim. The engine's own upgrade path is the
+ * change with the widest blast radius on the machine, and it looks like routine maintenance.
+ */
+function engineIncident(hit: SurfaceHit): string | undefined {
+  if (hit.kind !== 'knowl-engine') return undefined;
+  return 'a global install while serve processes were running half-installed, hit EBUSY on the SQLite binary, and turned every open tab\'s knowl red; the order that works is: stop every serve, install, then knowl-sync.';
+}
+
+/**
+ * PreToolUse on a write: the pre-flight card. Advisory, and returned as text for the caller
+ * to wrap in the host's pre-tool advice envelope -- never a refusal.
+ */
+export async function fleetPrecheckBestEffort(input: NormalizedHostHook, config: ProjectConfig | null): Promise<string | undefined> {
+  try {
+    if (!isFleetEnabled(config)) return undefined;
+    const mode = fleetCardsMode(config);
+    if (mode === 'off') return undefined;
+    const relative = relativePaths(input.projectRoot, changedPathsOf(input));
+    if (relative.length === 0) return undefined;
+    const repo = fleetRepoName(config, input.projectRoot);
+    const key = fleetKey(input);
+
+    let hit: SurfaceHit | undefined;
+    for (const file of relative) {
+      hit = classifySharedSurfacePath(path.resolve(input.projectRoot, file), input.projectRoot);
+      if (hit) break;
+    }
+    const readers = await readersOf(input.projectRoot, relative, input.externalSessionId);
+    if (!hit && readers.size === 0) return undefined;
+
+    const report = await liveFleet(input, repo);
+    const live = sessionsById(report);
+    const readerViews = [...readers.keys()].map(id => live.get(id)).filter((view): view is SessionView => Boolean(view));
+    if (!hit && readerViews.length === 0) return undefined;
+
+    const surface: SurfaceHit = hit ?? {
+      kind: 'live-read',
+      target: relative[0],
+      reason: 'another live session read this file and still holds a current copy; your edit will make it stale',
+      machineWide: false,
+    };
+    const affected = hit
+      ? report.sessions.filter(session => session.sessionId !== input.externalSessionId && (hit!.machineWide || session.repo === repo))
+      : readerViews;
+    if (affected.length === 0 && readerViews.length === 0) return undefined;
+
+    const card = await recordFleetCard({ kind: 'shared-surface', ...key, subject: surface.target, mode });
+    if (!card.first || mode !== 'enforce') return undefined;
+    return renderSharedSurfaceCard({ hit: surface, affected, readers: readerViews, incident: engineIncident(surface) });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Stop: close the turn in the fleet store, drop claims the turn did not touch, and -- when
+ * this turn's writes invalidated what another live session read -- hand back the nudge text
+ * for the caller's stop envelope. Shadow records the nudge and returns nothing.
+ */
+export async function fleetTurnStopBestEffort(
+  input: NormalizedHostHook,
+  config: ProjectConfig | null,
+  /** False when another verdict already holds this stop: the turn is still closed, but no nudge is computed or ledgered. */
+  deliverable = true,
+): Promise<string | undefined> {
+  try {
+    if (!isFleetEnabled(config)) return undefined;
+    const key = fleetKey(input);
+    const repo = fleetRepoName(config, input.projectRoot);
+    await touchFleetSession({ ...key, projectRoot: input.projectRoot, repo });
+    const { writes } = await recordFleetTurnStop({ ...key, summary: storable(input.assistantMessage) ?? null });
+    await releaseFleetClaims({ ...key, untouchedBy: writes });
+
+    const mode = fleetNudgeMode(config);
+    if (mode === 'off' || !deliverable || writes.length === 0 || input.status === 'failed') return undefined;
+
+    // After the write, "holds a current copy" means the reader re-read since; those are fine.
+    // A reader whose copy no longer matches is the one to tell.
+    const stale = await staleReadersOf(input.projectRoot, writes, input.externalSessionId);
+    if (stale.size === 0) return undefined;
+    const report = await liveFleet(input, repo);
+    const live = sessionsById(report);
+    const views: StaleReadView[] = [];
+    for (const [sessionId, paths] of stale) {
+      const session = live.get(sessionId);
+      if (!session) continue;
+      const fresh: string[] = [];
+      for (const file of paths) {
+        const card = await recordFleetCard({ kind: 'stale-read', ...key, subject: `${sessionId}:${file}`, mode });
+        if (card.first) fresh.push(file);
+      }
+      if (fresh.length > 0) views.push({ session, paths: fresh });
+    }
+    if (views.length === 0 || mode !== 'enforce') return undefined;
+    return renderStaleReadNudge(views);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Readers whose recorded copy of a path no longer matches the file on disk. */
+async function staleReadersOf(root: string, relative: string[], excludeSessionId: string): Promise<Map<string, string[]>> {
+  const stale = new Map<string, string[]>();
+  const client = getClient();
+  for (const file of relative) {
+    const rows = await client.execute({
+      sql: `SELECT r.locator, r.observed_hash, b.external_session_id
+            FROM work_read_sets r
+            JOIN host_session_bindings b ON b.memory_session_id = r.session_id AND b.active = 1
+            WHERE r.released_at IS NULL AND (r.locator = ? OR r.locator LIKE ?)`,
+      args: [`file://${file}`, `symbol://${file}#%`],
+    });
+    if (rows.rows.length === 0) continue;
+    const current = await fileHash(root, file);
+    for (const row of rows.rows) {
+      const external = String(row.external_session_id);
+      if (external === excludeSessionId) continue;
+      const locator = String(row.locator);
+      const isStale = locator.startsWith('symbol://') || current === null || String(row.observed_hash) !== current;
+      if (!isStale) continue;
+      const list = stale.get(external) ?? [];
+      if (!list.includes(file)) list.push(file);
+      stale.set(external, list);
+    }
+  }
+  return stale;
+}
+
+export async function fleetSessionStopBestEffort(input: NormalizedHostHook, config: ProjectConfig | null): Promise<void> {
+  try {
+    if (!isFleetEnabled(config)) return;
+    await endFleetSession(fleetKey(input));
+  } catch {
+    // Nothing: a session that could not be marked ended is swept by retention.
+  }
+}

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -3,8 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { NormalizedHostHook } from '../core/host-hook-types.js';
 import { renderChangeCard, type ImpactCardEntry } from './change-card.js';
-import { hostProfile } from './hosts/index.js';
-import { hookSpecificOutput } from './hosts/claude.js';
+import { hostProfile, toolReadsFile, toolWritesFile } from './hosts/index.js';
 import {
   fleetObserveToolEventBestEffort, fleetPrecheckBestEffort, fleetSessionStartBestEffort, fleetSessionStopBestEffort,
   fleetToolCardBestEffort, fleetTurnStopBestEffort,
@@ -102,59 +101,6 @@ import { describeObservedUsePromotions, promoteByObservedUseBestEffort } from '.
 // off), so the number lives beside its predicate in core/config.ts rather than twice.
 
 /**
- * The tools whose paths become a read-set entry -- and the two that look like they belong here
- * and deliberately do not.
- *
- * A read-set row asserts "this session saw this text and holds a belief about it", and the
- * certain tier spends that assertion by interrupting the agent and, once the gate is enforcing,
- * refusing its write. So the
- * set is the tools that return *contents*: `Read`, and `NotebookRead`, whose target the host names
- * `notebook_path` rather than `file_path` -- which is why that key had to be added to `changedPaths`
- * and to the stdin allowlist in the same change, or this entry would have named a tool whose paths
- * never arrive.
- *
- * `Grep` and `Glob` are read-ish and are excluded. Their `path` argument is usually a directory,
- * which `normalizeLocator` already refuses -- but the case that decides this is the one where it
- * is a file. `Grep` returns matching lines and `Glob` returns names; recording either as a read
- * of that file would write one row per symbol in it, claiming the agent saw signatures it never
- * received. The next edit to any of those symbols then fires against a belief the session does
- * not hold: a fabricated false positive, pushed into tool-side context, which AgentNoiseBench
- * measures at ~20.8% mean accuracy cost to the agent receiving it. The trade is the one
- * `normalizeLocator`'s own directory heuristic already makes in this subsystem -- recall on a
- * tier allowed to be incomplete, never precision on the one tier allowed to interrupt.
- *
- * Matched verbatim and case-sensitively against the host's own name (`host-hook.ts:42` keeps it
- * raw for exactly this judgement). A host whose tool vocabulary has not been read is silent here
- * rather than guessed at, for the same asymmetry.
- */
-const IMPACT_READ_TOOLS = new Set(['Read', 'NotebookRead']);
-
-/** The write tools whose paths trigger a re-index and certain-tier detection. */
-const IMPACT_WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
-
-/**
- * Whether this event read or wrote a file, in the vocabulary of the host that sent it.
- *
- * The two sets above are Claude Code's names, and they were consulted for every host. On any
- * other one they matched nothing: reads were never recorded, so the detector had no beliefs to
- * invalidate, and writes were never recognised, so `runWriteGate` returned "no opinion" before
- * it ever asked the profile whether it could refuse. A host could therefore declare a working
- * deny channel and be structurally unable to reach it.
- *
- * A declared predicate **replaces** the fallback rather than layering over it, so a host that
- * declares one is saying "these and nothing else". The fallback remains Claude Code's names,
- * which is what `claude`, `generic` and `claude-desktop` still use; every other host now
- * declares its own, including `codex`, whose tool is `apply_patch`.
- */
-function toolReadsFile(input: NormalizedHostHook): boolean {
-  const { readsFiles } = hostProfile(input.host);
-  const toolName = input.toolName ?? '';
-  return readsFiles
-    ? readsFiles(input.hostEvent ?? '', toolName)
-    : IMPACT_READ_TOOLS.has(toolName);
-}
-
-/**
  * Whether this event is a shell command whose text we can read.
  *
  * Tested on the NORMALIZED shape rather than by re-asking the profile `isShellEvent`. Only the
@@ -167,15 +113,6 @@ function toolIsShell(input: NormalizedHostHook): boolean {
   return input.type === 'command' && typeof input.payload.command === 'string';
 }
 
-function toolWritesFile(input: NormalizedHostHook): boolean {
-  const { writesFiles, writeTools } = hostProfile(input.host);
-  const toolName = input.toolName ?? '';
-  if (writesFiles) return writesFiles(input.hostEvent ?? '', toolName);
-  // Preferred over the fallback set when a host declares it, so the gate and the pre-tool
-  // matcher built from the same list can never disagree about what a write is.
-  if (writeTools) return writeTools.includes(toolName);
-  return IMPACT_WRITE_TOOLS.has(toolName);
-}
 
 
 /**
@@ -752,15 +689,17 @@ async function observeToolTouch(input: NormalizedHostHook, projectId: string): P
 /**
  * The fleet's pre-flight, on the same pre-tool event the write gate answers.
  *
- * Advice, never a verdict: it rides the pre-tool `additionalContext` envelope, which the
- * Anthropic-shaped hosts read as context for the call about to run. Only those hosts get it
- * -- the envelope is theirs, and a host whose pre-tool event carries no context channel would
- * take the JSON as noise in front of every write.
+ * Advice, never a verdict, and the host decides whether it can carry any: `preToolContext` is
+ * absent for every host whose pre-tool envelope has not been read, so asking the profile is
+ * what keeps this from printing JSON in front of somebody's write. It used to test the host
+ * event name against Claude Code's spelling, which silently excluded every host that names the
+ * same event something else.
  */
 async function fleetPreflightOutput(input: NormalizedHostHook): Promise<Record<string, unknown> | undefined> {
-  if (input.hostEvent !== 'PreToolUse') return undefined;
+  const { preToolContext } = hostProfile(input.host);
+  if (!preToolContext) return undefined;
   const card = await fleetPrecheckBestEffort(input, await loadConfig(input.projectRoot).catch(() => null));
-  return card ? hookSpecificOutput('PreToolUse', card) : undefined;
+  return card ? preToolContext(card) : undefined;
 }
 
 /** The fleet's stop verdict, wrapped in the host's stop envelope when the host has one. */

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -4,6 +4,11 @@ import path from 'node:path';
 import { NormalizedHostHook } from '../core/host-hook-types.js';
 import { renderChangeCard, type ImpactCardEntry } from './change-card.js';
 import { hostProfile } from './hosts/index.js';
+import { hookSpecificOutput } from './hosts/claude.js';
+import {
+  fleetObserveToolEventBestEffort, fleetPrecheckBestEffort, fleetSessionStartBestEffort, fleetSessionStopBestEffort,
+  fleetToolCardBestEffort, fleetTurnStopBestEffort,
+} from './fleet-lifecycle.js';
 import { indexFile, listCodeSymbols } from '../code/symbol-index.js';
 import {
   areSkillNudgesEnabled, driftReminderEvery, isDriftBackoffEnabled, loadConfig, shouldSendDriftReminder,
@@ -744,6 +749,28 @@ async function observeToolTouch(input: NormalizedHostHook, projectId: string): P
  * write: the worst outcome this subsystem can produce is not a missed detection, it is a person
  * whose agent cannot edit a file because a memory server had an opinion about it.
  */
+/**
+ * The fleet's pre-flight, on the same pre-tool event the write gate answers.
+ *
+ * Advice, never a verdict: it rides the pre-tool `additionalContext` envelope, which the
+ * Anthropic-shaped hosts read as context for the call about to run. Only those hosts get it
+ * -- the envelope is theirs, and a host whose pre-tool event carries no context channel would
+ * take the JSON as noise in front of every write.
+ */
+async function fleetPreflightOutput(input: NormalizedHostHook): Promise<Record<string, unknown> | undefined> {
+  if (input.hostEvent !== 'PreToolUse') return undefined;
+  const card = await fleetPrecheckBestEffort(input, await loadConfig(input.projectRoot).catch(() => null));
+  return card ? hookSpecificOutput('PreToolUse', card) : undefined;
+}
+
+/** The fleet's stop verdict, wrapped in the host's stop envelope when the host has one. */
+async function evaluateFleetStop(input: NormalizedHostHook, deliverable: boolean): Promise<Record<string, unknown> | undefined> {
+  const profile = hostProfile(input.host);
+  const config = await loadConfig(input.projectRoot).catch(() => null);
+  const reason = await fleetTurnStopBestEffort(input, config, deliverable && typeof profile.stopContext === 'function');
+  return reason && profile.stopContext ? profile.stopContext(reason) : undefined;
+}
+
 async function runWriteGate(input: NormalizedHostHook): Promise<HostLifecycleResult> {
   try {
     if (!toolWritesFile(input)) return { accepted: true };
@@ -758,10 +785,17 @@ async function runWriteGate(input: NormalizedHostHook): Promise<HostLifecycleRes
 
     const session = await findHostSession(bindingKey(input, 'turn'))
       ?? await findHostSession(bindingKey(input, 'session'));
-    if (!session) return { accepted: true };
+    if (!session) {
+      const preflight = await fleetPreflightOutput(input);
+      return preflight ? { accepted: true, hostOutput: preflight } : { accepted: true };
+    }
 
     const decision = await shouldRefuseWrite(input.projectRoot, session.id, paths);
-    if (!decision.deny || !decision.reason) return { accepted: true, sessionId: session.id };
+    if (!decision.deny || !decision.reason) {
+      // Nothing to refuse, so the slot is free for advice: who else is standing on this file.
+      const preflight = await fleetPreflightOutput(input);
+      return preflight ? { accepted: true, sessionId: session.id, hostOutput: preflight } : { accepted: true, sessionId: session.id };
+    }
     // A host that declines to produce an envelope costs this one refusal: the gate has already
     // spent its one-shot, so the write proceeds and the finding stays open for the card to carry.
     // Silence is the right degradation -- the alternative is holding the block armed for a host
@@ -1016,13 +1050,18 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       describeAutoDrift(drift),
       describeObservedUsePromotions(standing),
     ].filter(Boolean).join('\n\n'), DEFAULT_CONTEXT_MAX_CHARS);
-    const recentBudget = warning
-      ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - warning.length - 2)
+    // The roster of other live sessions rides below the warnings and above the knowledge, and
+    // is charged against the cap the same way: it is empty for a session that is alone, and
+    // for a fleet of twenty it is the few lines that tell the agent the others exist at all.
+    const roster = await fleetSessionStartBestEffort(input, await loadConfig(input.projectRoot).catch(() => null));
+    const preface = truncateText([warning, roster].filter(Boolean).join('\n\n'), DEFAULT_CONTEXT_MAX_CHARS);
+    const recentBudget = preface
+      ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - preface.length - 2)
       : DEFAULT_CONTEXT_MAX_CHARS;
     const started = await bootstrapWithHandoff(projectId, input, 'session', true, recentBudget);
     // No second truncation here: `started.context` was already composed to `recentBudget`.
-    const context = warning
-      ? (started.context ? `${warning}\n\n${started.context}` : warning)
+    const context = preface
+      ? (started.context ? `${preface}\n\n${started.context}` : preface)
       : started.context;
     return {
       accepted: true,
@@ -1186,11 +1225,15 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         : null;
       const impact = input.status === 'failed' ? [] : await runToolEventImpact(input, started.session.id);
       await observeToolTouch(input, projectId);
+      // The fleet sees every event, failed ones included: a failure is the signal that
+      // matters most to it. What it SAYS is decided in the slot below, like everything else.
+      await fleetObserveToolEventBestEffort(input, captureConfig);
       // Adaptive continuation reminder: only nudge Claude after a run of tool calls
       // that ignored Knowl. Using a Knowl tool resets the drift counter, so an agent
       // that is querying/storing memory never sees a reminder.
       let hostOutput: Record<string, unknown> | undefined;
       let changes: ChangeSummary | undefined;
+      let fleetCard: string | undefined;
       if (input.event === 'session-event' && input.status !== 'failed') {
         const key = bindingKey(input, 'turn');
         const profile = hostProfile(input.host);
@@ -1240,6 +1283,14 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
           // counter on the same reasoning as the skill nudges below.
           await resetHostSuccessfulToolCount(key);
           hostOutput = profile.midTurnContext(lessonCard);
+        } else if (profile.midTurnContext('') !== undefined && (fleetCard = await fleetToolCardBestEffort(input, captureConfig))) {
+          // Below the change card and the lesson, above the capture nudges: another session
+          // already fixing this error, or a shared surface this command just moved. Computed
+          // lazily here rather than beside the other cards, because its ledger records a card
+          // as shown when it is rendered, and a card displaced by the change card would
+          // otherwise spend its one appearance on nothing. It is not a "go use memory"
+          // signal, so it leaves the drift counter alone.
+          hostOutput = profile.midTurnContext(fleetCard);
         } else if (profile.midTurnContext('') !== undefined) {
           // A change card always wins the single mid-turn slot; below it, a specific
           // capture suggestion beats the generic continuation reminder.
@@ -1360,7 +1411,8 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       // is only spent on delivery, so it keeps its chance at a later stop.
       const lessonStop = await evaluatePendingLessonStop(input);
       const silence = lessonStop ? undefined : await evaluateSilenceNudge(input);
-      const stopOutput = lessonStop ?? silence;
+      const fleetStop = await evaluateFleetStop(input, !lessonStop && !silence);
+      const stopOutput = lessonStop ?? silence ?? fleetStop;
       await closeHostSessionBinding(key);
       return { accepted: true, sessionId: session.id, ...(stopOutput ? { hostOutput: stopOutput } : {}) };
     }
@@ -1388,12 +1440,19 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // generic "stored nothing" verdict, and at most one of them may withhold this stop.
     const lessonStop = await evaluatePendingLessonStop(input);
     const silence = lessonStop ? undefined : await evaluateSilenceNudge(input);
-    const stopOutput = lessonStop ?? silence;
+    // Third and last of the stop verdicts, on the same rule: at most one may withhold a stop,
+    // and the fleet's is the most general of the three. The turn is closed in the fleet store
+    // either way; only the nudge waits its turn.
+    const fleetStop = await evaluateFleetStop(input, !lessonStop && !silence);
+    const stopOutput = lessonStop ?? silence ?? fleetStop;
     await closeHostSessionBinding(key);
     return { accepted: true, sessionId: session.id, promotion, ...(stopOutput ? { hostOutput: stopOutput } : {}) };
   }
 
   const key = bindingKey(input, 'session');
+  // The fleet learns the session is over before the bindings are consulted: a session whose
+  // binding was already lost is still a session the roster must stop listing.
+  await fleetSessionStopBestEffort(input, await loadConfig(input.projectRoot).catch(() => null));
   const session = await findHostSession(key);
   if (!session) {
     await closeHostSessionBindings(bindingKey(input, 'turn'));

--- a/src/session/hosts/claude.ts
+++ b/src/session/hosts/claude.ts
@@ -124,5 +124,9 @@ export const claudeProfile: HostProfile = {
     return hookSpecificOutput('PostToolUse', text);
   },
   denyToolCall: anthropicDenyToolCall,
+  // The advisory half of the same event: `additionalContext` on `PreToolUse`, which this host
+  // reads as context for the call that is about to run. Declared here and not on the hosts
+  // whose pre-tool envelope has not been read, so nobody is handed JSON they will print.
+  preToolContext: text => hookSpecificOutput('PreToolUse', text),
   stopContext: anthropicStopContext,
 };

--- a/src/session/hosts/codex.ts
+++ b/src/session/hosts/codex.ts
@@ -78,5 +78,9 @@ export const codexProfile: HostProfile = {
     return hookSpecificOutput('PostToolUse', text);
   },
   denyToolCall: anthropicDenyToolCall,
+  // The advisory half of the same event: `additionalContext` on `PreToolUse`, which this host
+  // reads as context for the call that is about to run. Declared here and not on the hosts
+  // whose pre-tool envelope has not been read, so nobody is handed JSON they will print.
+  preToolContext: text => hookSpecificOutput('PreToolUse', text),
   stopContext: anthropicStopContext,
 };

--- a/src/session/hosts/index.ts
+++ b/src/session/hosts/index.ts
@@ -1,4 +1,4 @@
-import type { HookHost } from '../../core/host-hook-types.js';
+import type { HookHost, NormalizedHostHook } from '../../core/host-hook-types.js';
 import type { HostProfile } from './profile.js';
 import {
   KNOWL_CLAUDE_MODE_LINE, KNOWL_HOST_NEUTRAL_MODE_LINE, KNOWL_MANUAL_MODE_LINE,
@@ -87,3 +87,70 @@ const HOST_DISPLAY_NAMES: Record<string, string> = {
   generic: 'Your host’s',
   cline: 'Cline',
 };
+
+/**
+ * The tools whose paths become a read-set entry -- and the two that look like they belong here
+ * and deliberately do not.
+ *
+ * A read-set row asserts "this session saw this text and holds a belief about it", and the
+ * certain tier spends that assertion by interrupting the agent and, once the gate is enforcing,
+ * refusing its write. So the
+ * set is the tools that return *contents*: `Read`, and `NotebookRead`, whose target the host names
+ * `notebook_path` rather than `file_path` -- which is why that key had to be added to `changedPaths`
+ * and to the stdin allowlist in the same change, or this entry would have named a tool whose paths
+ * never arrive.
+ *
+ * `Grep` and `Glob` are read-ish and are excluded. Their `path` argument is usually a directory,
+ * which `normalizeLocator` already refuses -- but the case that decides this is the one where it
+ * is a file. `Grep` returns matching lines and `Glob` returns names; recording either as a read
+ * of that file would write one row per symbol in it, claiming the agent saw signatures it never
+ * received. The next edit to any of those symbols then fires against a belief the session does
+ * not hold: a fabricated false positive, pushed into tool-side context, which AgentNoiseBench
+ * measures at ~20.8% mean accuracy cost to the agent receiving it. The trade is the one
+ * `normalizeLocator`'s own directory heuristic already makes in this subsystem -- recall on a
+ * tier allowed to be incomplete, never precision on the one tier allowed to interrupt.
+ *
+ * Matched verbatim and case-sensitively against the host's own name (`host-hook.ts:42` keeps it
+ * raw for exactly this judgement). A host whose tool vocabulary has not been read is silent here
+ * rather than guessed at, for the same asymmetry.
+ */
+const DEFAULT_READ_TOOLS = new Set(['Read', 'NotebookRead']);
+
+/** The write tools whose paths trigger a re-index and certain-tier detection. */
+const DEFAULT_WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+
+/**
+ * Whether this event read or wrote a file, in the vocabulary of the host that sent it.
+ *
+ * The two sets above are Claude Code's names, and they were consulted for every host. On any
+ * other one they matched nothing: reads were never recorded, so the detector had no beliefs to
+ * invalidate, and writes were never recognised, so `runWriteGate` returned "no opinion" before
+ * it ever asked the profile whether it could refuse. A host could therefore declare a working
+ * deny channel and be structurally unable to reach it.
+ *
+ * A declared predicate **replaces** the fallback rather than layering over it, so a host that
+ * declares one is saying "these and nothing else". The fallback remains Claude Code's names,
+ * which is what `claude`, `generic` and `claude-desktop` still use; every other host now
+ * declares its own, including `codex`, whose tool is `apply_patch`.
+ *
+ * They live here rather than beside their first caller because there are now two -- the impact
+ * subsystem and the fleet -- and a second copy of this rule is a second answer to "did this
+ * event write a file", which is the question the write gate and the fleet's claim both turn on.
+ */
+export function toolReadsFile(input: Pick<NormalizedHostHook, 'host' | 'hostEvent' | 'toolName'>): boolean {
+  const { readsFiles } = hostProfile(input.host);
+  const toolName = input.toolName ?? '';
+  return readsFiles
+    ? readsFiles(input.hostEvent ?? '', toolName)
+    : DEFAULT_READ_TOOLS.has(toolName);
+}
+
+export function toolWritesFile(input: Pick<NormalizedHostHook, 'host' | 'hostEvent' | 'toolName'>): boolean {
+  const { writesFiles, writeTools } = hostProfile(input.host);
+  const toolName = input.toolName ?? '';
+  if (writesFiles) return writesFiles(input.hostEvent ?? '', toolName);
+  // Preferred over the fallback set when a host declares it, so the gate and the pre-tool
+  // matcher built from the same list can never disagree about what a write is.
+  if (writeTools) return writeTools.includes(toolName);
+  return DEFAULT_WRITE_TOOLS.has(toolName);
+}

--- a/src/session/hosts/profile.ts
+++ b/src/session/hosts/profile.ts
@@ -192,6 +192,20 @@ export interface HostProfile {
    */
   denyToolCall?: (reason: string) => HostOutput | undefined;
   /**
+   * The host's envelope for advice attached to the tool call about to run, if it has one.
+   *
+   * Distinct from `denyToolCall` on the same event, and the distinction is the whole contract:
+   * this one lets the call proceed. A host reaches it only where the gate has already decided
+   * it has nothing to refuse, so the two can never both answer.
+   *
+   * Absent by default, and that is the honest state for most hosts: a pre-tool event that
+   * carries no context channel would take the JSON as noise printed in front of every write,
+   * and an envelope invented for a host whose reference has not been read is a guess repeated
+   * on every tool call. Claude Code and the hosts that reuse its schema have `additionalContext`
+   * documented on `PreToolUse`; the rest say nothing until theirs is read.
+   */
+  preToolContext?: (text: string) => HostOutput | undefined;
+  /**
    * The host's envelope for speaking to the agent as it stops, if it has one.
    *
    * Capability by return value again, and absent for every host whose stop channel is not

--- a/tests/architecture/module-boundaries.test.ts
+++ b/tests/architecture/module-boundaries.test.ts
@@ -20,7 +20,11 @@ const LAYERS: string[][] = [
   // Persistence and the knowledge lifecycle.
   ['store'],
   // Direct consumers of the store that no other feature layer sits beneath.
-  ['ai', 'workspace', 'skills', 'code'],
+  //
+  // `fleet` reads the host's on-disk session registry and Knowl's own session tables, and is
+  // consumed by `session` (the hook path), `mcp` and `cli`. It has no reason to reach any
+  // feature layer, so it sits with the other direct store consumers.
+  ['ai', 'workspace', 'skills', 'code', 'fleet'],
   // Feature layers built on the above.
   //
   // `cloud` sits here rather than one layer down even though today it imports only `core`.

--- a/tests/cli/agent-lifecycle.test.ts
+++ b/tests/cli/agent-lifecycle.test.ts
@@ -42,13 +42,19 @@ describe('agent lifecycle CLI', () => {
       tool_response: { stdout: `sk-test-123456789012345678901234567890${'x'.repeat(1_100_000)}`, exit_code: 0 },
     })]) as NodeJS.ReadStream);
 
-    expect(payload).toEqual({
+    // `stdout` is allowlisted for the fleet's error signature, tail-bounded: the 1.1 MB body
+    // is never held, and the head -- where this payload's secret-shaped token sits -- is the
+    // part that goes. Everything unnamed is still discarded.
+    const { stdout, ...response } = payload.tool_response as Record<string, unknown>;
+    expect({ ...payload, tool_response: response }).toEqual({
       session_id: 'stream-session',
       cwd: TEST_DIR,
       tool_name: 'Bash',
       tool_input: { command: 'npm test' },
       tool_response: { exit_code: 0 },
     });
+    expect(String(stdout)).toHaveLength(2_000);
+    expect(String(stdout)).not.toContain('sk-test');
   });
 
   it('retains subagent identity and Knowl write arguments while still discarding noise', async () => {

--- a/tests/cli/fleet-cli.test.ts
+++ b/tests/cli/fleet-cli.test.ts
@@ -27,6 +27,9 @@ function knowl(...args: string[]) {
       ...process.env,
       KNOWL_HOME: HOME,
       CLAUDE_CONFIG_DIR: CONFIG_DIR,
+      // Pins the roster to this fixture. Without it the real home's config dirs are read too,
+      // so a suite run from inside a live session sees the developer's own fleet.
+      KNOWL_CLAUDE_CONFIG_DIRS: CONFIG_DIR,
       // What Claude Code sets in the shell it runs commands in; the CLI marks that session `(you)`.
       CLAUDE_CODE_SESSION_ID: PEER_SESSION,
       NO_COLOR: '1',
@@ -66,12 +69,10 @@ describe('knowl fleet', { timeout: 120_000 }, () => {
     expect(peer).toMatchObject({ name: 'fleet-cli-peer-cd', repo: PEER_REPO, known: false, messageable: true });
   });
 
-  it('narrows to one repo and appends the card ledger', () => {
-    const result = knowl('fleet', '--repo', PEER_REPO, '--cards');
+  it('narrows to one repo', () => {
+    const result = knowl('fleet', '--repo', PEER_REPO);
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain(`1 live Claude Code session in ${PEER_REPO}`);
+    expect(result.stdout).toContain(`1 live agent session in ${PEER_REPO}`);
     expect(result.stdout).toContain('fleet-cli-peer-cd (you)');
-    expect(result.stdout).toContain('Fleet cards:');
-    expect(result.stdout).toMatch(/precision:\s+not yet measured/);
   });
 });

--- a/tests/cli/fleet-cli.test.ts
+++ b/tests/cli/fleet-cli.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * `knowl fleet` against the built CLI, from a directory that is not a Knowl project.
+ *
+ * That is the case the command exists for: the fleet is machine-level and the terminal a user
+ * asks from is often outside every repo, so a command that needed `.knowl/` there would answer
+ * "not a Knowl project" exactly where it was wanted. The registry fixture carries this test
+ * runner's own pid, the one pid the spawned child can be promised is alive.
+ */
+const ROOT = path.resolve('./.knowl-fleet-cli-test');
+const HOME = path.join(ROOT, 'home');
+const CONFIG_DIR = path.join(ROOT, 'claude');
+const CWD = path.join(ROOT, 'not-a-project');
+const PEER_REPO = 'fleet-cli-peer';
+const PEER_SESSION = 'fleet-cli-peer-session';
+const CLI = path.resolve('./dist/index.js');
+
+function knowl(...args: string[]) {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd: CWD,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      KNOWL_HOME: HOME,
+      CLAUDE_CONFIG_DIR: CONFIG_DIR,
+      // What Claude Code sets in the shell it runs commands in; the CLI marks that session `(you)`.
+      CLAUDE_CODE_SESSION_ID: PEER_SESSION,
+      NO_COLOR: '1',
+    },
+  });
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
+}
+
+// Each assertion spawns the real built CLI, which costs seconds of node startup per invocation.
+describe('knowl fleet', { timeout: 120_000 }, () => {
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(CWD, { recursive: true });
+    await fs.mkdir(path.join(CONFIG_DIR, 'sessions'), { recursive: true });
+    await fs.writeFile(path.join(CONFIG_DIR, 'sessions', `${process.pid}.json`), JSON.stringify({
+      pid: process.pid, sessionId: PEER_SESSION, cwd: path.join(ROOT, PEER_REPO), startedAt: Date.now() - 120_000,
+      name: 'fleet-cli-peer-cd', kind: 'interactive',
+    }));
+  });
+
+  afterAll(async () => {
+    // The child opened and closed the fleet database; on Windows the WAL sidecar can still be
+    // held for a moment after it exits, and a stray test root is worth less than a red run.
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('lists the live sessions as JSON without a Knowl project, marking the caller', () => {
+    const result = knowl('fleet', '--json');
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+
+    const report = JSON.parse(result.stdout);
+    expect(Array.isArray(report.sessions)).toBe(true);
+    expect(report.self).toMatchObject({ sessionId: PEER_SESSION });
+    const peer = report.sessions.find((session: { sessionId: string }) => session.sessionId === PEER_SESSION);
+    // Never heard from by any hook, so the store knows nothing and the folder names the repo.
+    expect(peer).toMatchObject({ name: 'fleet-cli-peer-cd', repo: PEER_REPO, known: false, messageable: true });
+  });
+
+  it('narrows to one repo and appends the card ledger', () => {
+    const result = knowl('fleet', '--repo', PEER_REPO, '--cards');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`1 live Claude Code session in ${PEER_REPO}`);
+    expect(result.stdout).toContain('fleet-cli-peer-cd (you)');
+    expect(result.stdout).toContain('Fleet cards:');
+    expect(result.stdout).toMatch(/precision:\s+not yet measured/);
+  });
+});

--- a/tests/cli/host-hook-fleet.test.ts
+++ b/tests/cli/host-hook-fleet.test.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { normalizeHostHook } from '../../src/cli/agents/host-hook.js';
+import { readLifecyclePayload } from '../../src/cli/agents/lifecycle.js';
+
+const ROOT = path.resolve('.knowl-host-hook-fleet-test');
+
+const read = (payload: unknown) => readLifecyclePayload(Readable.from([JSON.stringify(payload)]) as any);
+
+describe('fleet fields through the stdin filter', () => {
+  it('keeps the prompt and the final assistant message, head-bounded', async () => {
+    const payload = await read({ session_id: 's', cwd: ROOT, prompt: 'fix the flake', last_assistant_message: 'Done. ' + 'x'.repeat(5_000) });
+    expect(payload.prompt).toBe('fix the flake');
+    expect(String(payload.last_assistant_message)).toHaveLength(2_000);
+    expect(String(payload.last_assistant_message).startsWith('Done. ')).toBe(true);
+  });
+
+  it('keeps the TAIL of command output and of an error, so the failure line survives a long run', async () => {
+    const banner = 'passed line\n'.repeat(400);
+    const payload = await read({
+      session_id: 's', cwd: ROOT, tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      tool_response: { exit_code: 1, stdout: banner + 'FAIL tests/x.test.ts\n  → SQLITE_BUSY: database is locked', stderr: banner + 'npm ERR! code 1' },
+      error: banner + 'Error: the thing at the end',
+    });
+    const response = payload.tool_response as Record<string, string>;
+    expect(response.stdout.endsWith('→ SQLITE_BUSY: database is locked')).toBe(true);
+    expect(response.stdout.length).toBeLessThanOrEqual(2_000);
+    expect(response.stderr.endsWith('npm ERR! code 1')).toBe(true);
+    expect(String(payload.error).endsWith('Error: the thing at the end')).toBe(true);
+    expect(response.exit_code).toBe(1);
+  });
+
+  it('still drops fields nobody allowlisted', async () => {
+    const payload = await read({ session_id: 's', cwd: ROOT, transcript_path: '/x', permission_mode: 'bypass', tool_response: { interrupted: false } });
+    expect(payload).not.toHaveProperty('transcript_path');
+    expect(payload).not.toHaveProperty('permission_mode');
+    expect(payload.tool_response).toEqual({});
+  });
+});
+
+describe('fleet fields on the normalized event', () => {
+  it('attaches the failed command output beside the payload, never inside it', () => {
+    const event = normalizeHostHook('claude', 'PostToolUse', {
+      session_id: 'session-1', cwd: ROOT, tool_name: 'Bash',
+      tool_input: { command: 'npx vitest run' },
+      tool_response: { exit_code: 1, stdout: 'banner\n→ SQLITE_BUSY: database is locked', stderr: '' },
+    });
+    expect(event.errorText).toBe('banner\n→ SQLITE_BUSY: database is locked');
+    expect(event.status).toBeUndefined();
+    expect(event.payload).toEqual({ command: 'npx vitest run', exitCode: 1 });
+    expect(JSON.stringify(event.payload)).not.toContain('SQLITE_BUSY');
+  });
+
+  it('attaches nothing for a command that succeeded', () => {
+    const event = normalizeHostHook('claude', 'PostToolUse', {
+      session_id: 'session-1', cwd: ROOT, tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      tool_response: { exit_code: 0, stdout: 'secret-looking output' },
+    });
+    expect(event.errorText).toBeUndefined();
+  });
+
+  it('carries the error text of a failed tool', () => {
+    const event = normalizeHostHook('claude', 'PostToolUseFailure', {
+      session_id: 'session-1', cwd: ROOT, tool_name: 'Edit', error: 'File has been modified since read',
+    });
+    expect(event.status).toBe('failed');
+    expect(event.errorText).toBe('File has been modified since read');
+    expect(event.payload).toEqual({ message: 'File has been modified since read' });
+  });
+
+  it('carries the final assistant message on a clean Stop only', () => {
+    const clean = normalizeHostHook('claude', 'Stop', { session_id: 'session-1', cwd: ROOT, last_assistant_message: 'Fixed the retry.' });
+    expect(clean.assistantMessage).toBe('Fixed the retry.');
+    expect(clean.payload).toEqual({ status: 'finished' });
+    const failed = normalizeHostHook('claude', 'StopFailure', { session_id: 'session-1', cwd: ROOT, error: 'rate_limit', last_assistant_message: 'half' });
+    expect(failed.assistantMessage).toBeUndefined();
+    const end = normalizeHostHook('claude', 'SessionEnd', { session_id: 'session-1', cwd: ROOT, last_assistant_message: 'bye' });
+    expect(end.assistantMessage).toBeUndefined();
+  });
+});

--- a/tests/cli/hosts/profile-conformance.test.ts
+++ b/tests/cli/hosts/profile-conformance.test.ts
@@ -53,6 +53,18 @@ describe('host profile registry', () => {
     }
   });
 
+  it('a profile that carries pre-tool advice has a pre-tool event to carry it on', () => {
+    // `preToolContext` is only ever reached from the pre-tool hook, so a host declaring the
+    // envelope without registering the event has an envelope nothing can deliver -- the
+    // capability-by-return-value rule failing in the one direction it cannot catch itself.
+    for (const profile of Object.values(HOST_PROFILES)) {
+      if (!profile.preToolContext) continue;
+      const preTool = profile.hookEvents.filter(event => profile.normalizedEvent(event) === 'tool-precheck');
+      expect(preTool.length, `${profile.host} declares preToolContext with no pre-tool event`).toBeGreaterThan(0);
+      expect(profile.preToolContext('advice'), profile.host).toBeTruthy();
+    }
+  });
+
   it('a host that registers hook handlers declares the shape of the file they go in', () => {
     for (const profile of Object.values(HOST_PROFILES)) {
       // `generic` declares events so third-party callers can send them, but `knowl init`

--- a/tests/cli/posture.test.ts
+++ b/tests/cli/posture.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG, loadConfig } from '../../src/core/config.js';
 import { CONFIG_FIELDS } from '../../src/cli/config/schema.js';
 import { getEffectiveConfigValue, resetConfigValue, setConfigValue, setConfigValues } from '../../src/cli/config/service.js';
 import { captureEventsMode, captureScope } from '../../src/store/capture-config.js';
+import { fleetNudgeMode, isFleetDigestEnabled } from '../../src/fleet/config.js';
 import { isTranscriptFallbackEnabled } from '../../src/transcripts/config.js';
 
 /**
@@ -32,11 +33,13 @@ const MAXIMAL: Array<{ key: string; raw: string }> = [
   { key: 'capture.scope', raw: 'turn' },
   { key: 'impact.enabled', raw: 'true' },
   { key: 'impact.gate', raw: 'shadow' },
+  { key: 'fleet.digest', raw: 'on' },
+  { key: 'fleet.nudge', raw: 'enforce' },
 ];
 
 describe('the posture keys', () => {
   it('declares every new key in the schema with a default the editor can restore', () => {
-    for (const key of ['search.transcripts.fallback', 'capture.events', 'capture.scope']) {
+    for (const key of ['search.transcripts.fallback', 'capture.events', 'capture.scope', 'fleet.digest', 'fleet.nudge']) {
       const field = CONFIG_FIELDS.find(entry => entry.key === key);
       expect(field, key).toBeDefined();
       expect(field!.defaultValue, key).toBeDefined();
@@ -53,6 +56,8 @@ describe('the posture keys', () => {
     expect(captureScope(config)).toBe('turn');
     expect(config.capture?.nudge).toBe('enforce');
     expect(config.impact?.gate).toBe('shadow');
+    expect(isFleetDigestEnabled(config)).toBe(true);
+    expect(fleetNudgeMode(config)).toBe('enforce');
   });
 
   it('resets back to frugal: every key reads as its shipped default again', async () => {
@@ -66,17 +71,34 @@ describe('the posture keys', () => {
     expect(captureScope(config)).toBe('conversation');
     expect(await getEffectiveConfigValue(ROOT, 'capture.events')).toBe('off');
     expect(await getEffectiveConfigValue(ROOT, 'capture.scope')).toBe('conversation');
+    // The fleet's shipped defaults are not `off` across the board: the digest is, the nudge
+    // rests in shadow. A reset that read both as off would be a reset to a posture that never
+    // shipped.
+    expect(isFleetDigestEnabled(config)).toBe(false);
+    expect(fleetNudgeMode(config)).toBe('shadow');
+    expect(await getEffectiveConfigValue(ROOT, 'fleet.digest')).toBe('off');
+    expect(await getEffectiveConfigValue(ROOT, 'fleet.nudge')).toBe('shadow');
   });
 
   it('refuses a value outside the enum instead of storing it', async () => {
     await writeConfig();
     await expect(setConfigValue(ROOT, 'capture.events', 'always')).rejects.toThrow();
     await expect(setConfigValue(ROOT, 'capture.scope', 'session')).rejects.toThrow();
+    await expect(setConfigValue(ROOT, 'fleet.digest', 'enforce')).rejects.toThrow();
+    await expect(setConfigValue(ROOT, 'fleet.nudge', 'on')).rejects.toThrow();
   });
 
   it('fallback stays inert without transcripts enabled -- the AND is the contract', async () => {
     await writeConfig();
     await setConfigValue(ROOT, 'search.transcripts.fallback', 'true');
     expect(isTranscriptFallbackEnabled(await loadConfig(ROOT))).toBe(false);
+  });
+
+  it('the fleet keys stay inert with fleet.enabled false -- the same AND', async () => {
+    await writeConfig();
+    await setConfigValues(ROOT, [{ key: 'fleet.enabled', raw: 'false' }, { key: 'fleet.digest', raw: 'on' }, { key: 'fleet.nudge', raw: 'enforce' }]);
+    const config = await loadConfig(ROOT);
+    expect(isFleetDigestEnabled(config)).toBe(false);
+    expect(fleetNudgeMode(config)).toBe('off');
   });
 });

--- a/tests/fleet/report.test.ts
+++ b/tests/fleet/report.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { describeFleet } from '../../src/fleet/report.js';
+import type { HostSessionRecord } from '../../src/fleet/roster.js';
+import type { FleetSessionRow } from '../../src/fleet/store.js';
+
+/**
+ * `describeFleet` with all three sources supplied is pure, so this is the one place the join
+ * itself is asserted: which sessions are live, who may be messaged, and what a host with no
+ * session registry contributes. The registry half is Claude Code's; every other host exists
+ * here only as its store rows, which is exactly the case that used to be dropped.
+ */
+const NOW = new Date('2026-09-02T12:00:00.000Z');
+const minutesAgo = (n: number) => new Date(NOW.getTime() - n * 60_000).toISOString();
+
+const record = (over: Partial<HostSessionRecord> = {}): HostSessionRecord => ({
+  host: 'claude',
+  pid: 100,
+  sessionId: 'claude-1',
+  cwd: '/code/api',
+  name: 'api-7f',
+  startedAt: NOW.getTime() - 30 * 60_000,
+  kind: 'interactive',
+  configDir: '/home/u/.claude',
+  ...over,
+});
+
+const row = (over: Partial<FleetSessionRow> = {}): FleetSessionRow => ({
+  host: 'claude',
+  sessionId: 'claude-1',
+  projectRoot: '/code/api',
+  repo: 'api',
+  ask: null,
+  summary: null,
+  writes: [],
+  lastError: null,
+  lastErrorSig: null,
+  lastErrorAt: null,
+  turns: 1,
+  turnStartedAt: null,
+  turnEndedAt: null,
+  startedAt: minutesAgo(30),
+  updatedAt: minutesAgo(1),
+  endedAt: null,
+  ...over,
+});
+
+const describeWith = (registry: HostSessionRecord[], rows: FleetSessionRow[], extra = {}) =>
+  describeFleet({ registry, rows, claims: [], now: NOW, ...extra });
+
+describe('describeFleet across hosts', () => {
+  it('lists a session from a host that keeps no registry, from its store row alone', async () => {
+    const report = await describeWith([], [row({ host: 'codex', sessionId: 'codex-9', repo: 'web', projectRoot: '/code/web' })]);
+    expect(report.sessions).toHaveLength(1);
+    expect(report.sessions[0]).toMatchObject({
+      host: 'codex',
+      repo: 'web',
+      // Nothing named it, so it takes the folder-and-id form a nameless Claude session takes.
+      name: 'web-co',
+      known: true,
+      // Reachable by nothing: the messaging channel the cards name belongs to the registry hosts.
+      messageable: false,
+    });
+  });
+
+  it('drops a registry host row the registry does not list, but keeps a quiet unregistered one', async () => {
+    const report = await describeWith([], [
+      // Claude answered for its own sessions and did not list this one: the process is gone.
+      row({ sessionId: 'claude-dead', updatedAt: minutesAgo(1) }),
+      // No registry could have listed this one, and it moved recently enough to still count.
+      row({ host: 'windsurf', sessionId: 'windsurf-1', updatedAt: minutesAgo(45) }),
+    ]);
+    expect(report.sessions.map(session => session.sessionId)).toEqual(['windsurf-1']);
+  });
+
+  it('drops an unregistered session that has gone quiet past the live window', async () => {
+    const report = await describeWith([], [row({ host: 'codex', sessionId: 'codex-old', updatedAt: minutesAgo(3 * 60) })]);
+    expect(report.sessions).toEqual([]);
+  });
+
+  it('offers messaging only to a registry peer sharing the caller\'s config directory', async () => {
+    const registry = [
+      record({ sessionId: 'me' }),
+      record({ pid: 101, sessionId: 'same-dir', name: 'api-aa' }),
+      record({ pid: 102, sessionId: 'other-dir', name: 'api-bb', configDir: '/home/u/.claude-account-b' }),
+    ];
+    const report = await describeWith(registry, [], { selfSessionId: 'me', selfHost: 'claude' });
+    const messageable = Object.fromEntries(report.sessions.map(session => [session.sessionId, session.messageable]));
+    expect(messageable).toEqual({ me: true, 'same-dir': true, 'other-dir': false });
+  });
+
+  it('offers messaging to nobody when the asking session runs on a host that has none', async () => {
+    const report = await describeWith([record()], [], { selfSessionId: 'codex-9', selfHost: 'codex' });
+    expect(report.sessions.map(session => session.messageable)).toEqual([false]);
+  });
+
+  it('keeps a registry entry Knowl has never heard from, marked unknown', async () => {
+    const report = await describeWith([record()], []);
+    expect(report.sessions[0]).toMatchObject({ known: false, repo: 'api', host: 'claude' });
+  });
+});

--- a/tests/fleet/roster.test.ts
+++ b/tests/fleet/roster.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { claudeConfigDirs, isPidAlive, readHostSessionRegistry, sameDir, withinDir } from '../../src/fleet/roster.js';
+import { claudeConfigDirs, derivedSessionName, isPidAlive, readHostSessionRegistry, sameDir } from '../../src/fleet/roster.js';
 
 const root = path.resolve('./.knowl-peers-roster-test');
 const home = path.join(root, 'home');
@@ -104,15 +104,18 @@ describe('isPidAlive', () => {
 });
 
 describe('directory comparisons', () => {
-  it('treats a path and its child correctly and refuses siblings', () => {
-    expect(withinDir(root, path.join(root, 'home', 'x'))).toBe(true);
-    expect(withinDir(root, root)).toBe(true);
-    expect(withinDir(root, path.join(root, '..', 'elsewhere'))).toBe(false);
+  it('treats a trailing separator as the same directory', () => {
     expect(sameDir(root, root + path.sep)).toBe(true);
+    expect(sameDir(root, path.join(root, 'home'))).toBe(false);
   });
 
   it.runIf(process.platform === 'win32')('ignores drive-letter and path casing on Windows', () => {
     expect(sameDir('C:\\Code\\X', 'c:\\code\\x')).toBe(true);
-    expect(withinDir('C:\\Code', 'c:\\code\\x\\y')).toBe(true);
+  });
+});
+
+describe('derivedSessionName', () => {
+  it('is the folder and two characters of the id, so a host with no registry names alike', () => {
+    expect(derivedSessionName(CWD, 'session-300')).toBe('duckprep-server-se');
   });
 });

--- a/tests/fleet/roster.test.ts
+++ b/tests/fleet/roster.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { claudeConfigDirs, isPidAlive, readHostSessionRegistry, sameDir, withinDir } from '../../src/fleet/roster.js';
+
+const root = path.resolve('./.knowl-peers-roster-test');
+const home = path.join(root, 'home');
+const dirA = path.join(home, '.claude');
+const dirB = path.join(home, '.claude-account-b');
+
+/**
+ * Native on both platforms, because the host writes native paths into the registry and the
+ * name derivation is `path.basename`. A literal `C:\Code\...` is one path segment to POSIX,
+ * so the fallback name would come back as the whole string -- a green Windows run and a red
+ * Ubuntu one, which is the split CONTRIBUTING names.
+ */
+const CWD = path.resolve('/Code/DuckPrep-server');
+
+const record = (pid: number, extra: Record<string, unknown> = {}) => JSON.stringify({
+  pid,
+  sessionId: `session-${pid}`,
+  cwd: CWD,
+  startedAt: 1_788_000_000_000 + pid,
+  name: `duckprep-server-${pid}`,
+  kind: 'interactive',
+  version: '2.1.257',
+  messagingSocketPath: `\\\\.\\pipe\\LOCAL\\cc-msg-${pid}`,
+  ...extra,
+});
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(dirA, 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(dirB, 'sessions'), { recursive: true });
+  // A sibling that is not a config dir: no sessions folder.
+  fs.mkdirSync(path.join(home, '.claude-launchers'), { recursive: true });
+  fs.writeFileSync(path.join(dirA, 'sessions', '100.json'), record(100));
+  fs.writeFileSync(path.join(dirA, 'sessions', '200.json'), record(200));
+  fs.writeFileSync(path.join(dirA, 'sessions', '200.abcdef.key'), 'not a record');
+  fs.writeFileSync(path.join(dirA, 'sessions', 'broken.json'), '{not json');
+  fs.writeFileSync(path.join(dirA, 'sessions', 'nopid.json'), JSON.stringify({ sessionId: 'x', cwd: 'y' }));
+  fs.writeFileSync(path.join(dirB, 'sessions', '300.json'), record(300, { name: '' }));
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('claudeConfigDirs', () => {
+  it('lists CLAUDE_CONFIG_DIR first, then ~/.claude, then every ~/.claude-* sibling with a sessions folder', () => {
+    const dirs = claudeConfigDirs({ CLAUDE_CONFIG_DIR: dirB }, home);
+    expect(dirs).toEqual([path.resolve(dirB), path.resolve(dirA)]);
+  });
+
+  it('does not repeat a directory named twice and skips siblings without sessions/', () => {
+    const dirs = claudeConfigDirs({ CLAUDE_CONFIG_DIR: dirA }, home);
+    expect(dirs).toEqual([path.resolve(dirA), path.resolve(dirB)]);
+    expect(dirs.some(dir => dir.endsWith('.claude-launchers'))).toBe(false);
+  });
+
+  it('takes an explicit list over discovery', () => {
+    const dirs = claudeConfigDirs({ KNOWL_CLAUDE_CONFIG_DIRS: [dirB, path.join(home, '.claude-launchers')].join(path.delimiter), CLAUDE_CONFIG_DIR: dirA }, home);
+    expect(dirs).toEqual([path.resolve(dirB)]);
+  });
+});
+
+describe('readHostSessionRegistry', () => {
+  it('returns only records whose process is alive, oldest first, tagged with their config dir', () => {
+    const alive = (pid: number) => pid === 200 || pid === 300;
+    const records = readHostSessionRegistry([dirA, dirB], alive);
+    expect(records.map(r => r.pid)).toEqual([200, 300]);
+    expect(records[0]).toMatchObject({
+      sessionId: 'session-200',
+      name: 'duckprep-server-200',
+      cwd: CWD,
+      configDir: dirA,
+      kind: 'interactive',
+      version: '2.1.257',
+    });
+    expect(records[1].configDir).toBe(dirB);
+  });
+
+  it('skips malformed and incomplete records without throwing', () => {
+    const records = readHostSessionRegistry([dirA], () => true);
+    expect(records.map(r => r.pid)).toEqual([100, 200]);
+  });
+
+  it('derives a display name when the record carries none', () => {
+    const [record] = readHostSessionRegistry([dirB], () => true);
+    expect(record.name).toBe('duckprep-server-se');
+  });
+
+  it('tolerates a config dir with no sessions folder', () => {
+    expect(readHostSessionRegistry([path.join(home, '.claude-launchers')], () => true)).toEqual([]);
+  });
+});
+
+describe('isPidAlive', () => {
+  it('is true for this process and false for an impossible pid', () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+    expect(isPidAlive(2_147_483_000)).toBe(false);
+  });
+});
+
+describe('directory comparisons', () => {
+  it('treats a path and its child correctly and refuses siblings', () => {
+    expect(withinDir(root, path.join(root, 'home', 'x'))).toBe(true);
+    expect(withinDir(root, root)).toBe(true);
+    expect(withinDir(root, path.join(root, '..', 'elsewhere'))).toBe(false);
+    expect(sameDir(root, root + path.sep)).toBe(true);
+  });
+
+  it.runIf(process.platform === 'win32')('ignores drive-letter and path casing on Windows', () => {
+    expect(sameDir('C:\\Code\\X', 'c:\\code\\x')).toBe(true);
+    expect(withinDir('C:\\Code', 'c:\\code\\x\\y')).toBe(true);
+  });
+});

--- a/tests/fleet/signature.test.ts
+++ b/tests/fleet/signature.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { errorHeadLine, errorSignature, normalizeErrorLine, sameErrorHead } from '../../src/fleet/signature.js';
+
+const vitestRun = `
+ RUN  v3.2.4 C:/Code/knowl-wt-peers
+
+ ✓ tests/store/one.test.ts (3 tests) 120ms
+ ❯ tests/store/session-directory.test.ts (4 tests | 1 failed) 27412ms
+   × lists sessions under load
+     → SQLITE_BUSY: database is locked (C:\\Code\\knowl-wt-peers\\.knowl\\knowl.db)
+
+ Test Files  1 failed | 1 passed (2)
+      Tests  1 failed | 6 passed (7)
+   Start at  16:41:02
+   Duration  28.11s
+`;
+
+describe('normalizeErrorLine', () => {
+  it('replaces the session-specific tokens with placeholders and lowercases', () => {
+    expect(normalizeErrorLine('Error: ENOENT: no such file, open \'C:\\Users\\Admin\\x\\y.ts:12:5\' at 2026-09-02T16:41:02.123Z (pid 44084)'))
+      .toBe('error: enoent: no such file, open \'<path>:<n>:<n>\' at <time> (pid <n>)');
+  });
+
+  it('strips ANSI colour codes', () => {
+    expect(normalizeErrorLine('\u001b[31mFAIL\u001b[0m expected 3 to be 4')).toBe('fail expected <n> to be <n>');
+  });
+});
+
+describe('errorHeadLine', () => {
+  it('picks the line that names the failure from the tail of a test run, not the runner banner', () => {
+    expect(errorHeadLine(vitestRun)).toBe('→ SQLITE_BUSY: database is locked (C:\\Code\\knowl-wt-peers\\.knowl\\knowl.db)');
+  });
+
+  it('falls back to the last non-noise line, then the last line', () => {
+    expect(errorHeadLine('building…\nat foo (x.js:1:1)\nsomething odd happened')).toBe('something odd happened');
+    expect(errorHeadLine('at foo (x.js:1:1)')).toBe('at foo (x.js:1:1)');
+    expect(errorHeadLine('')).toBe('');
+  });
+});
+
+describe('errorSignature', () => {
+  it('is identical for the same failure seen from two worktrees', () => {
+    const a = errorSignature(vitestRun);
+    const b = errorSignature(vitestRun.replace(/knowl-wt-peers/g, 'knowl-wt-other').replace('27412ms', '31002ms'));
+    expect(a).toBeDefined();
+    expect(a).toEqual(b);
+    expect(a!.head).toBe('→ sqlite_busy: database is locked (<path>)');
+    expect(a!.sig).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('differs for a different failure', () => {
+    const a = errorSignature('Error: SQLITE_BUSY: database is locked');
+    const b = errorSignature('TypeError: Cannot read properties of undefined (reading "rows")');
+    expect(a!.sig).not.toBe(b!.sig);
+  });
+
+  it('refuses text too short to mean anything', () => {
+    expect(errorSignature('ok')).toBeUndefined();
+    expect(errorSignature('   ')).toBeUndefined();
+  });
+});
+
+describe('sameErrorHead', () => {
+  it('joins the same failure phrased two ways and keeps different assertions apart', () => {
+    expect(sameErrorHead('sqlite_busy: database is locked (<path>)', 'error: sqlite_busy: database is locked (<path>)')).toBe(true);
+    expect(sameErrorHead('expected <n> to be <n>', 'expected undefined to be defined')).toBe(false);
+    expect(sameErrorHead('', 'x')).toBe(false);
+  });
+});

--- a/tests/fleet/store.test.ts
+++ b/tests/fleet/store.test.ts
@@ -2,9 +2,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  closeFleetDb, endFleetSession, fleetCardReport, fleetDbPath, getFleetSession, listFleetSessions, markFleetSeen,
+  closeFleetDb, endFleetSession, fleetDbPath, getFleetSession, listFleetSessions, markFleetSeen,
   matchingFleetClaims, openFleetClaim, openFleetClaimsForSession, readFleetSeen, recordFleetCard, recordFleetError,
-  recordFleetTurnStart, recordFleetTurnStop, recordFleetWrite, releaseFleetClaims, resolveFleetCard, sweepFleet,
+  listFleetCards, recordFleetTurnStart, recordFleetTurnStop, recordFleetWrite, releaseFleetClaims, sweepFleet,
   touchFleetSession,
 } from '../../src/fleet/store.js';
 
@@ -126,20 +126,14 @@ describe('fleet claims', () => {
 });
 
 describe('fleet cards and watermarks', () => {
-  it('records a card once per subject and measures precision from adjudications', async () => {
-    const first = await recordFleetCard({ kind: 'same-problem', ...a, subject: 'sig-1', mode: 'enforce' });
-    const repeat = await recordFleetCard({ kind: 'same-problem', ...a, subject: 'sig-1', mode: 'enforce' });
-    const shadow = await recordFleetCard({ kind: 'shared-surface', ...a, subject: '.knowl/config.json', mode: 'shadow' });
-    expect(first.first).toBe(true);
-    expect(repeat).toEqual({ id: first.id, first: false });
-    expect(shadow.first).toBe(true);
-
-    expect(await resolveFleetCard(first.id, 'acted')).toBe(true);
-    expect(await resolveFleetCard(first.id, 'false_positive')).toBe(false);
-    expect(await resolveFleetCard(shadow.id, 'false_positive')).toBe(true);
-
-    expect(await fleetCardReport()).toEqual({ shown: 1, shadowed: 1, adjudicated: 2, falsePositives: 1, precision: 0.5 });
-    expect(await fleetCardReport('same-problem')).toMatchObject({ shown: 1, shadowed: 0, precision: 1 });
+  it('claims a subject once per session, and a different session or subject separately', async () => {
+    expect(await recordFleetCard({ kind: 'same-problem', ...a, subject: 'sig-1' })).toBe(true);
+    expect(await recordFleetCard({ kind: 'same-problem', ...a, subject: 'sig-1' })).toBe(false);
+    // Same subject, different kind and different session: neither is the one already claimed.
+    expect(await recordFleetCard({ kind: 'shared-surface', ...a, subject: 'sig-1' })).toBe(true);
+    expect(await recordFleetCard({ kind: 'same-problem', ...b, subject: 'sig-1' })).toBe(true);
+    expect((await listFleetCards(a)).map(card => `${card.kind}:${card.subject}`).sort())
+      .toEqual(['same-problem:sig-1', 'shared-surface:sig-1']);
   });
 
   it('remembers what a session has seen of the others', async () => {

--- a/tests/fleet/store.test.ts
+++ b/tests/fleet/store.test.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  closeFleetDb, endFleetSession, fleetCardReport, fleetDbPath, getFleetSession, listFleetSessions, markFleetSeen,
+  matchingFleetClaims, openFleetClaim, openFleetClaimsForSession, readFleetSeen, recordFleetCard, recordFleetError,
+  recordFleetTurnStart, recordFleetTurnStop, recordFleetWrite, releaseFleetClaims, resolveFleetCard, sweepFleet,
+  touchFleetSession,
+} from '../../src/fleet/store.js';
+
+const home = path.resolve('./.knowl-fleet-store-test');
+const previousHome = process.env.KNOWL_HOME;
+
+const a = { host: 'claude', sessionId: 'session-a' };
+const b = { host: 'claude', sessionId: 'session-b' };
+const root = 'C:\\Code\\DuckPrep-server';
+
+beforeAll(async () => {
+  fs.rmSync(home, { recursive: true, force: true });
+  process.env.KNOWL_HOME = home;
+});
+
+afterAll(async () => {
+  await closeFleetDb();
+  if (previousHome === undefined) delete process.env.KNOWL_HOME; else process.env.KNOWL_HOME = previousHome;
+  // Windows may hold the WAL sidecars a beat after close; the global teardown sweeps what this misses.
+  try { fs.rmSync(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 }); } catch { /* swept later */ }
+});
+
+describe('fleet sessions', () => {
+  it('lives under the Knowl home, not inside a repo', () => {
+    expect(fleetDbPath()).toBe(path.join(home, 'fleet.db'));
+  });
+
+  it('upserts a session, tracks a turn, and clears the writes when the turn ends', async () => {
+    await touchFleetSession({ ...a, projectRoot: root, repo: 'duckprep' });
+    await touchFleetSession({ ...a, projectRoot: root, repo: 'duckprep' });
+    await recordFleetTurnStart({ ...a, ask: 'fix the SQLITE_BUSY flake in the session directory' });
+    await recordFleetWrite({ ...a, paths: ['src/store/session-directory.ts'] });
+    await recordFleetWrite({ ...a, paths: ['src/store/database.ts', 'src/store/session-directory.ts'] });
+
+    const during = await getFleetSession(a);
+    expect(during).toMatchObject({ repo: 'duckprep', turns: 1, ask: 'fix the SQLITE_BUSY flake in the session directory', endedAt: null });
+    expect(during!.writes).toEqual(['src/store/database.ts', 'src/store/session-directory.ts']);
+    expect(during!.turnStartedAt).toBeTruthy();
+    expect(during!.turnEndedAt).toBeNull();
+
+    const stopped = await recordFleetTurnStop({ ...a, summary: 'Added retry-with-backoff around the directory read.' });
+    expect(stopped.writes).toEqual(['src/store/database.ts', 'src/store/session-directory.ts']);
+    const after = await getFleetSession(a);
+    expect(after!.writes).toEqual([]);
+    expect(after!.summary).toBe('Added retry-with-backoff around the directory read.');
+    expect(after!.turnEndedAt).toBeTruthy();
+  });
+
+  it('keeps a bounded, deduplicated write list', async () => {
+    await touchFleetSession({ ...b, projectRoot: root, repo: 'duckprep' });
+    await recordFleetTurnStart(b);
+    const many = Array.from({ length: 30 }, (_, index) => `src/file-${index}.ts`);
+    const writes = await recordFleetWrite({ ...b, paths: many });
+    expect(writes).toHaveLength(20);
+    expect(writes[0]).toBe('src/file-10.ts');
+    expect(writes[19]).toBe('src/file-29.ts');
+  });
+
+  it('lists live sessions and drops ended ones', async () => {
+    const before = await listFleetSessions();
+    expect(before.map(row => row.sessionId).sort()).toEqual(['session-a', 'session-b']);
+    await endFleetSession(b);
+    const after = await listFleetSessions();
+    expect(after.map(row => row.sessionId)).toEqual(['session-a']);
+    // A resumed session is the same conversation: touching it again brings it back.
+    await touchFleetSession({ ...b, projectRoot: root, repo: 'duckprep' });
+    expect((await getFleetSession(b))!.endedAt).toBeNull();
+  });
+
+  it('records the last error head and signature', async () => {
+    await recordFleetError({ ...a, head: 'sqlite_busy: database is locked (<path>)', sig: 'abc123' });
+    expect(await getFleetSession(a)).toMatchObject({ lastError: 'sqlite_busy: database is locked (<path>)', lastErrorSig: 'abc123' });
+  });
+});
+
+describe('fleet claims', () => {
+  it('opens one claim per session and signature, accumulating files', async () => {
+    const first = await openFleetClaim({ ...a, projectRoot: root, repo: 'duckprep', sig: 'sig-1', head: 'sqlite_busy: database is locked', machineWide: false, files: ['src/x.ts'] });
+    const second = await openFleetClaim({ ...a, projectRoot: root, repo: 'duckprep', sig: 'sig-1', head: 'sqlite_busy: database is locked', machineWide: false, files: ['src/y.ts'] });
+    expect(second.id).toBe(first.id);
+    expect(second.files).toEqual(['src/x.ts', 'src/y.ts']);
+    expect(await openFleetClaimsForSession(a)).toHaveLength(1);
+  });
+
+  it('matches another session on the exact signature or a fuzzy head, within scope', async () => {
+    const exact = await matchingFleetClaims({ sig: 'sig-1', head: 'anything', projectRoot: root, excludeSessionId: 'session-b' });
+    expect(exact.map(claim => claim.sessionId)).toEqual(['session-a']);
+
+    const fuzzy = await matchingFleetClaims({ sig: 'other', head: 'error: sqlite_busy: database is locked', projectRoot: root, excludeSessionId: 'session-b' });
+    expect(fuzzy.map(claim => claim.sessionId)).toEqual(['session-a']);
+
+    const otherRepo = await matchingFleetClaims({ sig: 'sig-1', head: 'sqlite_busy: database is locked', projectRoot: 'C:\\Code\\Other', excludeSessionId: 'session-b' });
+    expect(otherRepo).toEqual([]);
+
+    const self = await matchingFleetClaims({ sig: 'sig-1', head: 'sqlite_busy: database is locked', projectRoot: root, excludeSessionId: 'session-a' });
+    expect(self).toEqual([]);
+  });
+
+  it('a machine-wide claim is visible from any repo', async () => {
+    await openFleetClaim({ ...b, projectRoot: 'C:\\Code\\knowl-cloud', repo: 'knowl-cloud', sig: 'engine-1', head: 'ebusy: resource busy or locked, knowl serve', machineWide: true, files: [] });
+    const seen = await matchingFleetClaims({ sig: 'engine-1', head: 'x', projectRoot: root, excludeSessionId: 'session-a' });
+    expect(seen.map(claim => claim.sessionId)).toEqual(['session-b']);
+  });
+
+  it('releases only the claims whose files went untouched, then everything on demand', async () => {
+    await openFleetClaim({ ...a, projectRoot: root, repo: 'duckprep', sig: 'sig-2', head: 'typeerror: cannot read properties of undefined', machineWide: false, files: ['src/z.ts'] });
+    expect(await releaseFleetClaims({ ...a, untouchedBy: ['src/x.ts'] })).toBe(1);
+    const left = await openFleetClaimsForSession(a);
+    expect(left.map(claim => claim.sig)).toEqual(['sig-1']);
+    expect(await releaseFleetClaims(a)).toBe(1);
+    expect(await openFleetClaimsForSession(a)).toEqual([]);
+  });
+
+  it('ending a session releases its claims', async () => {
+    expect(await openFleetClaimsForSession(b)).toHaveLength(1);
+    await endFleetSession(b);
+    expect(await openFleetClaimsForSession(b)).toEqual([]);
+  });
+});
+
+describe('fleet cards and watermarks', () => {
+  it('records a card once per subject and measures precision from adjudications', async () => {
+    const first = await recordFleetCard({ kind: 'same-problem', ...a, subject: 'sig-1', mode: 'enforce' });
+    const repeat = await recordFleetCard({ kind: 'same-problem', ...a, subject: 'sig-1', mode: 'enforce' });
+    const shadow = await recordFleetCard({ kind: 'shared-surface', ...a, subject: '.knowl/config.json', mode: 'shadow' });
+    expect(first.first).toBe(true);
+    expect(repeat).toEqual({ id: first.id, first: false });
+    expect(shadow.first).toBe(true);
+
+    expect(await resolveFleetCard(first.id, 'acted')).toBe(true);
+    expect(await resolveFleetCard(first.id, 'false_positive')).toBe(false);
+    expect(await resolveFleetCard(shadow.id, 'false_positive')).toBe(true);
+
+    expect(await fleetCardReport()).toEqual({ shown: 1, shadowed: 1, adjudicated: 2, falsePositives: 1, precision: 0.5 });
+    expect(await fleetCardReport('same-problem')).toMatchObject({ shown: 1, shadowed: 0, precision: 1 });
+  });
+
+  it('remembers what a session has seen of the others', async () => {
+    expect(await readFleetSeen(a)).toEqual(new Map());
+    await markFleetSeen({ ...a, seen: [{ otherSessionId: 'session-b', updatedAt: '2026-09-02T10:00:00.000Z' }] });
+    await markFleetSeen({ ...a, seen: [{ otherSessionId: 'session-b', updatedAt: '2026-09-02T10:05:00.000Z' }] });
+    expect(await readFleetSeen(a)).toEqual(new Map([['session-b', '2026-09-02T10:05:00.000Z']]));
+  });
+
+  it('sweeps stale sessions with everything hanging off them', async () => {
+    expect(await sweepFleet(new Date(Date.now() - 60_000).toISOString())).toBe(0);
+    expect(await sweepFleet(new Date(Date.now() + 60_000).toISOString())).toBe(2);
+    expect(await listFleetSessions()).toEqual([]);
+    expect(await readFleetSeen(a)).toEqual(new Map());
+  });
+});

--- a/tests/fleet/surfaces.test.ts
+++ b/tests/fleet/surfaces.test.ts
@@ -21,6 +21,19 @@ describe('classifySharedSurfacePath', () => {
     expect(classifySharedSurfacePath(inRepo('.claude', 'hooks', 'lesson-gate.mjs'), root)).toMatchObject({ kind: 'host-hooks', target: '.claude/hooks/lesson-gate.mjs', machineWide: false });
   });
 
+  it('names every host\'s hooks and settings, not only Claude Code\'s', () => {
+    // A Codex or Windsurf hooks file is as shared as Claude Code's; listing one host meant the
+    // card fired for one and stayed silent while another rewrote the same kind of file.
+    expect(classifySharedSurfacePath(inRepo('.codex', 'hooks.json'), root)).toMatchObject({ kind: 'host-hooks', target: '.codex/hooks.json' });
+    expect(classifySharedSurfacePath(inRepo('.windsurf', 'hooks.json'), root)).toMatchObject({ kind: 'host-hooks' });
+    expect(classifySharedSurfacePath(inRepo('.github', 'hooks', 'knowl.json'), root)).toMatchObject({ kind: 'host-hooks' });
+    expect(classifySharedSurfacePath(inRepo('.cursor', 'mcp.json'), root)).toMatchObject({ kind: 'host-settings' });
+    expect(classifySharedSurfacePath('/home/admin/.codex/config.toml')).toMatchObject({ kind: 'host-settings', machineWide: true });
+    expect(classifySharedSurfacePath('/home/admin/.gemini/antigravity/mcp_config.json')).toMatchObject({ kind: 'host-settings', machineWide: true });
+    // A host directory is not a licence for everything under it.
+    expect(classifySharedSurfacePath(inRepo('.github', 'workflows', 'ci.yml'), root)).toBeUndefined();
+  });
+
   it('marks the user-level Claude directory as machine-wide, for either account layout and either platform', () => {
     expect(classifySharedSurfacePath('C:\\Users\\Admin\\.claude\\settings.json')).toMatchObject({ kind: 'host-settings', machineWide: true });
     expect(classifySharedSurfacePath('C:\\Users\\Admin\\.claude-account-b\\settings.json')).toMatchObject({ kind: 'host-settings', machineWide: true });

--- a/tests/fleet/surfaces.test.ts
+++ b/tests/fleet/surfaces.test.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { classifySharedSurfaceCommand, classifySharedSurfacePath } from '../../src/fleet/surfaces.js';
+
+/**
+ * Native paths wherever a repo root is involved, because the repo-relative display goes through
+ * `path.relative`: a literal `C:\Code\...` is a single segment to POSIX, so the display falls
+ * back to the whole string and the suite passes on Windows and fails on Ubuntu.
+ *
+ * The machine-wide cases below stay literal, in both spellings on purpose -- that branch splits
+ * the path itself rather than asking `path`, so it must classify a Windows layout from Linux and
+ * the other way round.
+ */
+const root = path.resolve('/Code/DuckPrep-server');
+const inRepo = (...segments: string[]) => path.join(root, ...segments);
+
+describe('classifySharedSurfacePath', () => {
+  it('names the knowl config, host settings and hook scripts', () => {
+    expect(classifySharedSurfacePath(inRepo('.knowl', 'config.json'), root)).toMatchObject({ kind: 'knowl-config', target: '.knowl/config.json', machineWide: false });
+    expect(classifySharedSurfacePath(inRepo('.claude', 'settings.local.json'), root)).toMatchObject({ kind: 'host-settings', target: '.claude/settings.local.json', machineWide: false });
+    expect(classifySharedSurfacePath(inRepo('.claude', 'hooks', 'lesson-gate.mjs'), root)).toMatchObject({ kind: 'host-hooks', target: '.claude/hooks/lesson-gate.mjs', machineWide: false });
+  });
+
+  it('marks the user-level Claude directory as machine-wide, for either account layout and either platform', () => {
+    expect(classifySharedSurfacePath('C:\\Users\\Admin\\.claude\\settings.json')).toMatchObject({ kind: 'host-settings', machineWide: true });
+    expect(classifySharedSurfacePath('C:\\Users\\Admin\\.claude-account-b\\settings.json')).toMatchObject({ kind: 'host-settings', machineWide: true });
+    expect(classifySharedSurfacePath('/home/admin/.claude/hooks/x.sh')).toMatchObject({ kind: 'host-hooks', machineWide: true });
+  });
+
+  it('names migrations, manifests, env files and generated output', () => {
+    expect(classifySharedSurfacePath(inRepo('server', 'migrations', '202609020001_peers.sql'), root)).toMatchObject({ kind: 'migrations' });
+    expect(classifySharedSurfacePath(inRepo('package-lock.json'), root)).toMatchObject({ kind: 'manifest' });
+    expect(classifySharedSurfacePath(inRepo('.env.local'), root)).toMatchObject({ kind: 'env' });
+    expect(classifySharedSurfacePath(inRepo('src', 'api.generated.ts'), root)).toMatchObject({ kind: 'generated' });
+  });
+
+  it('leaves ordinary source files alone', () => {
+    expect(classifySharedSurfacePath(inRepo('server', 'src', 'shared', 'question-source.ts'), root)).toBeUndefined();
+    expect(classifySharedSurfacePath(inRepo('docs', 'migrations-guide.md'), root)).toBeUndefined();
+  });
+});
+
+describe('classifySharedSurfaceCommand', () => {
+  it('recognises the commands that replace the engine under every session', () => {
+    expect(classifySharedSurfaceCommand('npm install -g @dat999zx/knowl@latest')).toMatchObject({ kind: 'knowl-engine', machineWide: true });
+    expect(classifySharedSurfaceCommand('npm i -g knowl && knowl doctor')).toMatchObject({ kind: 'knowl-engine' });
+    expect(classifySharedSurfaceCommand('knowl upgrade')).toMatchObject({ kind: 'knowl-engine' });
+    expect(classifySharedSurfaceCommand('pwsh -c knowl-sync')).toMatchObject({ kind: 'knowl-engine' });
+  });
+
+  it('does not fire on ordinary knowl use or local installs', () => {
+    expect(classifySharedSurfaceCommand('knowl query "peers roster"')).toBeUndefined();
+    expect(classifySharedSurfaceCommand('npm install')).toBeUndefined();
+    expect(classifySharedSurfaceCommand('npm install -g typescript')).toBeUndefined();
+  });
+});

--- a/tests/mcp/fleet-tool.test.ts
+++ b/tests/mcp/fleet-tool.test.ts
@@ -12,11 +12,12 @@ import type { ProjectConfig } from '../../src/core/types.js';
 /**
  * The MCP half of fleet awareness: one tool, gated on a switch that ships ON.
  *
- * The roster is Claude Code's own session registry, so the fixture is a registry: one record
- * under a private CLAUDE_CONFIG_DIR carrying this very process's pid, the only pid a test can
- * promise is alive. Whatever real sessions the machine is running appear beside it -- the
- * roster reads every config dir under the home on purpose -- so the assertions narrow by a
- * folder name nothing else on the box is called rather than by count.
+ * The roster joins Claude Code's own session registry to the fleet store, so the fixture is a
+ * registry: one record under a private config dir carrying this very process's pid, the only
+ * pid a test can promise is alive. `KNOWL_CLAUDE_CONFIG_DIRS` pins the roster to that one
+ * directory -- without it the roster reads every config dir under the real home, so a suite run
+ * from inside a live session sees the developer's own fleet and its verdicts (which peer is
+ * reachable, above all) depend on where it was run.
  */
 const ROOT = path.resolve('./.knowl-fleet-tool-test');
 const HOME = path.join(ROOT, 'home');
@@ -24,7 +25,11 @@ const CONFIG_DIR = path.join(ROOT, 'claude');
 const PEER_REPO = 'fleet-tool-peer';
 const PEER_CWD = path.join(ROOT, PEER_REPO);
 const PEER = { host: 'claude', sessionId: 'fleet-tool-peer-session' };
-const previous = { home: process.env.KNOWL_HOME, configDir: process.env.CLAUDE_CONFIG_DIR };
+const previous = {
+  home: process.env.KNOWL_HOME,
+  configDir: process.env.CLAUDE_CONFIG_DIR,
+  configDirs: process.env.KNOWL_CLAUDE_CONFIG_DIRS,
+};
 
 const baseConfig = (): ProjectConfig => ({ version: 1, security: { rejectSecrets: true, secretPatterns: [] } });
 // Three configs, because the default is the interesting one: `enabled` absent must read as on.
@@ -79,11 +84,12 @@ beforeAll(async () => {
   }));
   process.env.KNOWL_HOME = HOME;
   process.env.CLAUDE_CONFIG_DIR = CONFIG_DIR;
+  process.env.KNOWL_CLAUDE_CONFIG_DIRS = CONFIG_DIR;
   await initDb(ROOT);
   projectId = (await repo.createProject(ROOT, 'fleet tool')).id;
   await touchFleetSession({ ...PEER, projectRoot: PEER_CWD, repo: PEER_REPO });
   await recordFleetTurnStart({ ...PEER, ask: 'fix the flaky roster test' });
-  await recordFleetCard({ ...PEER, kind: 'same-problem', subject: 'sig-1', mode: 'shadow' });
+  await recordFleetCard({ ...PEER, kind: 'same-problem', subject: 'sig-1' });
 });
 
 afterAll(async () => {
@@ -91,6 +97,7 @@ afterAll(async () => {
   await closeFleetDb();
   if (previous.home === undefined) delete process.env.KNOWL_HOME; else process.env.KNOWL_HOME = previous.home;
   if (previous.configDir === undefined) delete process.env.CLAUDE_CONFIG_DIR; else process.env.CLAUDE_CONFIG_DIR = previous.configDir;
+  if (previous.configDirs === undefined) delete process.env.KNOWL_CLAUDE_CONFIG_DIRS; else process.env.KNOWL_CLAUDE_CONFIG_DIRS = previous.configDirs;
   await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
 });
 
@@ -139,7 +146,7 @@ describe('knowl_fleet registration', () => {
 describe('knowl_fleet listing', () => {
   it('lists a live session from the host registry with what the store knows about it', async () => {
     const text = textOf(await callTool(FLEET_UNSET, 'knowl_fleet', { inRepo: PEER_REPO }));
-    expect(text).toContain(`1 live Claude Code session in ${PEER_REPO}`);
+    expect(text).toContain(`1 live agent session in ${PEER_REPO}`);
     expect(text).toContain('fleet-tool-peer-ab');
     expect(text).toContain('on: fix the flaky roster test');
     // The way to reach a session is the host's, and the listing has to say so or the agent
@@ -149,21 +156,11 @@ describe('knowl_fleet listing', () => {
 
   it('says so when the repo filter matches nothing', async () => {
     const text = textOf(await callTool(FLEET_ON, 'knowl_fleet', { inRepo: 'no-such-repo-anywhere' }));
-    expect(text).toMatch(/^No live Claude Code sessions in repo "no-such-repo-anywhere"\./);
+    expect(text).toMatch(/^No live agent sessions in repo "no-such-repo-anywhere"\./);
   });
 
-  it('appends the card ledger on request, with an unadjudicated ledger reading as unmeasured', async () => {
-    const text = textOf(await callTool(FLEET_ON, 'knowl_fleet', { inRepo: PEER_REPO, cards: true }));
-    expect(text).toContain('Fleet cards:');
-    expect(text).toMatch(/shadowed:\s+1/);
-    expect(text).toMatch(/adjudicated:\s+0 of 1/);
-    // No evidence is not a perfect score; the same rule `knowl status` applies to the write gate.
-    expect(text).toMatch(/precision:\s+not yet measured/);
-    expect(text).not.toMatch(/100\.0%/);
-  });
-
-  it('leaves the ledger out unless asked', async () => {
+  it('names the host each session runs under', async () => {
     const text = textOf(await callTool(FLEET_ON, 'knowl_fleet', { inRepo: PEER_REPO }));
-    expect(text).not.toContain('Fleet cards:');
+    expect(text).toContain('claude');
   });
 });

--- a/tests/mcp/fleet-tool.test.ts
+++ b/tests/mcp/fleet-tool.test.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import { knowlToolDefinitions } from '../../src/mcp/tools.js';
+import { CORE_TOOL_DEFINITIONS } from '../../src/mcp/tool-definitions.js';
+import { closeFleetDb, recordFleetCard, recordFleetTurnStart, touchFleetSession } from '../../src/fleet/store.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The MCP half of fleet awareness: one tool, gated on a switch that ships ON.
+ *
+ * The roster is Claude Code's own session registry, so the fixture is a registry: one record
+ * under a private CLAUDE_CONFIG_DIR carrying this very process's pid, the only pid a test can
+ * promise is alive. Whatever real sessions the machine is running appear beside it -- the
+ * roster reads every config dir under the home on purpose -- so the assertions narrow by a
+ * folder name nothing else on the box is called rather than by count.
+ */
+const ROOT = path.resolve('./.knowl-fleet-tool-test');
+const HOME = path.join(ROOT, 'home');
+const CONFIG_DIR = path.join(ROOT, 'claude');
+const PEER_REPO = 'fleet-tool-peer';
+const PEER_CWD = path.join(ROOT, PEER_REPO);
+const PEER = { host: 'claude', sessionId: 'fleet-tool-peer-session' };
+const previous = { home: process.env.KNOWL_HOME, configDir: process.env.CLAUDE_CONFIG_DIR };
+
+const baseConfig = (): ProjectConfig => ({ version: 1, security: { rejectSecrets: true, secretPatterns: [] } });
+// Three configs, because the default is the interesting one: `enabled` absent must read as on.
+const FLEET_ON: ProjectConfig = { ...baseConfig(), fleet: { enabled: true } };
+const FLEET_OFF: ProjectConfig = { ...baseConfig(), fleet: { enabled: false } };
+const FLEET_UNSET: ProjectConfig = baseConfig();
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+let projectId = '';
+
+async function callTool(config: ProjectConfig, name: string, args: Record<string, unknown>): Promise<any> {
+  const server = createMcpServer(projectId, ROOT, config);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(resolve => {
+    transport.onSend = message => { if (message.id === id) resolve(message); };
+  });
+
+  const initialized = waitFor('init');
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'fleet-test', version: '1.0' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+  const answered = waitFor('call');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name, arguments: args } });
+  const response = await answered;
+  await server.close();
+  return response.result;
+}
+
+const textOf = (result: any): string => String(result?.content?.[0]?.text ?? '');
+
+beforeAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+  await fs.mkdir(path.join(CONFIG_DIR, 'sessions'), { recursive: true });
+  await fs.writeFile(path.join(CONFIG_DIR, 'sessions', `${process.pid}.json`), JSON.stringify({
+    pid: process.pid, sessionId: PEER.sessionId, cwd: PEER_CWD, startedAt: Date.now() - 60_000,
+    name: 'fleet-tool-peer-ab', kind: 'interactive',
+  }));
+  process.env.KNOWL_HOME = HOME;
+  process.env.CLAUDE_CONFIG_DIR = CONFIG_DIR;
+  await initDb(ROOT);
+  projectId = (await repo.createProject(ROOT, 'fleet tool')).id;
+  await touchFleetSession({ ...PEER, projectRoot: PEER_CWD, repo: PEER_REPO });
+  await recordFleetTurnStart({ ...PEER, ask: 'fix the flaky roster test' });
+  await recordFleetCard({ ...PEER, kind: 'same-problem', subject: 'sig-1', mode: 'shadow' });
+});
+
+afterAll(async () => {
+  await closeDb();
+  await closeFleetDb();
+  if (previous.home === undefined) delete process.env.KNOWL_HOME; else process.env.KNOWL_HOME = previous.home;
+  if (previous.configDir === undefined) delete process.env.CLAUDE_CONFIG_DIR; else process.env.CLAUDE_CONFIG_DIR = previous.configDir;
+  await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('knowl_fleet registration', () => {
+  it('is listed when fleet.enabled is true or absent, and not when false', () => {
+    const names = (config: ProjectConfig) => knowlToolDefinitions(config).map(tool => tool.name);
+    expect(names(FLEET_ON)).toContain('knowl_fleet');
+    expect(names(FLEET_UNSET)).toContain('knowl_fleet');
+    expect(names(FLEET_OFF)).not.toContain('knowl_fleet');
+  });
+
+  it('adds exactly one tool, and none to a server with no config at all', () => {
+    // The budget rule every gated set cites: a registered tool costs guidance-card space in
+    // every session of every user. And `null` is the init-error server, which offers the core
+    // set alone -- the reason the gate is `config && isFleetEnabled(config)` and not the reader.
+    expect(knowlToolDefinitions(FLEET_UNSET)).toHaveLength(knowlToolDefinitions(FLEET_OFF).length + 1);
+    expect(knowlToolDefinitions(null)).toHaveLength(CORE_TOOL_DEFINITIONS.length);
+  });
+
+  it('answers a call while gated off with a disabled error, not "unknown tool"', async () => {
+    const result = await callTool(FLEET_OFF, 'knowl_fleet', {});
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('fleet.enabled=false');
+    expect(textOf(result)).not.toMatch(/Unknown tool/i);
+  });
+
+  it('validates arguments while gated off, which proves the schema is registered', async () => {
+    // Dispatch validates against SCHEMA_BY_TOOL before it reaches the gate, so a refusal that
+    // names the argument is only possible if the gated-off tool's schema is in that map.
+    const result = await callTool(FLEET_OFF, 'knowl_fleet', { inRepo: 42 });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('inRepo');
+    expect(textOf(result)).not.toContain('fleet.enabled=false');
+  });
+
+  it('does not offer the act-as rebind, so a repo name filters rather than re-targets', async () => {
+    // `repo` on this surface means "run as that linked repo" and is intercepted before the
+    // handler; the filter had that name first and every call naming a repo was refused with
+    // "not in a workspace". The filter is `inRepo`, and `repo` is declined as the act-as it is.
+    const result = await callTool(FLEET_ON, 'knowl_fleet', { repo: PEER_REPO });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('does not take a "repo" argument');
+  });
+});
+
+describe('knowl_fleet listing', () => {
+  it('lists a live session from the host registry with what the store knows about it', async () => {
+    const text = textOf(await callTool(FLEET_UNSET, 'knowl_fleet', { inRepo: PEER_REPO }));
+    expect(text).toContain(`1 live Claude Code session in ${PEER_REPO}`);
+    expect(text).toContain('fleet-tool-peer-ab');
+    expect(text).toContain('on: fix the flaky roster test');
+    // The way to reach a session is the host's, and the listing has to say so or the agent
+    // will look for a knowl verb that does not exist.
+    expect(text).toContain('SendMessage');
+  });
+
+  it('says so when the repo filter matches nothing', async () => {
+    const text = textOf(await callTool(FLEET_ON, 'knowl_fleet', { inRepo: 'no-such-repo-anywhere' }));
+    expect(text).toMatch(/^No live Claude Code sessions in repo "no-such-repo-anywhere"\./);
+  });
+
+  it('appends the card ledger on request, with an unadjudicated ledger reading as unmeasured', async () => {
+    const text = textOf(await callTool(FLEET_ON, 'knowl_fleet', { inRepo: PEER_REPO, cards: true }));
+    expect(text).toContain('Fleet cards:');
+    expect(text).toMatch(/shadowed:\s+1/);
+    expect(text).toMatch(/adjudicated:\s+0 of 1/);
+    // No evidence is not a perfect score; the same rule `knowl status` applies to the write gate.
+    expect(text).toMatch(/precision:\s+not yet measured/);
+    expect(text).not.toMatch(/100\.0%/);
+  });
+
+  it('leaves the ledger out unless asked', async () => {
+    const text = textOf(await callTool(FLEET_ON, 'knowl_fleet', { inRepo: PEER_REPO }));
+    expect(text).not.toContain('Fleet cards:');
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -199,8 +199,11 @@ describe('MCP Server Layer', () => {
   it('keeps tools/list exactly aligned with the canonical inventory', async () => {
     const res = await runRpcRequest('tools/list');
     const names = res.result.tools.map((tool: any) => tool.name);
-    expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES].sort());
-    expect(new Set(names).size).toBe(27);
+    // Plus the one gated tool whose gate ships open. `knowl_fleet` is listed unless a repo turns
+    // it off and stays out of the guidance inventory all the same, because a gated tool is not a
+    // promise every session can rely on -- so a plain config sees the canonical set and it.
+    expect([...names].sort()).toEqual([...KNOWL_MCP_TOOL_NAMES, 'knowl_fleet'].sort());
+    expect(new Set(names).size).toBe(28);
   });
 
   it('lists both resume tools', async () => {

--- a/tests/store/host-lifecycle-fleet.test.ts
+++ b/tests/store/host-lifecycle-fleet.test.ts
@@ -9,7 +9,7 @@ import { fleetTurnStartBestEffort } from '../../src/session/fleet-lifecycle.js';
 import { closeFleetDb, getFleetSession, listFleetCards, openFleetClaimsForSession } from '../../src/fleet/store.js';
 
 /**
- * Two Claude Code sessions in one repo, seen through the hooks. The host's registry is faked
+ * Two sessions in one repo, seen through the hooks. The host's registry is faked
  * with two records that both name this process's pid, so both count as alive; everything else
  * is the real lifecycle against a real store.
  */
@@ -26,6 +26,8 @@ let projectId = '';
 
 const A = 'session-a';
 const B = 'session-b';
+/** A Codex session: no registry record anywhere, so the store rows are the whole of it. */
+const C = 'session-c';
 
 const hook = (input: Partial<NormalizedHostHook> & { externalSessionId: string }): NormalizedHostHook => ({
   host: 'claude',
@@ -80,7 +82,7 @@ describe('fleet through the lifecycle', () => {
     // folder name, because Knowl has heard nothing from it yet.
     const first = await handleHostLifecycleEvent(projectId, hook({ event: 'session-start', externalSessionId: B, title: 'Agent session' }));
     expect(first.accepted).toBe(true);
-    expect(first.context).toContain('LIVE SESSIONS (1 other Claude Code session on this machine)');
+    expect(first.context).toContain('LIVE SESSIONS (1 other agent session on this machine)');
     expect(first.context).toContain(path.basename(ROOT));
     expect(first.context).toContain('test-a');
     expect(first.context).not.toContain('same repo as you');
@@ -89,7 +91,7 @@ describe('fleet through the lifecycle', () => {
     // A starts second and is told about B, under the repo name B's own row recorded.
     const start = await handleHostLifecycleEvent(projectId, hook({ event: 'session-start', externalSessionId: A, title: 'Agent session' }));
     expect(start.accepted).toBe(true);
-    expect(start.context).toContain('LIVE SESSIONS (1 other Claude Code session on this machine)');
+    expect(start.context).toContain('LIVE SESSIONS (1 other agent session on this machine)');
     expect(start.context).toContain('test-repo');
     expect(start.context).toContain('test-b');
     expect(start.context).toContain('same repo as you');
@@ -224,6 +226,48 @@ describe('fleet through the lifecycle', () => {
     await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: B, projectRoot: ROOT, prompt: 'write the changelog entry' }, config);
     const moved = await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: A, projectRoot: ROOT }, config);
     expect(moved).toContain('write the changelog entry');
+  });
+
+  it('sees a session on a host that keeps no registry, and does not offer to message it', async () => {
+    // A Codex session in the same repo. Nothing lists its process anywhere -- Codex publishes no
+    // session registry -- so the only record it exists is the rows its own hooks write here.
+    const codex = (input: Partial<NormalizedHostHook>): NormalizedHostHook =>
+      hook({ host: 'codex', externalSessionId: C, ...input });
+
+    await handleHostLifecycleEvent(projectId, codex({
+      type: 'command', toolName: 'shell',
+      payload: { command: 'npm run typecheck', exitCode: 2 },
+      errorText: 'src/store/reader.ts(12,3): error TS2345: Argument of type string is not assignable',
+    }));
+    // `apply_patch` is Codex's only write tool, and the tool-name regex this replaced never
+    // matched it as an edit for any host but by luck. Without the write there is no claim.
+    await handleHostLifecycleEvent(projectId, codex({
+      type: 'checkpoint', toolName: 'apply_patch', captureKey: 'patch-c-1',
+      payload: { changedPaths: ['src/x.ts'] },
+    }));
+    const claims = await openFleetClaimsForSession({ host: 'codex', sessionId: C });
+    expect(claims).toHaveLength(1);
+    expect(claims[0].head).toContain('error ts2345: argument of type string is not assignable');
+
+    // A hits the same failure and is told about the Codex session by name -- and told to raise
+    // it with the user, because SendMessage cannot reach another host.
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'error', status: 'failed', toolName: 'Bash',
+      payload: { message: 'Tool failed' },
+      errorText: 'src/store/writer.ts(88,7): error TS2345: Argument of type string is not assignable',
+    }));
+    const card = additionalContext(await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'checkpoint', toolName: 'Grep', captureKey: 'grep-a-3', payload: { summary: 'Grep completed' },
+    })));
+    expect(card).toContain('ANOTHER SESSION IS ALREADY ON THIS PROBLEM');
+    expect(card).toContain('editing: src/x.ts');
+    expect(card).toContain('(codex) cannot be messaged from here');
+    expect(card).not.toContain('SendMessage');
+
+    // And it is on the roster a new session starts with, under the same repo.
+    const start = await handleHostLifecycleEvent(projectId, hook({ event: 'session-start', externalSessionId: B, title: 'Agent session' }));
+    expect(start.context).toContain('LIVE SESSIONS (2 other agent sessions on this machine)');
+    expect(start.context).toContain('† visible here, not reachable with SendMessage (codex');
   });
 
   it('marks the session ended on SessionEnd', async () => {

--- a/tests/store/host-lifecycle-fleet.test.ts
+++ b/tests/store/host-lifecycle-fleet.test.ts
@@ -1,0 +1,235 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { NormalizedHostHook } from '../../src/core/host-hook-types.js';
+import { closeDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { handleHostLifecycleEvent } from '../../src/session/host-lifecycle.js';
+import { fleetTurnStartBestEffort } from '../../src/session/fleet-lifecycle.js';
+import { closeFleetDb, getFleetSession, listFleetCards, openFleetClaimsForSession } from '../../src/fleet/store.js';
+
+/**
+ * Two Claude Code sessions in one repo, seen through the hooks. The host's registry is faked
+ * with two records that both name this process's pid, so both count as alive; everything else
+ * is the real lifecycle against a real store.
+ */
+const ROOT = path.resolve('.knowl-host-lifecycle-fleet-test');
+const HOME = path.join(ROOT, 'knowl-home');
+const CONFIG_DIR = path.join(ROOT, 'claude-config');
+const previous = {
+  KNOWL_HOME: process.env.KNOWL_HOME,
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+  KNOWL_CLAUDE_CONFIG_DIRS: process.env.KNOWL_CLAUDE_CONFIG_DIRS,
+};
+
+let projectId = '';
+
+const A = 'session-a';
+const B = 'session-b';
+
+const hook = (input: Partial<NormalizedHostHook> & { externalSessionId: string }): NormalizedHostHook => ({
+  host: 'claude',
+  event: 'session-event',
+  projectRoot: ROOT,
+  payload: {},
+  ...input,
+});
+
+const registryRecord = (sessionId: string, name: string) => JSON.stringify({
+  pid: process.pid, sessionId, cwd: ROOT, startedAt: Date.now() - 600_000, name, kind: 'interactive', version: '2.1.257',
+});
+
+const additionalContext = (result: { hostOutput?: Record<string, unknown> }): string | undefined =>
+  (result.hostOutput?.hookSpecificOutput as { additionalContext?: string } | undefined)?.additionalContext;
+
+beforeAll(async () => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.mkdirSync(path.join(ROOT, '.knowl'), { recursive: true });
+  fs.mkdirSync(path.join(ROOT, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(CONFIG_DIR, 'sessions'), { recursive: true });
+  fs.writeFileSync(path.join(CONFIG_DIR, 'sessions', '1.json'), registryRecord(A, 'test-a'));
+  fs.writeFileSync(path.join(CONFIG_DIR, 'sessions', '2.json'), registryRecord(B, 'test-b'));
+  fs.writeFileSync(path.join(ROOT, 'src', 'x.ts'), 'export const x = 1;\n');
+  fs.writeFileSync(path.join(ROOT, '.knowl', 'config.json'), JSON.stringify({
+    version: 1,
+    workspace: { workspace: 'test', repo: 'test-repo' },
+    impact: { enabled: true, gate: 'off' },
+    fleet: { cards: 'enforce', nudge: 'enforce', digest: 'on' },
+  }));
+  process.env.KNOWL_HOME = HOME;
+  process.env.CLAUDE_CONFIG_DIR = CONFIG_DIR;
+  // Only the faked registry: without this the roster would also list whatever real sessions
+  // are running on the developer's machine, and the counts below would depend on them.
+  process.env.KNOWL_CLAUDE_CONFIG_DIRS = CONFIG_DIR;
+  await initDb(ROOT);
+  projectId = (await repo.createProject(ROOT, 'Fleet lifecycle')).id;
+});
+
+afterAll(async () => {
+  await closeFleetDb();
+  await closeDb();
+  for (const key of ['KNOWL_HOME', 'CLAUDE_CONFIG_DIR', 'KNOWL_CLAUDE_CONFIG_DIRS'] as const) {
+    if (previous[key] === undefined) delete process.env[key]; else process.env[key] = previous[key];
+  }
+  try { fs.rmSync(ROOT, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 }); } catch { /* swept by the global teardown */ }
+});
+
+describe('fleet through the lifecycle', () => {
+  it('names the other live session on the SessionStart card', async () => {
+    // B starts first. The host registry already lists A's process, so A appears -- under its
+    // folder name, because Knowl has heard nothing from it yet.
+    const first = await handleHostLifecycleEvent(projectId, hook({ event: 'session-start', externalSessionId: B, title: 'Agent session' }));
+    expect(first.accepted).toBe(true);
+    expect(first.context).toContain('LIVE SESSIONS (1 other Claude Code session on this machine)');
+    expect(first.context).toContain(path.basename(ROOT));
+    expect(first.context).toContain('test-a');
+    expect(first.context).not.toContain('same repo as you');
+    expect((await getFleetSession({ host: 'claude', sessionId: B }))).toMatchObject({ repo: 'test-repo', endedAt: null });
+
+    // A starts second and is told about B, under the repo name B's own row recorded.
+    const start = await handleHostLifecycleEvent(projectId, hook({ event: 'session-start', externalSessionId: A, title: 'Agent session' }));
+    expect(start.accepted).toBe(true);
+    expect(start.context).toContain('LIVE SESSIONS (1 other Claude Code session on this machine)');
+    expect(start.context).toContain('test-repo');
+    expect(start.context).toContain('test-b');
+    expect(start.context).toContain('same repo as you');
+    expect(start.context).toContain('knowl_fleet');
+    expect(start.context!.length).toBeLessThanOrEqual(3_000);
+  });
+
+  it('tells the second session that the first is already on the same error', async () => {
+    // B hits the error and starts editing: that opens B's claim.
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: B, type: 'command', toolName: 'Bash',
+      payload: { command: 'npx vitest run tests/one.test.ts', exitCode: 1 },
+      errorText: 'FAIL tests/one.test.ts\n  → Error: SQLITE_BUSY: database is locked (C:\\b\\.knowl\\knowl.db)',
+    }));
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: B, type: 'checkpoint', toolName: 'Edit', captureKey: 'edit-b-1',
+      payload: { changedPaths: ['src/x.ts'] },
+    }));
+    const claims = await openFleetClaimsForSession({ host: 'claude', sessionId: B });
+    expect(claims).toHaveLength(1);
+    expect(claims[0]).toMatchObject({ files: ['src/x.ts'], machineWide: false });
+    expect(claims[0].head).toContain('sqlite_busy: database is locked');
+
+    // A hits the same error from its own worktree as a tool FAILURE, which the host's mid-turn
+    // slot never carries -- so the card waits for A's next call.
+    const failed = await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'error', status: 'failed', toolName: 'Bash',
+      payload: { message: 'Tool failed' },
+      errorText: 'FAIL tests/one.test.ts\n  → Error: SQLITE_BUSY: database is locked (C:\\a\\.knowl\\knowl.db)',
+    }));
+    expect(failed.hostOutput).toBeUndefined();
+    const next = await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'checkpoint', toolName: 'Grep', captureKey: 'grep-a-1', payload: { summary: 'Grep completed' },
+    }));
+    const card = additionalContext(next);
+    expect(card).toContain('ANOTHER SESSION IS ALREADY ON THIS PROBLEM');
+    expect(card).toContain('test-b hit the same error');
+    expect(card).toContain('sqlite_busy: database is locked');
+    expect(card).toContain('editing: src/x.ts');
+    expect(card).toContain('SendMessage(to:"test-b", notify_when_idle:true)');
+
+    // Once. The next call gets nothing from the fleet.
+    const again = await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'checkpoint', toolName: 'Grep', captureKey: 'grep-a-2', payload: { summary: 'Grep completed' },
+    }));
+    expect(additionalContext(again) ?? '').not.toContain('ANOTHER SESSION');
+    const ledger = await listFleetCards({ host: 'claude', sessionId: A });
+    expect(ledger.filter(row => row.kind === 'same-problem')).toHaveLength(1);
+  });
+
+  it('runs a pre-flight card before an edit to a shared surface', async () => {
+    const precheck = await handleHostLifecycleEvent(projectId, hook({
+      event: 'tool-precheck', hostEvent: 'PreToolUse', externalSessionId: A, toolName: 'Edit',
+      payload: { changedPaths: ['.knowl/config.json'] },
+    }));
+    expect(precheck.accepted).toBe(true);
+    expect(precheck.denied).toBeUndefined();
+    expect((precheck.hostOutput?.hookSpecificOutput as { hookEventName?: string })?.hookEventName).toBe('PreToolUse');
+    const card = additionalContext(precheck)!;
+    expect(card).toContain('SHARED SURFACE · knowl-config · .knowl/config.json');
+    expect(card).toContain('test-b');
+    expect(card).toContain('notify_when_idle:true');
+
+    const repeat = await handleHostLifecycleEvent(projectId, hook({
+      event: 'tool-precheck', hostEvent: 'PreToolUse', externalSessionId: A, toolName: 'Edit',
+      payload: { changedPaths: ['.knowl/config.json'] },
+    }));
+    expect(repeat.hostOutput).toBeUndefined();
+
+    const ordinary = await handleHostLifecycleEvent(projectId, hook({
+      event: 'tool-precheck', hostEvent: 'PreToolUse', externalSessionId: A, toolName: 'Edit',
+      payload: { changedPaths: ['src/nobody-read-this.ts'] },
+    }));
+    expect(ordinary.hostOutput).toBeUndefined();
+  });
+
+  it('withholds the stop once when this turn changed a file the other session read', async () => {
+    // B reads src/x.ts at file granularity; the read set records the hash it saw.
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: B, type: 'checkpoint', toolName: 'Read', captureKey: 'read-b-x',
+      payload: { changedPaths: ['src/x.ts'] },
+    }));
+    // A rewrites it and ends its turn.
+    fs.writeFileSync(path.join(ROOT, 'src', 'x.ts'), 'export const x = 2;\n');
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'checkpoint', toolName: 'Edit', captureKey: 'edit-a-x',
+      payload: { changedPaths: ['src/x.ts'] },
+    }));
+    const stop = await handleHostLifecycleEvent(projectId, hook({
+      event: 'turn-stop', externalSessionId: A, status: 'finished', payload: { status: 'finished' },
+      assistantMessage: 'Bumped x to 2 so the retry path has something to compare.',
+    }));
+    expect(stop.accepted).toBe(true);
+    expect(stop.hostOutput).toMatchObject({ decision: 'block' });
+    const reason = String((stop.hostOutput as { reason?: string }).reason);
+    expect(reason).toContain('ANOTHER SESSION READ WHAT YOU JUST CHANGED');
+    expect(reason).toContain('test-b');
+    expect(reason).toContain('src/x.ts');
+    expect(reason).toContain('SendMessage(to:"test-b")');
+
+    const row = await getFleetSession({ host: 'claude', sessionId: A });
+    expect(row?.summary).toBe('Bumped x to 2 so the retry path has something to compare.');
+    expect(row?.writes).toEqual([]);
+    expect(row?.turnEndedAt).toBeTruthy();
+
+    // The next stop for the same file says nothing: the nudge is once per reader and path.
+    await handleHostLifecycleEvent(projectId, hook({
+      externalSessionId: A, type: 'checkpoint', toolName: 'Edit', captureKey: 'edit-a-x-2', payload: { changedPaths: ['src/x.ts'] },
+    }));
+    const second = await handleHostLifecycleEvent(projectId, hook({
+      event: 'turn-stop', externalSessionId: A, status: 'finished', payload: { status: 'finished' },
+    }));
+    expect(second.hostOutput).toBeUndefined();
+  });
+
+  it('records the turn ask and digests what the other session moved on to', async () => {
+    const config = { version: 1, fleet: { digest: 'on' as const } } as any;
+    const first = await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: A, projectRoot: ROOT, prompt: 'now port the fix to the reindex path' }, config);
+    expect(first).toContain('SESSIONS MOVED (1)');
+    expect(first).toContain('test-b');
+    expect((await getFleetSession({ host: 'claude', sessionId: A }))?.ask).toBe('now port the fix to the reindex path');
+
+    // Nothing moved since: silence.
+    const quiet = await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: A, projectRoot: ROOT }, config);
+    expect(quiet).toBeUndefined();
+
+    // An ask the secret validator refuses is dropped whole; the previous ask stands.
+    await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: A, projectRoot: ROOT, prompt: 'use api_key=sk-live-1234567890abcdef1234567890abcdef for the call' }, config);
+    expect((await getFleetSession({ host: 'claude', sessionId: A }))?.ask).toBe('now port the fix to the reindex path');
+
+    // B moves; A hears about it once.
+    await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: B, projectRoot: ROOT, prompt: 'write the changelog entry' }, config);
+    const moved = await fleetTurnStartBestEffort({ host: 'claude', externalSessionId: A, projectRoot: ROOT }, config);
+    expect(moved).toContain('write the changelog entry');
+  });
+
+  it('marks the session ended on SessionEnd', async () => {
+    const end = await handleHostLifecycleEvent(projectId, hook({ event: 'session-stop', externalSessionId: B, status: 'finished', payload: { status: 'finished' } }));
+    expect(end.accepted).toBe(true);
+    expect((await getFleetSession({ host: 'claude', sessionId: B }))?.endedAt).toBeTruthy();
+    expect(await openFleetClaimsForSession({ host: 'claude', sessionId: B })).toEqual([]);
+  });
+});


### PR DESCRIPTION
Twenty Claude Code sessions ran on one machine across four repos, and none of them knew the others existed. Two measured failures out of that, weeks apart:

- Two sessions hit the same test failure and each started fixing it, in the same files.
- One session ran a global install of the engine every other session's hooks were running on, and learned about the seventeen `knowl serve` processes holding the SQLite binary from the `EBUSY`.

Neither is a memory problem in the usual sense. Nothing was stale — the fact simply had no home.

## What already exists, and what does not

The host keeps the half it can. Claude Code writes one registry file per live session at `<config dir>/sessions/<pid>.json` — pid, session id, cwd, name, socket path — which is exactly what its own `ListAgents` reads, and it removes the file when the session exits. It also ships `SendMessage`, including `notify_when_idle` for "tell me when that session finishes".

What it records nowhere: what each session is **on**, which failure it has **claimed**, and what it **wrote this turn**. That half is this PR.

## Where the state lives, and why not in the project store

One machine-level file, `~/.knowl/fleet.db`, beside `resume.db` and for the same reason its docblock gives: the fact being recorded is about the machine, not any repo. A session in `~/work/api` upgrading the engine is a fact `~/work/web` needs.

As project-store tables it would have cost a migration level, a schema pin, a snapshot policy, a drizzle mirror **and** a federated read across every linked repo on every hook event to answer "who else is running". None of those buy anything here. It also means both of a user's Claude config directories (`~/.claude`, `~/.claude-account-b`) share one fleet, which the host's own messaging cannot do.

Same shape as `resume-store.ts` throughout: WAL, `busy_timeout=10000`, `synchronousPragma()`, a module-level client cache and a `closeFleetDb()` for Windows tests.

## What a session gets, and when

| Hook | What happens | Delivered as |
| --- | --- | --- |
| `SessionStart` | `LIVE SESSIONS` roster, grouped by repo, own repo first | in the start card, priced against `DEFAULT_CONTEXT_MAX_CHARS` before the knowledge is composed |
| `UserPromptSubmit` | the turn's ask recorded; with `fleet.digest=on`, a delta of what other sessions moved to | shares the existing reminder envelope — one JSON object per hook |
| `PostToolUse` / `…Failure` | writes and error signatures recorded; a write within 15 min of a failure opens a claim on it | the card takes the mid-turn slot **below** the change card and the destructive-command lesson |
| `PreToolUse` (write tools) | pre-flight for shared surfaces and for files another live session still holds current | `hookSpecificOutput('PreToolUse', …)` — advice, never a `permissionDecision` |
| `Stop` | answer head stored, untouched claims released; a write that staled another session's read withholds the stop **once per reader and path** | `stopContext`, third in precedence after the lesson gate and the silence nudge |
| `SessionEnd` | row closed, claims released | — |

The roster is empty when a session is alone, so a single-session user never sees a line about any of this.

### The card that matters

```
ANOTHER SESSION IS ALREADY ON THIS PROBLEM
duckprep-server-e0 hit the same error 7 min ago and is working on it right now:
  error: sqlite_busy: database is locked (<path>)
  editing: src/store/session-directory.ts, src/store/database.ts
  its focus: fix the flake in the session directory
Do not fix this in parallel. Either:
  · SendMessage(to:"duckprep-server-e0", message:"…") to split the work, or
  · SendMessage(to:"duckprep-server-e0", notify_when_idle:true) and pick it up after, or
  · tell the user both sessions hit it and let them decide.
```

Every card names the file, the peer and the exact call to make. That is deliberate: SWE-Touch (arXiv 2608.02499) measured a bare announcement of a conflicting edit as **no better than the silent edit, and worse for 3 of 4 models**, and CooperBench found communication halves merge conflicts while moving end-to-end success by a statistically insignificant amount. The same reasoning `change-card.ts` already records for its `was:`/`now:` pair. A card with nothing actionable in it is the version those papers measured.

### Matching "the same problem"

Two sessions never see byte-identical text — different worktree paths, different line numbers, different elapsed times. `src/fleet/signature.ts` takes the tail of the output, picks the line that names the failure (last strong marker, then first weak one, then last non-noise line), replaces every session-unique token with a placeholder, and hashes that. Fuzzy fallback is token Jaccard ≥ 0.8, which joins `sqlite_busy: database is locked (<path>)` with `error: sqlite_busy: database is locked` and keeps `expected <n> to be <n>` apart from `expected undefined to be defined`.

Claims are keyed by the **problem**, not the file or the task. Anthropic's own parallel-Claude compiler run used task-keyed lock files and reports the exact failure mode this avoids: *"Every agent would hit the same bug, fix that bug, and then overwrite each other's changes."*

## Two host fields that never reached the engine

`ROOT_FIELDS` in `lifecycle.ts` dropped `prompt` and `last_assistant_message`, and every retained string kept only its **first** 2,000 characters.

Two consequences, both fixed here:

1. `normalizeHostHookUnchecked` computes `correctionSignal` from `raw.prompt`. That field never arrived, so the branch could not fire in production. It passed its tests because `tests/cli/host-hook.test.ts` calls `normalizeHostHook` directly with a literal object, bypassing the stdin filter entirely. Allow-listing `prompt` makes the existing detector live.
2. A failing command prints its banner first and its error last, so the head of a 400-line vitest run is the list of files that passed. `error`, `stdout` and `stderr` now keep their **tail** at the same bound, via a rolling window keyed off the packed `keyValue` token.

### On storing conversation text

`fleet.db` keeps a 240-character head of each turn's ask and answer, plus one normalised error line. That is the only place Knowl stores any of a conversation, and it is stated as an exception rather than slipped in:

- It is bounded at write and never enters `payload`, so nothing reaches `memory_session_events`. `errorText` and `assistantMessage` sit **beside** the payload on `NormalizedHostHook`, in memory only, with the reason in their docblocks.
- Every line passes `validateKnowledgeWrite` first, and a line the secret validator refuses is dropped **whole**, not trimmed — a secret is not made safe by being shorter. `tests/cli/agent-lifecycle.test.ts` asserts a `sk-`prefixed token in `stdout` does not survive.
- `fleet.enabled=false` switches all of it off.

Without it the roster can list sessions and not say what any of them is doing, which answers a question nobody asked.

## Configuration

| Key | Default | Why that default |
| --- | --- | --- |
| `fleet.enabled` | `true` | The only default-on key here. The roster prints nothing when a session is alone, and nobody opts into avoiding this collision before it has happened to them. |
| `fleet.digest` | `off` | Costs lines on every turn of a busy fleet. |
| `fleet.cards` | `enforce` | A card is advice on a channel the agent already receives, never a refusal — the measured bar the write gate waits behind does not apply. |
| `fleet.nudge` | `shadow` | It withholds a stop, which costs a turn. Same ladder as `capture.nudge`, for the same reason. |

None of them is in `DEFAULT_CONFIG`, so `upgradeConfigDefaults` does not stamp them into every config on the machine. `knowl posture maximal` adds `fleet.digest=on` and `fleet.nudge=enforce`.

**`fleet.enabled` defaulting on is the one call worth arguing about**, so stating it plainly: it adds `knowl_fleet` to the tool list of every session that has a config, which is why `tests/mcp/server.test.ts` now expects 28 names rather than 27 for a plain config. It is kept out of `KNOWL_MCP_TOOL_GROUPS`, so the guidance cards and their pinned lengths are untouched. Happy to flip it to opt-in if you would rather the tool budget stay where it is.

## Surfaces

- **`knowl_fleet`** — `{ inRepo?, cards? }`. The filter is `inRepo` rather than `repo` because on this surface a property named `repo` is the act-as rebind: `callToolAsRepo` reads it off the raw arguments before dispatch, and the first draft was refused with "not in a workspace" on every call. A test pins that.
- **`knowl fleet`** — `--repo`, `--json`, `--cards`. Machine-level, so it asks for no Knowl project: the terminal a person asks from is often outside all of their repos.
- **`knowl fleet --cards`** — the precision ledger. Every card shown or shadowed is a `fleet_cards` row with a `resolution`, exactly as `impact_findings` does, and for the same reason: **nothing here may graduate from advising to refusing without that number.** Nothing in this PR blocks anything.

## Honest limits, in the code as well as here

- The installed `PreToolUse` matcher names `writeTools` only (that is `nestedMatcher`, deliberately, to avoid a process spawn per Read). Bash is not among them, so the engine-install pre-flight can only fire **after** the command ran; that card says so and asks for repair rather than pretending it stopped anything.
- A Claude `Stop` finishes the turn's memory session and releases its read set, so the stale-read nudge sees readers **mid-turn** only.
- Sessions under another Claude config directory are listed but marked not messageable, because the host's socket cannot reach them. The card says which and never sends the agent chasing a refusal.
- Every entry point is `BestEffort` and swallows: a fleet that cannot be read is a session that is alone for one event, which is what it was before this PR.

## Naming

`peer` in this codebase means a **linked workspace repo** — `ActiveWorkspace.peers`, `seen_peer_commits`, `evaluatePeerChanges`, `peer-skills.ts` — and two of those live in the files this PR edits. So the module is `src/fleet/`, and `src/fleet` is added to `LAYERS` in `module-boundaries.test.ts` beside the other direct store consumers.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean, 0 errors |
| `npm run build` | clean |
| `npm run docs:check` | current — every tool and command documented |
| `git diff --check` | clean |
| `npx vitest run` | **385 files / 3,676 passed / 5 skipped / 0 failed** |

Rebased onto `434371f` (#228) and re-run there; the changelog was the only conflict. Baseline on unmodified `upstream/main` in the same worktree was 376/377 files, the single failure being `module-boundaries` reporting `src/fleet` unplaced.

`tests/store/host-lifecycle-fleet.test.ts` drives two sessions through the real lifecycle — a faked registry naming this process's pid, a real store, real hooks — and asserts every surface above: the roster, the same-problem card and its once-only ledger entry, the pre-flight, the withheld stop, the digest delta, and the end-of-session close. `tests/cli/agent-lifecycle.test.ts` gained the tail-retention and secret assertions; `tests/mcp/server.test.ts` moved from 27 to 28 names.

One existing test changed meaning rather than being adjusted to pass: `streams allowlisted nested fields without retaining ignored output` asserted `tool_response` was exactly `{ exit_code }`. It now asserts the tail is retained, is 2,000 characters, and does not contain the payload's secret-shaped token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
