### PR TITLE
fix(hosts): Antigravity recorded nothing, and codex lost two thirds of its commands

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -66,7 +66,13 @@ knowl doctor               # what is configured, what is stale
 | Claude Desktop | platform config directory | — |
 | Hermes Agent | `config.yaml` in the Hermes home (global) | same file, `hooks:` block |
 
-† Antigravity is two products reading two files. The IDE's "View raw config" opens `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads `~/.gemini/config/mcp_config.json`, which Gemini CLI's migration often leaves at 0 bytes — an empty file, not a broken one. Both are confirmed against real installs, and `knowl init antigravity` writes both. The hooks path and event names are still quoted from Google's reference rather than observed.
+† Antigravity is two products reading two files. The IDE's "View raw config" opens `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads `~/.gemini/config/mcp_config.json`, which Gemini CLI's migration often leaves at 0 bytes — an empty file, not a broken one. Both are confirmed against real installs, and `knowl init antigravity` writes both.
+
+The hooks path, event names, payload and tool vocabulary are now read off an installed bundle (`~/.gemini/antigravity/builtin/skills/agy-customizations/docs/hooks.md` plus its conversation transcripts, 2026-09-04) rather than quoted. Three things that reference settles, each of which had produced a working-looking integration that recorded nothing:
+
+- **Only `PreToolUse` and `PostToolUse` take a `{matcher, hooks}` wrapper.** `PreInvocation`, `PostInvocation` and `Stop` are a flat handler list. Wrapped, Antigravity parses them and does not run them.
+- **The payload is protojson**: every key camelCase, the session under `conversationId`, the root under `workspacePaths`, and the tool as one `toolCall: {name, args}` object whose arguments are PascalCase (`TargetFile`, `AbsolutePath`, `CommandLine`). Knowl's stdin allowlist and normalizer both speak snake_case, so every event arrived with no session id and no root — see `normalizePayload` on the host profile.
+- **The tool names are lowercase step types**: `replace_file_content`, `multi_replace_file_content`, `write_to_file` write; `view_file` reads; `run_command` is the shell.
 
 **Codex** hooks are behind `[features].codex_hooks = true` in `~/.codex/config.toml`, are experimental, and **do not run on Windows at all**. Everything else works there; only the hook-driven capabilities are unavailable. Because of that, Codex — like Antigravity and Windsurf, whose MCP entry is global while their hooks are per project — keeps the conditional lifecycle card rather than being told outright that its hooks own the session.
 

--- a/src/cli/agents/hook-config.ts
+++ b/src/cli/agents/hook-config.ts
@@ -1,6 +1,7 @@
 import { readTextIfExists, MergeStatus, writeWithBackup } from './files.js';
 import { HookHost } from './host-hook.js';
 import { hostProfile } from '../../session/hosts/index.js';
+import { ANTIGRAVITY_GROUPED_EVENTS } from '../../session/hosts/antigravity.js';
 import { KNOWL_MCP_SERVER_KEY } from '../../core/knowl-guidance.js';
 import { HOOK_TOOL_NAME, type HookTransport } from '../../core/hooks-transport.js';
 
