### PR TITLE
fix(antigravity): write the CLI's MCP config too, not only the IDE's

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -57,12 +57,12 @@ knowl doctor               # what is configured, what is stale
 | Codex CLI | `.codex/config.toml` | `.codex/hooks.json` |
 | GitHub Copilot | `.github/mcp.json` | `.github/hooks/knowl.json` |
 | OpenHands | `config.toml` — **manual, see below** | `.openhands/hooks.json` |
-| Antigravity | `~/.gemini/antigravity/mcp_config.json` † | `.agents/hooks.json` |
+| Antigravity | `~/.gemini/antigravity/mcp_config.json` (IDE) and `~/.gemini/config/mcp_config.json` (CLI) † | `.agents/hooks.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | `.windsurf/hooks.json` |
 | Cursor | `.cursor/mcp.json` | `.cursor/hooks.json` |
 | Claude Desktop | platform config directory | — |
 
-† The MCP path is confirmed against a real Antigravity install, and is **not** `~/.gemini/config/mcp_config.json` — that one is a migration leftover left at 0 bytes, and it is what the IDE's "View raw config" does *not* open. The hooks path and event names are still quoted from Google's reference rather than observed; the installed build here predates the 2.0 hooks feature, so it could not settle them.
+† Antigravity is two products reading two files. The IDE's "View raw config" opens `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads `~/.gemini/config/mcp_config.json`, which Gemini CLI's migration often leaves at 0 bytes — an empty file, not a broken one. Both are confirmed against real installs, and `knowl init antigravity` writes both. The hooks path and event names are still quoted from Google's reference rather than observed.
 
 **Codex** hooks are behind `[features].codex_hooks = true` in `~/.codex/config.toml`, are experimental, and **do not run on Windows at all**. Everything else works there; only the hook-driven capabilities are unavailable. Because of that, Codex — like Antigravity and Windsurf, whose MCP entry is global while their hooks are per project — keeps the conditional lifecycle card rather than being told outright that its hooks own the session.
 

