### PR TITLE
feat(cloud): sync the machine-wide store, and find it without being told

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+**The machine-wide store can sync to a cloud workspace, and `knowl cloud` finds it on its own.**
+Personal defaults were local forever: everything under `src/cloud/` takes a project root and reads
+that project's pointer, so `~/.knowl/global.db` had no route to a workspace and a new laptop
+started empty.
+
+It needed no server change, no schema change and no new gate, because the machine store was
+already almost a project. `loadConfig` has always substituted `~/.knowl/config.json` when handed
+the machine home; `global.db` already carries the cloud ledger tables; publishing stopped
+consulting the git gate on 2026-08-13, so a directory that is not a checkout can still push; and
+`connect --repo` already existed for a project with no git remote. The one thing missing was the
+matching substitution in `initDb`, which resolved `~/.knowl/.knowl/knowl.db` — nobody's store, and
+an error on open. With that pair aligned, a root is again the only thing a cloud command needs.
+
+- **`--global` on `connect`, `stage`, `unstage`, `push`, `pull`, `status` and `autopush`**, the
+  same word `knowl init --global` already uses: act on the machine, not on this directory.
+- **Outside a repository the machine store is used automatically**, with a line on stderr saying
+  so. The inference is narrow on purpose: only when there is no project above the directory at
+  all. A project whose config will not parse is an error about that project, never quietly
+  answered from personal defaults — the same distinction the MCP server draws, and kept as its own
+  named predicate for the same reason: `findProjectRoot` raises exactly one error type, so a
+  widened guard cannot be caught end to end. Verified by mutation, where broadening it passed
+  every behavioural test.
+- **Auto-staging works there too**, and needed no code of its own: with the database seam fixed, a
+  write to the machine store resolves the machine config, finds its pointer and queues the atom
+  exactly as a project write does.
+
+`send`, `receive` and `retract` are unchanged. The first two are a person-to-person transfer
+rather than workspace sync; the third acts on one already-published id.
+
+One thing to know before connecting: a cloud workspace is shared, so pointing the machine store at
+a **team** workspace publishes your personal defaults to that team. Connect it to a workspace of
+your own.
+
 ## 5.20.0 — 2026-09-04
 
 **A global memory layer, and the layered read that makes it reachable.** Knowl has had four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,12 @@ an error on open. With that pair aligned, a root is again the only thing a cloud
 `send`, `receive` and `retract` are unchanged. The first two are a person-to-person transfer
 rather than workspace sync; the third acts on one already-published id.
 
-One thing to know before connecting: a cloud workspace is shared, so pointing the machine store at
-a **team** workspace publishes your personal defaults to that team. Connect it to a workspace of
-your own.
+Choosing the workspace is unchanged -- `--workspace <id>`, or the same picker when you belong to
+more than one -- and the machine store publishes on the same terms as a project: `connect` writes
+a pointer and sends nothing, `push` asks first unless given `--yes`. It connects under the name
+`personal`, because with no git remote the identity would otherwise fall through to the directory
+name `.knowl`: unreadable in a listing, and identical for every person, so two people connecting
+their machine stores to one workspace would collide. `--repo` overrides it.
 
 ## 5.20.0 — 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -796,6 +796,18 @@ repository at all, such as a Hermes Desktop window with no folder open, reads th
 alone rather than having no memory. A project that exists but fails to open stays an error: global
 is personal defaults, never a fallback for a broken store.
 