@@ -428,6 +429,25 @@ export async function verifyFlatHookConfig(
  */
 const ANTIGRAVITY_HOOK_NAME = 'knowl';
 
+/**
+ * One event's handlers, in the shape Antigravity's reference gives *that* event.
+ *
+ * Two shapes in one file: the tool events wrap in `{matcher, hooks}`, and `PreInvocation`,
+ * `PostInvocation` and `Stop` are a bare handler list. Reusing `nestedEntry` for all five wrote
+ * the wrapper everywhere, which Antigravity parses and ignores -- so the three invocation
+ * events, including the only one that bootstraps a session, were registered and dead.
+ *
+ * No `statusMessage` either: its handler schema is `type`, `command`, `timeout` and nothing
+ * else, and a key a host does not define is usually ignored and occasionally fatal to parsing
+ * the whole file -- which would take every other hook set in it down too.
+ */
+function antigravityEntries(platform: NodeJS.Platform, host: HookHost, event: string): Record<string, unknown>[] {
+  const handler = { type: 'command', command: knowlHookCommand(platform, host, event), timeout: 30 };
+  return ANTIGRAVITY_GROUPED_EVENTS.has(event)
+    ? [{ matcher: nestedMatcher(host, event, '.*'), hooks: [handler] }]
+    : [handler];
+}
+
 export async function mergeAntigravityHookConfig(
   configPath: string,
   platform: NodeJS.Platform,
@@ -436,7 +456,7 @@ export async function mergeAntigravityHookConfig(
   const existing = await readTextIfExists(configPath);
   const config = existing === undefined ? {} as Record<string, unknown> : JSON.parse(existing) as Record<string, unknown>;
   const ours: Record<string, unknown> = {};
-  for (const event of hostProfile(host).hookEvents) ours[event] = [nestedEntry(platform, host, event)];
+  for (const event of hostProfile(host).hookEvents) ours[event] = antigravityEntries(platform, host, event);
   const next = { ...config, [ANTIGRAVITY_HOOK_NAME]: ours };
   if (existing !== undefined && equal(config, next)) return 'unchanged';
   const hadOwnEntry = config[ANTIGRAVITY_HOOK_NAME] !== undefined;
@@ -453,7 +473,8 @@ export async function verifyAntigravityHookConfig(
     const config = JSON.parse(await readTextIfExists(configPath) ?? '{}') as Record<string, any>;
     const ours = config[ANTIGRAVITY_HOOK_NAME];
     return Boolean(ours) && hostProfile(host).hookEvents.every(event => Array.isArray(ours[event])
-      && ours[event].some((entry: unknown) => equal(entry, nestedEntry(platform, host, event))));
+      && antigravityEntries(platform, host, event)
+        .every(wanted => ours[event].some((entry: unknown) => equal(entry, wanted))));
   } catch {
     return false;
   }

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -37,9 +37,7 @@ const stringValue = (value: unknown, max = MAX_STRING): string | undefined =>
 const recordValue = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
 
-function requireProjectRoot(host: HookHost, raw: Record<string, unknown>): string {
-  const declared = stringValue(hostProfile(host).projectRoot?.(raw));
-  if (declared) return path.resolve(declared);
+function requireProjectRoot(raw: Record<string, unknown>): string {
   const cwd = stringValue(raw.cwd);
   if (cwd) return path.resolve(cwd);
   const roots = Array.isArray(raw.workspace_roots) ? raw.workspace_roots : [];
@@ -332,11 +330,14 @@ function validateNormalizedHostHook(input: NormalizedHostHook): NormalizedHostHo
   return input;
 }
 
-function normalizeHostHookUnchecked(host: string, eventName: string, raw: Record<string, unknown>): NormalizedHostHook {
+function normalizeHostHookUnchecked(host: string, eventName: string, payload: Record<string, unknown>): NormalizedHostHook {
   if (!isHookHost(host)) throw new Error(`Unsupported hook host: ${host}`);
   const normalizedHost = host;
   const profile = hostProfile(normalizedHost);
-  const projectRoot = requireProjectRoot(normalizedHost, raw);
+  // Before anything reads a field: a host whose payload uses other names says so once here,
+  // rather than in every extractor below. See `normalizePayload`.
+  const raw = profile.normalizePayload?.(payload) ?? payload;
+  const projectRoot = requireProjectRoot(raw);
   const identity = profile.identity(raw);
   if (!identity.externalSessionId) throw new IncompleteHostHookPayloadError('Host hook payload requires a session id.');
   const ids = { externalSessionId: identity.externalSessionId, externalTurnId: identity.externalTurnId };

--- a/src/cli/agents/lifecycle.ts
+++ b/src/cli/agents/lifecycle.ts
@@ -12,7 +12,10 @@ const sessionEventTypes: SessionEventType[] = ['start', 'command', 'test', 'erro
 const MAX_RETAINED_STRING = 2_000;
 const MAX_RETAINED_ARRAY_ITEMS = 50;
 const ROOT_FIELDS = new Set([
-  'session_id', 'sessionId', 'thread_id', 'turn_id', 'turnId', 'conversation_id', 'generation_id', 'cwd', 'workspace_roots',
+  // `cascade_id` is Windsurf's third identity fallback and was read by its profile while this
+  // list dropped it -- harmless only for as long as Windsurf also sends one of the first two.
+  'session_id', 'sessionId', 'thread_id', 'turn_id', 'turnId', 'conversation_id', 'cascade_id', 'generation_id',
+  'cwd', 'workspace_roots',
   'title', 'query', 'agent', 'type', 'status', 'summary', 'command', 'exit_code', 'exitCode', 'passed',
   'message', 'code', 'text', 'changedPaths', 'changed_paths', 'commit', 'file_path', 'filePath', 'path', 'notebook_path',
   'tool_name', 'toolName', 'error', 'error_code', 'error_message', 'tool_input', 'toolInput', 'tool_response', 'toolResponse',
@@ -25,6 +28,13 @@ const ROOT_FIELDS = new Set([
   // a hook that computes from a field it never receives passes every test that bypasses stdin.
   // Neither reaches `payload`; see `errorText` / `assistantMessage` on NormalizedHostHook.
   'prompt', 'last_assistant_message',
+  // Antigravity's payload is protojson: every key camelCase, the session under
+  // `conversationId`, the root under `workspacePaths`, and the tool nested in `toolCall`
+  // rather than split across `tool_name`/`tool_input`. This list is an allowlist, so before
+  // these three lines every Antigravity hook arrived with no session id and no root and threw
+  // `IncompleteHostHookPayloadError` -- which the entry swallows in silence, so the host looked
+  // exactly like one nobody had configured. `normalizePayload` restates them downstream.
+  'conversationId', 'workspacePaths', 'toolCall',
 ]);
 /**
  * Keys whose LAST characters matter more than their first.
@@ -54,6 +64,7 @@ const NESTED_FIELDS: Record<string, Set<string>> = {
   tool_response: new Set(['exit_code', 'exitCode', 'stdout', 'stderr']),
   toolResponse: new Set(['exit_code', 'exitCode', 'stdout', 'stderr']),
   error: new Set(['code', 'type', 'message', 'error']),
+  toolCall: new Set(['name', 'args']),
 };
 // Fields kept inside an allowlisted array of objects, e.g. tool_input.atoms[i].
 // Without this, allowing `atoms` above would retain whole atom bodies; only the
@@ -61,7 +72,16 @@ const NESTED_FIELDS: Record<string, Set<string>> = {
 const NESTED_ARRAY_ITEM_FIELDS: Record<string, Set<string>> = {
   atoms: new Set(['title']),
 };
-const ARRAY_FIELDS = new Set(['workspace_roots', 'changedPaths', 'changed_paths', 'file_paths', 'filePaths']);
+const ARRAY_FIELDS = new Set(['workspace_roots', 'workspacePaths', 'changedPaths', 'changed_paths', 'file_paths', 'filePaths']);
+/**
+ * The `toolCall.args` leaves Antigravity's normalizer reads, and nothing else.
+ *
+ * Named individually rather than allowed wholesale, because the sibling keys are the file's new
+ * contents (`CodeContent`, `ReplacementContent`, `ReplacementChunks`). Every other host's tool
+ * arguments are allowlisted down to the fields that are actually read; letting one host's
+ * arguments through by their parent would put whole file bodies in this process for no reader.
+ */
+const TOOL_CALL_ARG_FIELDS = new Set(['TargetFile', 'AbsolutePath', 'CommandLine', 'Query']);
 
 function shouldDiscardPath(stack: Array<string | number | null>): boolean {
   if (stack.length === 0) return false;
@@ -76,6 +96,11 @@ function shouldDiscardPath(stack: Array<string | number | null>): boolean {
   if (stack.length >= 4 && typeof stack[2] === 'number') {
     // A field of an object inside an allowlisted array. Nothing deeper is ever kept.
     return stack.length > 4 || !NESTED_ARRAY_ITEM_FIELDS[String(stack[1])]?.has(String(stack[3]));
+  }
+  // `toolCall.args` is the one allowlisted pair with a third level worth keeping, and the one
+  // whose siblings are file contents. Everything under it is named or dropped.
+  if (parent === 'toolCall' && stack.length > 2) {
+    return stack.length > 3 || stack[1] !== 'args' || !TOOL_CALL_ARG_FIELDS.has(String(stack[2]));
   }
   if (NESTED_FIELDS[parent]) return !NESTED_FIELDS[parent].has(String(stack[1]));
   return true;

--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -1053,25 +1053,42 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
     await resetTurnCapture(turnCaptureKey(bindingKey(input, 'turn')));
 
     const sessionBinding = await findHostSession(bindingKey(input, 'session'));
+    // The roster rides the first turn of a session that has not bootstrapped yet, because a
+    // host may have no session-start event at all: Antigravity's `PreInvocation` is the first
+    // thing that fires there, and `fleetSessionStartBestEffort` hangs off session-start alone --
+    // so that host wrote to the fleet, appeared in everyone else's roster, and was itself told
+    // nothing about the sessions it was sharing a repo with. A missing binding is exactly "this
+    // session has not started yet", so this fires once on those hosts and never on the rest.
+    const roster = sessionBinding
+      ? ''
+      : await fleetSessionStartBestEffort(input, await loadConfig(input.projectRoot).catch(() => null));
+    // Charged against the same cap as the session-start card rather than added on top of it:
+    // the host was promised a size, and the roster is the cheaper half to keep whole.
+    const turnBudget = roster ? Math.max(0, DEFAULT_CONTEXT_MAX_CHARS - roster.length - 2) : undefined;
+    const withRoster = (context: string | undefined): string | undefined =>
+      roster ? (context ? `${roster}\n\n${context}` : roster) : context;
+
     if (!sessionBinding && hostProfile(input.host).sharesSessionBinding) {
-      const started = await bootstrapWithHandoff(projectId, input, 'session', true);
+      const started = await bootstrapWithHandoff(projectId, input, 'session', true, turnBudget);
       await bindHostSession(bindingKey(input, 'turn'), started.session.id);
+      const context = withRoster(started.context);
       return {
         accepted: true,
         sessionId: started.session.id,
-        context: started.context,
+        context,
         contextTruncated: started.truncated,
-        hostOutput: hostContextOutput(input, withCorrection(started.context)),
+        hostOutput: hostContextOutput(input, withCorrection(context)),
       };
     }
-    const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding);
+    const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding, turnBudget);
     if (!sessionBinding) await bindHostSession(bindingKey(input, 'session'), started.session.id);
+    const context = withRoster(started.context);
     return {
       accepted: true,
       sessionId: started.session.id,
-      context: started.context,
+      context,
       contextTruncated: started.truncated,
-      hostOutput: hostContextOutput(input, withCorrection(started.context)),
+      hostOutput: hostContextOutput(input, withCorrection(context)),
     };
   }
 

--- a/src/session/hosts/antigravity.ts
+++ b/src/session/hosts/antigravity.ts
@@ -18,6 +18,31 @@ export const ANTIGRAVITY_HOOK_EVENTS = [
 ] as const;
 
 /**
+ * The two events whose handlers wrap in `{matcher, hooks}`; the other three take a bare handler.
+ *
+ * Antigravity's reference is explicit that only the tool events have a matcher target and that
+ * `PreInvocation`, `PostInvocation` and `Stop` are "Flat (list of handler objects directly)".
+ * Writing the grouped shape there produces a file it parses and ignores, which is how the
+ * integration shipped with three of its five events -- including the only one that starts a
+ * session -- registered and dead.
+ */
+export const ANTIGRAVITY_GROUPED_EVENTS: ReadonlySet<string> = new Set(['PreToolUse', 'PostToolUse']);
+
+/**
+ * The write tools, read off a real install's trajectory rather than guessed.
+ *
+ * The previous list was `write_file`, `edit_file`, `WriteFile`, `EditFile` and
+ * `replace_file_content` -- four names Antigravity has never emitted and one it has. Its
+ * reference says tool names are the step type lowercased with `CORTEX_STEP_TYPE_` stripped, so
+ * the PascalCase half could not have been right; the two real names it was missing account for
+ * more than a third of the writes in the transcripts these were read from.
+ */
+const ANTIGRAVITY_WRITE_TOOLS = ['replace_file_content', 'multi_replace_file_content', 'write_to_file'] as const;
+
+const record = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+
+/**
  * Antigravity's context channel: steps spliced into the conversation trajectory.
  *
  * `ephemeralMessage` is the transient variant -- the other two are `userMessage`, which would
@@ -68,15 +93,40 @@ export const antigravityProfile: HostProfile = {
   lifecycleClaimable: false,
   midTurnDeliveryVerified: false,
   hookConfigStyle: 'antigravity-nested',
-  // Not quoted from a reference -- Antigravity documents its hook payload, not its agent's tool
-  // vocabulary. A wrong name costs detection here and nothing else: the gate degrades to "no
-  // opinion", which is its designed failure direction.
-  readsFiles: (_event, tool) => ['read_file', 'view_file', 'ReadFile'].includes(tool),
-  writesFiles: (_event, tool) =>
-    ['write_file', 'edit_file', 'replace_file_content', 'WriteFile', 'EditFile'].includes(tool),
+  // Observed, not guessed: `view_file` is the only read tool that names a single file, and the
+  // three writes are the whole write vocabulary. `grep_search` and `list_dir` read too, but not
+  // a file the read-set could record.
+  readsFiles: (_event, tool) => tool === 'view_file',
+  // The list, not a predicate: `toolWritesFile` and the pre-tool matcher then read the same
+  // three names, so the gate can never want to refuse a tool the host was told not to announce.
+  writeTools: ANTIGRAVITY_WRITE_TOOLS,
+  /**
+   * protojson, so every key is camelCase and the tool arrives as one object.
+   *
+   * `conversationId` is the session -- the previous three fallbacks (`session_id`,
+   * `conversation_id`, `thread_id`) were snake_case and Antigravity sends none of them, so
+   * every event failed the session-id check. The tool split is `toolCall: {name, args}` where
+   * the rest of the pipeline reads `tool_name`/`tool_input`, and the arguments are PascalCase:
+   * `TargetFile` on all three writes, `AbsolutePath` on the read, `CommandLine` on the shell.
+   * `workspacePaths` is the root, and missing it is what threw on every event.
+   */
+  normalizePayload(raw) {
+    const call = record(raw.toolCall);
+    const args = record(call?.args) ?? {};
+    const roots = Array.isArray(raw.workspacePaths) ? raw.workspacePaths : [];
+    return {
+      ...raw,
+      ...(roots.length > 0 ? { workspace_roots: roots } : {}),
+      ...(call?.name !== undefined ? { tool_name: call.name } : {}),
+      // `Query` is `grep_search`'s pattern, and it is here for the same reason the shared
+      // discriminator list exists: without it two searches inside the debounce window
+      // normalise to one event and the second is dropped with its change card.
+      ...(call ? { tool_input: { file_path: args.TargetFile ?? args.AbsolutePath, command: args.CommandLine, query: args.Query } } : {}),
+    };
+  },
   identity(raw): HostIdentity {
     return {
-      externalSessionId: hostString(raw.session_id) ?? hostString(raw.conversation_id) ?? hostString(raw.thread_id),
+      externalSessionId: hostString(raw.conversationId) ?? hostString(raw.conversation_id),
       externalTurnId: hostString(raw.turn_id) ?? hostString(raw.generation_id),
       ...agentIdentityFrom(raw),
     };
@@ -84,8 +134,11 @@ export const antigravityProfile: HostProfile = {
   normalizedEvent(hostEvent) {
     return ANTIGRAVITY_EVENT_MAP[hostEvent];
   },
+  // `run_command`, not `bash`/`shell`. The shared helper knows the two Anthropic-shaped names
+  // and neither is Antigravity's, so every command it ran normalised to a nameless checkpoint:
+  // no command text, no exit code, and nothing for the fleet to fingerprint a shared failure on.
   isShellEvent(_hostEvent, toolName) {
-    return toolNameIsShell(toolName);
+    return toolName === 'run_command' || toolNameIsShell(toolName);
   },
   startContext(_event, context) {
     return injectEphemeral(context);

--- a/src/session/hosts/codex.ts
+++ b/src/session/hosts/codex.ts
@@ -73,8 +73,14 @@ export const codexProfile: HostProfile = {
   normalizedEvent(hostEvent) {
     return PASCAL_EVENT_MAP_WITH_PRETOOL[hostEvent];
   },
+  // `shell` is not the only name, and by volume it is not the main one. Across this machine's
+  // codex sessions the shell tool is called `shell_command` 14,329 times, `shell` 2,059 and
+  // `exec_command` 1,174; all three are in the shipped codex.exe 0.149.1. The shared helper
+  // knows `bash` and `shell`, so two thirds of every codex command normalised to a nameless
+  // checkpoint -- no command text, no exit code, and nothing for the fleet to fingerprint a
+  // shared failure on. `apply_patch` is unaffected; it was never routed through here.
   isShellEvent(_hostEvent, toolName) {
-    return toolNameIsShell(toolName);
+    return toolNameIsShell(toolName) || toolName === 'shell_command' || toolName === 'exec_command';
   },
   startContext(event, context) {
     return hookSpecificOutput(startEventName(event), context);

--- a/src/session/hosts/profile.ts
+++ b/src/session/hosts/profile.ts
@@ -184,18 +184,24 @@ export interface HostProfile {
    */
   readonly lifecycleClaimable?: boolean;
   /**
-   * The working directory this event happened in, if this host does not name it `cwd`.
+   * This host's payload restated in the field names the normalizer reads, if the two differ.
    *
-   * `cwd` then `workspace_roots[0]` was hardcoded for every host, and it is the one field with
-   * no graceful degradation: a host that names it something else throws
-   * `IncompleteHostHookPayloadError` on *every* event, which the hook entry deliberately
-   * swallows in silence -- so the integration reports nothing, logs nothing, and looks exactly
-   * like a host nobody has configured.
+   * The normalizer speaks one vocabulary -- `cwd`/`workspace_roots`, `tool_name`, `tool_input`,
+   * `command`, `file_path` -- and every host read so far either speaks it or a documented
+   * alias of it. Antigravity does not: its payload is protojson, so the root is
+   * `workspacePaths`, the tool is one `toolCall: {name, args}` object, and its arguments are
+   * PascalCase (`TargetFile`, `CommandLine`). Five extractors would each need a host-shaped
+   * fallback; one mapping here is the same fix once.
    *
-   * Optional because the two default names cover every host read so far. It exists so the next
-   * one can say so in its profile rather than having the default quietly decide for it.
+   * The root is the field with no graceful degradation -- miss it and every event throws
+   * `IncompleteHostHookPayloadError`, which the hook entry swallows in silence, so the
+   * integration reports nothing, logs nothing, and looks exactly like a host nobody has
+   * configured. Everything else degrades quietly instead: an unmapped tool name means no write
+   * detected and no gate, which is worse to diagnose and cheaper to survive.
+   *
+   * Runs after the stdin allowlist, so a key this returns has to be allowlisted there first.
    */
-  projectRoot?: (raw: Record<string, unknown>) => string | undefined;
+  normalizePayload?: (raw: Record<string, unknown>) => Record<string, unknown>;
   identity(raw: Record<string, unknown>): HostIdentity;
   normalizedEvent(hostEvent: string): NormalizedHookEventName | undefined;
   isShellEvent(hostEvent: string, toolName: string): boolean;

--- a/tests/cli/host-config-shapes.test.ts
+++ b/tests/cli/host-config-shapes.test.ts
@@ -224,7 +224,14 @@ describe('the deny path each host actually declared', () => {
       ['codex', 'PreToolUse', { session_id: 's', tool_name: 'apply_patch' }],
       ['copilot', 'preToolUse', { session_id: 's', tool_name: 'str_replace' }],
       ['openhands', 'pre_tool_use', { conversation_id: 's', tool_name: 'str_replace_editor' }],
-      ['antigravity', 'PreToolUse', { session_id: 's', tool_name: 'edit_file' }],
+      // protojson, and the whole row is a different vocabulary: `conversationId` for the
+      // session and one `toolCall` object for the tool. This row used to read `session_id` and
+      // `edit_file` -- neither of which Antigravity has ever sent -- so it pinned a contract
+      // that could not fire against a real install.
+      ['antigravity', 'PreToolUse', {
+        conversationId: 's',
+        toolCall: { name: 'replace_file_content', args: { TargetFile: path.join(root, 'src/a.ts') } },
+      }],
       // Windsurf names the action and sends no tool name at all.
       ['windsurf', 'pre_write_code', { conversation_id: 's' }],
     ];

--- a/tests/cli/hosts/antigravity.test.ts
+++ b/tests/cli/hosts/antigravity.test.ts
@@ -1,0 +1,108 @@
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { normalizeHostHook } from '../../../src/cli/agents/host-hook.js';
+import { readLifecyclePayload } from '../../../src/cli/agents/lifecycle.js';
+import { hostProfile, toolWritesFile } from '../../../src/session/hosts/index.js';
+import { mergeHookConfig, verifyHookConfig } from '../../../src/cli/agents/hook-config.js';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+
+const ROOT = path.resolve('.knowl-antigravity-test');
+
+/**
+ * One Antigravity hook payload, in the shape its reference documents and its transcripts show:
+ * protojson (every key camelCase), the session under `conversationId`, the root under
+ * `workspacePaths`, and the tool as one `toolCall` object whose arguments are PascalCase.
+ *
+ * Written as stdin rather than passed straight to the normalizer, because the stdin allowlist
+ * is where this integration actually died: it dropped all three fields, so every event threw
+ * `IncompleteHostHookPayloadError`, the hook entry swallowed it, and the host looked exactly
+ * like one nobody had configured. A test that hands the normalizer a payload directly passes
+ * against that bug.
+ */
+const through = async (raw: unknown) => readLifecyclePayload(Readable.from([JSON.stringify(raw)]) as any);
+
+describe('an Antigravity hook payload survives the stdin filter', () => {
+  it('keeps the session, the root and the tool call', async () => {
+    const payload = await through({
+      conversationId: 'ec33ebf9-0cba-4100-8142-c61503f6c587',
+      workspacePaths: [ROOT],
+      toolCall: { name: 'replace_file_content', args: { TargetFile: path.join(ROOT, 'src/a.ts'), Description: 'x' } },
+    });
+    expect(payload.conversationId).toBe('ec33ebf9-0cba-4100-8142-c61503f6c587');
+    expect(payload.workspacePaths).toEqual([ROOT]);
+    expect((payload.toolCall as any).name).toBe('replace_file_content');
+    expect((payload.toolCall as any).args.TargetFile).toBe(path.join(ROOT, 'src/a.ts'));
+  });
+
+  it('drops the file contents beside them', async () => {
+    const payload = await through({
+      conversationId: 'c1', workspacePaths: [ROOT],
+      toolCall: { name: 'write_to_file', args: { TargetFile: path.join(ROOT, 'a.ts'), CodeContent: 'SECRET-BODY' } },
+    });
+    expect(JSON.stringify(payload)).not.toContain('SECRET-BODY');
+  });
+});
+
+describe('the normalized Antigravity event', () => {
+  it('resolves the session and the root that used to throw', async () => {
+    const event = normalizeHostHook('antigravity', 'PreInvocation', await through({
+      conversationId: 'c1', workspacePaths: [ROOT], invocationNum: 3,
+    }));
+    expect(event.externalSessionId).toBe('c1');
+    expect(event.projectRoot).toBe(ROOT);
+    expect(event.event).toBe('turn-start');
+  });
+
+  it('reads the write tool and its target out of toolCall', async () => {
+    const event = normalizeHostHook('antigravity', 'PostToolUse', await through({
+      conversationId: 'c1', workspacePaths: [ROOT],
+      toolCall: { name: 'replace_file_content', args: { TargetFile: path.join(ROOT, 'src/a.ts') } },
+    }));
+    expect(event.toolName).toBe('replace_file_content');
+    expect(event.payload.changedPaths).toEqual(['src/a.ts']);
+  });
+
+  it('reads a shell run as a command, not as a nameless checkpoint', async () => {
+    const event = normalizeHostHook('antigravity', 'PostToolUse', await through({
+      conversationId: 'c1', workspacePaths: [ROOT],
+      toolCall: { name: 'run_command', args: { CommandLine: 'npm test' } },
+    }));
+    expect(event.payload.command).toBe('npm test');
+  });
+
+  it('recognises the tools a real install emits, and no invented ones', () => {
+    const profile = hostProfile('antigravity');
+    expect([...profile.writeTools!]).toEqual(['replace_file_content', 'multi_replace_file_content', 'write_to_file']);
+    for (const tool of profile.writeTools!) {
+      expect(toolWritesFile({ host: 'antigravity', toolName: tool }), tool).toBe(true);
+    }
+    expect(toolWritesFile({ host: 'antigravity', toolName: 'edit_file' })).toBe(false);
+    expect(profile.readsFiles!('PostToolUse', 'view_file')).toBe(true);
+    expect(profile.isShellEvent('PostToolUse', 'run_command')).toBe(true);
+  });
+});
+
+describe('the Antigravity hooks file', () => {
+  it('wraps only the tool events, and leaves the invocation events flat', async () => {
+    const file = path.join(await mkdtemp(path.join(os.tmpdir(), 'knowl-ag-')), 'hooks.json');
+    expect(await mergeHookConfig(file, 'linux', 'antigravity')).toBe('configured');
+    const config = JSON.parse(await readFile(file, 'utf8'));
+
+    // Grouped: a matcher and a `hooks` wrapper, matching exactly the write tools.
+    expect(config.knowl.PreToolUse[0].matcher).toBe('^(replace_file_content|multi_replace_file_content|write_to_file)$');
+    expect(config.knowl.PostToolUse[0].hooks[0].command).toBe('knowl agent-hook antigravity PostToolUse --json');
+
+    // Flat: the handler itself, no matcher, no wrapper -- the shape Antigravity's reference
+    // gives these three. Wrapped, they parse and never fire.
+    for (const event of ['PreInvocation', 'PostInvocation', 'Stop']) {
+      expect(config.knowl[event], event).toEqual([
+        { type: 'command', command: `knowl agent-hook antigravity ${event} --json`, timeout: 30 },
+      ]);
+    }
+    // Not in Antigravity's handler schema; an undefined key can take the whole file down.
+    expect(JSON.stringify(config)).not.toContain('statusMessage');
+    expect(await verifyHookConfig(file, 'linux', 'antigravity')).toBe(true);
+  });
+});

--- a/tests/cli/hosts/host-payload-roundtrip.test.ts
+++ b/tests/cli/hosts/host-payload-roundtrip.test.ts
@@ -1,0 +1,124 @@
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { normalizeHostHook, type HookHost } from '../../../src/cli/agents/host-hook.js';
+import { readLifecyclePayload } from '../../../src/cli/agents/lifecycle.js';
+import { toolWritesFile } from '../../../src/session/hosts/index.js';
+
+/**
+ * One payload per host, in that host's own vocabulary, driven through the real stdin path.
+ *
+ * The bug this generalises took Antigravity's integration to zero and nobody noticed for a
+ * release: its payload names every field differently, the stdin allowlist dropped all three of
+ * them, and every event then threw `IncompleteHostHookPayloadError` -- which the hook entry
+ * swallows in silence, so the host reported nothing, logged nothing, and looked exactly like
+ * one nobody had configured. Every unit test it had passed, because they all handed the
+ * normalizer an object directly and skipped the filter that was eating the payload.
+ *
+ * So: through `readLifecyclePayload` for every host, never around it. What this pins is the
+ * contract Knowl *claims* for each host end to end -- allowlist, normalizer, event map and tool
+ * vocabulary agreeing with each other. It cannot prove a vendor sends this shape; only reading
+ * a real install does that, and `docs/hosts.md` records which hosts have had one read.
+ */
+const ROOT = path.resolve('.knowl-host-roundtrip-test');
+const FILE = path.join(ROOT, 'src/a.ts');
+
+const through = async (raw: unknown) => readLifecyclePayload(Readable.from([JSON.stringify(raw)]) as never);
+
+type Row = {
+  host: HookHost;
+  /** A write, in this host's own event and tool names. */
+  write: { event: string; raw: Record<string, unknown> };
+  /** A shell command, likewise. Absent for a host with no shell channel of its own. */
+  shell?: { event: string; raw: Record<string, unknown> };
+};
+
+const ROWS: Row[] = [
+  {
+    host: 'claude',
+    write: { event: 'PostToolUse', raw: { session_id: 's', cwd: ROOT, tool_name: 'Edit', tool_input: { file_path: FILE } } },
+    shell: { event: 'PostToolUse', raw: { session_id: 's', cwd: ROOT, tool_name: 'Bash', tool_input: { command: 'npm test' } } },
+  },
+  {
+    host: 'codex',
+    write: { event: 'PostToolUse', raw: { session_id: 's', cwd: ROOT, tool_name: 'apply_patch', tool_input: { file_path: FILE } } },
+    // `shell_command` and not `shell`: it is the name codex 0.149.1 actually calls, by an order
+    // of magnitude, and the shared bash/shell helper did not know it.
+    shell: { event: 'PostToolUse', raw: { session_id: 's', cwd: ROOT, tool_name: 'shell_command', tool_input: { command: 'npm test' } } },
+  },
+  {
+    host: 'copilot',
+    write: { event: 'postToolUse', raw: { session_id: 's', cwd: ROOT, tool_name: 'str_replace', tool_input: { file_path: FILE } } },
+    shell: { event: 'postToolUse', raw: { session_id: 's', cwd: ROOT, tool_name: 'bash', tool_input: { command: 'npm test' } } },
+  },
+  {
+    host: 'openhands',
+    write: { event: 'post_tool_use', raw: { conversation_id: 's', cwd: ROOT, tool_name: 'str_replace_editor', tool_input: { path: FILE } } },
+    shell: { event: 'post_tool_use', raw: { conversation_id: 's', cwd: ROOT, tool_name: 'terminal', tool_input: { command: 'npm test' } } },
+  },
+  {
+    // Cursor names the ACTION and sends no tool name at all, on both halves.
+    host: 'cursor',
+    write: { event: 'afterFileEdit', raw: { conversation_id: 's', cwd: ROOT, file_path: FILE } },
+    shell: { event: 'afterShellExecution', raw: { conversation_id: 's', cwd: ROOT, command: 'npm test' } },
+  },
+  {
+    host: 'windsurf',
+    write: { event: 'post_write_code', raw: { conversation_id: 's', cwd: ROOT, file_path: FILE } },
+    shell: { event: 'post_run_command', raw: { conversation_id: 's', cwd: ROOT, command: 'npm test' } },
+  },
+  {
+    // Through the shipped plugin, which sends normalized event names directly.
+    host: 'cline',
+    write: { event: 'session-event', raw: { conversation_id: 's', cwd: ROOT, tool_name: 'write_to_file', tool_input: { path: FILE } } },
+    shell: { event: 'session-event', raw: { conversation_id: 's', cwd: ROOT, tool_name: 'execute_command', tool_input: { command: 'npm test' } } },
+  },
+  {
+    host: 'hermes',
+    write: { event: 'post_tool_call', raw: { session_id: 's', cwd: ROOT, tool_name: 'write_file', tool_input: { path: FILE } } },
+    shell: { event: 'post_tool_call', raw: { session_id: 's', cwd: ROOT, tool_name: 'terminal', tool_input: { command: 'npm test' } } },
+  },
+  {
+    // protojson: camelCase throughout, one `toolCall` object, PascalCase arguments, and the
+    // root under `workspacePaths` rather than `cwd`.
+    host: 'antigravity',
+    write: {
+      event: 'PostToolUse',
+      raw: { conversationId: 's', workspacePaths: [ROOT], toolCall: { name: 'replace_file_content', args: { TargetFile: FILE } } },
+    },
+    shell: {
+      event: 'PostToolUse',
+      raw: { conversationId: 's', workspacePaths: [ROOT], toolCall: { name: 'run_command', args: { CommandLine: 'npm test' } } },
+    },
+  },
+  {
+    // The third-party contract: normalized event names, an explicit `type`, and paths reported
+    // outright rather than inferred from a tool's arguments.
+    host: 'generic',
+    write: { event: 'session-event', raw: { sessionId: 's', cwd: ROOT, type: 'checkpoint', toolName: 'Write', changedPaths: [FILE] } },
+    shell: { event: 'session-event', raw: { sessionId: 's', cwd: ROOT, type: 'command', toolName: 'Bash', command: 'npm test' } },
+  },
+];
+
+describe.each(ROWS)('$host, through the stdin filter it actually runs behind', row => {
+  it('resolves the session and the project root', async () => {
+    const event = normalizeHostHook(row.host, row.write.event, await through(row.write.raw));
+    expect(event.externalSessionId).toBe('s');
+    expect(event.projectRoot).toBe(ROOT);
+  });
+
+  it('recognises its own write, and the file it wrote', async () => {
+    const event = normalizeHostHook(row.host, row.write.event, await through(row.write.raw));
+    // Both halves matter and they fail separately: an unrecognised tool leaves the write gate
+    // and the fleet's claim with nothing to act on, and a lost path leaves the change card and
+    // the read-set with nothing to name.
+    expect(toolWritesFile(event), `${row.host} does not recognise its own write tool`).toBe(true);
+    expect(event.payload.changedPaths, `${row.host} lost the path it wrote`).toEqual(['src/a.ts']);
+  });
+
+  it('carries a shell command as a command, not as a nameless checkpoint', async () => {
+    if (!row.shell) return;
+    const event = normalizeHostHook(row.host, row.shell.event, await through(row.shell.raw));
+    expect(event.payload.command, `${row.host} dropped the command text`).toBe('npm test');
+  });
+});

--- a/tests/cli/hosts/profile-conformance.test.ts
+++ b/tests/cli/hosts/profile-conformance.test.ts
@@ -172,6 +172,29 @@ describe('host profile registry', () => {
     expect(profile.midTurnContext('x')).toBeUndefined();
   });
 
+  it('reads no payload field the stdin allowlist throws away', async () => {
+    // The failure this pins killed Antigravity outright and left Windsurf one fallback short:
+    // a profile reads a field, `readLifecyclePayload` drops it before the profile ever runs,
+    // and the event dies on "requires a session id" -- which the hook entry swallows in
+    // silence, so the host reports nothing, logs nothing, and looks exactly like one nobody
+    // configured. Neither side is wrong on its own; only the pair is, which is why this asks
+    // them together rather than asserting a list.
+    const { readLifecyclePayload } = await import('../../../src/cli/agents/lifecycle.js');
+    const { Readable } = await import('node:stream');
+
+    for (const host of ALL_HOSTS) {
+      const profile = hostProfile(host);
+      const read = new Set<string>();
+      const spy = new Proxy({}, { get: (_t, key) => { if (typeof key === 'string') read.add(key); return undefined; } });
+      profile.identity(spy as Record<string, unknown>);
+      profile.normalizePayload?.(spy as Record<string, unknown>);
+      // A truthy value per key, so a survivor is visible and a dropped key is absent.
+      const sent = Object.fromEntries([...read].map(key => [key, 'x']));
+      const kept = await readLifecyclePayload(Readable.from([JSON.stringify(sent)]) as never);
+      for (const key of read) expect(kept, `${host} reads ${key}, which stdin drops`).toHaveProperty(key);
+    }
+  });
+
   it('extracts identity from each host\'s own payload keys', () => {
     expect(hostProfile('claude').identity({ session_id: 's', agent_id: 'a', agent_type: 'Explore' }))
       .toEqual({ externalSessionId: 's', externalTurnId: undefined, agentId: 'a', agentType: 'Explore' });


### PR DESCRIPTION
`knowl fleet` had never once listed an Antigravity session. The fleet was not the reason: `fleet.db` has held `claude` and `hermes` rows and nothing else since it was created, because every Antigravity hook died before it reached the engine — four independent times over.

## Antigravity

**The payload is protojson.** Every key camelCase, the session under `conversationId`, the root under `workspacePaths`, the tool as one `toolCall: {name, args}` object with PascalCase arguments. The stdin filter is a strict allowlist and carried none of those names, so every event reached the normalizer empty and threw `IncompleteHostHookPayloadError` — which the hook entry swallows in silence. No row, no log, no symptom: identical to a host nobody had configured.

**Three of five registered events were written in a shape it parses and ignores.** Only `PreToolUse` and `PostToolUse` take the `{matcher, hooks}` wrapper; `PreInvocation`, `PostInvocation` and `Stop` are a bare handler list. `PreInvocation` is the only event that starts a session there, so even an intact payload would have had nothing to arrive at. `statusMessage` is not in its handler schema either, and a key a host does not define can take the whole file down.

**The identity read snake_case** — `session_id`, `conversation_id`, `thread_id`.

**The tool names were invented.** `write_file`, `edit_file`, `WriteFile`, `EditFile` have never been emitted by the product; its own reference says tool names are the step type lowercased, so the PascalCase half could not have been right. The real writes are `replace_file_content`, `multi_replace_file_content` and `write_to_file`, the read is `view_file`, and the shell is `run_command` — which the shared bash/shell predicate did not match.

All of it now read off the installed bundle — its own `hooks.md` and five conversation transcripts — rather than quoted. `docs/hosts.md` says so.

Payload remapping is one new profile member, `normalizePayload`, applied once before anything reads a field. It replaces `projectRoot`, which solved one field of the same problem and had no callers; five extractors would otherwise each have needed a host-shaped fallback.

## Codex

Found while verifying the rest. `isShellEvent` delegated to the shared helper, which knows `bash` and `shell`. Across this machine's codex sessions the shell tool is called `shell_command` **14,329** times, `shell` 2,059 and `exec_command` 1,174 — all three present in the shipped codex.exe 0.149.1. Two thirds of every codex command normalised to a nameless checkpoint: no command text, no exit code, nothing for the fleet to fingerprint a shared failure on.

(`read_file` was called zero times in two months. Codex reads files through the shell, so its read-set is inherently dark — not something this changes.)

## The fleet's own half

`fleetSessionStartBestEffort` — roster, sweep, row — hangs off `session-start`, and Antigravity has no such event. Once its hooks worked it would appear in everyone else's roster and be told nothing about the sessions it shared a repo with. The turn-start branch now renders the roster when there is no session binding yet, which is exactly "nothing has bootstrapped this session": it fires once on a host with no session-start event and never on one that has it, with no host name anywhere in the condition.

## Two guards

Every existing test passed against a completely dark host. They all handed the normalizer an object directly and skipped the filter that was eating the payload; one even pinned Antigravity's contract as `{session_id, tool_name: 'edit_file'}`, two names it has never sent.

- A Proxy records every field each profile's `identity` and `normalizePayload` read, sends exactly those through the real stdin filter, and asserts each survives. It found a second instance immediately: Windsurf reads `cascade_id` and the allowlist dropped it — harmless only while Windsurf also sends one of the other two. Now allowlisted.
- One payload per host in that host's own vocabulary, through the same filter: the session resolves, the root resolves, the host's own write tool is recognised, the path it wrote survives, and a command's text reaches the payload. Ten hosts. Removing either fix above fails it on exactly that host.

Neither guard proves a vendor sends the shape a row claims. Only reading a real install does, and `docs/hosts.md` records which hosts have had one read.

## Verification

`tsc --noEmit`, `eslint .` and `docs:check` clean; **396 test files / 3794 tests pass**, 5 skipped.

Verified against real installs on this machine: claude and hermes (live fleet rows), antigravity (bundle docs + transcripts), codex (binary strings + two months of session logs). Copilot is installed but its logs carry no tool-call data. Cursor, Windsurf, OpenHands, Cline and Claude Desktop are not installed here — their contracts are pinned by the round-trip test, not confirmed against a vendor.

**After merging and reinstalling, run `knowl init antigravity`** — an existing `.agents/hooks.json` is the old shape, and `doctor` now reports it stale rather than OK.
