### PR TITLE
chore: release 5.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.17.0 — 2026-09-03
+
+The agent sessions running on one machine stop being invisible to each other, and an agent can
+ask what its own branch broke.
 
 **A push no longer fails anonymously on an over-long field.** The cloud contract caps `title`,
 `source` and `conflictKey` at 500 characters; the local store caps nothing, so a research atom
@@ -37,11 +40,12 @@ where it publishes one and from recency where it does not. Only the sessions the
 can actually reach are offered as something to `SendMessage`; the rest are listed, marked, and
 raised with the user instead. `knowl fleet` lists it from any terminal, inside a project or not,
 and the `knowl_fleet` MCP tool lists it to an agent — registered unless `fleet.enabled` is
-`false`, the one switch here that ships on, because the roster prints nothing when a session is
-alone and nobody opts into it until after the collision. The rest follows the capture ladder and
-ships quiet: `fleet.digest` (`off`), `fleet.cards` (`enforce`, since a card is advice and never a
-refusal) and `fleet.nudge` (`shadow`, since it withholds a stop). `knowl posture maximal` now also
-turns the digest on and arms the nudge.
+`false`. Two of the four switches ship active, and the line between them is what a surface can
+cost you: `fleet.enabled` because the roster prints nothing at all when a session is alone, and
+`fleet.cards` (`enforce`) because a card is advice on a channel the agent is already reading and
+never a refusal. The two that would cost you something ship quiet — `fleet.digest` (`off`) spends
+lines on every turn, and `fleet.nudge` (`shadow`) withholds a stop, so it records what it would
+have said until you arm it. `knowl posture maximal` turns the digest on and arms the nudge.
 
 **An agent can ask what its own branch broke.** `knowl pr --since` has always answered "which
 stored knowledge does this diff invalidate", and it was CLI-only — so the actor most able to act

--- a/README.md
+++ b/README.md
@@ -494,6 +494,21 @@ changed in two places. Restore verifies schema, size, SHA-256, and SQLite integr
 
 </td>
 </tr>
+<tr>
+<td colspan="2" valign="top">
+
+**🛰️ The sessions on this machine can see each other**
+
+Twenty agents across four repos, and none of them knew the others existed — so two hit the same
+failure and both start fixing it, and a third upgrades the engine the rest are standing on. Knowl
+records what each session is on, what it wrote this turn, and which failure it has claimed, then
+says so *before* the second session starts the same fix. Every host with Knowl hooks is in it and
+they see each other, Codex beside Claude Code. Prints nothing when you are the only one running.
+
+`fleet` · `knowl_fleet`
+
+</td>
+</tr>
 </table>
 
 The commands worth knowing on day one:
@@ -507,6 +522,7 @@ knowl conflicts                        # items that contradict each other
 knowl timeline <item-id>               # every version an atom ever had
 knowl context --token-budget 1500      # a fixed-size briefing for an agent
 knowl pr --since origin/main           # knowledge your diff may invalidate
