### PR TITLE
fix(tier): "two independent confirmations" now means two days, and the backlog is promoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+**"Two independent confirmations" now means two days, and the items that had already earned it
+are promoted.** The comment above `VERIFY_THRESHOLD` promised independent confirmations; the query
+counted rows, so two `knowl_feedback` calls in one turn — one agent, one item, one source — promoted
+an item to `verified`. Measured on the project's own store, every item the row count would have
+promoted was a burst inside a single session: four useful events in seven minutes on one, two four
+minutes apart on another. The feedback path now counts distinct days, the unit the observed-use path
+already uses, and neither clears the bar. The second half is the one that matters more: promotion
+was edge-triggered only, run at the instant a feedback row was written and never again, so an item
+whose confirmations crossed the bar before `knowl_feedback` was wired to standing stayed `asserted`
+forever — the store holds one with three useful events against a threshold of two. Session start
+now re-evaluates the feedback predicate over every asserted item, capped and audited the way the
+observed-use pass is, so the backlog drains instead of stranding (#223).
+
 **A push no longer fails anonymously on an over-long field.** The cloud contract caps `title`,
 `source` and `conflictKey` at 500 characters; the local store caps nothing, so a research atom
 with a long citation list sat staged until push, where the server's zod rejection came back as

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1155,6 +1155,14 @@ knowl_feedback({
 collection also uses this heat: an item is hot when it has at least three retrievals or was
 retrieved within the last 21 days.
 
+Feedback also moves standing. An item reported useful on two separate days is promoted from
+`asserted` to `verified` — days rather than events, so a burst of confirmations inside one
+session counts once — and a correction demotes it immediately. Promotion is checked when the
+feedback lands and again at every session start, so an item whose confirmations accumulated
+while nothing was evaluating them is promoted on the next session rather than never. Items are
+also promoted on observed use alone when they answer distinct questions across distinct days and
+cite files the drift check has had the chance to contradict.
+
 ## Workspaces
 
 Knowl workspaces provide linked federation across related repositories without merging their

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -95,7 +95,10 @@ import { bootstrapAgentSession } from '../store/context-bootstrap.js';
 import { consumePendingSessionHandoff, recordPendingSessionHandoff } from './session-handoff.js';
 import { DEFAULT_CONTEXT_MAX_CHARS, truncateText } from '../core/token-budget.js';
 import { describeAutoDrift, runAutoDriftCheckBestEffort, type AutoDriftResult } from '../store/drift-auto.js';
-import { describeObservedUsePromotions, promoteByObservedUseBestEffort } from '../store/tier.js';
+import {
+  describeConfirmedFeedbackPromotions, describeObservedUsePromotions,
+  promoteByConfirmedFeedbackBestEffort, promoteByObservedUseBestEffort,
+} from '../store/tier.js';
 
 // The cadence moved to `reminders.driftEvery` (default DEFAULT_DRIFT_REMINDER_EVERY = 12, `0`
 // off), so the number lives beside its predicate in core/config.ts rather than twice.
@@ -961,6 +964,11 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     // A project with no git history therefore never promotes on observed use, which is the
     // same falsifiability rule as `affected_paths`, applied to the repository instead.
     const standing = drift?.checked ? await promoteByObservedUseBestEffort(projectId) : null;
+    // The feedback path's re-evaluation, and not gated on drift: a confirmation is an agent
+    // saying the item was right, which needs no witness in a position to contradict it. Without
+    // this pass an item whose confirmations crossed the bar before `knowl_feedback` was wired to
+    // standing stays asserted forever, because that path only ever looks at the instant it fires.
+    const confirmed = await promoteByConfirmedFeedbackBestEffort(projectId);
 
     // Warnings are priced BEFORE the card is rendered, so the card is composed to what is left
     // rather than rendered wide and sliced. `drift` and `standing` are resolved above and the
@@ -988,6 +996,7 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
       await staleGuidanceWarningBestEffort(input.projectRoot),
       describeAutoDrift(drift),
       describeObservedUsePromotions(standing),
+      describeConfirmedFeedbackPromotions(confirmed),
     ].filter(Boolean).join('\n\n'), DEFAULT_CONTEXT_MAX_CHARS);
     // The roster of other live sessions rides below the warnings and above the knowledge, and
     // is charged against the cap the same way: it is empty for a session that is alone, and

--- a/src/store/tier.ts
+++ b/src/store/tier.ts
@@ -3,10 +3,21 @@ import * as repo from './repository.js';
 import type { CommitChange } from '../core/types.js';
 
 /**
- * Confirmed-useful feedback events required before an asserted item is promoted. One use
- * can be a coincidence of phrasing; two independent confirmations are the item earning
- * its place. Kept deliberately low because feedback is rare — agents report it after
- * actually using a result, not on every retrieval.
+ * Distinct DAYS carrying a confirmed-useful feedback event before an asserted item is
+ * promoted. One use can be a coincidence of phrasing; two independent confirmations are the
+ * item earning its place. Kept deliberately low because feedback is rare — agents report it
+ * after actually using a result, not on every retrieval.
+ *
+ * Days, not rows. The comment above has always said "independent" and the query counted
+ * `COUNT(*)`, so two `knowl_feedback` calls in one turn, on one item, by one agent, promoted it
+ * — one source counted twice, the correlated-confirmation bias the observed-use path below
+ * already refuses at a different scale ("twenty retrievals inside one session are one agent
+ * circling one problem"). Measured on this project's own store before the change (#223): every
+ * item the row count would have promoted was a burst inside a single session — four events in
+ * seven minutes on one, two four minutes apart on another — and under distinct days not one of
+ * them clears the bar. Not `query_fingerprint`, which the observed-use path uses as its second
+ * axis: `recordKnowledgeFeedback` carries no query, so every feedback row's fingerprint is NULL
+ * and a distinct count over it is zero forever.
  */
 export const VERIFY_THRESHOLD = 2;
 
@@ -22,10 +33,14 @@ export type TierChange = {
  * deliberate consequence applied here, so the boundary between "we log what happened"
  * and "what happened has weight" is a function call you can find.
  *
- * Promotion needs VERIFY_THRESHOLD confirmed-useful events. A correction demotes
- * immediately and unconditionally: one proof of wrongness outweighs any history of
+ * Promotion needs confirmed-useful events on VERIFY_THRESHOLD distinct days. A correction
+ * demotes immediately and unconditionally: one proof of wrongness outweighs any history of
  * usefulness — the poisoning literature's core finding is confidence accumulating
  * without ground truth, and this is the ground-truth valve.
+ *
+ * This runs at the instant a feedback row is written and nowhere else, which is why
+ * `promoteByConfirmedFeedback` exists: an item whose confirmations crossed the bar before this
+ * path was wired, or while the path was disabled, satisfies the predicate and is never asked.
  */
 export async function applyFeedbackToTier(
   projectId: string,
@@ -45,36 +60,152 @@ export async function applyFeedbackToTier(
   }
 
   if (feedback.useful !== true || item.tier === 'verified') return null;
-
-  // Counted from when the current tier began, not from the item's whole history. An
-  // unbounded count made both resets cosmetic: a correction or a rewording dropped the
-  // item to asserted, and the very next confirmation re-promoted it on the strength of
-  // events that had confirmed a claim the item no longer makes.
-  // NULL tier_since means a row written before the column existed: it has never been
-  // reset, so its full history still belongs to its current standing.
-  // `>=`, not `>`. `tier_since` is stamped at creation and at every reset, and ISO timestamps
-  // are millisecond-granular — so a confirmation recorded in the same millisecond as the
-  // boundary was dropped, and the item silently needed VERIFY_THRESHOLD + 1 events. It only
-  // looked correct because most machines take a millisecond to get from one call to the next;
-  // on CI's ubuntu runner three tests in this area failed at random depending on which side of
-  // a tick they landed. An event AT the boundary belongs to the standing that began there.
-  //
-  // This does not weaken what the boundary is for. The event that causes a reset is a
-  // correction or an edit, never `useful = 1`, so it is already excluded by the predicate
-  // above it — the guard against re-promotion on stale confirmations is untouched.
-  const row = (await getClient().execute({
-    sql: `SELECT COUNT(*) AS confirmations FROM knowledge_access
-          WHERE knowledge_item_id = ? AND surface = 'feedback' AND useful = 1
-            AND retrieved_at >= COALESCE(?, '')`,
-    args: [itemId, item.tierSince ?? null],
-  })).rows[0];
-  if (Number(row?.confirmations ?? 0) < VERIFY_THRESHOLD) return null;
+  if (await confirmedDaysSinceTierBegan(itemId, item.tierSince ?? null) < VERIFY_THRESHOLD) return null;
 
   const updated = await repo.updateKnowledgeItem(itemId, { tier: 'verified' });
   await repo.createKnowledgeCommit(projectId, `Promote to verified: ${item.title}`, [
     { itemId, action: 'update', before: item, after: updated },
   ]);
   return { itemId, tier: 'verified', reason: 'promoted' };
+}
+
+/**
+ * The feedback path's one predicate, shared by the edge-triggered promotion above and the
+ * sweep below so the two cannot disagree about what "confirmed" means.
+ *
+ * Counted from when the current tier began, not from the item's whole history. An
+ * unbounded count made both resets cosmetic: a correction or a rewording dropped the
+ * item to asserted, and the very next confirmation re-promoted it on the strength of
+ * events that had confirmed a claim the item no longer makes.
+ * NULL tier_since means a row written before the column existed: it has never been
+ * reset, so its full history still belongs to its current standing.
+ * `>=`, not `>`. `tier_since` is stamped at creation and at every reset, and ISO timestamps
+ * are millisecond-granular — so a confirmation recorded in the same millisecond as the
+ * boundary was dropped, and the item silently needed VERIFY_THRESHOLD + 1 events. It only
+ * looked correct because most machines take a millisecond to get from one call to the next;
+ * on CI's ubuntu runner three tests in this area failed at random depending on which side of
+ * a tick they landed. An event AT the boundary belongs to the standing that began there.
+ *
+ * This does not weaken what the boundary is for. The event that causes a reset is a
+ * correction or an edit, never `useful = 1`, so it is already excluded by the predicate
+ * above it — the guard against re-promotion on stale confirmations is untouched.
+ *
+ * `substr(retrieved_at, 1, 10)` is the calendar day of an ISO timestamp, the same expression
+ * `promoteByObservedUse` groups on. Two confirmations minutes apart are one day and count once.
+ *
+ * Always on the base client: a SQLite transaction belongs to the connection, so inside
+ * `withClientTransaction` this statement is already part of it (see `database.ts`).
+ */
+async function confirmedDaysSinceTierBegan(itemId: string, tierSince: string | null): Promise<number> {
+  const row = (await getClient().execute({
+    sql: `SELECT COUNT(DISTINCT substr(retrieved_at, 1, 10)) AS days FROM knowledge_access
+          WHERE knowledge_item_id = ? AND surface = 'feedback' AND useful = 1
+            AND retrieved_at >= COALESCE(?, '')`,
+    args: [itemId, tierSince],
+  })).rows[0];
+  return Number(row?.days ?? 0);
+}
+
+export type ConfirmedFeedbackResult = {
+  promoted: TierChange[];
+  /** Eligible items the per-run cap left behind. Reported, never silently dropped. */
+  deferred: number;
+};
+
+/**
+ * Promote every asserted item whose confirmations already clear the bar, because the
+ * edge-triggered path never looks back.
+ *
+ * `applyFeedbackToTier` is reachable from `knowl_feedback` alone and runs solely at the
+ * instant a feedback row is written; nothing re-evaluates. So any item that crossed the
+ * threshold before that path existed — this project's own store holds one with three useful
+ * events against a threshold of two, `tier_since` NULL, still `asserted` — stays unpromoted
+ * forever, and a tightened predicate does not help an item the predicate is never run against
+ * (#223). This is the re-evaluation, run once per session start beside `promoteByObservedUse`.
+ *
+ * The same predicate as the edge, deliberately, re-checked per item inside the transaction:
+ * the candidate query is a cheap filter, and the per-item check is the one the feedback tool
+ * would have applied had it fired. A correction since the tier began is excluded here where the
+ * edge does not need to exclude it — a correction demotes and resets `tier_since` on the way
+ * through, so the edge never sees one, but a pre-column row (`tier_since` NULL) with a
+ * historic correction never had that reset applied, and "one proof of wrongness outweighs any
+ * history of usefulness" is the rule this path exists to honour.
+ *
+ * Not gated on the drift check the way observed use is. Observed use promotes on recurrence,
+ * which is only meaningful if something was in a position to contradict the item; a
+ * confirmation is an agent saying the item was right, and needs no such witness. Capped the
+ * same way, for the same blast-radius reason.
+ */
+export async function promoteByConfirmedFeedback(projectId: string): Promise<ConfirmedFeedbackResult> {
+  const rows = (await getClient().execute({
+    sql: `SELECT ki.id AS id, COUNT(DISTINCT substr(ka.retrieved_at, 1, 10)) AS days
+          FROM knowledge_items ki
+          JOIN knowledge_access ka
+            ON ka.knowledge_item_id = ki.id
+           AND ka.surface = 'feedback'
+           AND ka.useful = 1
+           AND ka.retrieved_at >= COALESCE(ki.tier_since, '')
+          WHERE ki.status = 'active'
+            AND ki.tier = 'asserted'
+            AND NOT EXISTS (
+              SELECT 1 FROM knowledge_access bad
+              WHERE bad.knowledge_item_id = ki.id
+                AND bad.caused_correction = 1
+                AND bad.retrieved_at >= COALESCE(ki.tier_since, '')
+            )
+          GROUP BY ki.id
+          HAVING COUNT(DISTINCT substr(ka.retrieved_at, 1, 10)) >= ?`,
+    args: [VERIFY_THRESHOLD],
+  })).rows;
+
+  if (rows.length === 0) return { promoted: [], deferred: 0 };
+
+  const ranked = rows
+    .map(row => ({ id: String(row.id), days: Number(row.days) }))
+    .sort((a, b) => b.days - a.days || a.id.localeCompare(b.id));
+  const selected = ranked.slice(0, OBSERVED_USE_MAX_PER_RUN);
+
+  const promoted: TierChange[] = [];
+  const changes: CommitChange[] = [];
+
+  await withClientTransaction(async tx => {
+    for (const candidate of selected) {
+      const item = await repo.getKnowledgeItem(candidate.id, tx);
+      if (!item || item.status !== 'active' || item.tier !== 'asserted') continue;
+      if (await confirmedDaysSinceTierBegan(candidate.id, item.tierSince ?? null) < VERIFY_THRESHOLD) continue;
+
+      const updated = await repo.updateKnowledgeItem(candidate.id, { tier: 'verified' }, undefined, tx);
+      changes.push({ itemId: candidate.id, action: 'update', before: item, after: updated });
+      promoted.push({ itemId: candidate.id, tier: 'verified', reason: 'promoted' });
+    }
+
+    if (changes.length > 0) {
+      await repo.createKnowledgeCommit(
+        projectId,
+        `Promote to verified by confirmed feedback: ${changes.length} item(s)`,
+        changes,
+        tx,
+      );
+    }
+  });
+
+  return { promoted, deferred: ranked.length - selected.length };
+}
+
+/** Hooks must never fail the host: a failed sweep reads as "nothing promoted". */
+export async function promoteByConfirmedFeedbackBestEffort(projectId: string): Promise<ConfirmedFeedbackResult | null> {
+  try {
+    return await promoteByConfirmedFeedback(projectId);
+  } catch {
+    return null;
+  }
+}
+
+/** The session-start line for the sweep. Silent when nothing moved, like its sibling below. */
+export function describeConfirmedFeedbackPromotions(result: ConfirmedFeedbackResult | null): string | undefined {
+  if (!result || result.promoted.length === 0) return undefined;
+  const more = result.deferred > 0 ? ` ${result.deferred} more are eligible and will follow on later sessions.` : '';
+  return `STANDING: ${result.promoted.length} knowledge item(s) promoted to verified on confirmed feedback — reported useful on ${VERIFY_THRESHOLD}+ separate days.${more} A correction demotes immediately.`;
 }
 
 /** Feedback recording must never fail because standing could not be updated. */

--- a/tests/store/tier.test.ts
+++ b/tests/store/tier.test.ts
@@ -10,6 +10,7 @@ import {
   OBSERVED_USE_MAX_PER_RUN,
   OBSERVED_USE_MIN_DAYS,
   OBSERVED_USE_MIN_QUESTIONS,
+  promoteByConfirmedFeedback,
   promoteByObservedUse,
   VERIFY_THRESHOLD,
 } from '../../src/store/tier.js';
@@ -53,16 +54,49 @@ describe('evidence tier and provenance', () => {
     expect(legacy.provenance).toBeNull();
   });
 
+  /**
+   * One confirmed-useful feedback event, `day` calendar days after the item's CURRENT
+   * `tier_since`. Anchored to the boundary rather than the wall clock for the reason the
+   * observed-use suite gives: an edit or a correction moves the boundary, and wall-clock offsets
+   * would leave pre-reset rows sitting after the new boundary. A minute past the boundary so the
+   * `>=` test below is the only one that exercises the boundary instant itself.
+   */
+  async function confirmOnDay(itemId: string, day: number) {
+    const since = Date.parse((await repo.getKnowledgeItem(itemId))!.tierSince!);
+    await recordKnowledgeFeedback({
+      itemId, used: true, useful: true,
+      retrievedAt: new Date(since + day * 86_400_000 + 60_000).toISOString(),
+    });
+  }
+
+  /** VERIFY_THRESHOLD confirmations on VERIFY_THRESHOLD distinct days. */
+  async function confirmAcrossDays(itemId: string) {
+    for (let day = 0; day < VERIFY_THRESHOLD; day++) await confirmOnDay(itemId, day);
+  }
+
+  /**
+   * Put the item's boundary a month back. The reset tests need the climb to sit in the PAST:
+   * a reset moves `tier_since` forward by milliseconds, so confirmations seeded on days after
+   * a just-created boundary would still clear the new one and the test would pass an item it
+   * is supposed to refuse -- the same trap the observed-use suite records below.
+   */
+  async function backdateBoundary(itemId: string) {
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET tier_since = ? WHERE id = ?',
+      args: [new Date(Date.now() - 30 * 86_400_000).toISOString(), itemId],
+    });
+  }
+
   it('promotes only at the confirmation threshold, then demotes on correction', async () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'fact', title: 'Useful fact', content: 'Confirmed by use twice.',
     });
 
