### PR TITLE
fix(store): a project can be held open per consumer, not per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+**A project can be held open per consumer, without the process-global handle deciding for
+everyone.** `initDb` writes to one module-level context and `getDb`/`getClient` read it, so two
+projects open at once in one process silently share the last one opened: reproduced by opening A
+then B and issuing a write through the caller that held A, which landed in B's file — A's store
+empty, B's holding A's row, no error and no log line. `closeDb` is the other half, because it
+releases the whole pool, so the first consumer to finish tore down every other one's connection
+and the survivors got `Database has not been initialized` from a call they had made correctly.
+
+**No shipped consumer is affected, and this is hardening rather than a bugfix.** Every one of
+them opens exactly one project per process — the CLI is one-shot, and the MCP server binds a
+project at startup and hops namespaces with `withDbPath`, which has been scoped since 3.0.1. The
+subprocess boundary has been hiding the defect; the in-process library export planned for the
+OpenClaw plugin removes it, because a long-running gateway holds several workspaces open in one
+address space.
+
+`openProjectScope(root)` returns a handle whose `run(body)` executes inside the same
+`AsyncLocalStorage` the namespace hop already uses, so ambient reads resolve to that project
+rather than to whoever opened last, and whose `release()` maps to `releaseClient` — one database,
+leaving the pool alone. `withProjectScope(root, body)` is the open-run-release form. Two handles
+on one project are refcounted, and a database the process-wide context is also using is never
+released by a scope. Nothing assigns the global handle, so `initDb`/`closeDb` and every existing
+call site behave exactly as before.
+
+**A Hermes session with Knowl selected as the memory provider gets its own card back.** Selecting
+Knowl in Settings > Memory & Context replaced the orientation card with keyword search over the
+user's literal sentence: `pre_llm_call` returned nothing when `memory.provider` was `knowl`, and
+the provider's `prefetch` ran `knowl query <the prompt> --limit 5` on every turn instead. Recall
+is the hook's job again on every host, whatever the dropdown says. `system_prompt_block` went with
+it — `register` already publishes the rules section, and both halves loaded on such a session, so
+the rules were in the system prompt twice.
+
 ## 5.21.0 — 2026-09-04
 
 **The code index reads Python and Go.** The Tree-sitter index behind `symbol://` locators, the

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -74,17 +74,26 @@ export function isKnowlHome(root: string): boolean {
   return path.resolve(root) === path.resolve(knowlHome());
 }
 
