### PR TITLE
feat(evidence): file evidence is hashed where a session actually read the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+**File evidence can go stale, which the README has promised since it was written.**
+`isEvidenceStale` compares a file's current hash against the one the evidence recorded, and no
+shipped writer ever recorded one: `affectedPaths` became file evidence with `contentHash` NULL, the
+one module that hashed files has no importer, and the MCP schema has no field for a caller to
+supply one. Symbol evidence went stale; file evidence could not. The obvious fix — hash every cited
+path — would have turned an agent's unverified assertion about a file into a staleness claim about
+it, and that gate was real. The read-set is now the gate: a cited path some session provably
+opened (`work_read_sets` holds a `file://` or `symbol://` row for it, captured from the tool
+stream and never from the agent's own report) is hashed from disk at write time; a path merely
+declared stays unhashed and never reports stale. One disk read per observed path per write, on the
+write path only. `session-evidence.ts` is untouched and still unwired; whether to delete it is a
+separate call (#225).
+
 **A push no longer fails anonymously on an over-long field.** The cloud contract caps `title`,
 `source` and `conflictKey` at 500 characters; the local store caps nothing, so a research atom
 with a long citation list sat staged until push, where the server's zod rejection came back as

--- a/src/store/evidence-repository.ts
+++ b/src/store/evidence-repository.ts
@@ -185,15 +185,71 @@ export async function unlinkKnowledgeEvidence(itemId: string, evidenceId: string
   });
 }
 
