### PR TITLE
fix(test): the README anchor check modelled a slug GitHub never generates

### DIFF
--- a/tests/core/knowl-guidance.test.ts
+++ b/tests/core/knowl-guidance.test.ts
@@ -301,11 +301,22 @@ describe('canonical Knowl agent guidance', () => {
     const reference = await fs.readFile(path.resolve('docs/reference.md'), 'utf8');
     // The README links deep into the reference; a renamed section there must not
     // silently leave the front door pointing at an anchor that no longer exists.
+    //
+    // Each space becomes its own hyphen -- `\s` and not `\s+`. GitHub strips the punctuation
+    // between two words and leaves both surrounding spaces, so `A — B` anchors as `a--b` with
+    // two hyphens, which is what `#seeing-what-exists-and-what-is-on--knowl-config-list` in this
+    // file's own table of contents has always relied on. Collapsing the run instead produced a
+    // slug GitHub never generates, so a correct README link to any em-dashed heading read as
+    // broken. Latent until one existed: every README anchor pointed at a punctuation-free
+    // heading, so the two models agreed everywhere it was tested.
     const slugs = new Set(
       [...reference.matchAll(/^#{1,6}\s+(.+)$/gm)].map(match =>
-        match[1].toLowerCase().trim().replace(/`/g, '').replace(/[^\w\s-]/g, '').replace(/\s+/g, '-'),
+        match[1].toLowerCase().trim().replace(/`/g, '').replace(/[^\w\s-]/g, '').replace(/\s/g, '-'),
       ),
     );
+    // Pinned directly rather than only through whatever the README happens to link today, so the
+    // double-hyphen rule stays checked even in a release where no front-door link uses one.
+    expect(slugs.has('seeing-what-exists-and-what-is-on--knowl-config-list')).toBe(true);
     const anchors = [...readme.matchAll(/docs\/reference\.md#([a-z0-9-]+)/g)].map(match => match[1]);
     expect(anchors.length).toBeGreaterThan(10);
     expect(anchors.filter(anchor => !slugs.has(anchor))).toEqual([]);


### PR DESCRIPTION
Found by CI on the 5.17.0 release branch, where the README gained its first deep link into an em-dashed reference heading.

## The bug

`keeps the README delegating to the full reference it summarizes` builds its slug set with `.replace(/\s+/g, '-')`, collapsing a run of whitespace into a single hyphen. GitHub does not. It strips the punctuation between two words and leaves **both** surrounding spaces, so `### A — B` anchors as `a--b`.

This file's own table of contents has always relied on that:

```
[What exists and what is on](#seeing-what-exists-and-what-is-on--knowl-config-list)
```

pointing at `### Seeing what exists and what is on \`knowl config list\`` — em dash and all — and it resolves on GitHub today.

So the assertion would have called a **correct** README link to any em-dashed heading broken, and the only way to satisfy it was to write an anchor that does not resolve. It stayed latent because every README anchor happened to point at a punctuation-free heading, where the two models agree.

## The fix

`\s` rather than `\s+`. The double-hyphen case is also pinned directly now, instead of only through whatever the README links on the day — otherwise a release that happens to use no em-dashed anchor lets the model rot again silently.

No source changes; one test file.