+/**
+ * The knowledge database a project root is addressed by.
+ *
+ * The machine home is not a project, and its knowledge lives in `global.db` BESIDE the config
+ * rather than in `.knowl/knowl.db` beneath it. `loadConfig` already makes exactly this
+ * substitution for exactly this root (`src/core/config.ts`), so without the matching one here
+ * a caller handing the home to both gets a config from one place and a database from another
+ * -- in practice `~/.knowl/.knowl/knowl.db`, which is nobody's store and fails to open.
+ *
+ * This is what lets the machine store be addressed the way a project is: `cloud push --global`
+ * resolves a root, and everything downstream opens the right file with no further argument.
+ * Shared by `initDb` and `openProjectScope` so the ambient and the scoped route to a project
+ * cannot disagree about which file it is.
+ */
+function projectDatabasePath(projectRoot: string): string {
+  return isKnowlHome(projectRoot) ? globalStorePath() : resolveStorage(projectRoot).knowledge;
+}
+
 export async function initDb(projectRoot: string): Promise<LibSQLDatabase<typeof schema>> {
-  // The machine home is not a project, and its knowledge lives in `global.db` BESIDE the config
-  // rather than in `.knowl/knowl.db` beneath it. `loadConfig` already makes exactly this
-  // substitution for exactly this root (`src/core/config.ts`), so without the matching one here
-  // a caller handing the home to both gets a config from one place and a database from another
-  // -- in practice `~/.knowl/.knowl/knowl.db`, which is nobody's store and fails to open.
-  //
-  // This is what lets the machine store be addressed the way a project is: `cloud push --global`
-  // resolves a root, and everything downstream opens the right file with no further argument.
-  const dbPath = isKnowlHome(projectRoot) ? globalStorePath() : resolveStorage(projectRoot).knowledge;
-  return initDbPath(dbPath, { configRoot: projectRoot });
+  return initDbPath(projectDatabasePath(projectRoot), { configRoot: projectRoot });
 }
 
 export async function initDbPath(dbPath: string, options: InitDbOptions = {}): Promise<LibSQLDatabase<typeof schema>> {
@@ -191,6 +200,118 @@ export async function withRepoRoot<T>(projectRoot: string, run: () => Promise<T>
     // Same rule as `withDbPath`: a database nothing had open before this call is not one the
     // caller asked to keep pooled.
     if (!previous) await releaseClient(dbPath);
+  }
+}
+
+/**
+ * A project held open by ONE consumer, with no claim on the process-wide context.
+ *
+ * `initDb` writes to a single module-global handle, and `getDb`/`getClient` read it. That is
+ * correct for every consumer shipped today, because every one of them opens exactly one project
+ * per process: the CLI is one-shot, and the MCP server binds a project at startup and hops
+ * namespaces with `withDbPath`. It is silently wrong the moment two projects are open at once.
+ * Reproduced 2026-09-05: `initDb(A)` then `initDb(B)` in one process, and a write issued by the
+ * caller that thought it held A landed in B's file -- A's store empty, B's holding A's row, no
+ * error and no log line anywhere. `closeDb` compounds it, because it calls `releaseAll`: the
+ * first consumer to finish tore down every other consumer's connection, and the survivors got
+ * `Database has not been initialized` from a call they had made correctly.
+ *
+ * A scope is the pair that fixes both. `run` executes its body inside the same
+ * `AsyncLocalStorage` the namespace hop already uses, so the ambient reads every repository
+ * function does resolve to THIS project rather than to whoever opened last -- the same mechanism
+ * `withDbPath` and `withRepoRoot` were given for the same class of bug one level down. `release`
+ * maps to `releaseClient`, which finishes with one database and leaves the pool alone.
+ *
+ * Additive on purpose. The global handle is untouched: nothing here assigns `globalContext`, so
+ * a scope opened beside a live CLI or server is invisible to it, and `initDb`/`closeDb` keep
+ * behaving exactly as they did. What this unblocks is the in-process library export, where a
+ * long-running gateway holds several workspaces open in one address space and the subprocess
+ * boundary that has been hiding the defect is gone.
+ */
+export type ProjectScope = {
+  /** The project root this scope resolves config and ownership from. */
+  readonly projectRoot: string;
+  /** The database file this scope's writes reach. */
+  readonly databasePath: string;
+  /** Run `body` with this project ambient, whatever else the process has open. */
+  run<T>(body: () => Promise<T>): Promise<T>;
+  /** Done with this project. Idempotent, and never touches another scope's connection. */
+  release(): Promise<void>;
+};
+
+/**
+ * How many scopes are holding each database open.
+ *
+ * Two sessions in one folder is the ordinary case for a gateway, not an edge one, and the pool
+ * is keyed by path -- so both scopes are handed the same client and the first to release would
+ * close the connection the second is still using. Counted rather than deduplicated because the
+ * scopes are genuinely independent: neither knows the other exists, and either may outlive it.
+ *
+ * A path the ambient context is also using is never released here at all. `initDb` put that
+ * client in the pool for the whole process, and closing it because a scope finished would break
+ * the CLI or server that opened it -- the same tearing-down this type exists to stop, in the
+ * other direction.
+ */
+const scopeHolders = new Map<string, number>();
+
+export async function openProjectScope(projectRoot: string): Promise<ProjectScope> {
+  const root = path.resolve(projectRoot);
+  const dbPath = path.resolve(projectDatabasePath(root));
+
+  const client = await acquireClient(dbPath, {
+    profileFingerprint: await currentProfileFingerprint(root),
+  });
+  scopeHolders.set(dbPath, (scopeHolders.get(dbPath) ?? 0) + 1);
+
+  const context: DbContext = {
+    db: drizzle(client, { schema }),
+    client,
+    projectRoot: root,
+    configRoot: root,
+    databasePath: dbPath,
+  };
+
+  let released = false;
+  return {
+    projectRoot: root,
+    databasePath: dbPath,
+    run: <T>(body: () => Promise<T>): Promise<T> => {
+      if (released) {
+        throw new DatabaseError(`Project scope for "${root}" has been released. Open a new one.`);
+      }
+      return scopedContext.run(context, body);
+    },
+    release: async (): Promise<void> => {
+      // Idempotent because a consumer's own teardown path is rarely the only one: a gateway
+      // releases on shutdown and on error, and a second release must not decrement a count
+      // some other scope is relying on.
+      if (released) return;
+      released = true;
+      const holders = (scopeHolders.get(dbPath) ?? 1) - 1;
+      if (holders > 0) {
+        scopeHolders.set(dbPath, holders);
+        return;
+      }
+      scopeHolders.delete(dbPath);
+      if (globalContext && globalContext.databasePath === dbPath) return;
+      await releaseClient(dbPath);
+    },
+  };
+}
+
+/**
+ * Open a project, run one body against it, and release it.
+ *
+ * The shape most callers want: `openProjectScope` exists for a consumer that keeps a project
+ * warm across many calls, and a caller doing one piece of work in another project should not
+ * have to get the `finally` right to avoid leaking a connection.
+ */
+export async function withProjectScope<T>(projectRoot: string, run: () => Promise<T>): Promise<T> {
+  const scope = await openProjectScope(projectRoot);
+  try {
+    return await scope.run(run);
+  } finally {
+    await scope.release();
   }
 }
 