+/** Literal `%` and `_` in a path must not become LIKE wildcards. */
+const escapeLike = (value: string) => value.replace(/[\\%_]/g, char => `\\${char}`);
+
+/**
+ * The hash to stamp on file evidence built from `affectedPaths`, or null when nothing observed
+ * the file.
+ *
+ * **The read-set is the gate, not the hash source.** `work_read_sets` holds a row for every file
+ * a session actually opened -- `file://path` where the file yielded no symbols or was read from
+ * the shell, `symbol://path#Name` per symbol otherwise -- filled from the captured tool stream
+ * and never from an agent's own report. A cited path with a row is a file some session provably
+ * looked at; one without is a declaration. Only the first is hashed, so an agent's unverified
+ * assertion about a file never becomes a staleness claim about it, and nothing here reads a
+ * declared path from disk. That distinction was load-bearing before this existed (#225): every
+ * `affectedPaths` entry became file evidence with `contentHash` NULL, which is why
+ * `isEvidenceStale` could never return true for file evidence this repo originated -- the one
+ * writer that set a hash, `session-evidence.ts`, has no importer.
+ *
+ * Hashed from disk at write time rather than copied out of the read-set, for two reasons. The
+ * symbol rows carry signature hashes, not a file hash, so for most code files the read-set has
+ * nothing at file granularity to copy. And the file the atom is written against is the one on
+ * disk now: an agent that read a file, edited it and then stored a claim about it holds a belief
+ * about the edited version, and evidence stamped with the pre-edit hash would report that
+ * belief stale the moment it was recorded. Same digest as `isEvidenceStale` and the read-set
+ * capture -- raw bytes, sha256 -- so the comparison side agrees with the write side.
+ *
+ * Any session's row counts, released or not. The MCP write path does not know which host
+ * session is calling it, and a row is evidence that the store saw the file's contents, which is
+ * the fact the gate turns on. One disk read per observed path per write, on the write path only;
+ * the recall path is unchanged.
+ */
+async function observedFileHash(locator: string): Promise<string | null> {
+  const relative = containedRepoPath(locator);
+  if (relative === null) return null;
+  const observed = await getClient().execute({
+    sql: `SELECT 1 FROM work_read_sets WHERE locator = ? OR locator LIKE ? ESCAPE '\\' LIMIT 1`,
+    args: [`file://${relative}`, `${escapeLike(`symbol://${relative}#`)}%`],
+  });
+  if (observed.rows.length === 0) return null;
+  try {
+    const content = await fs.readFile(path.resolve(getProjectRoot(), relative));
+    return crypto.createHash('sha256').update(content).digest('hex');
+  } catch {
+    // Observed once, gone or unreadable now. No hash is the pre-existing behaviour for this
+    // row, and a missing verdict costs nothing where a wrong one would.
+    return null;
+  }
+}
+
 export async function attachEvidenceToKnowledge(
   itemId: string,
   explicit: EvidenceInput[] | undefined,
   compatibility?: { sourceCommit?: string | null; affectedPaths?: string[] | null },
 ): Promise<void> {
-  const inputs = explicit?.length ? explicit : [
+  const inputs: EvidenceInput[] = explicit?.length ? explicit : [
     ...(compatibility?.sourceCommit ? [{ type: 'commit' as const, locator: compatibility.sourceCommit, observedAt: new Date().toISOString(), relationship: 'derived_from' as const }] : []),
-    ...((compatibility?.affectedPaths || []).map(locator => ({ type: 'file' as const, locator, observedAt: new Date().toISOString(), relationship: 'supports' as const }))),
   ];
+  if (!explicit?.length) {
+    for (const locator of compatibility?.affectedPaths || []) {
+      inputs.push({
+        type: 'file', locator, observedAt: new Date().toISOString(), relationship: 'supports',
+        contentHash: await observedFileHash(normalizeEvidenceLocator('file', locator)),
+      });
+    }
+  }
   for (const input of inputs) {
     const { relationship = 'supports', ...evidenceInput } = input;
     const evidence = await createEvidence(evidenceInput);

--- a/tests/store/evidence-hash-from-read-set.test.ts
+++ b/tests/store/evidence-hash-from-read-set.test.ts
@@ -1,0 +1,134 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { closeDb, getDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { recordRead } from '../../src/store/read-set.js';
+import { storeKnowledgeAtomsDeduped } from '../../src/store/knowledge-writer.js';
+import { attachEvidenceToKnowledge, isEvidenceStale, listEvidenceForItem } from '../../src/store/evidence-repository.js';
+
+/**
+ * File evidence built from `affectedPaths` carries a hash only where a session observed the
+ * file (#225). Before this, every such row had `contentHash` NULL, so `isEvidenceStale` could
+ * never say true for file evidence this repo originated -- and the reason it was never simply
+ * hashed is the property the third test pins: a declared path must not become a staleness
+ * claim, or an agent's unverified assertion about a file it never opened would report as fact.
+ */
+const ROOT = path.resolve('.knowl-evidence-read-set-test');
+
+const sha256 = (content: Buffer | string) => crypto.createHash('sha256').update(content).digest('hex');
+
+describe('file evidence hashed from what the read-set observed', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await fs.mkdir(path.join(ROOT, 'src'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'Evidence read-set test')).id;
+  });
+
+  beforeEach(async () => {
+    const db = getDb() as any;
+    await db.run(sql`DELETE FROM knowledge_evidence`);
+    await db.run(sql`DELETE FROM evidence`);
+    await db.run(sql`DELETE FROM knowledge_items`);
+    await db.run(sql`DELETE FROM work_read_sets`);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const writeFile = async (relative: string, content: string) => {
+    await fs.writeFile(path.join(ROOT, relative), content);
+    return sha256(content);
+  };
+
+  const seedItem = (title: string) => repo.createKnowledgeItem(projectId, {
+    category: 'fact', title, content: `${title} — content.`,
+  });
+
+  it('hashes a cited file the session read at file granularity, and the hash goes stale when it moves', async () => {
+    const hash = await writeFile('src/notes.md', '# notes\n');
+    await recordRead({ sessionId: 'sess-a', locator: 'file://src/notes.md', observedHash: hash, toolName: 'Read' });
+    const item = await seedItem('Notes fact');
+
+    await attachEvidenceToKnowledge(item.id, undefined, { affectedPaths: ['src/notes.md'] });
+
+    const [evidence] = await listEvidenceForItem(item.id);
+    expect(evidence).toMatchObject({ type: 'file', locator: 'src/notes.md', contentHash: hash });
+    expect(await isEvidenceStale(evidence, ROOT)).toBe(false);
+
+    await writeFile('src/notes.md', '# notes, rewritten\n');
+    expect(await isEvidenceStale(evidence, ROOT)).toBe(true);
+  });
+
+  it('counts a symbol-granularity read as observation, and hashes the whole file', async () => {
+    // A code file with symbols is recorded one `symbol://` row per symbol and no `file://` row
+    // at all, so the file hash has to come from disk -- the read-set proves the read happened.
+    const hash = await writeFile('src/auth.ts', 'export function createToken() { return "token"; }\n');
+    await recordRead({
+      sessionId: 'sess-b', locator: 'symbol://src/auth.ts#createToken', observedHash: 'sig-1', toolName: 'Read',
+    });
+    const item = await seedItem('Token fact');
+
+    await attachEvidenceToKnowledge(item.id, undefined, { affectedPaths: ['src/auth.ts'] });
+
+    const [evidence] = await listEvidenceForItem(item.id);
+    expect(evidence.contentHash).toBe(hash);
+    expect(await isEvidenceStale(evidence, ROOT)).toBe(false);
+    await writeFile('src/auth.ts', 'export function createAccessToken() { return "token"; }\n');
+    expect(await isEvidenceStale(evidence, ROOT)).toBe(true);
+  });
+
+  it('leaves a merely declared path unhashed, so a claim nobody verified never reports stale', async () => {
+    await writeFile('src/declared.ts', 'export const declared = 1;\n');
+    const item = await seedItem('Declared fact');
+
+    await attachEvidenceToKnowledge(item.id, undefined, { affectedPaths: ['src/declared.ts'] });
+
+    const [evidence] = await listEvidenceForItem(item.id);
+    expect(evidence).toMatchObject({ type: 'file', locator: 'src/declared.ts', contentHash: null });
+    await writeFile('src/declared.ts', 'export const declared = 2;\n');
+    expect(await isEvidenceStale(evidence, ROOT)).toBe(false);
+  });
+
+  it('does not confuse a sibling whose name shares a prefix with an observed file', async () => {
+    // `symbol://src/auth.ts#…` must not vouch for `src/auth.tsx`, and a `_` in a path is a
+    // character, not a wildcard.
+    await writeFile('src/auth.tsx', 'export const Auth = () => null;\n');
+    await recordRead({ sessionId: 'sess-c', locator: 'symbol://src/auth.ts#createToken', observedHash: 'sig-1' });
+    const item = await seedItem('Sibling fact');
+
+    await attachEvidenceToKnowledge(item.id, undefined, { affectedPaths: ['src/auth.tsx'] });
+
+    expect((await listEvidenceForItem(item.id))[0].contentHash).toBeNull();
+  });
+
+  it('never reads a locator that escapes the root, observed or not', async () => {
+    await recordRead({ sessionId: 'sess-d', locator: 'file://src/notes.md', observedHash: 'h' });
+    const item = await seedItem('Escaping fact');
+
+    await attachEvidenceToKnowledge(item.id, undefined, { affectedPaths: ['../../../Windows/win.ini'] });
+
+    expect((await listEvidenceForItem(item.id))[0].contentHash).toBeNull();
+  });
+
+  it('reaches the batch write path, which is what knowl_store and knowl_ingest_atoms call', async () => {
+    const hash = await writeFile('src/store.ts', 'export const store = true;\n');
+    await recordRead({ sessionId: 'sess-e', locator: 'file://src/store.ts', observedHash: hash, toolName: 'Read' });
+
+    const result = await storeKnowledgeAtomsDeduped(projectId, [{
+      category: 'fact', title: 'Store fact', content: 'Written with a cited path the session read.',
+      affectedPaths: ['src/store.ts'],
+    }] as any);
+
+    const evidence = await listEvidenceForItem(result.itemIds[0]);
+    expect(evidence.find(row => row.type === 'file')?.contentHash).toBe(hash);
+  });
+});


### PR DESCRIPTION
The read-set route from #225, with your precision folded in: the `type === 'file'` branch was never dead, only unreachable from here, and it stays.

## What was wrong

`isEvidenceStale` needs a `contentHash` and no shipped writer set one on file evidence this repo originates. Every `affectedPaths` entry became a file row with `contentHash` NULL; `session-evidence.ts` has no importer; the MCP schema has no field for it. Rows arriving through `sync-apply` or `portability` can carry a hash, which is why the branch is not deleted.

## Why not just hash every cited path

Because the gate was real. Agent-declared paths never touched disk on recall, and an agent's unverified assertion about a file it never opened never became a staleness claim about it. Hashing everything would have removed that in the name of a bug fix.

## The read-set is the gate, not the hash source

`attachEvidenceToKnowledge`'s `affectedPaths` path now asks `work_read_sets` whether *any* session holds a `file://path` or `symbol://path#…` row for the cited path — captured from the tool stream, never from the agent's own report. Only then is the file hashed from disk, at write time. A declared path stays unhashed and never reports stale.

Hashed from disk rather than copied out of the read-set, and this is the one place I went a different way from the comment:

- **Symbol rows carry signature hashes, not a file hash.** For most code files (any with ≤ 200 symbols) the read-set has nothing at file granularity to copy.
- **The file the atom is written against is the one on disk now.** An agent that reads a file, edits it, then stores a claim about it holds a belief about the edited version. Evidence stamped with the pre-edit hash would report that belief stale the moment it was recorded.

Same digest as `isEvidenceStale` and the capture path (raw bytes, sha256). One disk read per observed path per write, on the write path only. Recall is unchanged.

Any session's row counts, released or not: the MCP write path does not know which host session is calling, and a row is evidence the store saw the file's contents, which is the fact the gate turns on. That is a trade — a sibling session's read vouches for this one's citation — and I would rather name it than hide it.

## Tests (`tests/store/evidence-hash-from-read-set.test.ts`)

- A `file://` read: evidence carries the hash, `isEvidenceStale` is false, then true after the file changes.
- A `symbol://` read of a code file: the whole file is hashed, same before/after.
- A declared path with no read: `contentHash` null, and still `false` after the file changes — the gate.
- `src/auth.ts`'s symbol rows do not vouch for `src/auth.tsx`; `_` in a path is a character, not a LIKE wildcard.
- An escaping locator is never read, observed or not.
- The batch write path (`knowl_store` / `knowl_ingest_atoms`) reaches it.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npx eslint` on the touched files | clean |
| `npm run build` | clean |
| `npx vitest run` | **388 files / 3696 passed / 5 skipped / 0 failed** |

**Falsification:** dropping the read-set check makes the declared-path test fail (the gate is gone); dropping the hash makes the first two fail.

`session-evidence.ts` is untouched. Deleting it is your call; nothing here depends on it either way.

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