-    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    await confirmOnDay(item.id, 0);
     expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
 
-    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    await confirmOnDay(item.id, 1);
     const promoted = await applyFeedbackToTier(projectId, item.id, { useful: true });
     expect(promoted).toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
@@ -70,6 +104,31 @@ describe('evidence tier and provenance', () => {
     const demoted = await applyFeedbackToTier(projectId, item.id, { causedCorrection: true });
     expect(demoted).toEqual({ itemId: item.id, tier: 'asserted', reason: 'demoted' });
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  // The comment above VERIFY_THRESHOLD promised "two independent confirmations" and the query
+  // counted rows, so two knowl_feedback calls in one turn — one agent, one item, one source —
+  // promoted. Measured on the project's own store: every item the row count would have promoted
+  // was a burst inside a single session. Days are the unit the sibling path already uses.
+  it('refuses a burst of confirmations inside one day — independent means separate days', async () => {
+    const item = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Bursty fact', content: 'Confirmed twice in seven minutes.',
+    });
+    const since = Date.parse((await repo.getKnowledgeItem(item.id))!.tierSince!);
+    for (let minute = 1; minute <= VERIFY_THRESHOLD * 2; minute++) {
+      await recordKnowledgeFeedback({
+        itemId: item.id, used: true, useful: true,
+        retrievedAt: new Date(since + minute * 60_000).toISOString(),
+      });
+    }
+
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    // The same item, confirmed once more on another day, has now been confirmed independently.
+    await confirmOnDay(item.id, 1);
+    expect(await applyFeedbackToTier(projectId, item.id, { useful: true }))
+      .toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
   });
 
   it('a content edit resets verified to asserted — verified means verified-verbatim', async () => {
@@ -91,23 +150,23 @@ describe('evidence tier and provenance', () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'fact', title: 'Reworded fact', content: 'Original wording.',
     });
-    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
-      await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
-      await applyFeedbackToTier(projectId, item.id, { useful: true });
-    }
+    await backdateBoundary(item.id);
+    await confirmAcrossDays(item.id);
+    await applyFeedbackToTier(projectId, item.id, { useful: true });
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
 
     await repo.updateKnowledgeItem(item.id, { content: 'A materially different claim.' });
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
 
     // One confirmation of the NEW wording is below the threshold. The pre-edit events
