### PR TITLE
chore: release 5.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## 5.17.0 — 2026-09-03
+## 5.18.0 — 2026-09-03
 
-The agent sessions running on one machine stop being invisible to each other, and an agent can
-ask what its own branch broke.
+Hooks can run on the MCP server the host already holds open, and file evidence can finally
+go stale.
 
 **File evidence can go stale, which the README has promised since it was written.**
 `isEvidenceStale` compares a file's current hash against the one the evidence recorded, and no
@@ -49,7 +49,15 @@ asked for it. The payload travels as `${field}` templates the host fills in, is 
 server whichever way the host rendered each one, and then goes through the same allowlist the
 stdin path applies, so nothing reaches the handler by this route that the other would have dropped.
 Calling the tool while the transport is `command` is refused rather than run, so a client holding
-a stale tool list cannot capture every event twice (#224).
+a stale tool list cannot capture every event twice. A write the gate refuses still says why on the
+server's stderr, which is where the host writes its MCP log — the same second copy the process
+path prints, and worth more here, because a block whose verdict this new transport got subtly
+wrong would otherwise be completely silent (#224).
+
+## 5.17.0 — 2026-09-03
+
+The agent sessions running on one machine stop being invisible to each other, and an agent can
+ask what its own branch broke.
 
 **A push no longer fails anonymously on an over-long field.** The cloud contract caps `title`,
 `source` and `conflictKey` at 500 characters; the local store caps nothing, so a research atom

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1087,6 +1087,12 @@ test, command, user, and agent records do not become stale automatically. File e
 its stored hash with the current file. Symbol evidence uses a `symbol://` locator against the
 local index.
 
+File evidence built from `affectedPaths` is hashed only where a session actually opened the file
+— the read set holds a `file://` or `symbol://` row for it, captured from the tool stream rather
+than from the agent's own report. A path that was merely cited is stored without a hash and never
+reports stale, so an unverified assertion about a file does not become a staleness claim about
+it. Evidence you pass explicitly carries whatever `contentHash` you supply.
+
 The incremental Tree-sitter index supports `.ts`, `.tsx`, `.js`, and `.jsx`. It records relevant
 symbols and import/export relationships for local inspection; code indexing and symbol
 resolution never fan out to workspace peers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.17.0",
+      "version": "5.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.17.0",
+      "version": "5.18.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Hooks over MCP, evidence staleness that can actually fire, and feedback counted in days.

## CHANGELOG repair — read this first

`## Unreleased` existed when #233, #234 and #237 branched. #231 (release 5.17.0) consumed it into `## 5.17.0 — 2026-09-03` before any of them merged, and git then applied all three entries at the same anchor — so three unreleased features were sitting under an already-published version heading. They are moved into `## 5.18.0`; 5.17.0 keeps the entries it actually shipped (#217, #216, #229, #230).

The published v5.17.0 release notes are unaffected: `cd.yml` extracts the section with awk at tag time, and the tag predates the merges. Only the file in the repo was wrong.

This is the `## Unreleased` trap in a new shape — not "the section was missing", but "the section was renamed out from under three open PRs". Nothing catches it: each PR's diff showed a clean `## Unreleased` anchor, and all four CI legs stay green either way.

## Docs

- **#234 shipped no docs at all.** The reference said automatic staleness is limited to "hashed file evidence" and never said what makes evidence hashed — which before #234 was *nothing this repo wrote*, and after it is the read-set gate. Now documented beside the staleness rules: `affectedPaths` evidence is hashed only where a session actually opened the file, a merely cited path is stored unhashed and never reports stale, and explicit evidence keeps whatever hash you pass.
- **#233's section** (`docs/reference.md`, feedback and standing) checked against `src/store/tier.ts` — accurate as merged, including the session-start re-evaluation.
- **#237's section** (*Hook transport*), `docs/hosts.md` and the generated tool-count region checked against the code — accurate as merged. Its `docs/hosts.md` cross-link uses the two-hyphen em-dash anchor (`#hook-transport--hookstransport`), which is the form GitHub actually generates.
- README left alone. Its "file and symbol evidence go stale by themselves when the code moves" is now true for the normal path rather than aspirational; the precision belongs in the reference.

## Verification

| Gate | Result |
| --- | --- |
| `node scripts/check-version-sync.mjs` | all four files at 5.18.0 |
| `npm run typecheck` | clean |
| `npm run build` | clean |
| `npm run docs:check` | current |
| `npm test` | **390 files / 3720 passed / 5 skipped / 0 failed** |

No source changes — changelog, the four version files, and one reference passage.