### PR TITLE
feat(hooks): the lifecycle can run on the server the host already holds open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+**Hooks can run on the server the host already holds open, instead of as a process per event.**
+Every Knowl hook has been a `command` hook: a fresh `knowl agent-hook` process per event, measured
+at ~230ms of Node startup each and paid twice per tool call, serialized against the agent's own
+work because the host waits on the pre-tool hook. Over 102 real Claude Code sessions that is 31s
+of startup at the median session and 190s at the 90th percentile — while the MCP server sat there
+with the database open and the embedding model loaded. Claude Code 2.1.257 and Codex 0.148 can run
+a hook as a call to a tool on a connected MCP server, so `hooks.transport: mcp` now writes the
+mid-session events as `mcp_tool` hooks calling `knowl_hook` and registers that tool; `SessionStart`
+stays a process because both hosts say it fires before servers finish connecting. Opt-in and
+`command` by default, because moving costs a catalog entry — MCP has no hidden-tool concept, and a
+34th tool against a surface already measured at ~10.5K tokens is paid only by the repositories that
+asked for it. The payload travels as `${field}` templates the host fills in, is rebuilt on the
+server whichever way the host rendered each one, and then goes through the same allowlist the
+stdin path applies, so nothing reaches the handler by this route that the other would have dropped.
+Calling the tool while the transport is `command` is refused rather than run, so a client holding
+a stale tool list cannot capture every event twice (#224).
+
 **A push no longer fails anonymously on an over-long field.** The cloud contract caps `title`,
 `source` and `conflictKey` at 500 characters; the local store caps nothing, so a research atom
 with a long citation list sat staged until push, where the server's zod rejection came back as

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ privacy boundary: do not put it behind a public proxy or tunnel.
 ### Everything else
 
 <!-- generated:tool-count -->
-**28 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 1 when linked into a local workspace, 1 when change impact is on, and 1 for fleet awareness unless it is switched off)
+**28 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 1 when linked into a local workspace, 1 when change impact is on, 1 for fleet awareness unless it is switched off, and 1 when hooks run over MCP)
 <!-- /generated:tool-count -->
 and two resource URIs · the
 **complete CLI**, from `knowl status` to `knowl audit` · a **read-only integrity audit** ·

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -37,6 +37,12 @@ Every host gets **memory**: `knowl_query`, `knowl_store` and the rest, over MCP.
 
 ⚠️ means Knowl emits the envelope and the host accepts it, but nobody has watched it reach the model. Anything deciding "has this agent already been told" reads `midTurnDeliveryVerified`, never the presence of an envelope — so a ⚠️ host keeps getting the MCP copy and is never left silent on a guess. Flipping one to ✅ is a one-line change once someone observes a real session.
 