--- a/src/cli/agents/files.ts
+++ b/src/cli/agents/files.ts
@@ -54,7 +54,9 @@ export async function writeWithBackup(configPath: string, content: string, exist
 
 export async function mergeJsonMcpConfig(configPath: string, entry: McpEntry): Promise<MergeStatus> {
   const existing = await readTextIfExists(configPath);
-  const config = existing === undefined ? {} as Record<string, unknown> : JSON.parse(existing) as Record<string, unknown>;
+  // A 0-byte file is what Gemini CLI's migration leaves at `~/.gemini/config/mcp_config.json`,
+  // which the Antigravity CLI then reads; an empty file holds no servers, it is not a parse error.
+  const config = existing === undefined || existing.trim() === '' ? {} as Record<string, unknown> : JSON.parse(existing) as Record<string, unknown>;
   const servers = config.mcpServers && typeof config.mcpServers === 'object' && !Array.isArray(config.mcpServers)
     ? config.mcpServers as Record<string, unknown>
     : {};

--- a/src/cli/agents/hook-host-adapter.ts
+++ b/src/cli/agents/hook-host-adapter.ts
@@ -17,7 +17,8 @@ import type { HookHost } from '../../core/host-hook-types.js';
  * letting a person paste it is the honest degradation.
  */
 type McpTarget =
-  | { kind: 'json'; scope: IntegrationScope; configPath: (root: string) => string }
+  /** Every file a host reads its list from; the first is the one reported. Antigravity has two. */
+  | { kind: 'json'; scope: IntegrationScope; configPaths: (root: string) => string[] }
   | { kind: 'manual'; configPath: (root: string) => string; message: string };
 
 export interface HookHostAdapterSpec {
@@ -65,7 +66,8 @@ export function createHookHostAdapter(spec: HookHostAdapterSpec, environment: Ag
     name: spec.name,
     label: spec.label,
     async detect(root): Promise<AgentDetection> {
-      const configPath = spec.mcp.configPath(root);
+      const configPaths = spec.mcp.kind === 'json' ? spec.mcp.configPaths(root) : [spec.mcp.configPath(root)];
+      const configPath = configPaths[0];
       const installed = await environment.commandExists(spec.command);
       return {
         installed,
@@ -83,18 +85,24 @@ export function createHookHostAdapter(spec: HookHostAdapterSpec, environment: Ag
         // ran unattended -- writing `.openhands/hooks.json` into projects that had never heard of
         // OpenHands. That is the same defect the Copilot `.mcp.json` collision caused, arriving
         // through a different door.
-        configured: spec.mcp.kind === 'json' ? await jsonMcpConfigured(configPath, entry) : installed,
+        // Every file, not the first: a host reading the one without the entry sees no server.
+        configured: spec.mcp.kind === 'json'
+          ? (await Promise.all(configPaths.map(file => jsonMcpConfigured(file, entry)))).every(Boolean)
+          : installed,
         scope: mcpScope,
         configPath,
       };
     },
     async configure(root): Promise<AgentIntegrationResult> {
-      const configPath = spec.mcp.configPath(root);
       if (spec.mcp.kind === 'manual') {
-        return { agent: spec.name, status: 'skipped', scope: mcpScope, configPath, message: spec.mcp.message };
+        return { agent: spec.name, status: 'skipped', scope: mcpScope, configPath: spec.mcp.configPath(root), message: spec.mcp.message };
       }
-      const status = await mergeJsonMcpConfig(configPath, entry);
-      return { agent: spec.name, status, scope: mcpScope, configPath };
+      const configPaths = spec.mcp.configPaths(root);
+      const statuses: string[] = [];
+      for (const file of configPaths) statuses.push(await mergeJsonMcpConfig(file, entry));
+      // The most significant change across the files: a fresh entry anywhere is 'configured'.
+      const status = (['configured', 'updated', 'unchanged'] as const).find(s => statuses.includes(s)) ?? 'unchanged';
+      return { agent: spec.name, status, scope: mcpScope, configPath: configPaths[0] };
     },
     async verify(root) {
       // **Not `detect().configured` for a manual target.** The two answer different questions
@@ -141,7 +149,7 @@ export function hookHostSpecs(environment: AgentEnvironment): HookHostAdapterSpe
       // `knowl init claude` -- which put Copilot into doctor's WARN list and let `doctor --fix`
       // run `knowl init copilot` unattended, opting repositories into a host nobody chose.
       // `.github/mcp.json` is Copilot's own documented project path and collides with nothing.
-      mcp: { kind: 'json', scope: 'project', configPath: root => path.join(root, '.github', 'mcp.json') },
+      mcp: { kind: 'json', scope: 'project', configPaths: root => [path.join(root, '.github', 'mcp.json')] },
       hooksPath: root => path.join(root, '.github', 'hooks', 'knowl.json'),
     },
     {
@@ -164,13 +172,16 @@ export function hookHostSpecs(environment: AgentEnvironment): HookHostAdapterSpe
       mcp: {
         kind: 'json',
         scope: 'global',
-        // `.gemini/antigravity/`, not `.gemini/config/`. Verified against a real install on
-        // 2026-08-22: the antigravity one held a live server list and a recent mtime, while
-        // `config/mcp_config.json` was **0 bytes** from a migration months earlier -- and that
-        // dead file is the exact one whose parse error used to take `knowl init` down for every
-        // host. Google's own docs name the antigravity path as what the IDE's "View raw config"
-        // opens, which is the one a person can check against what they see.
-        configPath: () => path.join(environment.homeDir, '.gemini', 'antigravity', 'mcp_config.json'),
+        // Two products, two files. The IDE reads `.gemini/antigravity/mcp_config.json` (what its
+        // "View raw config" opens; verified against a real install 2026-08-22). The `agy` CLI
+        // reads `.gemini/config/mcp_config.json` -- its embedded docs name it as the global
+        // config, and `/mcp` in the CLI showed nothing while only the IDE file was written
+        // (verified 2026-09-03). That second file is the one Gemini CLI's migration leaves at
+        // 0 bytes, which `mergeJsonMcpConfig` now reads as empty rather than malformed.
+        configPaths: () => [
+          path.join(environment.homeDir, '.gemini', 'antigravity', 'mcp_config.json'),
+          path.join(environment.homeDir, '.gemini', 'config', 'mcp_config.json'),
+        ],
       },
       hooksPath: root => path.join(root, '.agents', 'hooks.json'),
     },
@@ -181,7 +192,7 @@ export function hookHostSpecs(environment: AgentEnvironment): HookHostAdapterSpe
       mcp: {
         kind: 'json',
         scope: 'global',
-        configPath: () => path.join(environment.homeDir, '.codeium', 'windsurf', 'mcp_config.json'),
+        configPaths: () => [path.join(environment.homeDir, '.codeium', 'windsurf', 'mcp_config.json')],
       },
       hooksPath: root => path.join(root, '.windsurf', 'hooks.json'),
     },

--- a/tests/cli/host-config-shapes.test.ts
+++ b/tests/cli/host-config-shapes.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { afterAll, describe, expect, it } from 'vitest';
 import { mergeHookConfig, verifyHookConfig } from '../../src/cli/agents/hook-config.js';
@@ -405,5 +405,32 @@ describe('what a refusal actually does to the hook process', () => {
   it('reads a flat host’s timeout off its profile, not off its name', () => {
     expect(hostProfile('cursor').hookEntryTimeout).toBe(30);
     expect(hostProfile('windsurf').hookEntryTimeout).toBeUndefined();
+  });
+});
+
+describe('Antigravity MCP entry reaches both the IDE and the CLI', () => {
+  // The IDE reads `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads
+  // `~/.gemini/config/mcp_config.json` -- the file Gemini CLI's migration leaves at 0 bytes.
+  it('writes both files, parsing an empty one as no config', async () => {
+    const { createHookHostAdapter, hookHostSpecs } = await import('../../src/cli/agents/hook-host-adapter.js');
+    const home = await workspace();
+    const ide = path.join(home, '.gemini', 'antigravity', 'mcp_config.json');
+    const cli = path.join(home, '.gemini', 'config', 'mcp_config.json');
+    await mkdir(path.dirname(cli), { recursive: true });
+    await writeFile(cli, '', 'utf8');
+    const environment = { platform: 'linux' as const, homeDir: home, appDataDir: home, commandExists: async () => true };
+    const adapter = createHookHostAdapter(hookHostSpecs(environment).find(spec => spec.name === 'antigravity')!, environment);
+
+    expect((await adapter.detect(home)).configured).toBe(false);
+    expect((await adapter.configure(home)).status).toBe('configured');
+    for (const file of [ide, cli]) {
+      expect((await readJson(file)).mcpServers.knowl.args, file).toEqual(['serve', '--host', 'antigravity']);
+    }
+    expect((await adapter.detect(home)).configured).toBe(true);
+
+    // One file missing the entry is not configured: the host that reads it sees nothing.
+    await writeFile(cli, '{}', 'utf8');
+    expect((await adapter.detect(home)).configured).toBe(false);
+    expect((await adapter.configure(home)).status).toBe('configured');
   });
 });


### PR DESCRIPTION
## Summary
- `knowl init antigravity` configured the IDE but the new `agy` CLI's `/mcp` showed nothing: the CLI reads `~/.gemini/config/mcp_config.json` (per its embedded docs), the IDE reads `~/.gemini/antigravity/mcp_config.json`. 901a343 wrote only the latter.
- The json `McpTarget` now takes `configPaths: string[]`; `configured` requires the entry in every file, `configure` merges into each. Antigravity lists both.
- `mergeJsonMcpConfig` treats an empty file as `{}` — Gemini CLI's migration leaves that CLI file at 0 bytes, and it is empty, not malformed. Shared fix, protects every JSON host.
- docs/hosts.md path table and footnote updated.

Other hosts audited for the same IDE-vs-CLI split: none confirmed (Copilot `.github/mcp.json` is a documented CLI path, Cursor's file serves both IDE and cursor-agent, Windsurf has no CLI, the rest have one reader).

## Test plan
- [x] new test: both files written, 0-byte file tolerated, one missing entry → not configured
- [x] `tsc --noEmit`, eslint, host-config-shapes + agents tests
- [x] full suite (3744 tests), lint, docs:check on the same diff
- [x] real `node dist/index.js init antigravity -y` on a machine with both products wrote the CLI file