+knowl fleet                            # every agent session live on this machine, and what it is on
 knowl config list                      # every setting, its value, and how to change it
 knowl doctor                           # setup, retrieval, and registration
 ```
@@ -528,7 +544,9 @@ knowl doctor                           # setup, retrieval, and registration
 - **Evidence** — attach files, symbols, commits, tests, commands, or URLs to an atom. File and
   symbol evidence go stale *by themselves* when the code moves.
 - **Drift detection** — `knowl pr --since origin/main` flags knowledge your diff may have
-  invalidated, before you merge it.
+  invalidated, before you merge it, and `knowl_drift` asks the same question from inside the agent
+  that wrote the branch. What it reports is a cited path that is *gone*, not one merely edited —
+  that distinction is what keeps the signal readable.
 - **The claims drift cannot reach** — drift watches files, and about half the store cites none.
   `knowl status` dates those instead, by how long since anyone last *restated* them, and names the
   ones furthest past their own category's cadence. It ranks rather than flags: for prose there is
@@ -598,6 +616,44 @@ knowl doctor                           # setup, retrieval, and registration
   a repo that never ran it has not scored 0%, it has measured nothing.
 
 → [Tasks, sessions, and lifecycle](docs/reference.md#tasks-sessions-and-agent-lifecycle)
+
+</details>
+
+<details>
+<summary><b>The sessions on this machine can see each other</b> — one roster, on every host</summary>
+<br>
+
+The other half of the same problem: not one session across time, but several at once. Claude Code
+keeps a registry of its live sessions and lets one message another; it records nothing about what
+any of them is *doing*, and no other host records anything at all.
+
+- **A roster at session start** — who else is running, grouped by repo, own repo first. Empty when
+  you are alone, so a single-session user never sees a line about any of this.
+- **Every host with Knowl hooks is in it, and they see each other.** A Codex session appears on a
+  Claude session's roster and the reverse. Liveness comes from the host's own session registry
+  where it publishes one, and from recency where it does not.
+- **"Another session is already on this problem"** — two sessions never see byte-identical output,
+  so failures are matched on a normalised signature rather than raw text, and a claim is keyed to
+  the *problem* rather than the file. The card names the peer, its files, and the exact call to
+  make; a bare announcement of a conflicting edit is measurably no better than saying nothing.
+- **A pre-flight before a shared surface moves** — hooks, host settings, migrations, lock files,
+  and the `knowl` install every other session's hooks are running on. Advice on a channel the
+  agent already receives, never a refusal.
+- **A stop-time nudge** when this turn's writes invalidated a file another live session had read,
+  joined through the read set rather than guessed. Shadow by default — it records what it would
+  have said, because delivering it withholds a stop and that costs a turn.
+- **Only reachable peers are offered as something to message.** A session on another host or under
+  another config directory is listed and marked, and the card asks you instead — a card that told
+  the agent to message a session it cannot address teaches it to skip the next one.
+- **Machine-level, not per-repo.** `~/.knowl/fleet.db`, beside the resume keys: a session in
+  `~/work/api` upgrading the engine is a fact `~/work/web` needs. `knowl fleet` reads it from any
+  terminal, inside a project or not.
+- **`fleet.enabled` ships on**, and so do the cards — the roster costs a directory listing and says
+  nothing when you are alone, and a card is advice on a channel the agent already reads. What
+  ships quiet is what would cost you something: the per-turn digest, and the stop-time nudge that
+  withholds a stop.
+
+→ [Who else is running](docs/reference.md#who-else-is-running--the-fleet)
 
 </details>
 
@@ -738,8 +794,11 @@ adds to `.gitignore`:
 | `.knowl/knowl.db` | Atoms, assertions, knowledge commits, full-text index, feedback, embeddings |
 | `.knowl/skills/` | File-backed skill packages |
 
-Workspace manifests live outside member repositories, because their checkout paths are
-machine-local. Exports and snapshots are written only when you ask for them.
+A little lives beside your home directory instead, under `~/.knowl/`, because it is true of the
+machine rather than of any one repository: resume keys, the fleet's record of the sessions running
+right now, your cloud credential, and the local mirror of a cloud workspace. Workspace manifests
+live outside member repositories for the same reason — their checkout paths are machine-local.
+Exports and snapshots are written only when you ask for them.
 
 ## Documentation
 
@@ -752,6 +811,7 @@ usually what you actually need to know.
 | What an atom is, and what each field means | [Knowledge model](docs/reference.md#core-knowledge-model) |
 | How a query is ranked, and what wins ties | [Retrieval and context](docs/reference.md#retrieval-and-context) |
 | What a hook records, and when | [Tasks, sessions, lifecycle](docs/reference.md#tasks-sessions-and-agent-lifecycle) |
+| What the other sessions on this machine are doing | [The fleet](docs/reference.md#who-else-is-running--the-fleet) |
 | How an atom notices the code moved | [Evidence and drift](docs/reference.md#evidence-code-intelligence-and-drift) |
 | How several repos share memory safely | [Workspaces](docs/reference.md#workspaces) |
 | How a procedure becomes reusable | [Skills and synthesis](docs/reference.md#learned-skills-and-synthesis) |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -981,9 +981,13 @@ hours after its last event, and a clean exit closes its row immediately. Only se
 host's own messaging can actually reach are offered as something to `SendMessage`; the rest are
 listed, marked, and raised with the user instead.
 
-**On by default**, and the only feature in this document that is: the roster costs a directory
-listing and prints nothing when a session is alone, and nobody opts into "tell me other sessions
-exist" until after the collision.
+**On by default**, along with `fleet.cards` below — and what separates those two from everything
+else here is what a surface can *cost*. Anything that refuses a tool call or withholds a stop
+ships silent: `impact.gate` and `capture.nudge` are `off` when unset, and the fleet's own
+`fleet.nudge` is `shadow`, recording what it would have said. A roster costs a directory listing
+and prints nothing at all when a session is alone, and a card is advice on a channel the agent is
+already reading — neither is on that ladder, and nobody opts into "tell me other sessions exist"
+until after the collision has happened to them.
 
 ```bash
 knowl fleet                 # every live session: host, repo, state, what it is on, what it is editing
