### PR TITLE
chore: release 5.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.20.0 — 2026-09-04
 
 **A global memory layer, and the layered read that makes it reachable.** Knowl has had four
 namespaces since long before this release -- session, project, organization, global -- with

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.19.0",
+      "version": "5.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.19.0",
+      "version": "5.20.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Release 5.20.0.

Renames `## Unreleased` to `## 5.20.0 — 2026-09-04` and bumps the four version-carrying files
`scripts/check-version-sync.mjs` reads. No code changes.

## What ships

- **A global memory layer** (#247) — `~/.knowl/global.db`, `knowl link global`, `knowl store
  --namespace global`, and the layered read that finally reaches the non-project namespaces under
  vector search. Sessions with no project at all resolve to global alone.
- **Hermes driven by a plugin** (#245) — the shell hooks 5.19.0 wrote are never registered by the
  `serve` backend Hermes Desktop launches, so `knowl init hermes` now installs a Python plugin and
  removes them.
- **Antigravity recorded nothing** (#246) — protojson payloads, a wrong stdin allowlist and three
  events written in a shape Antigravity ignores. Also: codex was missing `shell_command`.
- **`knowl cloud push` can drain a queue again** (04b7a62).

## Verification

`node scripts/check-version-sync.mjs` passes.

> **Note on the audit check:** npm's audit endpoint (`/-/npm/v1/security/audits/quick`) has been
> returning 503 since ~06:40 UTC, failing `npm run audit:prod` on #247 twice and hanging locally
> for 120s. It is an npm outage, not a finding. `package.json` and `package-lock.json` are
> unchanged since the last green main run, so the dependency tree being audited is identical.
> `cd.yml` does not audit, so publishing is unaffected.