@@ -334,6 +455,12 @@ export function getConfigRoot(): string {
 
 /**
  * Closes the database connection.
+ *
+ * Process-wide, deliberately: this is the shutdown of the store, and its counterpart is
+ * `initDb` rather than `openProjectScope`. A consumer holding scopes therefore must not call
+ * it -- `release()` is that consumer's teardown, and it closes one database rather than the
+ * pool. Same rule the MCP server already follows, stated here because a scope makes it
+ * reachable from a second kind of caller.
  */
 export async function closeDb(): Promise<void> {
   if (globalContext) {

--- a/tests/store/scoped-project-handles.test.ts
+++ b/tests/store/scoped-project-handles.test.ts
@@ -1,0 +1,247 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, getConfigRoot, getProjectRoot, initDb, openProjectScope, withProjectScope } from '../../src/store/database.js';
+import { poolSize, releaseAll } from '../../src/store/connection-pool.js';
+import { createKnowledgeItem } from '../../src/store/repository.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+
+// A fresh pair per test rather than one pair cleaned between them. Windows holds the `-shm` and
+// `-wal` sidecars after close, so the `rm` that is supposed to reset a shared fixture routinely
+// fails and is swallowed -- and every assertion here is about which rows are in which FILE, so
+// a fixture carrying the previous test's rows fails for a reason that has nothing to do with the
+// code. `.knowl-` prefixed, so global teardown sweeps them.
+let FIRST = '';
+let SECOND = '';
+let counter = 0;
+
+const dbOf = (root: string) => path.join(root, '.knowl', 'knowl.db');
+
+async function makeRepo(root: string) {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, {
+    ...DEFAULT_CONFIG,
+    search: { vector: { ...DEFAULT_CONFIG.search?.vector, enabled: false } },
+  });
+}
+
+/**
+ * The titles in one project's database file, read through a connection of this test's own.
+ *
+ * Deliberately not `getDb()` or the pool: the thing under test is which FILE a write reached,
+ * and asking the same layer that chose the file would assert nothing.
+ */
+async function titlesIn(root: string): Promise<string[]> {
+  const client = createClient({ url: `file:${dbOf(root)}` });
+  try {
+    const result = await client.execute('SELECT title FROM knowledge_items ORDER BY title');
+    return result.rows.map(row => String(row.title));
+  } finally {
+    client.close();
+  }
+}
+
+describe('two projects open in one process', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    counter += 1;
+    FIRST = path.resolve(`./.knowl-scoped-first-${counter}-test`);
+    SECOND = path.resolve(`./.knowl-scoped-second-${counter}-test`);
+    for (const dir of [FIRST, SECOND]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    for (const dir of [FIRST, SECOND]) await makeRepo(dir);
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+    for (const dir of [FIRST, SECOND]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  // The defect this pins, reproduced on 2026-09-05: `initDb` overwrites one module-global
+  // context, so opening a second project silently repointed the first one's writes. The row
+  // landed in the second project's file, the first project's store stayed empty, and nothing
+  // anywhere said so.
+  it('writes through the first handle into the first project, not the second', async () => {
+    const first = await openProjectScope(FIRST);
+    const second = await openProjectScope(SECOND);
+
+    try {
+      await first.run(async () => {
+        await createKnowledgeItem('project-first', {
+          category: 'fact', title: 'Belongs to the first project', content: 'Written through the first handle.',
+        });
+      });
+
+      expect(await titlesIn(FIRST)).toEqual(['Belongs to the first project']);
+      expect(await titlesIn(SECOND)).toEqual([]);
+    } finally {
+      await first.release();
+      await second.release();
+    }
+  });
+
+  it('keeps each handle pointed at its own project, in whatever order they are used', async () => {
+    const first = await openProjectScope(FIRST);
+    const second = await openProjectScope(SECOND);
+
+    try {
+      // Interleaved on purpose: a handle that resolved its database once and cached it would
+      // pass a test that used each one only once, in order.
+      await second.run(async () => {
+        await createKnowledgeItem('project-second', {
+          category: 'fact', title: 'Second, written first', content: 'Written through the second handle.',
+        });
+      });
+      await first.run(async () => {
+        await createKnowledgeItem('project-first', {
+          category: 'fact', title: 'First, written second', content: 'Written through the first handle.',
+        });
+      });
+
+      expect(await titlesIn(FIRST)).toEqual(['First, written second']);
+      expect(await titlesIn(SECOND)).toEqual(['Second, written first']);
+    } finally {
+      await first.release();
+      await second.release();
+    }
+  });
+
+  it('carries the project and config root of the handle whose body is running', async () => {
+    const first = await openProjectScope(FIRST);
+    const second = await openProjectScope(SECOND);
+
+    try {
+      // `resolveWriteDefaults` stamps `origin_repo` from the config root and auto-staging reads
+      // it for a cloud pointer, so a handle that moved only the database would write into one
+      // project and label it with another's name.
+      await first.run(async () => {
+        expect(getProjectRoot()).toBe(FIRST);
+        expect(getConfigRoot()).toBe(FIRST);
+      });
+      await second.run(async () => {
+        expect(getProjectRoot()).toBe(SECOND);
+        expect(getConfigRoot()).toBe(SECOND);
+      });
+    } finally {
+      await first.release();
+      await second.release();
+    }
+  });
+
+  // The second half of the defect: `closeDb` releases the WHOLE pool, so one consumer finishing
+  // used to tear down every other open handle in the process. Reproduced as
+  // `DatabaseError: Database has not been initialized. Run initDb() first.` thrown by the
+  // handle that had done nothing wrong.
+  it('leaves the other handle working after one of them is released', async () => {
+    const first = await openProjectScope(FIRST);
+    const second = await openProjectScope(SECOND);
+
+    try {
+      await first.release();
+
+      await second.run(async () => {
+        await createKnowledgeItem('project-second', {
+          category: 'fact', title: 'Still open', content: 'The surviving handle still writes.',
+        });
+      });
+
+      expect(await titlesIn(SECOND)).toEqual(['Still open']);
+    } finally {
+      await second.release();
+    }
+  });
+
+  it('releases only its own database, and is safe to release twice', async () => {
+    const first = await openProjectScope(FIRST);
+    const second = await openProjectScope(SECOND);
+    expect(poolSize()).toBe(2);
+
+    await first.release();
+    await first.release();
+    expect(poolSize()).toBe(1);
+
+    await second.release();
+    expect(poolSize()).toBe(0);
+  });
+
+  it('refuses to run a body after it has been released, rather than running it somewhere else', async () => {
+    const scope = await openProjectScope(FIRST);
+    await scope.release();
+
+    expect(() => scope.run(async () => {})).toThrow(/has been released/);
+  });
+
+  it('opens, runs and releases in one call', async () => {
+    await withProjectScope(FIRST, async () => {
+      await createKnowledgeItem('project-first', {
+        category: 'fact', title: 'Through the one-shot form', content: 'Written inside withProjectScope.',
+      });
+    });
+
+    expect(await titlesIn(FIRST)).toEqual(['Through the one-shot form']);
+    // Stronger than an empty read: the other project's database was never even created, so the
+    // scope reached exactly one file.
+    expect(await fs.access(dbOf(SECOND)).then(() => true, () => false)).toBe(false);
+    expect(poolSize()).toBe(0);
+  });
+
+  // Two sessions in one folder is the ordinary case for a gateway, and a refcount is the only
+  // thing standing between that and one of them closing the connection the other is using.
+  it('keeps the connection alive while a second handle on the same project holds it', async () => {
+    const one = await openProjectScope(FIRST);
+    const two = await openProjectScope(FIRST);
+
+    try {
+      await one.release();
+
+      await two.run(async () => {
+        await createKnowledgeItem('project-first', {
+          category: 'fact', title: 'Shared connection', content: 'The second handle still writes.',
+        });
+      });
+
+      expect(await titlesIn(FIRST)).toEqual(['Shared connection']);
+    } finally {
+      await two.release();
+    }
+  });
+
+  // The CLI and the MCP server both call `initDb` once and then read the ambient context for the
+  // rest of the process. A scope must be invisible to them, in both directions.
+  it('never disturbs the process-wide context a one-shot caller depends on', async () => {
+    await initDb(FIRST);
+    const ambient = getClient();
+
+    const scope = await openProjectScope(SECOND);
+    try {
+      await scope.run(async () => {
+        expect(getClient()).not.toBe(ambient);
+      });
+
+      // The identity is the assertion: a reassigned global would be a different object here.
+      expect(getClient()).toBe(ambient);
+      expect(getProjectRoot()).toBe(FIRST);
+    } finally {
+      await scope.release();
+    }
+
+    expect(getClient()).toBe(ambient);
+    await closeDb();
+  });
+
+  it('does not release a database the process-wide context is still using', async () => {
+    await initDb(FIRST);
+    const ambient = getClient();
+
+    const scope = await openProjectScope(FIRST);
+    await scope.run(async () => { expect(getClient()).toBe(ambient); });
+    await scope.release();
+
+    // `releaseClient` here would close the connection `initDb` handed the CLI, and the next
+    // ambient statement would fail on a closed client rather than on anything the caller did.
+    await getClient().execute('SELECT 1');
+    await closeDb();
+  });
+});


### PR DESCRIPTION
## The defect

`src/store/database.ts` keeps one module-level `globalContext`, `initDb` overwrites it
unconditionally, and `getDb`/`getClient` read it. Two projects open at once in one process
therefore share the last one opened.

Reproduced, on this branch's parent:

```
initDb(A); initDb(B);
// a write issued by the caller that believes it holds A
A titles: []
B titles: ["ROW"]
```

No error, no warning, no log line. The correct store goes quietly stale while knowledge
accumulates in another project's file.

`closeDb` is the second half. It calls `releaseAll`, which closes and WAL-checkpoints *every*
pooled client, so the first consumer to finish tears down every other one's connection — the
survivors get `Database has not been initialized. Run initDb() first.` from a call they made
correctly.

Found independently by two reviewers during review of the OpenClaw in-process plugin spec, and
reproduced empirically by both.

## Why it is latent today

**No user is affected by this, and the changelog entry says so.** Every shipped consumer opens
exactly one project per process: the CLI is one-shot (`initDb` → work → `closeDb`), the MCP
server binds a project at startup and reaches other databases with `withDbPath`, and acp-proxy
does the same. The subprocess boundary has been hiding the defect — a load-bearing property
nobody had written down.

This is hardening, not a user-facing bugfix. What it unblocks is the planned in-process library
export, where a long-running gateway holds several workspaces open in one address space and that
boundary is gone. Landing it separately keeps the engine fix reviewable on its own.

## What changed

`src/store/database.ts` only, additively:

- **`openProjectScope(root)`** returns a handle whose `run(body)` executes inside the same
  `AsyncLocalStorage` the namespace hop already uses, so ambient reads resolve to *that* project
  rather than to whoever opened last. Same mechanism `withDbPath` and `withRepoRoot` were given
  for the same class of bug one level down.
- **`release()` maps to `releaseClient(dbPath)`**, the primitive that already exists for "done
  with one database, leave the pool alone" — never `closeDb`/`releaseAll`.
- **`withProjectScope(root, body)`** is the open-run-release form.
- `projectDatabasePath` is extracted from `initDb` so the ambient and scoped routes to a project
  cannot disagree about which file it is.

Two cases the naive shape gets wrong, both tested:

- Two scopes on **one** project are handed the same pooled client, so holders are refcounted.
  Without it the first to release closes the connection the second is still using — the same
  tearing-down this exists to stop, one level in.
- A scope **never** releases a database the process-wide context also has open. That client
  belongs to whoever called `initDb`, for the life of the process.

**Nothing assigns `globalContext`.** A scope opened beside a live CLI or server is invisible to
it; `initDb`/`closeDb` are unchanged and all 154 existing `initDb(`/`closeDb(` call sites keep
the behaviour they have. No public export renamed, no CLI behaviour changed.

## Tests

`tests/store/scoped-project-handles.test.ts`, 10 cases, including the two required regressions:
a write through the first of two handles lands in the first project's file and not the second's,
and releasing one handle leaves the other working.

Verified against three mutants before trusting them:

| mutant | tests failed |
| --- | --- |
| context pinned at open time, `run` just calls the body | 6 |
| `run` assigns `globalContext` instead of scoping | 2 |
| `release` maps to `releaseAll` | 3 |

Fixtures are per-test rather than shared: every assertion is about which *file* a row reached,
and on Windows the `rm` resetting a shared fixture routinely fails on a held `-shm` sidecar and
is swallowed, so a leftover row would fail the next test for a reason unrelated to the code.

## Docs

None changed, deliberately. No user-facing document describes this: `docs/reference.md` covers
the CLI and MCP surfaces, and the library export it matters for is not shipped yet. The
explanation lives in the docblocks, which is where this repo puts it.

## Verification

All green on Windows / Node 24 before pushing:

```
npm run build                     ok
npm test                          409 files, 3869 passed, 5 skipped, 0 failed
npx eslint .                      clean
npm run typecheck                 clean
npm run docs:check                current
node scripts/check-version-sync.mjs  5.21.0 consistent
```
