### PR TITLE
chore: release 5.19.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.19.0 — 2026-09-03
 
 Hermes Agent at Claude Code parity: `knowl init hermes`.
 
 **Hermes Agent** is configured through the shell hooks in its own `config.yaml`, which take Claude Code's wire format: `knowl init hermes` writes `mcp_servers.knowl` and one `hooks.<event>` entry each for `on_session_start`, `pre_llm_call`, `pre_tool_call` (matched to `write_file|patch`), `post_tool_call`, `pre_verify`, `on_session_end` and `on_session_finalize`. `pre_llm_call` carries the turn card, `pre_tool_call` blocks a refused write on exit 2, and `pre_verify` — which fires before an edit turn finishes and accepts Claude's `{"decision": "block"}` — carries the capture nudge, so Hermes reaches every capability. Init edits `config.yaml` as a YAML document (comments survive) and never runs `hermes` itself, whose own mutators rewrite the file without comments and can stop on an interactive prompt. Hermes asks for consent once per hook at the terminal on first use; gateway and Hermes Desktop runs need that approval or `hooks_auto_accept: true`. Home is `HERMES_HOME`, else `%LOCALAPPDATA%\hermes` on Windows, else `~/.hermes`.
 
 User-owned YAML config files (`config.yaml`) are merged as documents: every comment survives (comment blocks may be re-indented to sit with their key), the file's line-ending convention is kept, and a file that fails to parse is reported and left untouched. `yaml` is now a direct dependency.
+
+**Antigravity is two products reading two MCP files, and `knowl init antigravity` now writes both.** The IDE's "View raw config" opens `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads `~/.gemini/config/mcp_config.json`, which Gemini CLI's migration often leaves at 0 bytes. The adapter had pointed at the IDE file alone, so the CLI's `/mcp` stayed empty. An empty JSON config is now read as "no servers" rather than a parse error, and a JSON MCP target takes a list of files: `detect` reports configured only when every file holds the entry, and `configure` merges into each.
 
 ## 5.18.0 — 2026-09-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.18.0",
+      "version": "5.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.18.0",
+      "version": "5.19.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release 5.19.0

Follows #240 (merged as `9b1257f`). This PR is the single release commit on top of main.

### In this release

- **Hermes Agent host** — `knowl init hermes` writes `mcp_servers.knowl` and seven shell-hook entries into Hermes' `config.yaml`. Hermes' hooks take Claude Code's wire format, so the write gate (`pre_tool_call`, exit 2), the prompt card (`pre_llm_call`) and the capture nudge (`pre_verify`, which keeps an edit turn going) all work with no plugin. Verified end to end through `hermes hooks test` against Hermes v0.21.0 on Windows.
- **Antigravity writes both MCP files** (`a3b3f12`, already on main, changelog entry added here) — IDE and `agy` CLI read different files; an empty JSON config is read as "no servers".
- `yaml` becomes a direct dependency for comment-preserving edits of user-owned YAML configs.

### Release mechanics

- Version bumped to 5.19.0 in `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `server.json`; `node scripts/check-version-sync.mjs` passes.
- `## Unreleased` renamed to `## 5.19.0 — 2026-09-03`, the convention `cd.yml` extracts release notes from.
- `npm run docs:check`: generated regions current.

### After merge

Watch main CI to green, then tag the merge commit:

```bash
git tag -a v5.19.0 <merge-sha> -m "5.19.0"
git push origin v5.19.0
```

`cd.yml` publishes to npm and creates the GitHub release from the changelog section.