@@ -2595,7 +2599,20 @@ Knowl keeps project data under `.knowl/`, which `knowl init` adds to `.gitignore
   optional embeddings.
 - `.knowl/skills/` — file-backed learned-skill packages.
 
-Workspace manifests live outside member repositories because their checkout paths are
+Some state is about the machine rather than any repository, and lives under `~/.knowl/` instead
+(`KNOWL_HOME` moves it):
+
+- `~/.knowl/resume.db` — parked workstreams, so a key handed over in one repo resolves from any
+  directory.
+- `~/.knowl/fleet.db` — the agent sessions running right now: what each is on, what it wrote this
+  turn, its last error, and the problems it has claimed. Every field is bounded at write, and rows
+  are swept on a retention window; see [the fleet](#who-else-is-running--the-fleet). A repository
+  with `fleet.enabled: false` records nothing in it — the switch is per repository, while the file
+  is one per machine.
+- `~/.knowl/cloud/<workspace>/` — the local mirror of a cloud workspace, and the credential from
+  `knowl cloud login`, which never enters `.knowl/config.json`.
+
+Workspace manifests live outside member repositories for the same reason: their checkout paths are
 machine-local. Portable JSONL exports and snapshots are created only when requested.
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.16.0",
+      "version": "5.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.16.0",
+      "version": "5.17.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
The fleet (#229), `knowl_drift` (#230), and the two cloud fixes from #228.

No source changes — the changelog, the four version files, and the README/reference lines this release warrants.

## Docs, checked against the code rather than copied forward

Reading the reference against the PRs being released is what catches this, and `docs:check` never would — it verifies the two generated regions and tool/command coverage, never that curated prose still matches the code. Three claims were wrong and one thing was missing:

- **"The only feature in this document that is [on by default]"** — false. `search.pathsChanged`, `reminders.driftBackoff`, `reminders.skills` and `cloud.autoStage` all default on, and so does `fleet.cards` at `enforce`. Replaced with the rule that is actually true and is the *reason* for the default: what ships quiet is what can refuse a tool call or withhold a stop (`impact.gate` and `capture.nudge` are `off` when unset, `fleet.nudge` is `shadow`), and a roster that prints nothing at all when a session is alone is not on that ladder.
- **The same error in the README**, and in the fleet changelog entry — which called `fleet.cards` quiet in the same sentence that printed its `enforce` default.
- **`~/.knowl/` was documented nowhere**, in either file. The fleet's machine-level database therefore had no home to be described in. Both now list it beside the resume keys, the cloud mirror, and the credential.
- **The local-data entry does not claim the file is absent when the feature is off.** `knowl fleet` opens the database whatever a repo's config says, and `fleet.enabled` is per repository while the file is one per machine, so it says a repo with it off records nothing in it.

## Also

README gains the fleet as a feature cell and a details block; the drift bullet gains `knowl_drift` and the removed-not-edited rule; the day-one command list gains `knowl fleet`.

## Verification

`check:versions` agrees across all four files (six occurrences) · `docs:check` clean · `typecheck` clean · `git diff --check` clean. The tag goes on the merge commit after CI is green here.