### PR TITLE
chore: release 5.21.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.21.0",
+  "version": "5.21.1",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.21.1 — 2026-09-05
 
 **A project can be held open per consumer, without the process-global handle deciding for
 everyone.** `initDb` writes to one module-level context and `getDb`/`getClient` read it, so two

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.21.0",
+  "version": "5.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.21.0",
+      "version": "5.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.21.0",
+  "version": "5.21.1",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.21.0",
+  "version": "5.21.1",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.21.0",
+      "version": "5.21.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Patch release. Carries #258 only: the multi-project database misroute hardening.

Version bumped in `package.json`, `package-lock.json` (both places), `.claude-plugin/plugin.json` and `server.json` (both places); `scripts/check-version-sync.mjs` passes. `## Unreleased` renamed in place to `## 5.21.1 — 2026-09-05`, and the awk extraction `cd.yml` runs for the GitHub release notes returns a non-empty section.

Patch rather than minor: #258 adds `openProjectScope`/`withProjectScope` but changes no existing behaviour — nothing assigns `globalContext`, no export was renamed, and no CLI behaviour moved. No shipped consumer opens more than one project per process, so nothing observable changes for any user of 5.21.0.

Verified locally before pushing: build, eslint, `tsc --noEmit`, `docs:check`, `check-version-sync` — all green at 5.21.1.