+## One process per event, or one server
+
+Every hook above is installed as a `command` hook: a fresh `knowl agent-hook` process per event, ~230ms of Node startup each, serialized against the agent's own tool calls because the host waits on the pre-tool hook. Over 102 real Claude Code sessions that is 31s at the median session and 190s at the 90th percentile.
+
+Claude Code (2.1.257+) and Codex (0.148+) can run a hook as a call to a tool on an already-connected MCP server instead. Set `hooks.transport` to `mcp` in `.knowl/config.json` and re-run `knowl init <host>`: the mid-session events become `mcp_tool` hooks calling `knowl_hook` on the `knowl serve` process the host already holds open, and the server registers that tool. `SessionStart` stays a process (both hosts say it fires before servers finish connecting), as does `SessionEnd`. No other host has the hook type yet; on those the setting changes nothing. The trade and the details are in the [reference](reference.md#hook-transport--hookstransport).
+
 ## Setup
 
 ```bash

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -501,11 +501,44 @@ atom candidate after three runs, but that promoted atom is still descriptive kno
 executable `.knowl/skills` package. Failed terminal events create a handoff for the next matching
 host session.
 
-Hooks run as separate, short-lived `knowl agent-hook` processes. They normalize host events and
-never start, stop, or supervise the long-lived stdio `knowl serve` process. Lifecycle capture
-itself stores no raw prompts, transcripts, stdout, stderr, or environment variables. When
+Hooks run as separate, short-lived `knowl agent-hook` processes by default. They normalize host
+events and never start, stop, or supervise the long-lived stdio `knowl serve` process. Lifecycle
+capture itself stores no raw prompts, transcripts, stdout, stderr, or environment variables. When
 transcript indexing is explicitly enabled, the separate transcript index reads supported host
 transcript files already present on the machine; it does not create them.
+
+### Hook transport — `hooks.transport`
+
+A hook process costs ~230ms of Node startup, paid twice per tool call (`PreToolUse` and
+`PostToolUse`) and serialized against the agent's own work, because the host waits on the
+pre-tool hook. Measured over 102 real Claude Code sessions that is 31s at the median session
+and 190s at the 90th percentile. Claude Code (2.1.257+) and Codex (0.148+) can instead run a
+hook as a call to a tool on an MCP server they already hold open — which is the `knowl serve`
+process, with its database open and its embedding model loaded.
+
+```jsonc
+// .knowl/config.json
+"hooks": {
+  "transport": "mcp"   // "command" (default) spawns a process per event
+}
+```
+
+With `mcp`, `knowl init claude` and `knowl init codex` (and `knowl doctor --fix`) write the
+mid-session events — `PreToolUse`, `PostToolUse`, `Stop`, `PreCompact`, the subagent events —
+as `mcp_tool` hooks calling `knowl_hook`, and the server registers that tool. Two things stay
+processes on purpose: `SessionStart`, because both hosts document that it fires before their MCP
+servers finish connecting, and `SessionEnd`, because nothing documents whether the server is
+still up when it fires. The prompt-time reminder is unchanged. Every other host keeps its process
+hooks whatever the setting says; only hosts with the hook type declare the events that may move.
+
+The cost is one entry in the server's tool list. MCP has no hidden-tool concept, so `knowl_hook`
+is visible to the model in repositories that turned this on; its description says not to call
+it, and calling it while the transport is `command` is refused rather than run, so a client
+holding a stale tool list cannot capture every event twice. A hook that fires from a directory
+that is not the server's project is answered with silence, where a process hook would have
+opened that project's store — the one case the two transports differ in, and the reason this is
+a choice rather than a default. The setting takes effect at the next `knowl init <host>` and the
+next server start.
 
 ### Leaving work for later
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -20,7 +20,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, HOOK_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS } from '../src/mcp/tool-definitions.js';
 import { DEFAULT_PRESET_ID, VECTOR_PRESETS } from '../src/core/vector-profile.js';
 import { stripManagedKnowlGuidance } from '../src/core/agents-guidance.js';
 import { renderManagedKnowlGuidanceSection } from '../src/core/knowl-guidance.js';
@@ -38,7 +38,7 @@ function contextLabel(tokens: number): string {
 /** Region id -> [file, body]. */
 const regions: Record<string, [string, string]> = {
   'tool-count': [README, [
-    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace, ${WORKSPACE_TOOL_DEFINITIONS.length} when linked into a local workspace, ${IMPACT_TOOL_DEFINITIONS.length} when change impact is on, and ${FLEET_TOOL_DEFINITIONS.length} for fleet awareness unless it is switched off)`,
+    `**${CORE_TOOL_DEFINITIONS.length} MCP tools** (plus ${TRANSCRIPT_TOOL_DEFINITIONS.length} when transcript search is on, ${CLOUD_TOOL_DEFINITIONS.length} when connected to a cloud workspace, ${WORKSPACE_TOOL_DEFINITIONS.length} when linked into a local workspace, ${IMPACT_TOOL_DEFINITIONS.length} when change impact is on, ${FLEET_TOOL_DEFINITIONS.length} for fleet awareness unless it is switched off, and ${HOOK_TOOL_DEFINITIONS.length} when hooks run over MCP)`,
   ].join('\n')],
 
   'embedding-presets': [REFERENCE, [
@@ -81,6 +81,7 @@ const referenceText = fs.readFileSync(REFERENCE, 'utf8');
 for (const tool of [
   ...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ...CLOUD_TOOL_DEFINITIONS,
   ...WORKSPACE_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS, ...FLEET_TOOL_DEFINITIONS,
+  ...HOOK_TOOL_DEFINITIONS,
 ]) {
   if (!referenceText.includes(`\`${tool.name}\``)) {
     failures.push(`docs/reference.md documents no tool named ${tool.name}`);

--- a/src/cli/agents/hook-config.ts
+++ b/src/cli/agents/hook-config.ts
@@ -1,10 +1,24 @@
 import { readTextIfExists, MergeStatus, writeWithBackup } from './files.js';
 import { HookHost } from './host-hook.js';
 import { hostProfile } from '../../session/hosts/index.js';
+import { KNOWL_MCP_SERVER_KEY } from '../../core/knowl-guidance.js';
+import { HOOK_TOOL_NAME, type HookTransport } from '../../core/hooks-transport.js';
 
 // `statusMessage` is in the Anthropic-shaped hosts' schema and not in OpenHands'.
-type NestedHook = { type: 'command'; command: string; timeout: number; statusMessage?: string };
+type NestedCommandHook = { type: 'command'; command: string; timeout: number; statusMessage?: string };
+/**
+ * A hook that calls a tool on an already-connected MCP server instead of spawning a process.
+ * The same fields on Claude Code (2.1.257) and Codex (0.148): `server`, `tool`, `input` with
+ * `${path}` templates read off the hook's JSON input, `timeout` in seconds, `statusMessage`.
+ */
+type NestedMcpHook = {
+  type: 'mcp_tool'; server: string; tool: string; input: Record<string, string>; timeout: number; statusMessage?: string;
+};
+type NestedHook = NestedCommandHook | NestedMcpHook;
 type NestedEntry = { matcher: string; hooks: NestedHook[] };
+
+/** What a nested merge or verify may be told beyond the host: today, only the transport. */
+export type HookConfigOptions = { transport?: HookTransport };
 // One entry in a flat command list. `timeout` is Cursor's; Windsurf documents no such field.
 type FlatEntry = { command: string; timeout?: number };
 
@@ -40,6 +54,22 @@ export function knowlHookCommand(platform: NodeJS.Platform, host: HookHost, even
 const ownsCommand = (value: unknown, host: HookHost) =>
   typeof value === 'string' && value.includes(` agent-hook ${host} `);
 
+/**
+ * Whether a nested hook entry is Knowl's own lifecycle handler for this host, in either shape.
+ *
+ * The `mcp_tool` half is keyed on the tool and on the `host` template constant, not on the
+ * server name alone: a person's own `mcp_tool` hook against the knowl server is theirs, and
+ * the same server serves several hosts' files, so the host in the input is what says whose
+ * entry this is. Recognising both shapes is what lets a transport change replace the other
+ * shape's entries rather than stack beside them.
+ */
+const ownsHook = (hook: Record<string, unknown>, host: HookHost): boolean => {
+  if (ownsCommand(hook.command, host)) return true;
+  if (hook.type !== 'mcp_tool' || hook.tool !== HOOK_TOOL_NAME) return false;
+  const input = hook.input;
+  return typeof input === 'object' && input !== null && (input as Record<string, unknown>).host === host;
+};
+
 export function knowlReminderCommand(platform: NodeJS.Platform, host: HookHost): string {
   const executable = platform === 'win32' ? 'knowl.cmd' : 'knowl';
   return `${executable} agent-reminder ${host} --json`;
@@ -69,13 +99,13 @@ function reminderEntry(platform: NodeJS.Platform, host: HookHost): { hooks: Nest
 
 function removeOwnedNestedHandlers(
   entries: Record<string, any>[],
-  owns: (command: unknown) => boolean,
+  owns: (hook: Record<string, unknown>) => boolean,
 ): { entries: Record<string, any>[]; removed: boolean } {
   let removed = false;
   const retained = entries.flatMap(entry => {
     if (!Array.isArray(entry.hooks)) return [entry];
     const hooks = entry.hooks.filter((hook: Record<string, unknown>) => {
-      const owned = owns(hook.command);
+      const owned = owns(hook);
       removed ||= owned;
       return !owned;
     });
@@ -112,14 +142,79 @@ function nestedMatcher(host: HookHost, event: string, wildcard: string): string 
   return `^(${tools.join('|')})$`;
 }
 
-function nestedEntry(platform: NodeJS.Platform, host: HookHost, event: string): NestedEntry {
+/**
+ * The hook input fields the `mcp_tool` entry forwards, as `${field}` templates.
+ *
+ * A command hook receives the host's whole JSON payload on stdin and `readLifecyclePayload`
+ * keeps the allowlisted parts of it. An `mcp_tool` hook receives only what its `input` names,
+ * so this is that allowlist restated as templates: the identity fields both hosts' profiles
+ * read, the tool name, the two tool objects, the subagent identity, and the prompt and
+ * final-message heads the fleet reduces to one line. Nothing here reaches the server that the
+ * stdin path would have dropped, and the server runs the same filter over it again.
+ */
+const MCP_HOOK_INPUT_FIELDS = [
+  'session_id', 'conversation_id', 'thread_id', 'turn_id', 'cwd', 'hook_event_name',
+  'tool_name', 'tool_input', 'tool_response', 'agent_id', 'agent_type',
+  'prompt', 'last_assistant_message', 'error',
+] as const;
+
+/**
+ * The leaves of the two tool objects, forwarded a second time by dotted path.
+ *
+ * Codex documents that a placeholder filling a whole value keeps its JSON type, so
+ * `${tool_input}` arrives as the object. Claude Code documents substitution for string values
+ * and says nothing about an object-valued path, so the same template may arrive as text or
+ * not at all. The leaves the lifecycle actually reads are therefore named individually as
+ * well -- `${tool_input.file_path}` is the documented form on both hosts -- and the server
+ * rebuilds the object from them when the whole-object template did not resolve. The set is
+ * `lifecycle.ts`'s nested allowlist for the two objects, spelled out.
+ */
+const MCP_HOOK_INPUT_LEAVES = [
+  'tool_input.command', 'tool_input.file_path', 'tool_input.notebook_path', 'tool_input.path',
+  'tool_input.pattern', 'tool_input.glob', 'tool_input.query', 'tool_input.url',
+  'tool_input.title', 'tool_input.id', 'tool_input.supersedeId', 'tool_input.supersedes',
+  'tool_response.exit_code', 'tool_response.stdout', 'tool_response.stderr',
+] as const;
+
+/** `tool_input.file_path` -> `tool_input__file_path`: one flat key per leaf, no dots to misread. */
+export const mcpHookLeafKey = (leaf: string): string => leaf.replace('.', '__');
+
+export function mcpHookInput(host: HookHost, event: string): Record<string, string> {
+  const input: Record<string, string> = { host, event };
+  for (const field of MCP_HOOK_INPUT_FIELDS) input[field] = `\${${field}}`;
+  for (const leaf of MCP_HOOK_INPUT_LEAVES) input[mcpHookLeafKey(leaf)] = `\${${leaf}}`;
+  return input;
+}
+
+/** Whether this event goes over MCP for this host under the given transport. */
+function overMcp(host: HookHost, event: string, transport: HookTransport | undefined): boolean {
+  return transport === 'mcp' && (hostProfile(host).mcpToolHookEvents ?? []).includes(event);
+}
+
+function nestedEntry(platform: NodeJS.Platform, host: HookHost, event: string, options: HookConfigOptions = {}): NestedEntry {
   // OpenHands' schema has no `statusMessage`, and its matcher wildcard is `*` rather than the
   // regex `.*` the Anthropic-shaped hosts take. Emitting a field a host does not define is
   // usually ignored and occasionally fatal to parsing the whole file, which would take every
   // other handler in it down too.
   const openHands = hostProfile(host).hookConfigStyle === 'openhands-toplevel';
+  const matcher = nestedMatcher(host, event, openHands ? '*' : '.*');
+  if (overMcp(host, event, options.transport)) {
+    // Same 30s as the command entry. The host's default for this type is 600s, which would let
+    // a wedged server hold a PreToolUse -- and the user behind it -- for ten minutes.
+    return {
+      matcher,
+      hooks: [{
+        type: 'mcp_tool',
+        server: KNOWL_MCP_SERVER_KEY,
+        tool: HOOK_TOOL_NAME,
+        input: mcpHookInput(host, event),
+        timeout: 30,
+        statusMessage: nestedStatusMessage(event),
+      }],
+    };
+  }
   return {
-    matcher: nestedMatcher(host, event, openHands ? '*' : '.*'),
+    matcher,
     hooks: [{
       type: 'command',
       command: knowlHookCommand(platform, host, event),
@@ -156,6 +251,7 @@ export async function mergeNestedHookConfig(
   host: HookHost,
   /** Top-level keys this host's file must carry beside its events; see `hookFileExtraKeys`. */
   extraKeys: Record<string, unknown> = {},
+  options: HookConfigOptions = {},
 ): Promise<MergeStatus> {
   const existing = await readTextIfExists(configPath);
   const config = existing === undefined ? {} as Record<string, unknown> : JSON.parse(existing) as Record<string, unknown>;
@@ -181,16 +277,18 @@ export async function mergeNestedHookConfig(
   // after it was rewritten. None is today; ordering it this way means none ever can be.
   for (const event of retiredEventsFor(host)) {
     const current = Array.isArray(hooks[event]) ? hooks[event] as Record<string, any>[] : [];
-    const retained = removeOwnedNestedHandlers(current, command => ownsCommand(command, host));
+    const retained = removeOwnedNestedHandlers(current, hook => ownsHook(hook, host));
     hadOwnEntry ||= retained.removed;
     if (retained.entries.length > 0) nextHooks[event] = retained.entries;
     else delete nextHooks[event];
   }
   for (const event of events) {
     const current = Array.isArray(hooks[event]) ? hooks[event] as Record<string, any>[] : [];
-    const filtered = removeOwnedNestedHandlers(current, command => ownsCommand(command, host));
+    // Both shapes are Knowl's own, so switching the transport replaces the other shape's
+    // entry instead of leaving a process hook and a tool hook to fire side by side.
+    const filtered = removeOwnedNestedHandlers(current, hook => ownsHook(hook, host));
     hadOwnEntry ||= filtered.removed;
-    nextHooks[event] = [...filtered.entries, nestedEntry(platform, host, event)];
+    nextHooks[event] = [...filtered.entries, nestedEntry(platform, host, event, options)];
   }
   // A host without a declared prompt event never gets a prompt-time reminder handler -- and
   // never has Claude's event name substituted for its own, which is what the old fallback did.
@@ -204,9 +302,9 @@ export async function mergeNestedHookConfig(
     // Two removals, one key. The first strips a *lifecycle* handler Knowl once wrote under the
     // prompt event and no longer does; the second strips the previous reminder so re-running
     // init replaces it instead of stacking a second copy.
-    const withoutLegacy = removeOwnedNestedHandlers(promptCurrent, command => ownsCommand(command, host));
+    const withoutLegacy = removeOwnedNestedHandlers(promptCurrent, hook => ownsHook(hook, host));
     hadOwnEntry ||= withoutLegacy.removed;
-    const withoutReminder = removeOwnedNestedHandlers(withoutLegacy.entries, command => ownsReminderCommand(command, host));
+    const withoutReminder = removeOwnedNestedHandlers(withoutLegacy.entries, hook => ownsReminderCommand(hook.command, host));
     hadOwnEntry ||= withoutReminder.removed;
     nextHooks[promptEvent] = [...withoutReminder.entries, reminderEntry(platform, host)];
   }
@@ -227,6 +325,7 @@ export async function verifyNestedHookConfig(
   platform: NodeJS.Platform,
   host: HookHost,
   extraKeys: Record<string, unknown> = {},
+  options: HookConfigOptions = {},
 ): Promise<boolean> {
   try {
     const parsed = JSON.parse(await readTextIfExists(configPath) ?? '{}') as Record<string, any>;
@@ -243,7 +342,7 @@ export async function verifyNestedHookConfig(
       ? config.hooks[promptEvent]
       : [];
     const promptHandlers = promptEntries.flatMap((entry: any) => Array.isArray(entry.hooks) ? entry.hooks : []);
-    const noRetiredPromptHandler = !promptHandlers.some((hook: any) => ownsCommand(hook.command, host));
+    const noRetiredPromptHandler = !promptHandlers.some((hook: any) => ownsHook(hook, host));
     const reminderHandlers = promptHandlers.filter((hook: any) => ownsReminderCommand(hook.command, host));
     const promptValid = promptEvent
       ? reminderHandlers.length === 1 && promptEntries.some((entry: unknown) => equal(entry, reminderEntry(platform, host)))
@@ -253,11 +352,14 @@ export async function verifyNestedHookConfig(
     // this the dead handler survives every re-init and every `doctor --fix`.
     const noRetiredEvents = retiredEventsFor(host).every(event =>
       !(config.hooks?.[event] as any[] | undefined)?.some((entry: any) =>
-        (Array.isArray(entry.hooks) ? entry.hooks : []).some((hook: any) => ownsCommand(hook.command, host))));
+        (Array.isArray(entry.hooks) ? entry.hooks : []).some((hook: any) => ownsHook(hook, host))));
     const extrasPresent = Object.entries(extraKeys).every(([key, value]) => equal(config[key], value));
     return noRetiredPromptHandler && promptValid && noRetiredEvents && extrasPresent
       && events.every(event => Array.isArray(config.hooks?.[event])
-      && config.hooks[event].some((entry: unknown) => equal(entry, nestedEntry(platform, host, event))));
+      // Exactly the entry the current transport would write. A file written under the other
+      // transport therefore verifies false, which is what puts "lifecycle hooks missing or
+      // stale" in front of the person and `doctor --fix` behind the rewrite.
+      && config.hooks[event].some((entry: unknown) => equal(entry, nestedEntry(platform, host, event, options))));
   } catch {
     return false;
   }
@@ -371,12 +473,16 @@ export async function mergeHookConfig(
   configPath: string,
   platform: NodeJS.Platform,
   host: HookHost,
+  // The transport reaches only the nested writer. The flat and Antigravity shapes belong to
+  // hosts that declare no `mcpToolHookEvents`, and `nestedEntry` asks the profile before it
+  // asks the option, so a host without the field keeps its process hooks whatever is set.
+  options: HookConfigOptions = {},
 ): Promise<MergeStatus> {
   switch (hostProfile(host).hookConfigStyle) {
     case 'none': return 'unchanged';
     case 'flat-commands': return mergeFlatHookConfig(configPath, platform, host, extraKeys(host));
     case 'antigravity-nested': return mergeAntigravityHookConfig(configPath, platform, host);
-    default: return mergeNestedHookConfig(configPath, platform, host, extraKeys(host));
+    default: return mergeNestedHookConfig(configPath, platform, host, extraKeys(host), options);
   }
 }
 
@@ -384,11 +490,12 @@ export async function verifyHookConfig(
   configPath: string,
   platform: NodeJS.Platform,
   host: HookHost,
+  options: HookConfigOptions = {},
 ): Promise<boolean> {
   switch (hostProfile(host).hookConfigStyle) {
     case 'none': return true;
     case 'flat-commands': return verifyFlatHookConfig(configPath, platform, host, extraKeys(host));
     case 'antigravity-nested': return verifyAntigravityHookConfig(configPath, platform, host);
-    default: return verifyNestedHookConfig(configPath, platform, host, extraKeys(host));
+    default: return verifyNestedHookConfig(configPath, platform, host, extraKeys(host), options);
   }
 }

--- a/src/cli/agents/hook-host-adapter.ts
+++ b/src/cli/agents/hook-host-adapter.ts
@@ -4,6 +4,7 @@ import { mcpEntryMatches, mergeJsonMcpConfig, McpEntry } from './files.js';
 import { mergeHookConfig, verifyHookConfig } from './hook-config.js';
 import { AgentAdapter, AgentDetection, AgentEnvironment, AgentIntegrationResult, AgentName, IntegrationScope } from './types.js';
 import { KNOWL_MCP_SERVER_KEY } from '../../core/knowl-guidance.js';
+import { resolveHookTransport } from '../../core/hooks-transport.js';
 import type { HookHost } from '../../core/host-hook-types.js';
 
 /**
@@ -113,11 +114,11 @@ export function createHookHostAdapter(spec: HookHostAdapterSpec, environment: Ag
     async lifecycleCapability() { return 'supported'; },
     async configureLifecycle(root) {
       const pathname = spec.hooksPath(root);
-      const status = await mergeHookConfig(pathname, environment.platform, spec.name);
+      const status = await mergeHookConfig(pathname, environment.platform, spec.name, { transport: await resolveHookTransport(root) });
       return { agent: spec.name, status, scope: 'project', configPath: pathname };
     },
     async verifyLifecycle(root) {
-      return verifyHookConfig(spec.hooksPath(root), environment.platform, spec.name);
+      return verifyHookConfig(spec.hooksPath(root), environment.platform, spec.name, { transport: await resolveHookTransport(root) });
     },
   };
 }

--- a/src/cli/agents/project-adapters.ts
+++ b/src/cli/agents/project-adapters.ts
@@ -5,6 +5,7 @@ import { mcpEntryMatches, mergeCodexTomlConfig, mergeJsonMcpConfig, McpEntry } f
 import { AgentAdapter, AgentDetection, AgentEnvironment, AgentIntegrationResult } from './types.js';
 import { unsupportedLifecycleResult } from './lifecycle-config.js';
 import { mergeHookConfig, verifyHookConfig } from './hook-config.js';
+import { resolveHookTransport } from '../../core/hooks-transport.js';
 import {
   installKnowlHostInstructions,
   NativeInstructionHost,
@@ -62,10 +63,10 @@ export function createCodexAdapter(environment: AgentEnvironment): AgentAdapter 
     async lifecycleCapability() { return 'supported'; },
     async configureLifecycle(root) {
       const pathname = lifecyclePath(root);
-      const status = await mergeHookConfig(pathname, environment.platform, 'codex');
+      const status = await mergeHookConfig(pathname, environment.platform, 'codex', { transport: await resolveHookTransport(root) });
       return { agent: 'codex', status, scope: 'project', configPath: pathname };
     },
-    async verifyLifecycle(root) { return verifyHookConfig(lifecyclePath(root), environment.platform, 'codex'); },
+    async verifyLifecycle(root) { return verifyHookConfig(lifecyclePath(root), environment.platform, 'codex', { transport: await resolveHookTransport(root) }); },
   };
 }
 
@@ -99,11 +100,11 @@ function createJsonProjectAdapter(
     async configureLifecycle(root) {
       if (name !== 'claude') return unsupportedLifecycleResult(name, 'project', configPath(root));
       const pathname = lifecyclePath(root);
-      const status = await mergeHookConfig(pathname, environment.platform, 'claude');
+      const status = await mergeHookConfig(pathname, environment.platform, 'claude', { transport: await resolveHookTransport(root) });
       return { agent: name, status, scope: 'project', configPath: pathname };
     },
     async verifyLifecycle(root) {
-      return name === 'claude' && verifyHookConfig(lifecyclePath(root), environment.platform, 'claude');
+      return name === 'claude' && verifyHookConfig(lifecyclePath(root), environment.platform, 'claude', { transport: await resolveHookTransport(root) });
     },
     ...(instructionHost ? {
       async configureInstructions(root: string) {

--- a/src/cli/config/schema.ts
+++ b/src/cli/config/schema.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CONFIG, DEFAULT_DRIFT_REMINDER_EVERY } from '../../core/config.js';
 import { DEFAULT_PRESET_ID, PRESET_IDS } from '../../core/vector-profile.js';
+import { HOOK_TRANSPORTS } from '../../core/hooks-transport.js';
 
 export type ConfigKey =
   | 'security.rejectSecrets'
@@ -37,12 +38,13 @@ export type ConfigKey =
   | 'fleet.digest'
   | 'fleet.cards'
   | 'fleet.nudge'
+  | 'hooks.transport'
   | 'cloud.autoStage'
   | 'updateCheck.enabled';
 
 export type ConfigCategory =
   | 'Search' | 'Security' | 'AI provider' | 'Memory namespaces' | 'Change impact' | 'Capture'
-  | 'Fleet' | 'Reminders' | 'Cloud' | 'Updates';
+  | 'Fleet' | 'Hooks' | 'Reminders' | 'Cloud' | 'Updates';
 
 /**
  * How a value should be asked for. Without this the UI had only `parse`, so every field
@@ -342,6 +344,15 @@ export const CONFIG_FIELDS: ConfigField[] = [
     parse: enumValue(FLEET_CARD_MODES), defaultValue: 'shadow',
     label: 'Stale-read nudge at stop',
     description: 'When this turn\'s writes changed code another live session had read: enforce withholds the stop once and asks the agent to tell that session, which costs a turn; shadow records what it would have asked. Off skips the check. Same ladder as capture.nudge, for the same reason: how often it would fire is measured before it is allowed to.',
+  },
+  {
+    // `command` first: it is the transport every install already runs on, and the one a typo
+    // falls back to. Not a ladder -- neither value costs the person anything a hook did not
+    // already cost; what `mcp` spends is one entry in the server's tool list.
+    key: 'hooks.transport', category: 'Hooks', type: 'enum', values: HOOK_TRANSPORTS,
+    parse: enumValue(HOOK_TRANSPORTS), defaultValue: 'command',
+    label: 'Hook transport',
+    description: 'How Claude Code and Codex reach Knowl\'s lifecycle handler. command spawns a fresh `knowl agent-hook` process per event, ~230ms each, serialized against the agent\'s own tool calls. mcp routes the mid-session events through the `knowl_hook` tool on the MCP server the host already holds open, and registers that tool; session start stays a command hook because it fires before servers connect. Takes effect at the next `knowl init <host>` or `knowl doctor --fix`, which rewrite the hooks file, and the next server start.',
   },
   // Both default ON and both stay out of DEFAULT_CONFIG, for the reason the Capture keys
   // above give: merged in, they are written into every config on the machine at the next

--- a/src/cli/hook-over-mcp.ts
+++ b/src/cli/hook-over-mcp.ts
@@ -1,0 +1,153 @@
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { findProjectRoot } from '../core/config.js';
+import { ProjectNotFoundError } from '../core/errors.js';
+import { HOOK_TOOL_NAME } from '../core/hooks-transport.js';
+import { readLifecyclePayload } from './agents/lifecycle.js';
+import { IncompleteHostHookPayloadError, normalizeHostHook } from './agents/host-hook.js';
+import { hostProfile, isHookHost } from '../session/hosts/index.js';
+import { handleHostLifecycleEvent } from '../session/host-lifecycle.js';
+
+/**
+ * The lifecycle hook, arriving as a tool call on the running MCP server instead of as a fresh
+ * `knowl agent-hook` process.
+ *
+ * It lives beside `agent-hook.ts` rather than under `session/` because it is that module's
+ * sibling and needs the same two things it does -- the stdin allowlist and the host-hook
+ * normaliser, both `cli/agents` -- which `session/` may not import (see
+ * `tests/architecture/module-boundaries.test.ts`). The MCP server reaches it through a dynamic
+ * import, which that test reads as a deferral rather than a static edge: the module is loaded
+ * on the first hook that arrives, and never in a server whose repo left the transport at
+ * `command`.
+ *
+ * This is `runAgentHook` with the process boundary removed: the same normaliser, the same
+ * handler, the same output, on a database that is already open in a process that is already
+ * warm. What differs is how the payload arrives and where the answer goes, and both of those
+ * are this module's whole job.
+ *
+ * **The payload arrives as tool arguments, not stdin.** The hooks file names each field as a
+ * `${path}` template (`hook-config.ts`, `mcpHookInput`), and the host fills in what it has. A
+ * template it could not fill may come back as the literal `${...}`, as an empty string, or not
+ * at all; an object-valued path may come back as the object, as its JSON, or as the text an
+ * object renders to. `hookPayloadFromArguments` folds every one of those into the shape the
+ * stdin path produces, and then the payload goes through `readLifecyclePayload` itself -- the
+ * same allowlist and the same string bounds -- so nothing reaches the handler by this route that
+ * would have been dropped by the other.
+ *
+ * **The answer goes back as text content.** Both hosts read a tool's text the way they read a
+ * command hook's stdout: JSON is parsed as the hook's verdict, anything else is plain text. So a
+ * `PreToolUse` refusal, a `Stop` block and a mid-turn `additionalContext` all travel exactly as
+ * they did, serialised into one text block. There is no exit code to get wrong.
+ *
+ * **Silence is a result, not a failure.** An event for a directory that is not this project, an
+ * incomplete payload, and the hook's own tool call are all answered with empty content, which
+ * the host reads as "nothing to say". They are the ordinary cases the process path is quiet about
+ * for the same reasons (see `runAgentHook`), and a hook that reported them would be a channel
+ * nobody reads when something is actually wrong.
+ */
+
+const TEMPLATE = /^\$\{[^}]*\}$/;
+
+/** A template the host left unfilled, or the text an object becomes when rendered into a string. */
+function unresolved(value: unknown): boolean {
+  if (value === undefined || value === null || value === '') return true;
+  return typeof value === 'string' && (TEMPLATE.test(value) || value === '[object Object]');
+}
+
+/** An object that arrived as itself, or as its JSON. Anything else is not an object. */
+function objectArgument(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>;
+  if (typeof value === 'string' && value.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+    } catch {
+      // Text that merely begins with a brace.
+    }
+  }
+  return undefined;
+}
+
+/** The two objects the hooks file forwards both whole and by leaf. */
+const OBJECT_FIELDS = ['tool_input', 'tool_response'] as const;
+
+/**
+ * The raw hook payload the command path would have read from stdin, rebuilt from tool arguments.
+ *
+ * Exported for its tests: the three arrival shapes above are what the host decides, and the
+ * only place to pin that every one of them yields the same payload is here.
+ */
+export function hookPayloadFromArguments(args: Record<string, unknown>): Record<string, unknown> {
+  const raw: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (key === 'host' || key === 'event' || key.includes('__') || unresolved(value)) continue;
+    raw[key] = value;
+  }
+  for (const parent of OBJECT_FIELDS) {
+    const leaves: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(args)) {
+      if (!key.startsWith(`${parent}__`) || unresolved(value)) continue;
+      leaves[key.slice(parent.length + 2)] = value;
+    }
+    // The whole object wins where both resolved: it is the host's own copy, and a leaf is only
+    // ever a subset of it.
+    const merged = { ...leaves, ...(objectArgument(args[parent]) ?? {}) };
+    if (Object.keys(merged).length > 0) raw[parent] = merged;
+    else delete raw[parent];
+  }
+  // A number that came through a template arrives as its digits. The normaliser reads
+  // `exit_code` as a number and would otherwise report every command as having exited 0.
+  const response = raw.tool_response as Record<string, unknown> | undefined;
+  if (response && typeof response.exit_code === 'string' && /^-?\d+$/.test(response.exit_code)) {
+    response.exit_code = Number(response.exit_code);
+  }
+  return raw;
+}
+
+const SILENT: CallToolResult = { content: [] };
+
+export async function runHookOverMcp(
+  args: Record<string, unknown>,
+  context: { projectId: string | null; projectRoot: string | null },
+): Promise<CallToolResult> {
+  const host = typeof args.host === 'string' ? args.host : '';
+  const event = typeof args.event === 'string' ? args.event : '';
+  if (!isHookHost(host) || !event || !context.projectId || !context.projectRoot) return SILENT;
+  try {
+    // Through the stdin reader on purpose: it is the allowlist, and a second copy of it here
+    // would be a second answer to what a hook may carry.
+    const payload = await readLifecyclePayload(
+      Readable.from([JSON.stringify(hookPayloadFromArguments(args))]) as unknown as typeof process.stdin,
+    );
+    // The host may fire a tool event for this very call. Recording it would file one session
+    // event per hook, each describing the hook that filed it.
+    if (typeof payload.tool_name === 'string' && payload.tool_name.endsWith(HOOK_TOOL_NAME)) return SILENT;
+
+    const normalized = normalizeHostHook(host, event, payload);
+    // The server serves one project. A hook fired from a directory that resolves elsewhere --
+    // the agent `cd`-ed into a sibling checkout -- belongs to that project's store, which this
+    // process cannot open; the command transport would have served it, this one stays quiet.
+    const root = await findProjectRoot(normalized.projectRoot);
+    if (path.resolve(root) !== path.resolve(context.projectRoot)) return SILENT;
+    normalized.projectRoot = context.projectRoot;
+
+    const result = await handleHostLifecycleEvent(context.projectId, normalized);
+
+    // Same gate and same `embed: false` as the process path, for parity rather than principle:
+    // in this process the model may already be warm, and the lexical pass is what the catch-up
+    // needs. Widening it is a separate measurement.
+    if (normalized.event === 'turn-stop' || normalized.event === 'session-stop') {
+      const { catchUpTranscripts } = await import('../transcripts/catch-up.js');
+      await catchUpTranscripts(context.projectRoot, { embed: false }).catch(() => undefined);
+    }
+
+    const output = result.hostOutput ?? (hostProfile(host).nativeOutput ? undefined : result);
+    return output ? { content: [{ type: 'text', text: JSON.stringify(output) }] } : SILENT;
+  } catch (error) {
+    if (error instanceof IncompleteHostHookPayloadError || error instanceof ProjectNotFoundError) return SILENT;
+    // A non-blocking error on both hosts: the tool runs, the stop proceeds, and the message is
+    // in the host's log -- the same place the process path's stderr went.
+    return { isError: true, content: [{ type: 'text', text: `Error handling agent hook: ${(error as Error).message}` }] };
+  }
+}

--- a/src/cli/hook-over-mcp.ts
+++ b/src/cli/hook-over-mcp.ts
@@ -142,6 +142,15 @@ export async function runHookOverMcp(
       await catchUpTranscripts(context.projectRoot, { embed: false }).catch(() => undefined);
     }
 
+    // The refusal reason, on stderr, exactly as the process path emits it -- the server's
+    // stderr is what the host writes to its MCP log, which is where that path's went. It is a
+    // second copy of what the verdict below already carries, and worth the same as there: this
+    // transport is new, and a block whose verdict we got subtly wrong would otherwise be
+    // completely silent, which is how a gate becomes impossible to diagnose from a bug report.
+    // `denied` is set only when the refusal was deliverable, so this never invents a reason for
+    // a host that declined to build an envelope.
+    if (result.denied !== undefined) console.error(result.denied);
+
     const output = result.hostOutput ?? (hostProfile(host).nativeOutput ? undefined : result);
     return output ? { content: [{ type: 'text', text: JSON.stringify(output) }] } : SILENT;
   } catch (error) {

--- a/src/core/hooks-transport.ts
+++ b/src/core/hooks-transport.ts
@@ -1,0 +1,52 @@
+import type { ProjectConfig } from './types.js';
+import { loadConfig } from './config.js';
+
+/**
+ * How a host reaches Knowl's lifecycle handler: a fresh `knowl agent-hook` process per event,
+ * or a tool call on the MCP server the host already holds open.
+ *
+ * `command` is what every host has always been installed with, and it costs a process per
+ * event. Measured on the installed entrypoint (#224): ~224–231ms per invocation, warm cache,
+ * after `module.enableCompileCache()`. Over 102 real Claude Code transcripts that is 31s of
+ * serialized startup at the p50 session and 190s at the p90 — serialized because `PreToolUse`
+ * runs ahead of the tool and the host waits on it.
+ *
+ * `mcp` moves the mid-session events onto the connection the host already has: Claude Code
+ * 2.1.257 and Codex 0.148 both run a hook as a call to a tool on a connected MCP server. The
+ * server already holds the database open and, on a store with local embeddings, has already
+ * loaded the model; every one of those is re-established per hook process today.
+ *
+ * Opt-in and `command` by default, because moving costs a tool. An `mcp_tool` hook names a
+ * tool on the server and MCP has no hidden-tool concept, so the lifecycle target appears in
+ * `tools/list` — a 34th tool against a surface already measured at ~10.5K tokens of
+ * definitions. Registering it only for a repo that turned this on is what answers that
+ * objection: a repo that never sets the key pays nothing, and the session-start event stays a
+ * `command` hook everywhere because the host's own reference says it fires before servers
+ * finish connecting.
+ */
+export type HookTransport = 'command' | 'mcp';
+
+export const HOOK_TRANSPORTS: readonly HookTransport[] = ['command', 'mcp'];
+
+/**
+ * The tool the `mcp` transport calls. One name, spelled here and nowhere else: the hooks file
+ * names it, the server registers it, and the dispatch wrapper exempts it from the change
+ * notice — three places that would drift apart if each spelled it for itself.
+ */
+export const HOOK_TOOL_NAME = 'knowl_hook';
+
+/** Anything unrecognised falls to `command`, the transport every install already works on. */
+export function hooksTransport(config?: ProjectConfig | null): HookTransport {
+  const value = config?.hooks?.transport;
+  return HOOK_TRANSPORTS.includes(value as HookTransport) ? value as HookTransport : 'command';
+}
+
+/**
+ * The transport a repo's hooks file should be written with, read from disk at the moment the
+ * file is written. An unreadable or absent config is `command`, for the reason every gate in
+ * this codebase fails toward its quietest value: the failure mode of turning something on by
+ * accident is a hooks file that names a tool the server was never told to register.
+ */
+export async function resolveHookTransport(root: string): Promise<HookTransport> {
+  return hooksTransport(await loadConfig(root).catch(() => null));
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -537,6 +537,16 @@ export interface ProjectConfig {
     nudge?: 'off' | 'shadow' | 'enforce';
   };
   /**
+   * How the host reaches the lifecycle handler. `command` (the default, and what every install
+   * has always used) spawns `knowl agent-hook` per event; `mcp` writes the mid-session events
+   * as calls to `knowl_hook` on the server the host already holds open, and registers that
+   * tool. Read at `knowl init` and `knowl doctor --fix`, which write the hooks file, and at
+   * server start, which decides the tool list. See `core/hooks-transport.ts`.
+   */
+  hooks?: {
+    transport?: 'command' | 'mcp';
+  };
+  /**
    * This repo's half of workspace membership. The other half is the workspace manifest
    * listing this repo; either alone is not membership, which is what makes linkage
    * un-forgeable by a cloned repository.

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -267,6 +267,34 @@ export const FLEET_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
 ];
 
+/**
+ * Registered only when the repo set `hooks.transport: mcp`.
+ *
+ * The lifecycle handler, reachable as a tool so a host's `mcp_tool` hooks can call it on the
+ * connection they already hold instead of spawning `knowl agent-hook` per event (#224). MCP has
+ * no hidden-tool concept, so it appears in `tools/list` for those repos -- which is why it is
+ * gated on the setting rather than always on: a repo that never turned it on never pays the
+ * entry. The description exists to tell a model that reads the catalog to leave it alone, and
+ * says so in the words a model acts on.
+ */
+export const HOOK_TOOL_DEFINITIONS: ToolDefinition[] = [
+        {
+          name: 'knowl_hook',
+          description: "Internal: the target of the host's lifecycle hooks when hooks.transport is mcp. The host calls it on every tool event; an agent never should -- calling it records a session event that did not happen.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              host: { type: 'string', minLength: 1, maxLength: 40, description: 'The hook host whose file this entry was written into.' },
+              event: { type: 'string', minLength: 1, maxLength: 80, description: "The host's own name for the event." },
+            },
+            required: ['host', 'event'],
+            // The rest of the payload arrives as whatever the host filled in for the templates
+            // in its hooks file; the handler runs the stdin allowlist over it.
+            additionalProperties: true,
+          },
+        },
+];
+
 /** Every tool the server always offers, in listing order. */
 export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -48,7 +48,8 @@ import { isTranscriptFallbackEnabled, isTranscriptSearchEnabled } from '../trans
 import { hasIndexableArchive } from '../transcripts/paths.js';
 import { handleSessionList, handleTranscriptRead, handleTranscriptSearch, NO_TRANSCRIPT_MATCHES_PREFIX } from '../transcripts/mcp-handlers.js';
 import { sanitizeToolErrorMessage, ToolInputError, validateToolArguments } from './tool-schema.js';
-import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
+import { CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, HOOK_TOOL_DEFINITIONS, IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS, type ToolDefinition } from './tool-definitions.js';
+import { HOOK_TOOL_NAME, hooksTransport } from '../core/hooks-transport.js';
 import { checkKnowledgeDrift, getCurrentGitCommit, listChangedFilesSince, listRenamedPathsSince } from '../store/drift.js';
 import { isFleetEnabled } from '../fleet/config.js';
 import { describeFleet, renderFleetReport } from '../fleet/report.js';
@@ -242,6 +243,12 @@ export function knowlToolDefinitions(config: ProjectConfig | null): ToolDefiniti
     tools.push(...FLEET_TOOL_DEFINITIONS);
   }
 
+  // Off unless asked for, because it is the one tool here that costs a catalog entry for
+  // something no agent should ever call. See `core/hooks-transport.ts`.
+  if (config && hooksTransport(config) === 'mcp') {
+    tools.push(...HOOK_TOOL_DEFINITIONS);
+  }
+
   if (config?.cloud) {
     tools.push(...CLOUD_TOOL_DEFINITIONS);
   }
@@ -266,6 +273,7 @@ const SCHEMA_BY_TOOL = new Map<string, Record<string, unknown>>(
   [
     ...knowlToolDefinitions(null), ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS,
     ...CLOUD_TOOL_DEFINITIONS, ...WORKSPACE_TOOL_DEFINITIONS, ...FLEET_TOOL_DEFINITIONS,
+    ...HOOK_TOOL_DEFINITIONS,
   ]
     .map(tool => [tool.name, tool.inputSchema]),
 );
@@ -1788,6 +1796,20 @@ export function registerTools(
 
       // Re-checks its own gate for the reason the transcript handlers do: a cached tool list
       // keeps this callable after `fleet.enabled` goes false.
+      else if (name === HOOK_TOOL_NAME) {
+        // Refused, not run, when the transport is `command`: a client holding a stale tool list
+        // can still call it, and running the lifecycle here while the process hook also fires
+        // would capture every event twice.
+        if (hooksTransport(config) !== 'mcp') {
+          return { isError: true, content: [{ type: 'text', text: 'hooks.transport is `command` in this repository, so the lifecycle runs in `knowl agent-hook` processes and this tool does nothing. Set `hooks.transport` to `mcp` and re-run `knowl init <host>` to route hooks here.' }] };
+        }
+        // Deferred on purpose, and into a sibling layer: the handler is `agent-hook.ts`'s twin
+        // and lives beside it, and a server whose repo never turned the transport on never
+        // loads it. See the module's own header for the layering.
+        const { runHookOverMcp } = await import('../cli/hook-over-mcp.js');
+        return runHookOverMcp(args as Record<string, unknown>, { projectId, projectRoot });
+      }
+
       else if (name === 'knowl_fleet') {
         if (!isFleetEnabled(config)) {
           return { isError: true, content: [{ type: 'text', text: FLEET_DISABLED_MESSAGE }] };
@@ -2167,6 +2189,11 @@ export function registerTools(
     // Before `getProjectRoot()`, not just before dispatch: startup fills that variable in
     // behind the handshake, and reading it early would take a watermark against `null`.
     await whenReady();
+    // The hook target answers the host, not the agent. Its text is parsed as the hook's JSON
+    // verdict, so a change notice or a capture nudge appended to it would break the parse and
+    // discard a PreToolUse refusal -- and the notice it would carry is the one the hook path
+    // itself delivers on the next tool event.
+    if (request.params.name === HOOK_TOOL_NAME) return callToolAsRepo(request);
     // The caller's root deliberately, even for a call acting as another repo: the change notice
     // reports what moved in THIS session's store, and a write into a sibling moved nothing here.
     const projectRoot = getProjectRoot();

--- a/src/session/hosts/claude.ts
+++ b/src/session/hosts/claude.ts
@@ -104,6 +104,13 @@ export const claudeProfile: HostProfile = {
   // one of these; `Bash` is deliberately absent, because the gate needs the paths a tool
   // declares and a shell command does not declare any.
   writeTools: ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'],
+  // Every registered event but the two boundaries. Claude Code 2.1.257's hooks reference
+  // offers `mcp_tool` on every event and warns that `SessionStart` "typically fires before
+  // servers finish connecting"; `SessionEnd` is kept a process for the mirror-image reason.
+  mcpToolHookEvents: [
+    'SubagentStart', 'PreToolUse', 'PostToolUse', 'PostToolUseFailure',
+    'PreCompact', 'Stop', 'StopFailure', 'SubagentStop',
+  ],
   identity(raw): HostIdentity {
     return {
       externalSessionId: hostString(raw.session_id) ?? hostString(raw.conversation_id) ?? hostString(raw.thread_id),

--- a/src/session/hosts/codex.ts
+++ b/src/session/hosts/codex.ts
@@ -51,6 +51,11 @@ export const codexProfile: HostProfile = {
   lifecycleClaimable: false,
   midTurnDeliveryVerified: true,
   hookConfigStyle: 'claude-nested',
+  // Codex's hooks reference lists the events that accept `mcp_tool` by name -- PreToolUse,
+  // PostToolUse, SessionStart, PreCompact, PostCompact, SubagentStart, UserPromptSubmit,
+  // SubagentStop, Stop -- and says SessionEnd does not. Of the registered events that leaves
+  // these six; SessionStart is eligible there and still kept a process, see the profile field.
+  mcpToolHookEvents: ['SubagentStart', 'PreToolUse', 'PostToolUse', 'PreCompact', 'Stop', 'SubagentStop'],
   // **Codex does not use Claude's tool names**, so the shared fallback matched nothing here and
   // the write gate answered "no opinion" before consulting the deny envelope below. Verified by
   // the same string inspection of codex.exe 0.147.0 that established the event list: `Edit`,

--- a/src/session/hosts/profile.ts
+++ b/src/session/hosts/profile.ts
@@ -144,6 +144,23 @@ export interface HostProfile {
    */
   readonly hookEntryTimeout?: number;
   /**
+   * The events this host can run as a call to a tool on a connected MCP server, when the repo
+   * sets `hooks.transport: mcp`. Absent means the host has no such hook type and every event
+   * stays a `command` hook whatever the setting says.
+   *
+   * A subset of `hookEvents`, and never the session-start event: both hosts that have the
+   * type document that it fires before their MCP servers finish connecting, so a hook there
+   * meets "not connected" on the first run — and session start is the one event whose output
+   * the user actually notices, since it is what returns their bootstrap context. Session end
+   * is left out for the mirror-image reason: nothing documents whether the server is still
+   * up when it fires, and Codex says outright that it is not eligible.
+   *
+   * Declared per host rather than derived as `hookEvents` minus the two, because the vendors
+   * disagree: Codex lists the events that accept the type, and a Claude-only event that never
+   * appears in that list has to stay a process there.
+   */
+  readonly mcpToolHookEvents?: readonly string[];
+  /**
    * Whether the MCP card may state, unconditionally, that this host's hooks own the lifecycle.
    *
    * Registering hook events is not the same as those hooks running, and the card is the one

--- a/tests/cli/hook-over-mcp.test.ts
+++ b/tests/cli/hook-over-mcp.test.ts
@@ -1,0 +1,176 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { hookPayloadFromArguments, runHookOverMcp } from '../../src/cli/hook-over-mcp.js';
+import { mcpHookInput } from '../../src/cli/agents/hook-config.js';
+
+/**
+ * The lifecycle hook arriving as a tool call (#224). The first block pins what the host may
+ * hand us -- three arrival shapes for one payload -- and the second runs real events through
+ * the real handler on a real store, the way `agent-lifecycle.test.ts` does for the process path.
+ */
+describe('rebuilding the stdin payload from tool arguments', () => {
+  const base = { host: 'claude', event: 'PostToolUse', session_id: 's-1', cwd: '/repo', tool_name: 'Bash' };
+
+  it('takes the whole object when the host kept its JSON type (Codex)', () => {
+    const payload = hookPayloadFromArguments({
+      ...base,
+      tool_input: { command: 'npm test', unsafe: 'kept here, dropped by the allowlist later' },
+      tool_response: { exit_code: 1, stdout: 'failing' },
+      tool_input__command: '${tool_input.command}',
+    });
+    expect(payload).toEqual({
+      session_id: 's-1', cwd: '/repo', tool_name: 'Bash',
+      tool_input: { command: 'npm test', unsafe: 'kept here, dropped by the allowlist later' },
+      tool_response: { exit_code: 1, stdout: 'failing' },
+    });
+  });
+
+  it('parses the object when it arrived as its JSON text', () => {
+    const payload = hookPayloadFromArguments({
+      ...base, tool_input: JSON.stringify({ file_path: '/repo/src/a.ts' }),
+    });
+    expect(payload.tool_input).toEqual({ file_path: '/repo/src/a.ts' });
+  });
+
+  it('rebuilds the object from its leaves when the whole-object template did not resolve', () => {
+    for (const whole of ['${tool_input}', '[object Object]', '', undefined]) {
+      const payload = hookPayloadFromArguments({
+        ...base,
+        tool_input: whole,
+        tool_input__file_path: '/repo/src/a.ts',
+        tool_input__command: '${tool_input.command}',
+        tool_response: '${tool_response}',
+        tool_response__exit_code: '2',
+        tool_response__stderr: '${tool_response.stderr}',
+        agent_id: '${agent_id}',
+      });
+      expect(payload, String(whole)).toEqual({
+        session_id: 's-1', cwd: '/repo', tool_name: 'Bash',
+        tool_input: { file_path: '/repo/src/a.ts' },
+        // Digits through a template are a number again, or every command exits 0.
+        tool_response: { exit_code: 2 },
+      });
+    }
+  });
+
+  it('never carries host, event or a leaf key through as a root field', () => {
+    const payload = hookPayloadFromArguments({ ...base, tool_input__file_path: '/repo/x' });
+    expect(payload).not.toHaveProperty('host');
+    expect(payload).not.toHaveProperty('event');
+    expect(payload).not.toHaveProperty('tool_input__file_path');
+  });
+
+  it('the template the hooks file writes resolves to exactly the keys this reads', () => {
+    // Every key the writer emits is either a root field, `host`/`event`, or a `parent__leaf`
+    // of one of the two objects. A key outside that set would be forwarded and then dropped
+    // by the allowlist, which is a cost with no reader.
+    for (const key of Object.keys(mcpHookInput('claude', 'PostToolUse'))) {
+      if (key === 'host' || key === 'event') continue;
+      if (key.includes('__')) expect(key.startsWith('tool_input__') || key.startsWith('tool_response__'), key).toBe(true);
+    }
+  });
+});
+
+const ROOT = path.join(os.tmpdir(), 'knowl-hook-over-mcp-test');
+const OTHER = path.join(os.tmpdir(), 'knowl-hook-over-mcp-other');
+
+describe('running a hook over MCP', () => {
+  let projectId = '';
+
+  beforeAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const dir of [ROOT, OTHER]) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+      await fs.mkdir(path.join(dir, '.knowl'), { recursive: true });
+      // The root marker `findProjectRoot` walks for (see `isProjectRoot`), with change impact
+      // on so the read-set capture below has a reason to run.
+      await fs.writeFile(path.join(dir, '.knowl', 'config.json'), JSON.stringify({
+        version: 1, security: { rejectSecrets: true, secretPatterns: [] }, impact: { enabled: true },
+      }));
+    }
+    await fs.writeFile(path.join(ROOT, 'notes.md'), '# notes\n');
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'hook over mcp')).id;
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const dir of [ROOT, OTHER]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const context = () => ({ projectId, projectRoot: ROOT });
+
+  const sessionEvents = async (): Promise<number> => Number((await getClient().execute(
+    'SELECT COUNT(*) AS n FROM memory_session_events',
+  )).rows[0].n);
+
+  it('records a tool event the way the process path would, and answers with empty content', async () => {
+    const before = await sessionEvents();
+    const result = await runHookOverMcp({
+      host: 'claude', event: 'PostToolUse', session_id: 'mcp-sess-1', cwd: ROOT,
+      tool_name: 'Bash', tool_input: '${tool_input}', tool_input__command: 'npm test',
+      tool_response: '${tool_response}', tool_response__exit_code: '0',
+    }, context());
+
+    expect(result.isError).toBeUndefined();
+    expect(await sessionEvents()).toBeGreaterThan(before);
+    // Text, if any, is JSON the host parses as a hook verdict; never prose.
+    for (const block of result.content) {
+      expect(block.type).toBe('text');
+      expect(() => JSON.parse((block as { text: string }).text)).not.toThrow();
+    }
+  });
+
+  it('records a read into the read-set at the file granularity a Read tool implies', async () => {
+    await runHookOverMcp({
+      host: 'claude', event: 'PostToolUse', session_id: 'mcp-sess-2', cwd: ROOT,
+      tool_name: 'Read', tool_input__file_path: path.join(ROOT, 'notes.md'),
+    }, context());
+
+    const rows = (await getClient().execute({
+      sql: 'SELECT locator FROM work_read_sets WHERE locator = ? AND released_at IS NULL',
+      args: ['file://notes.md'],
+    })).rows;
+    expect(rows).toHaveLength(1);
+  });
+
+  it('is silent for a directory that is not this project', async () => {
+    const before = await sessionEvents();
+    const result = await runHookOverMcp({
+      host: 'claude', event: 'PostToolUse', session_id: 'mcp-sess-3', cwd: OTHER,
+      tool_name: 'Bash', tool_input__command: 'ls',
+    }, context());
+    expect(result).toEqual({ content: [] });
+    expect(await sessionEvents()).toBe(before);
+  });
+
+  it('is silent for its own tool call, an incomplete payload, and an unknown host', async () => {
+    const before = await sessionEvents();
+    expect(await runHookOverMcp({
+      host: 'claude', event: 'PostToolUse', session_id: 's', cwd: ROOT, tool_name: 'mcp__knowl__knowl_hook',
+    }, context())).toEqual({ content: [] });
+    expect(await runHookOverMcp({ host: 'claude', event: 'PostToolUse', session_id: 's' }, context())).toEqual({ content: [] });
+    expect(await runHookOverMcp({ host: 'nothost', event: 'PostToolUse', cwd: ROOT }, context())).toEqual({ content: [] });
+    expect(await runHookOverMcp({ host: 'claude', event: 'PostToolUse', cwd: ROOT }, { projectId: null, projectRoot: null })).toEqual({ content: [] });
+    expect(await sessionEvents()).toBe(before);
+  });
+
+  it('answers a pre-tool question with the host envelope or with nothing, never with an error', async () => {
+    const result = await runHookOverMcp({
+      host: 'claude', event: 'PreToolUse', session_id: 'mcp-sess-4', cwd: ROOT,
+      tool_name: 'Edit', tool_input__file_path: path.join(ROOT, 'notes.md'),
+    }, context());
+    expect(result.isError).toBeUndefined();
+    for (const block of result.content) {
+      const parsed = JSON.parse((block as { text: string }).text);
+      expect(parsed.hookSpecificOutput?.hookEventName).toBe('PreToolUse');
+    }
+  });
+});

--- a/tests/cli/hook-transport.test.ts
+++ b/tests/cli/hook-transport.test.ts
@@ -1,0 +1,144 @@
+import path from 'node:path';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { afterAll, describe, expect, it } from 'vitest';
+import { mergeHookConfig, verifyHookConfig, mcpHookInput } from '../../src/cli/agents/hook-config.js';
+import { hostProfile } from '../../src/session/hosts/index.js';
+import { HOOK_TOOL_NAME, hooksTransport } from '../../src/core/hooks-transport.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * `hooks.transport: mcp` writes the mid-session events as `mcp_tool` hooks and leaves the
+ * session boundaries as processes (#224).
+ *
+ * The shape assertions are literals from the two vendors' hook references, for the reason
+ * `host-config-shapes.test.ts` gives: a hooks file in the wrong shape is parsed without error
+ * and acted on not at all.
+ */
+const workspaces: string[] = [];
+const workspace = async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'knowl-hooktransport-'));
+  workspaces.push(dir);
+  return dir;
+};
+const readJson = async (p: string) => JSON.parse(await readFile(p, 'utf8'));
+const handlersOf = (config: any, event: string): any[] =>
+  (config.hooks[event] ?? []).flatMap((entry: any) => entry.hooks ?? []);
+
+afterAll(async () => {
+  for (const dir of workspaces) await rm(dir, { recursive: true, force: true });
+});
+
+describe('the setting', () => {
+  it('reads command for anything but a literal mcp', () => {
+    expect(hooksTransport(null)).toBe('command');
+    expect(hooksTransport({ version: 1 } as ProjectConfig)).toBe('command');
+    expect(hooksTransport({ version: 1, hooks: { transport: 'mcp' } } as ProjectConfig)).toBe('mcp');
+    expect(hooksTransport({ version: 1, hooks: { transport: 'MCP' as any } } as ProjectConfig)).toBe('command');
+  });
+
+  it('keeps session start a process on every host that has the type', () => {
+    for (const host of ['claude', 'codex'] as const) {
+      const events = hostProfile(host).mcpToolHookEvents!;
+      expect(events, host).not.toContain('SessionStart');
+      expect(events, host).not.toContain('SessionEnd');
+      for (const event of events) expect(hostProfile(host).hookEvents, `${host}:${event}`).toContain(event);
+    }
+  });
+});
+
+describe('Claude Code settings under hooks.transport: mcp', () => {
+  it('writes mcp_tool entries for the mid-session events and command entries for the boundaries', async () => {
+    const file = path.join(await workspace(), 'settings.local.json');
+    expect(await mergeHookConfig(file, 'linux', 'claude', { transport: 'mcp' })).toBe('configured');
+
+    const config = await readJson(file);
+    // The fields Claude Code's reference lists for the type, and nothing it does not.
+    const [post] = handlersOf(config, 'PostToolUse');
+    expect(post).toEqual({
+      type: 'mcp_tool',
+      server: 'knowl',
+      tool: HOOK_TOOL_NAME,
+      input: mcpHookInput('claude', 'PostToolUse'),
+      timeout: 30,
+      statusMessage: '',
+    });
+    expect(post.input.host).toBe('claude');
+    expect(post.input.event).toBe('PostToolUse');
+    expect(post.input.session_id).toBe('${session_id}');
+    expect(post.input.tool_input__file_path).toBe('${tool_input.file_path}');
+
+    // The pre-tool matcher still names the write tools, so the server is not asked about reads.
+    expect(config.hooks.PreToolUse[0].matcher).toBe('^(Edit|Write|MultiEdit|NotebookEdit)$');
+    expect(handlersOf(config, 'PreToolUse')[0].type).toBe('mcp_tool');
+
+    // Both boundaries stay processes: the host's own reference says SessionStart fires before
+    // servers finish connecting.
+    expect(handlersOf(config, 'SessionStart')[0]).toMatchObject({ type: 'command', command: 'knowl agent-hook claude SessionStart --json' });
+    expect(handlersOf(config, 'SessionEnd')[0]).toMatchObject({ type: 'command', command: 'knowl agent-hook claude SessionEnd --json' });
+
+    // The prompt reminder is not a lifecycle event and is untouched.
+    expect(handlersOf(config, 'UserPromptSubmit')[0].command).toBe('knowl agent-reminder claude --json');
+
+    expect(await verifyHookConfig(file, 'linux', 'claude', { transport: 'mcp' })).toBe(true);
+    // The same file verifies false under the other transport, which is what puts "lifecycle
+    // hooks missing or stale" in front of the person and `doctor --fix` behind the rewrite.
+    expect(await verifyHookConfig(file, 'linux', 'claude', { transport: 'command' })).toBe(false);
+  });
+
+  it('is idempotent, and switching transport replaces the other shape rather than stacking beside it', async () => {
+    const file = path.join(await workspace(), 'settings.local.json');
+    await mergeHookConfig(file, 'linux', 'claude');
+    expect(handlersOf(await readJson(file), 'PostToolUse').map((h: any) => h.type)).toEqual(['command']);
+
+    expect(await mergeHookConfig(file, 'linux', 'claude', { transport: 'mcp' })).toBe('updated');
+    expect(await mergeHookConfig(file, 'linux', 'claude', { transport: 'mcp' })).toBe('unchanged');
+    expect(handlersOf(await readJson(file), 'PostToolUse').map((h: any) => h.type)).toEqual(['mcp_tool']);
+
+    expect(await mergeHookConfig(file, 'linux', 'claude', { transport: 'command' })).toBe('updated');
+    const back = await readJson(file);
+    expect(handlersOf(back, 'PostToolUse').map((h: any) => h.type)).toEqual(['command']);
+    expect(JSON.stringify(back)).not.toContain('mcp_tool');
+    expect(await verifyHookConfig(file, 'linux', 'claude')).toBe(true);
+  });
+
+  it("leaves someone else's mcp_tool hook against the knowl server alone", async () => {
+    const file = path.join(await workspace(), 'settings.local.json');
+    const theirs = { type: 'mcp_tool', server: 'knowl', tool: 'knowl_query', input: { query: '${tool_input.file_path}' } };
+    await writeFile(file, JSON.stringify({ hooks: { PostToolUse: [{ matcher: 'Read', hooks: [theirs] }] } }), 'utf8');
+
+    await mergeHookConfig(file, 'linux', 'claude', { transport: 'mcp' });
+    await mergeHookConfig(file, 'linux', 'claude', { transport: 'command' });
+
+    const handlers = handlersOf(await readJson(file), 'PostToolUse');
+    expect(handlers).toContainEqual(theirs);
+    expect(handlers).toHaveLength(2);
+  });
+});
+
+describe('Codex hooks under hooks.transport: mcp', () => {
+  it('moves only the events Codex lists as accepting the type', async () => {
+    const file = path.join(await workspace(), 'hooks.json');
+    await mergeHookConfig(file, 'linux', 'codex', { transport: 'mcp' });
+
+    const config = await readJson(file);
+    for (const event of ['PreToolUse', 'PostToolUse', 'PreCompact', 'Stop', 'SubagentStart', 'SubagentStop']) {
+      expect(handlersOf(config, event)[0], event).toMatchObject({ type: 'mcp_tool', tool: HOOK_TOOL_NAME, input: { host: 'codex', event } });
+    }
+    expect(handlersOf(config, 'SessionStart')[0].type).toBe('command');
+    expect(handlersOf(config, 'SessionEnd')[0].type).toBe('command');
+    expect(await verifyHookConfig(file, 'linux', 'codex', { transport: 'mcp' })).toBe(true);
+  });
+});
+
+describe('hosts without the type', () => {
+  it('keep their process hooks whatever the setting says', async () => {
+    for (const [host, name] of [['cursor', 'hooks.json'], ['copilot', 'knowl.json'], ['openhands', 'hooks.json']] as const) {
+      const file = path.join(await workspace(), name);
+      await mergeHookConfig(file, 'linux', host, { transport: 'mcp' });
+      expect(JSON.stringify(await readJson(file)), host).not.toContain('mcp_tool');
+      expect(await verifyHookConfig(file, 'linux', host, { transport: 'mcp' }), host).toBe(true);
+      expect(await verifyHookConfig(file, 'linux', host), host).toBe(true);
+    }
+  });
+});

--- a/tests/mcp/gated-tool-surface.test.ts
+++ b/tests/mcp/gated-tool-surface.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS,
+  CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, HOOK_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS,
 } from '../../src/mcp/tool-definitions.js';
 import { knowlToolDefinitions } from '../../src/mcp/tools.js';
 import type { ProjectConfig } from '../../src/core/types.js';
@@ -30,6 +30,18 @@ describe('the gated tool surface', () => {
   it('offers knowl_cloud only to a connected repo', () => {
     expect(knowlToolDefinitions(cloudConfig).map(t => t.name)).toContain('knowl_cloud');
     expect(knowlToolDefinitions(workspaceConfig).map(t => t.name)).not.toContain('knowl_cloud');
+  });
+
+  it('offers knowl_hook only to a repo that routes its hooks over MCP', () => {
+    // The one tool no agent should call, so it is paid for only by repos that asked for it:
+    // MCP has no hidden-tool concept, and the lifecycle target is a catalog entry like any other.
+    const mcpHooks = { version: 1, hooks: { transport: 'mcp' } } as ProjectConfig;
+    const commandHooks = { version: 1, hooks: { transport: 'command' } } as ProjectConfig;
+    expect(knowlToolDefinitions(mcpHooks).map(t => t.name)).toContain('knowl_hook');
+    expect(knowlToolDefinitions(commandHooks).map(t => t.name)).not.toContain('knowl_hook');
+    expect(knowlToolDefinitions({ version: 1 } as ProjectConfig).map(t => t.name)).not.toContain('knowl_hook');
+    expect(knowlToolDefinitions(null).map(t => t.name)).not.toContain('knowl_hook');
+    expect(HOOK_TOOL_DEFINITIONS[0].description).toMatch(/an agent never should/i);
   });
 
   it('offers knowl_workspace only to a repo in a workspace', () => {


### PR DESCRIPTION
Option 1 from #224: an opt-in `hooks.transport` key, `command` by default, and the tool registered only for repos that turned it on.

## What changes when a repo sets `hooks.transport: mcp`

`knowl init claude` / `knowl init codex` (and `doctor --fix`) write the mid-session events as `mcp_tool` hooks:

```json
{ "type": "mcp_tool", "server": "knowl", "tool": "knowl_hook",
  "input": { "host": "claude", "event": "PostToolUse", "session_id": "${session_id}", "cwd": "${cwd}", "tool_name": "${tool_name}", "tool_input": "${tool_input}", "tool_input__file_path": "${tool_input.file_path}", … },
  "timeout": 30, "statusMessage": "" }
```

and `knowl serve` registers `knowl_hook`, whose handler is `runAgentHook` with the process boundary removed: same normaliser, same `handleHostLifecycleEvent`, same output, on the database the server already has open. Both hosts read a tool's text the way they read command-hook stdout, so a `PreToolUse` refusal, a `Stop` block and mid-turn `additionalContext` travel unchanged as one JSON text block. There is no exit code to get wrong.

**Two events stay processes on both hosts.** `SessionStart`, because both references say it fires before MCP servers finish connecting — and it is the one event whose output the user actually notices. `SessionEnd`, because nothing documents whether the server is still up when it fires, and Codex says outright it is not eligible. The events that may move are declared per profile (`mcpToolHookEvents`: 8 on Claude, 6 on Codex, matching Codex's own list) rather than derived, because the vendors disagree. Every other host declares none and keeps its process hooks whatever the setting says.

## The trade, as you framed it

- The tool is registered **only** when the config says `mcp` (`HOOK_TOOL_DEFINITIONS`, gated in `knowlToolDefinitions`), so a repo that never sets the key pays nothing in `tools/list`. Its description tells a model that reads the catalog to leave it alone, in the words a model acts on.
- Calling it while the transport is `command` is **refused rather than run**, so a client holding a stale tool list cannot capture every event twice.
- The `CallToolRequest` wrapper skips the change-notice and capture-nudge appends for this one tool: appended text would break the JSON parse and discard a `PreToolUse` deny, and the notice it would carry is the one the hook path itself delivers next event.
- The hook's own tool call (`mcp__knowl__knowl_hook` as `tool_name`) is silenced, or every hook would file a session event describing the hook that filed it.

## The one thing the docs do not settle

Claude Code documents `${path}` substitution for string values and says nothing about an object-valued path like `${tool_input}`; Codex says a placeholder filling a whole value keeps its JSON type. So the hooks file forwards the two tool objects **both whole and by leaf** (`tool_input__file_path: "${tool_input.file_path}"` is the documented form on both), and `hookPayloadFromArguments` accepts the object, its JSON text, the literal `${…}`, `[object Object]` or absence — rebuilding from leaves when the whole did not resolve, and turning a digit-only `exit_code` back into a number so a failing command does not read as exit 0. The rebuilt payload then goes through `readLifecyclePayload` itself over a `Readable`, so the stdin allowlist and string bounds apply identically; nothing reaches the handler by this route that the other would have dropped.

**I have not watched a live Claude Code session fill `${tool_input}`.** Every shape the doc permits is handled and tested, but the end-to-end run is yours to make on a host you trust — it is a one-line config change and a `knowl init claude` in any repo.

## Behavioural gap between the transports, named

A hook that fires from a directory resolving to a *different* project root than the server's — the agent `cd`-ed into a sibling checkout — is answered with silence. The process transport would have opened that project's store. It is the reason this is a choice rather than a default, and it is written in the reference.

## Also

- `hooks.transport` is in `CONFIG_FIELDS` (`knowl config list`, `knowl config set hooks.transport mcp`), the reference (a new *Hook transport* section under lifecycle, with the measured cost), `docs/hosts.md`, and the generated README tool count.
- `mergeHookConfig` / `verifyHookConfig` take `{ transport }`; `ownsHook` recognises both shapes, so switching transport **replaces** the other shape's entry instead of leaving a process hook and a tool hook to fire side by side, and a file written under the other transport verifies false — which is what puts "lifecycle hooks missing or stale" in front of the person and `doctor --fix` behind the rewrite.
- `agent-hook.ts` and the command path are untouched. The handler lives beside it as `src/cli/hook-over-mcp.ts`, not under `session/`: it needs the stdin allowlist and the host-hook normaliser, both `cli/agents`, which `session/` may not import. The server reaches it through a dynamic import, which `module-boundaries.test.ts` reads as a deferral — and a server whose repo left the transport at `command` never loads it.

## Tests

- `tests/cli/hook-transport.test.ts` — the Claude and Codex file shapes under `mcp` (literal fields from both references), boundaries stay `command`, the pre-tool matcher still names the write tools, idempotence, switching back and forth replaces rather than stacks, a foreign `mcp_tool` hook against the knowl server is left alone, hosts without the type are unchanged, the setting's parse.
- `tests/cli/hook-over-mcp.test.ts` — the three arrival shapes yield one payload; on a real store: a tool event is recorded and answered with empty content, a `Read` lands in the read-set at `file://` granularity, silence for another project's directory / the hook's own call / an incomplete payload / an unknown host, and a pre-tool question answers with the host envelope or nothing.
- `tests/mcp/gated-tool-surface.test.ts` — `knowl_hook` offered only under `mcp`.

## Verification

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npx eslint` on every touched file | clean |
| `npm run build` | clean |
| `npm run docs:check` (with `dist`) | current |
| `npx vitest run` | **389 files / 3708 passed / 5 skipped / 0 failed** |

Closes #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