-    // confirmed words that no longer exist and must not count toward this promotion.
-    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    // confirmed words that no longer exist and must not count toward this promotion — and they
+    // sit on days after the new boundary only if the boundary were ignored, which is the point.
+    await confirmOnDay(item.id, 0);
     expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
 
     // A full threshold of post-edit confirmations does promote again.
-    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    await confirmOnDay(item.id, 1);
     expect(await applyFeedbackToTier(projectId, item.id, { useful: true }))
       .toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
   });
@@ -126,13 +185,14 @@ describe('evidence tier and provenance', () => {
     const boundary = (await repo.getKnowledgeItem(item.id))!.tierSince!;
     expect(boundary).toBeTruthy();
 
-    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
-      await getClient().execute({
-        sql: `INSERT INTO knowledge_access (id, knowledge_item_id, surface, rank, useful, retrieved_at)
-              VALUES (?, ?, 'feedback', 1, 1, ?)`,
-        args: [`boundary-${i}`, item.id, boundary],
-      });
-    }
+    // One row AT the boundary instant, and the rest on later days: the boundary row is the
+    // one this test is about, and it must count as a day of its own.
+    await getClient().execute({
+      sql: `INSERT INTO knowledge_access (id, knowledge_item_id, surface, rank, useful, retrieved_at)
+            VALUES (?, ?, 'feedback', 1, 1, ?)`,
+      args: ['boundary-0', item.id, boundary],
+    });
+    for (let day = 1; day < VERIFY_THRESHOLD; day++) await confirmOnDay(item.id, day);
 
     expect(await applyFeedbackToTier(projectId, item.id, { useful: true }))
       .toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
@@ -142,10 +202,9 @@ describe('evidence tier and provenance', () => {
     const item = await repo.createKnowledgeItem(projectId, {
       category: 'fact', title: 'Corrected fact', content: 'A claim proven wrong.',
     });
-    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
-      await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
-      await applyFeedbackToTier(projectId, item.id, { useful: true });
-    }
+    await backdateBoundary(item.id);
+    await confirmAcrossDays(item.id);
+    await applyFeedbackToTier(projectId, item.id, { useful: true });
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
 
     await recordKnowledgeFeedback({ itemId: item.id, used: true, causedCorrection: true });
@@ -153,7 +212,7 @@ describe('evidence tier and provenance', () => {
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
 
     // Proof of wrongness must cost more than a single subsequent confirmation.
-    await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    await confirmOnDay(item.id, 0);
     expect(await applyFeedbackToTier(projectId, item.id, { useful: true })).toBeNull();
     expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
   });
@@ -170,8 +229,13 @@ describe('evidence tier and provenance', () => {
     });
     expect((await repo.getKnowledgeItem(item.id))?.tierSince).toBeNull();
 
-    for (let i = 0; i < VERIFY_THRESHOLD; i++) {
-      await recordKnowledgeFeedback({ itemId: item.id, used: true, useful: true });
+    // No boundary to anchor to, so the days are absolute — and in the past, which is where a
+    // pre-column row's confirmations actually are.
+    for (let day = 0; day < VERIFY_THRESHOLD; day++) {
+      await recordKnowledgeFeedback({
+        itemId: item.id, used: true, useful: true,
+        retrievedAt: new Date(Date.UTC(2026, 6, 20 + day, 12)).toISOString(),
+      });
     }
     expect(await applyFeedbackToTier(projectId, item.id, { useful: true }))
       .toEqual({ itemId: item.id, tier: 'verified', reason: 'promoted' });
@@ -421,5 +485,132 @@ describe('standing earned by observed use', () => {
     // Use of the new wording earns it back.
     await seedRetrievals(item.id, OBSERVED_USE_MIN_DAYS);
     expect((await promoteByObservedUse(projectId)).promoted).toHaveLength(1);
+  });
+});
+
+// Its own root again, for the same EBUSY reason as the suite above.
+const CONFIRMED_ROOT = path.resolve('.knowl-confirmed-feedback-test');
+
+/**
+ * The feedback path's re-evaluation. `applyFeedbackToTier` runs at the instant a feedback row
+ * is written and never again, so an item whose confirmations crossed the bar before that path
+ * existed satisfies the predicate and is never asked. This sweep is the asking.
+ */
+describe('standing earned by confirmed feedback the edge never saw', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(CONFIRMED_ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(CONFIRMED_ROOT, '.knowl'), { recursive: true });
+    await initDb(CONFIRMED_ROOT);
+    projectId = (await repo.createProject(CONFIRMED_ROOT, 'Confirmed feedback test')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_access`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+    await db.run(sql`DELETE FROM knowledge_commits`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(CONFIRMED_ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const seedItem = (title: string) => repo.createKnowledgeItem(projectId, {
+    category: 'fact', title, content: `${title} — content.`,
+  });
+
+  /** A confirmation `day` days after the item's current boundary, written with no promotion pass. */
+  async function confirmOnDay(itemId: string, day: number) {
+    const since = Date.parse((await repo.getKnowledgeItem(itemId))!.tierSince!);
+    await recordKnowledgeFeedback({
+      itemId, used: true, useful: true,
+      retrievedAt: new Date(since + day * 86_400_000 + 60_000).toISOString(),
+    });
+  }
+
+  it('promotes an item whose confirmations already clear the bar', async () => {
+    // The shape on the project's own store: rows written before the promotion path was wired,
+    // so nothing ever evaluated them.
+    const item = await seedItem('Confirmed before the path existed');
+    for (let day = 0; day < VERIFY_THRESHOLD; day++) await confirmOnDay(item.id, day);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+
+    const result = await promoteByConfirmedFeedback(projectId);
+    expect(result.promoted).toEqual([{ itemId: item.id, tier: 'verified', reason: 'promoted' }]);
+    expect(result.deferred).toBe(0);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('verified');
+
+    const row = (await getClient().execute({
+      sql: `SELECT COUNT(*) AS n FROM knowledge_commits WHERE message LIKE 'Promote to verified by confirmed feedback%'`,
+    })).rows[0];
+    expect(Number(row.n)).toBe(1);
+
+    // Idempotent: a second pass finds nothing left to do.
+    expect((await promoteByConfirmedFeedback(projectId)).promoted).toEqual([]);
+  });
+
+  it('applies the same day rule as the edge — a single-day burst is not confirmed', async () => {
+    const item = await seedItem('Burst before the path existed');
+    const since = Date.parse((await repo.getKnowledgeItem(item.id))!.tierSince!);
+    for (let minute = 1; minute <= 4; minute++) {
+      await recordKnowledgeFeedback({
+        itemId: item.id, used: true, useful: true,
+        retrievedAt: new Date(since + minute * 60_000).toISOString(),
+      });
+    }
+
+    expect((await promoteByConfirmedFeedback(projectId)).promoted).toEqual([]);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  it('refuses a pre-column row that was ever corrected, however many confirmations it carries', async () => {
+    // `tier_since` NULL means the demotion-and-reset that a correction performs today never
+    // ran for this row, so its history is the only record that it was once proven wrong.
+    const item = await seedItem('Legacy row with a correction in its past');
+    await getClient().execute({ sql: 'UPDATE knowledge_items SET tier_since = NULL WHERE id = ?', args: [item.id] });
+    for (let day = 0; day < VERIFY_THRESHOLD + 1; day++) {
+      await recordKnowledgeFeedback({
+        itemId: item.id, used: true, useful: true,
+        retrievedAt: new Date(Date.UTC(2026, 6, 20 + day, 12)).toISOString(),
+      });
+    }
+    await recordKnowledgeFeedback({
+      itemId: item.id, used: true, causedCorrection: true,
+      retrievedAt: new Date(Date.UTC(2026, 6, 25, 12)).toISOString(),
+    });
+
+    expect((await promoteByConfirmedFeedback(projectId)).promoted).toEqual([]);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  it('counts only from tier_since, so confirmations of replaced wording do not carry over', async () => {
+    const item = await seedItem('Reworded and confirmed');
+    await getClient().execute({
+      sql: 'UPDATE knowledge_items SET tier_since = ? WHERE id = ?',
+      args: [new Date(Date.now() - 30 * 86_400_000).toISOString(), item.id],
+    });
+    for (let day = 0; day < VERIFY_THRESHOLD; day++) await confirmOnDay(item.id, day);
+    await repo.updateKnowledgeItem(item.id, { content: 'A materially different claim.' });
+
+    expect((await promoteByConfirmedFeedback(projectId)).promoted).toEqual([]);
+    expect((await repo.getKnowledgeItem(item.id))?.tier).toBe('asserted');
+  });
+
+  it('caps a run and reports what it left, like the observed-use pass', async () => {
+    const overflow = 2;
+    for (let n = 0; n < OBSERVED_USE_MAX_PER_RUN + overflow; n++) {
+      const item = await seedItem(`Confirmed fact ${n}`);
+      for (let day = 0; day < VERIFY_THRESHOLD; day++) await confirmOnDay(item.id, day);
+    }
+
+    const first = await promoteByConfirmedFeedback(projectId);
+    expect(first.promoted).toHaveLength(OBSERVED_USE_MAX_PER_RUN);
+    expect(first.deferred).toBe(overflow);
+    const second = await promoteByConfirmedFeedback(projectId);
+    expect(second.promoted).toHaveLength(overflow);
+    expect(second.deferred).toBe(0);
   });
 });


### PR DESCRIPTION
Option 1 from #223, plus the fourth finding your comment added — which turned out to be the larger half.

## Distinct days, not rows

The comment above `VERIFY_THRESHOLD` promised "two independent confirmations"; the query counted `COUNT(*)`, so two `knowl_feedback` calls in one turn — one agent, one item, one source — promoted. Your replay on knowl's own store is the measurement: the two items with ≥ threshold useful events are `d2da7a00` (4 events in seven minutes) and `e8f1c49e` (two four minutes apart, one four days later). The feedback path now counts `COUNT(DISTINCT substr(retrieved_at, 1, 10))`, the same expression `promoteByObservedUse` groups on. `d2da7a00` scores 1 day and stays `asserted`.

Not `query_fingerprint`, for the reason in the issue: `recordKnowledgeFeedback` carries no query, so every feedback row's fingerprint is NULL and a distinct count over it is zero forever. The predicate is one function (`confirmedDaysSinceTierBegan`) shared by the edge and the sweep, so the two cannot disagree.

## The backlog is promoted

Promotion was edge-triggered only: `applyFeedbackToTier` runs at the instant a feedback row is written and nothing re-evaluates, so an item that crossed the bar before the path was wired stayed `asserted` forever. `promoteByConfirmedFeedback` is the re-evaluation, run at session start beside `promoteByObservedUse`:

- Same predicate as the edge, re-checked per item inside the transaction after the candidate query.
- Same per-run cap (`OBSERVED_USE_MAX_PER_RUN`) and its own knowledge commit (`Promote to verified by confirmed feedback: N item(s)`), so every automatic promotion stays auditable.
- **Not gated on the drift check** the way observed use is. Observed use promotes on recurrence, which only means something if the item was falsifiable; a confirmation is an agent saying the item was right, and needs no witness.
- A pre-column row (`tier_since` NULL) with a correction anywhere in its history is refused. The demotion-and-reset a correction performs today never ran for it, and "one proof of wrongness outweighs any history of usefulness" is the rule this path exists to honour.

On knowl's store, `e8f1c49e` scores 2 distinct days (2026-07-26 and 07-30) against a threshold of 2, so it is the one item the first session start after this lands will promote. `d2da7a00` will not.

The session line is silent when nothing moved, and sits last in the warning block for the reason the observed-use line does.

## Tests

- A burst inside one day is refused; the same item confirmed once more on another day promotes.
- The sweep promotes an item whose confirmations predate any evaluation, writes one commit, and is idempotent.
- The sweep applies the same day rule, refuses a corrected pre-column row, counts only from `tier_since`, and caps a run reporting what it deferred.
- Two existing reset tests had to backdate the boundary a month before seeding: a reset moves `tier_since` forward by milliseconds, so rows on days after a just-created boundary still cleared the new one — the same trap the observed-use suite already records in a comment.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npx eslint` on the touched files | clean |
| `npm run build` | clean |
| `npm run docs:check` | current |
| `npx vitest run` | **387 files / 3696 passed / 5 skipped / 0 failed** |

**Falsification:** restoring `COUNT(*)` fails the burst test and the sweep's day-rule test; removing the session-start call leaves the sweep tests green but the store's own `e8f1c49e` unpromoted, which is the case the issue is about.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