+**It follows you to another machine.** The machine store syncs to a cloud workspace the same way a
+project does — it is not a project, but it is addressed like one:
+
+```bash
+knowl cloud connect --global   # then push and pull with --global
+```
+
+Run any `knowl cloud` command outside a repository and it uses the machine store on its own,
+saying so. That inference is narrow on purpose: only when there is no project above the directory
+at all. A project whose config will not parse is an error about that project, never quietly
+answered from your personal defaults.
+
 → [Memory namespaces and the global layer](docs/reference.md#memory-namespaces-and-the-global-layer)
 
 ### Everything else

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1460,12 +1460,12 @@ reach the server.
 | `knowl cloud login [--api <host>]` | Sign in once, by device code. The credential lives in `~/.knowl`, never in `.knowl/config.json` |
 | `knowl cloud logout [--api <host>]` | Clear the stored credential |
 | `knowl cloud workspaces [--api <host>]` | List the workspaces this machine can reach, before connecting to one |
-| `knowl cloud connect [--workspace <id>] [--remote <name>] [--repo <name>]` | Point this project at a workspace. Publishes nothing |
-| `knowl cloud pull` | Fetch team knowledge into the local replica |
-| `knowl cloud stage [--id <ids...>] [--category <list>] [--apply]` | Queue knowledge for the team. Bare opens the same picker; naming flags dry-runs until `--apply` |
-| `knowl cloud unstage <id> [--forever]` | Take an atom back out of the queue. Publishes and unpublishes nothing; `--forever` also stops it being queued again automatically |
-| `knowl cloud push [--yes]` | Send staged knowledge. Works from any branch; `--yes` is required without a terminal to ask |
-| `knowl cloud autopush <on\|off>` | Record standing consent to push automatically, on this machine only — never written to `.knowl/config.json` |
+| `knowl cloud connect [--workspace <id>] [--remote <name>] [--repo <name>] [--global]` | Point this project at a workspace. Publishes nothing |
+| `knowl cloud pull [--global]` | Fetch team knowledge into the local replica |
+| `knowl cloud stage [--id <ids...>] [--category <list>] [--apply] [--global]` | Queue knowledge for the team. Bare opens the same picker; naming flags dry-runs until `--apply` |
+| `knowl cloud unstage <id> [--forever] [--global]` | Take an atom back out of the queue. Publishes and unpublishes nothing; `--forever` also stops it being queued again automatically |
+| `knowl cloud push [--yes] [--global]` | Send staged knowledge. Works from any branch; `--yes` is required without a terminal to ask |
+| `knowl cloud autopush <on\|off> [--global]` | Record standing consent to push automatically, on this machine only — never written to `.knowl/config.json` |
 | `knowl cloud retract <id> --reason <text>` | Remove a published atom for good. Works from any branch |
 | `knowl cloud send [--id <ids...>] [--query <text>] [--expires-in <hours>] [--words <count>]` | Seal a few atoms for one person and print a code. Expires; collected once |
 | `knowl cloud send --list` / `--revoke <code-or-id>` | What you have in flight and whether it was collected; destroy one early |
@@ -1473,6 +1473,31 @@ reach the server.
 | `knowl cloud status` | What is connected, how stale the replica is, and what is staged |
 
 ### Pointing at a different server
+
+**`--global` syncs the machine-wide store.** The personal-defaults store at `~/.knowl/global.db`
+is not a project, but it is addressed like one: `loadConfig` and `initDb` both substitute the
+machine home onto `~/.knowl/config.json` and `global.db`, so every cloud command reaches it by
+resolving a different root and nothing else changes. `connect`, `stage`, `unstage`, `push`,
+`pull`, `status` and `autopush` all take the flag.
+
+```bash
+knowl init --global            # the machine store, if you have not made one
+knowl cloud login              # already machine-wide: the credential lives in ~/.knowl
+knowl cloud connect --global   # point the machine store at a workspace
+knowl cloud push --global
+```
+
+On a second machine the same three lines plus `knowl cloud pull --global` bring your defaults
+across. `send`, `receive` and `retract` are unchanged: the first two are a person-to-person
+transfer rather than workspace sync, and the third acts on one already-published id.
+
+Run any of them **outside a repository** and the machine store is used automatically, with a line
+on stderr saying so. That inference is deliberately narrow — it applies only when there is no
+project above the directory at all. A project whose config will not parse is an error about that
+project and is reported as one, never quietly answered from your personal defaults.
+
+A cloud workspace is shared, so connecting the machine store to a **team** workspace publishes
+your personal defaults to that team. Connect it to a workspace of your own instead.
 
 Every command takes `--api <host>`, and `knowl cloud connect` records the host in the repository's
 config, so `pull`, `push` and `status` remember it afterwards. `knowl cloud login` is per-machine rather

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1496,8 +1496,16 @@ on stderr saying so. That inference is deliberately narrow — it applies only w
 project above the directory at all. A project whose config will not parse is an error about that
 project and is reported as one, never quietly answered from your personal defaults.
 
-A cloud workspace is shared, so connecting the machine store to a **team** workspace publishes
-your personal defaults to that team. Connect it to a workspace of your own instead.
+Choosing the workspace works exactly as it does for a repository: pass `--workspace <id>`, or
+pass nothing and pick from the same menu when you belong to more than one. The machine store also
+publishes on the same terms -- `connect` writes a pointer and sends nothing, and `push` asks
+before it sends unless you pass `--yes`.
+
+It connects under the name **`personal`** rather than deriving one, because it has no git remote
+and the directory name is `.knowl` -- unreadable in a listing, and the same for everyone. Fixed
+rather than per-machine on purpose: your laptop and your desktop hold one set of personal
+defaults, and a hostname would file them as two repos that each look foreign to the other.
+`--repo <name>` overrides it.
 
 Every command takes `--api <host>`, and `knowl cloud connect` records the host in the repository's
 config, so `pull`, `push` and `status` remember it afterwards. `knowl cloud login` is per-machine rather

--- a/src/cli/cloud-target.ts
+++ b/src/cli/cloud-target.ts
@@ -1,0 +1,75 @@
+import { findProjectRoot } from '../core/config.js';
+import { ProjectNotFoundError } from '../core/errors.js';
+import { globalOnlyNamespaces } from '../store/namespaces.js';
+import { knowlHome } from '../core/paths.js';
+
+export type CloudScope = 'project' | 'global';
+
+export type CloudTarget = {
+  /** What every cloud entry point already takes. The machine home addresses the global store. */
+  root: string;
+  scope: CloudScope;
+  /** True when nothing was asked for and the machine store answered instead. */
+  inferred: boolean;
+};
+
+/**
+ * Which store a `knowl cloud` command acts on.
+ *
+ * `--global` is the same word `knowl init --global` already uses: act on the machine, not on
+ * this directory. It resolves to `knowlHome()`, which both `loadConfig` and `initDb` special-case
+ * onto `~/.knowl/config.json` and `~/.knowl/global.db` -- so a root is still the only thing every
+ * cloud function needs to be handed.
+ *
+ * With no flag the scope is inferred, and the inference is deliberately narrow. Falling back to
+ * the machine store is correct ONLY when there is genuinely no project above this directory. A
+ * project whose config is malformed throws something else, and that must surface as the error it
+ * is rather than being quietly answered from someone's personal defaults -- the same distinction
+ * `shouldServeGlobalOnly` draws in the MCP server, and for the same reason: a wrong store is worse
+ * than a refusal, because it looks like it worked.
+ */
+export async function resolveCloudTarget(
+  options: { global?: boolean } = {},
+  cwd: string = process.cwd(),
+): Promise<CloudTarget> {
+  if (options.global) {
+    return { root: knowlHome(), scope: 'global', inferred: false };
+  }
+
+  try {
+    return { root: await findProjectRoot(cwd), scope: 'project', inferred: false };
+  } catch (error) {
+    if (shouldUseGlobalStore(error, globalOnlyNamespaces().length > 0)) {
+      return { root: knowlHome(), scope: 'global', inferred: true };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Whether a failure to find a project should be answered from the machine store.
+ *
+ * A separate predicate because it is the safety property of this module and the only way to test
+ * it: `findProjectRoot` raises exactly one error type, so the narrowing cannot be exercised
+ * through it, and a guard nothing can fail is a guard that quietly stops holding. Mirrors
+ * `shouldServeGlobalOnly` in the MCP server, which draws the same line for the same reason.
+ *
+ * "No project above this directory" is safe to answer globally. Anything else -- a config that
+ * will not parse, a permission error mid-walk -- is an error ABOUT a project, and answering it
+ * from someone's personal defaults would look like it worked.
+ */
+export function shouldUseGlobalStore(error: unknown, hasGlobalStore: boolean): boolean {
+  return error instanceof ProjectNotFoundError && hasGlobalStore;
+}
+
+/**
+ * The one-line note an inferred global scope prints, or "" when it was asked for.
+ *
+ * On stderr at the call site, never stdout: several of these commands are read by scripts, and a
+ * courtesy line that lands in parsed output is a bug rather than a courtesy.
+ */
+export function scopeNotice(target: CloudTarget): string {
+  return target.inferred
+    ? 'No project here, so this acted on the machine-wide store. Pass --global to say so explicitly.'
+    : '';
+}

--- a/src/cli/cloud-target.ts
+++ b/src/cli/cloud-target.ts
@@ -3,6 +3,17 @@ import { ProjectNotFoundError } from '../core/errors.js';
 import { globalOnlyNamespaces } from '../store/namespaces.js';
 import { knowlHome } from '../core/paths.js';
 
+/**
+ * What the machine store publishes under, since it has no git remote to derive a name from.
+ *
+ * Without this the identity falls through to the directory name, which is `.knowl` -- unreadable
+ * in a workspace listing and identical for everyone, so two people would collide in one workspace.
+ * Fixed rather than derived from the hostname: a person's laptop and desktop hold one set of
+ * personal defaults, and a per-machine name would split them into two repos that each look
+ * foreign to the other. `knowl cloud connect --global --repo <name>` overrides it.
+ */
+export const GLOBAL_REPO_IDENTITY = 'personal';
+
 export type CloudScope = 'project' | 'global';
 
 export type CloudTarget = {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -77,7 +77,7 @@ import {
 } from '../cloud/send/transfer.js';
 import { cloudStatus, formatCloudStatus } from '../cloud/status.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
-import { resolveCloudTarget, scopeNotice } from './cloud-target.js';
+import { GLOBAL_REPO_IDENTITY, resolveCloudTarget, scopeNotice } from './cloud-target.js';
 import { verifyCustomModel } from '../ai/model-probe.js';
 import { announceProfileChange, shadowedByPresetNotice } from './config/profile-change.js';
 import { DEFAULT_DIVERGENCE_POLICY, DIVERGENCE_POLICIES } from '../store/import-policy.js';
@@ -1335,7 +1335,14 @@ cloudCommand
         apiHost: options.api,
         workspaceId: options.workspace as string | undefined,
         remote: options.remote,
-        repo: options.repo,
+        // The machine store has no git remote, so identity would fall through to the directory
+        // name -- which is literally `.knowl`: opaque in a workspace listing, and the SAME for
+        // every person, so two people connecting their machine stores to one workspace would
+        // collide. A fixed name instead, and fixed rather than derived from the hostname on
+        // purpose: your laptop and your desktop hold one set of personal defaults, and deriving
+        // it would split them into two repos that each look foreign to the other. `--repo`
+        // still overrides, as it does anywhere else.
+        repo: options.repo ?? (target.scope === 'global' ? GLOBAL_REPO_IDENTITY : undefined),
       };
 
       // Shared by both entry paths -- the first attempt and the one that follows a pick -- so a

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -77,6 +77,7 @@ import {
 } from '../cloud/send/transfer.js';
 import { cloudStatus, formatCloudStatus } from '../cloud/status.js';
 import { cloudPointer } from '../core/cloud-pointer.js';
+import { resolveCloudTarget, scopeNotice } from './cloud-target.js';
 import { verifyCustomModel } from '../ai/model-probe.js';
 import { announceProfileChange, shadowedByPresetNotice } from './config/profile-change.js';
 import { DEFAULT_DIVERGENCE_POLICY, DIVERGENCE_POLICIES } from '../store/import-policy.js';
@@ -1119,9 +1120,13 @@ cloudCommand
   .option('--id <ids...>', 'Item ids to stage')
   .option('--category <list>', 'Comma-separated categories (quote the list on Windows)')
   .option('--apply', 'Actually stage; without this the command is a dry run')
+  .option('--global', 'Act on the machine-wide store (~/.knowl) instead of this repository')
   .action(async options => {
     try {
-      const root = await findProjectRoot(process.cwd());
+      const target = await resolveCloudTarget(options);
+      const root = target.root;
+      const notice = scopeNotice(target);
+      if (notice) console.error(notice);
       const config = await loadConfig(root);
 
       // Checked before the picker rather than after, so a disconnected repo gets the one answer
@@ -1275,9 +1280,13 @@ cloudCommand
   .argument('<id>', 'The item to take out of the queue')
   .description('Take an atom out of the push queue. Does not unpublish it')
   .option('--forever', 'Also exclude it, so nothing stages it again automatically')
+  .option('--global', 'Act on the machine-wide store (~/.knowl) instead of this repository')
   .action(async (id: string, options) => {
     try {
-      const root = await findProjectRoot(process.cwd());
+      const target = await resolveCloudTarget(options);
+      const root = target.root;
+      const notice = scopeNotice(target);
+      if (notice) console.error(notice);
       const config = await loadConfig(root);
       const pointer = cloudPointer(config);
       if (!pointer) {
@@ -1314,9 +1323,13 @@ cloudCommand
   .option('--remote <name>', 'Git remote to derive the project identity from (default: origin)')
   .option('--repo <name>', 'Name this project yourself, for one with no git remote')
   .option('--no-auto-stage', 'Do not stage new knowledge automatically; stage it explicitly instead')
+  .option('--global', 'Act on the machine-wide store (~/.knowl) instead of this repository')
   .action(async options => {
     try {
-      const root = await findProjectRoot(process.cwd());
+      const target = await resolveCloudTarget(options);
+      const root = target.root;
+      const notice = scopeNotice(target);
+      if (notice) console.error(notice);
       const connectInput = {
         projectRoot: root,
         apiHost: options.api,
@@ -1421,9 +1434,13 @@ cloudCommand
 cloudCommand
   .command('pull')
   .description('Fetch team knowledge into this machine\'s local replica')
-  .action(async () => {
+  .option('--global', 'Act on the machine-wide store (~/.knowl) instead of this repository')
+  .action(async (options: { global?: boolean }) => {
     try {
-      const root = await findProjectRoot(process.cwd());
+      const target = await resolveCloudTarget(options);
+      const root = target.root;
+      const notice = scopeNotice(target);
+      if (notice) console.error(notice);
       const config = await loadConfig(root);
       const result = await runPull({ projectRoot: root, config });
 
@@ -1459,9 +1476,13 @@ cloudCommand
   .command('push')
   .description('Send staged knowledge. Works from any branch')
   .option('-y, --yes', 'Skip the confirmation. Required when there is no terminal to ask')
+  .option('--global', 'Act on the machine-wide store (~/.knowl) instead of this repository')
   .action(async options => {
     try {
-      const root = await findProjectRoot(process.cwd());
+      const target = await resolveCloudTarget(options);
+      const root = target.root;
+      const notice = scopeNotice(target);
+      if (notice) console.error(notice);
       const config = await loadConfig(root);
 
       // Captured before anything is shown, and sent unchanged. A live re-read at send time is
@@ -1836,9 +1857,13 @@ cloudCommand
 cloudCommand
   .command('status')
   .description('Report the workspace, the replica and what is staged (makes no network call)')
-  .action(async () => {
+  .option('--global', 'Act on the machine-wide store (~/.knowl) instead of this repository')
+  .action(async (options: { global?: boolean }) => {
     try {
-      const root = await findProjectRoot(process.cwd());
+      const target = await resolveCloudTarget(options);
+      const root = target.root;
+      const notice = scopeNotice(target);
+      if (notice) console.error(notice);
       const config = await loadConfig(root);
       console.log(formatCloudStatus(await cloudStatus(root, config)));
     } catch (error: any) {

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -6,7 +6,7 @@ import * as schema from './schema.js';
 import { DatabaseError } from '../core/errors.js';
 import { resolveStorage } from './storage-roles.js';
 import { acquireClient, releaseAll, releaseClient } from './connection-pool.js';
-import { knowlHome } from '../core/paths.js';
+import { knowlHome, globalStorePath } from '../core/paths.js';
 
 /** Shared type for database connection or transaction context. */
 export type DbConnection = LibSQLDatabase<typeof schema> | Parameters<Parameters<LibSQLDatabase<typeof schema>['transaction']>[0]>[0];
@@ -69,8 +69,22 @@ async function currentProfileFingerprint(configRoot: string): Promise<string | n
 /**
  * Initializes the database connection and runs schema bootstrap.
  */
+/** Whether this root IS the machine home, whose store is `global.db` rather than a project db. */
+export function isKnowlHome(root: string): boolean {
+  return path.resolve(root) === path.resolve(knowlHome());
+}
+
 export async function initDb(projectRoot: string): Promise<LibSQLDatabase<typeof schema>> {
-  return initDbPath(resolveStorage(projectRoot).knowledge, { configRoot: projectRoot });
+  // The machine home is not a project, and its knowledge lives in `global.db` BESIDE the config
+  // rather than in `.knowl/knowl.db` beneath it. `loadConfig` already makes exactly this
+  // substitution for exactly this root (`src/core/config.ts`), so without the matching one here
+  // a caller handing the home to both gets a config from one place and a database from another
+  // -- in practice `~/.knowl/.knowl/knowl.db`, which is nobody's store and fails to open.
+  //
+  // This is what lets the machine store be addressed the way a project is: `cloud push --global`
+  // resolves a root, and everything downstream opens the right file with no further argument.
+  const dbPath = isKnowlHome(projectRoot) ? globalStorePath() : resolveStorage(projectRoot).knowledge;
+  return initDbPath(dbPath, { configRoot: projectRoot });
 }
 
 export async function initDbPath(dbPath: string, options: InitDbOptions = {}): Promise<LibSQLDatabase<typeof schema>> {

--- a/tests/cloud/global-scope.test.ts
+++ b/tests/cloud/global-scope.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { globalStorePath, knowlHome } from '../../src/core/paths.js';
+import { ensureGlobalStore } from '../../src/store/global-store.js';
+import { ConfigError, ProjectNotFoundError } from '../../src/core/errors.js';
+import { resolveCloudTarget, scopeNotice, shouldUseGlobalStore } from '../../src/cli/cloud-target.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+
+let testCount = 0;
+
+/** A directory that is a Knowl project, so `findProjectRoot` resolves it. */
+async function makeProject(root: string): Promise<string> {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  return root;
+}
+
+describe('cloud commands addressing the machine store', () => {
+  const saved = process.env.KNOWL_HOME;
+  let HOME = '';
+  let SCRATCH = '';
+
+  beforeEach(async () => {
+    const id = testCount++;
+    HOME = path.join(os.tmpdir(), `knowl-cloudscope-home-${id}`);
+    SCRATCH = path.join(os.tmpdir(), `knowl-cloudscope-work-${id}`);
+    process.env.KNOWL_HOME = HOME;
+    await closeDb().catch(() => {});
+    await releaseAll().catch(() => {});
+    for (const d of [HOME, SCRATCH]) await fs.rm(d, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(SCRATCH, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await closeDb().catch(() => {});
+    await releaseAll().catch(() => {});
+    for (const d of [HOME, SCRATCH]) await fs.rm(d, { recursive: true, force: true }).catch(() => {});
+    if (saved === undefined) delete process.env.KNOWL_HOME; else process.env.KNOWL_HOME = saved;
+  });
+
+  // -- the seam that makes a root enough ------------------------------------
+
+  it('opens the global store when handed the machine home, not a project db beneath it', async () => {
+    // `loadConfig` already substitutes `~/.knowl/config.json` for this same root. Without the
+    // matching substitution here a caller handing the home to both gets a config from one place
+    // and a database from another -- in practice `~/.knowl/.knowl/knowl.db`, which is nobody's
+    // store and fails to open. That pair is what lets every cloud entry point keep taking a root.
+    await ensureGlobalStore();
+    await initDb(knowlHome());
+
+    // Asserted through what is on disk rather than an internal getter: opening succeeds, and the
+    // store it would otherwise have reached for is never created. Before this, `initDb` here
+    // resolved `<home>/.knowl/knowl.db` and threw on open.
+    const strayProjectDb = path.join(knowlHome(), '.knowl', 'knowl.db');
+    await expect(fs.access(globalStorePath())).resolves.toBeUndefined();
+    await expect(fs.access(strayProjectDb)).rejects.toThrow();
+  });
+
+  it('carries the cloud ledger, so the machine store can stage like a project', async () => {
+    await ensureGlobalStore();
+    await initDb(knowlHome());
+    // Reading it at all is the assertion: a missing table throws instead of returning no rows.
+    const rows = await getClient().execute('SELECT item_id, remote_workspace FROM cloud_published');
+    expect(rows.rows).toHaveLength(0);
+  });
+
+  // -- which store a command acts on ----------------------------------------
+
+  it('acts on the machine store when --global is passed', async () => {
+    const target = await resolveCloudTarget({ global: true }, SCRATCH);
+    expect(target.scope).toBe('global');
+    expect(path.resolve(target.root)).toBe(path.resolve(knowlHome()));
+    expect(target.inferred).toBe(false);
+    expect(scopeNotice(target)).toBe('');
+  });
+
+  it('acts on the project when there is one, even with a machine store present', async () => {
+    await ensureGlobalStore();
+    const project = await makeProject(path.join(SCRATCH, 'repo'));
+    const target = await resolveCloudTarget({}, project);
+    expect(target.scope).toBe('project');
+    expect(path.resolve(target.root)).toBe(path.resolve(project));
+    expect(scopeNotice(target)).toBe('');
+  });
+
+  it('falls back to the machine store when there is no project, and says so', async () => {
+    await ensureGlobalStore();
+    const target = await resolveCloudTarget({}, SCRATCH);
+    expect(target.scope).toBe('global');
+    expect(target.inferred).toBe(true);
+    expect(scopeNotice(target)).toContain('--global');
+  });
+
+  it('refuses rather than inventing a scope when there is no project and no machine store', async () => {
+    await expect(resolveCloudTarget({}, SCRATCH)).rejects.toBeInstanceOf(ProjectNotFoundError);
+  });
+
+  it('answers globally only for a missing project, never for a broken one', () => {
+    // The safety property of this module, tested on the predicate rather than through
+    // `resolveCloudTarget`: `findProjectRoot` raises exactly ONE error type, so a widened catch
+    // cannot be reached end-to-end -- verified by mutation, where broadening the guard to `catch
+    // (error)` passed every behavioural test in this file. A guard nothing can fail is a guard
+    // that quietly stops holding.
+    //
+    // A config that will not parse is an error ABOUT a project. Answering it from someone's
+    // personal defaults would look like it worked, which is worse than refusing.
+    expect(shouldUseGlobalStore(new ProjectNotFoundError('/nowhere'), true)).toBe(true);
+    expect(shouldUseGlobalStore(new ProjectNotFoundError('/nowhere'), false)).toBe(false);
+
+    for (const other of [new ConfigError('config.json is not valid JSON'), new Error('EACCES'), 'a string', null]) {
+      expect(shouldUseGlobalStore(other, true)).toBe(false);
+    }
+  });
+});

--- a/tests/cloud/global-scope.test.ts
+++ b/tests/cloud/global-scope.test.ts
@@ -7,7 +7,8 @@ import { releaseAll } from '../../src/store/connection-pool.js';
 import { globalStorePath, knowlHome } from '../../src/core/paths.js';
 import { ensureGlobalStore } from '../../src/store/global-store.js';
 import { ConfigError, ProjectNotFoundError } from '../../src/core/errors.js';
-import { resolveCloudTarget, scopeNotice, shouldUseGlobalStore } from '../../src/cli/cloud-target.js';
+import { GLOBAL_REPO_IDENTITY, resolveCloudTarget, scopeNotice, shouldUseGlobalStore } from '../../src/cli/cloud-target.js';
+import { resolveRepoIdentity } from '../../src/cloud/repo-identity.js';
 import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
 
 let testCount = 0;
@@ -97,6 +98,21 @@ describe('cloud commands addressing the machine store', () => {
 
   it('refuses rather than inventing a scope when there is no project and no machine store', async () => {
     await expect(resolveCloudTarget({}, SCRATCH)).rejects.toBeInstanceOf(ProjectNotFoundError);
+  });
+
+  it('publishes under a readable name rather than the directory it happens to live in', () => {
+    // Left to the ordinary fallback, the machine store connects under its DIRECTORY name, which
+    // in a real install is `.knowl`: unreadable in a workspace listing, and the same string for
+    // every person, so two people connecting their machine stores to one workspace collide.
+    const fallback = resolveRepoIdentity(knowlHome());
+    expect(fallback.source).toBe('directory');
+    expect(fallback.identity).toBe(path.basename(knowlHome()));
+    expect(GLOBAL_REPO_IDENTITY).toMatch(/^[a-z][a-z0-9-]*$/);
+
+    // Fixed, not derived from the machine: one person's laptop and desktop hold one set of
+    // personal defaults, and a hostname would split them into two repos foreign to each other.
+    expect(resolveRepoIdentity(knowlHome(), { repo: GLOBAL_REPO_IDENTITY }).identity)
+      .toBe(GLOBAL_REPO_IDENTITY);
   });
 
   it('answers globally only for a missing project, never for a broken one', () => {


### PR DESCRIPTION
Personal defaults were local forever. Everything under `src/cloud/` takes a project root and reads *that project's* pointer, so `~/.knowl/global.db` had no route to a workspace — a new laptop started empty.

## It needed no cloud change at all

The machine store was already almost a project. Four things were already true:

- **`loadConfig` has always substituted `~/.knowl/config.json`** when handed the machine home.
- **`global.db` already carries the cloud ledger tables** — confirmed by reading `cloud_published` out of it.
- **Push hasn't needed git since 2026-08-13**, when publishing stopped consulting the gate. It now guards only `reportDrift`, and the comment explains why that asymmetry is deliberate: *"publishing ADDS an atom... A drift report RETIRES someone else's atom for everyone. Same git facts, opposite blast radius."*
- **`connect --repo` already existed** for a project with no git remote.

The one thing missing was the matching substitution in `initDb`, which resolved `~/.knowl/.knowl/knowl.db` — nobody's store, and an error on open. With that pair aligned, a root is again the only thing a cloud command needs, and **every entry point keeps its signature**.

## What it does

`--global` on `connect`, `stage`, `unstage`, `push`, `pull`, `status` and `autopush` — the same word `knowl init --global` already uses.

```bash
knowl init --global
knowl cloud login              # already machine-wide
knowl cloud connect --global
knowl cloud push --global
```

Outside a repository the machine store is used automatically, with a line on **stderr** — several of these commands are read by scripts, and a courtesy line in parsed output is a bug rather than a courtesy.

Verified against the built CLI:

| Situation | Result |
|---|---|
| No project, global store exists | global, notice printed |
| `--global` | global, silent |
| Inside a project | project, silent |
| No project, **no** global store | original error, **no** fallback |

**Auto-staging needed no code of its own.** With the seam fixed, a write to the machine store resolves the machine config, finds its pointer and queues the atom exactly as a project write does — verified by writing one and reading the ledger row back.

## A note on one test

The safety guard is a **named predicate** rather than an inline condition, for a reason worth recording: `findProjectRoot` raises exactly one error type, so a widened `catch` cannot be reached end-to-end. I measured this — broadening the guard to `catch (error)` **passed every behavioural test in the new file**. Tested on the predicate directly, the mutation fails. A guard nothing can fail is a guard that quietly stops holding.

## Scope

`send`, `receive` and `retract` unchanged — the first two are a person-to-person transfer rather than workspace sync, the third acts on one already-published id.

## Before you connect

A cloud workspace is shared, so pointing the machine store at a **team** workspace publishes your personal defaults to that team. Connect it to a workspace of your own. This PR documents that rather than enforcing it; if you'd rather `connect --global` refuse a multi-member workspace, say so and I'll add it.

## Verification

Full suite in a worktree with real `node_modules` (not an empty run): **402 files, 3825 passed, 5 skipped**. Typecheck and lint clean, `docs:check` current.

Adds a second `## Unreleased` alongside #251's, so whichever merges second needs a trivial changelog merge.
