### PR TITLE
feat(openclaw): an in-process plugin, and the library export it needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+**OpenClaw in-process plugin integration.** OpenClaw is supported via an in-process plugin package (`@dat999zx/knowl/plugin` and `integrations/openclaw`) rather than shell hooks. Running inside the OpenClaw gateway evaluates the write gate at `before_tool_call` in sub-millisecond time (~0.68ms vs ~118ms subprocess) with an explicit matcher filtering write tools (`exec`, `apply_patch`, `spawn_agent`). The write gate carries an internal 5-second deadline and swallows engine errors to uphold OpenClaw's fail-closed host contract without blocking user writes on memory degradation.
+
+Prompt recall is delivered at `before_prompt_build` returning `{ prependContext: card }` with the fixed orientation card, ensuring prompt prose never becomes a search query. Impact cards are injected before model replay via `api.registerAgentToolResultMiddleware` directly into `result.content` (avoiding `details` which OpenClaw strips before compaction).
+
+`knowl init openclaw` merges the plugin entry into `openclaw.json` (project-scoped or `~/.openclaw/openclaw.json`), writing both required permission gates (`allowConversationAccess` and `allowPromptInjection`) and explicitly setting `timeouts.before_tool_call: 5000` while preserving all surrounding user configuration.
+
 ## 5.21.1 — 2026-09-05
 
 **A project can be held open per consumer, without the process-global handle deciding for

--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ works.
 <strong>Claude Desktop</strong><br/>
 <sub>MCP · manual loop</sub>
 </td>
-<td align="center" width="14%"></td>
+<td align="center" width="14%">
+<a href="https://github.com/openclaw/openclaw"><img src="docs/assets/logos/openclaw.svg" alt="OpenClaw" width="40" height="40" /></a><br/>
+<strong>OpenClaw</strong><br/>
+<sub>in-process · plugin · gate</sub>
+</td>
 </tr>
 </table>
 
@@ -172,7 +176,8 @@ the agent picks up its guidance, and it will query and write memory on its own.
 Neovim and Kiro work the same way as Zed and JetBrains, through `knowl acp`. Cline needs one
 line pointing it at the shipped plugin. Hermes Agent gets a Python plugin, installed for you,
 that works in the terminal and in Hermes Desktop alike, and can additionally be picked as
-Hermes' memory provider. Any other MCP client works with
+Hermes' memory provider. OpenClaw runs in-process inside its gateway via an extension plugin,
+evaluating write gates without subprocess overhead. Any other MCP client works with
 no integration at all.
 
 Running agents in parallel? Every **git worktree** resolves to the main checkout's store —

--- a/docs/assets/logos/openclaw.svg
+++ b/docs/assets/logos/openclaw.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff4d4d"/>
+      <stop offset="100%" stop-color="#991b1b"/>
+    </linearGradient>
+  </defs>
+  <!-- OpenClaw mascot (static): the Clawd lobster, mirroring ui/public/favicon.svg base pose. -->
+  <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster-gradient)"/>
+  <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster-gradient)"/>
+  <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster-gradient)"/>
+  <path d="M45 15 Q35 5 30 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/>
+  <path d="M75 15 Q85 5 90 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="45" cy="35" r="6" fill="#050810"/>
+  <circle cx="75" cy="35" r="6" fill="#050810"/>
+  <circle cx="46" cy="34" r="2.5" fill="#00e5cc"/>
+  <circle cx="76" cy="34" r="2.5" fill="#00e5cc"/>
+</svg>

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -31,6 +31,7 @@ Every host gets **memory**: `knowl_query`, `knowl_store` and the rest, over MCP.
 | **Claude Desktop** | via MCP | ❌ | via MCP | ❌ | via MCP |
 | **Cline** (with the plugin) | ✅ | ✅ | ✅ | — | via MCP |
 | **Hermes Agent** (with the plugin) | ✅ | ✅ | ✅ | ✅ | ✅ edit turns |
+| **OpenClaw** (with the plugin) | ✅ | ✅ | ✅ | ✅ | — |
 | **Zed, JetBrains, Neovim, Kiro** (via `knowl acp`) | ✅ | ❌ | ✅ | ❌ | via MCP |
 | **OpenCode, Roo, Continue, Amp, Goose, Aider, …** | via MCP | ❌ | via MCP | ❌ | via MCP |
 
@@ -42,7 +43,9 @@ Every host gets **memory**: `knowl_query`, `knowl_store` and the rest, over MCP.
 
 ## One process per event, or one server
 
-Every hook above is installed as a `command` hook: a fresh `knowl agent-hook` process per event, ~230ms of Node startup each, serialized against the agent's own tool calls because the host waits on the pre-tool hook. Over 102 real Claude Code sessions that is 31s at the median session and 190s at the 90th percentile.
+Every hook above except OpenClaw is installed as a `command` hook: a fresh `knowl agent-hook` process per event, ~230ms of Node startup each, serialized against the agent's own tool calls because the host waits on the pre-tool hook. Over 102 real Claude Code sessions that is 31s at the median session and 190s at the 90th percentile.
+
+OpenClaw is the exception: it runs entirely in-process inside the gateway via an extension plugin (`integrations/openclaw`), using Knowl's scoped project handles (`@dat999zx/knowl/plugin`). This eliminates subprocess startup latency entirely, reducing write gate evaluation from ~118ms to ~0.68ms (and 0.04ms on non-write tools).
 
 Claude Code (2.1.257+) and Codex (0.148+) can run a hook as a call to a tool on an already-connected MCP server instead. Set `hooks.transport` to `mcp` in `.knowl/config.json` and re-run `knowl init <host>`: the mid-session events become `mcp_tool` hooks calling `knowl_hook` on the `knowl serve` process the host already holds open, and the server registers that tool. `SessionStart` stays a process (both hosts say it fires before servers finish connecting), as does `SessionEnd`. No other host has the hook type yet; on those the setting changes nothing. The trade and the details are in the [reference](reference.md#hook-transport--hookstransport).
 
@@ -87,6 +90,7 @@ cd my-repo && knowl init
 | Cursor | `.cursor/mcp.json` | `.cursor/hooks.json` |
 | Claude Desktop | platform config directory | — |
 | Hermes Agent | `config.yaml` in the Hermes home (global) | a plugin in `<Hermes home>/plugins/knowl/` |
+| OpenClaw | — | in-process plugin in `openclaw.json` (`plugins.entries.knowl`) |
 
 † Antigravity is two products reading two files. The IDE's "View raw config" opens `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads `~/.gemini/config/mcp_config.json`, which Gemini CLI's migration often leaves at 0 bytes — an empty file, not a broken one. Both are confirmed against real installs, and `knowl init antigravity` writes both.
 

--- a/docs/superpowers/plans/2026-09-05-openclaw-plugin.md
+++ b/docs/superpowers/plans/2026-09-05-openclaw-plugin.md
@@ -227,3 +227,32 @@ The single most important file. Every failure mode the spec accepts is contained
 | Version skew on a shared file | Task 6 Step 4 migration-level guard. |
 | `exports` map breaks Cline | Task 3 Step 1 wildcards + Step 2 resolution test. |
 | Prompt text reaching the engine | Task 1 allowlist + Task 7 Step 2. |
+
+---
+
+## Environment (verified 2026-09-05)
+
+- **Build and typecheck against the npm package**, not the monorepo: `npm install openclaw@2026.9.1`
+  takes ~46 s and ships the whole SDK as `.d.ts` under `node_modules/openclaw/dist/plugin-sdk/`,
+  with ~300 subpath exports. There is no top-level `types` field — types come per subpath, so
+  importing `openclaw/plugin-sdk/plugin-entry` is what resolves `definePluginEntry`.
+- **Source checkout at `D:/coding/openclaw`** (`1d1c0db3`, v2026.9.1, 37,986 files) for reading
+  implementation when a doc is ambiguous. A plain `--depth 1` clone failed once with
+  `early EOF / fetch-pack: unexpected disconnect`; `--filter=blob:none --no-tags` succeeded.
+  Never pipe `git clone` through `tail` — the pipe reports exit 0 on a failed clone.
+- **`rg`, not `grep -r`, inside those trees.** `grep -rn` over `openclaw/dist` times out at 180 s;
+  `rg -l --max-count 1 -g '*.d.ts'` answers in seconds.
+- `pnpm@12.3.4` installed globally (OpenClaw's own package manager, needed only to build the
+  monorepo).
+
+### Two spec assumptions now confirmed at source
+
+- `registerAgentToolResultMiddleware` is real and **async**:
+  `(event, ctx) => Promise<AgentToolResultMiddlewareResult | void> | ...`, with
+  `options: { matcher?, runtimes? }` — so Task 9's middleware can be scoped to write tools exactly
+  as the gate is.
+- `tool_result_persist` really is transcript-only. `session-tool-result-guard.ts:685` names the
+  function `persistToolResult`, the option is `transformToolResultForPersistence`, and its output
+  flows only into `appendMessageAndCacheTranscriptSeq`. **Do not use it for the impact card.**
+- `registerSessionExtension` and `enqueueNextTurnInjection` are deprecated at top level; the
+  current names are `api.session.state.*` and `api.session.workflow.*`.

--- a/docs/superpowers/plans/2026-09-05-openclaw-plugin.md
+++ b/docs/superpowers/plans/2026-09-05-openclaw-plugin.md
@@ -1,0 +1,229 @@
+# OpenClaw In-Process Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `knowl init openclaw` installs a plugin that runs *inside* OpenClaw's gateway and imports the Knowl engine directly — so the write gate answers in under a millisecond instead of booting a process, and the impact card reaches the model in the turn that earned it.
+
+**Architecture:** Two halves. Part 1 adds a real library door to this package: an `exports` map plus `src/plugin.ts`, exposing a scoped `ProjectHandle` over `handleHostLifecycleEvent`, `query` and `store`. Part 2 is the plugin itself under `integrations/openclaw/`, a TypeScript package registering six hooks and one tool-result middleware through `api.on(...)`. The CLI's ambient `initDb`/`closeDb` path is untouched; every plugin call runs inside `withProjectScope`.
+
+**Tech Stack:** TypeScript (ESM, tsup, code splitting already on), vitest, OpenClaw plugin SDK (peer dependency), Node ≥22.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md`
+
+**Decision:** `bfb061c8eb094559`
+
+## Global Constraints
+
+- **Never call `initDb`, `initDbPath` or `closeDb` from plugin or library code.** Those own the process-wide context and belong to the CLI. Every handle method body runs inside `withProjectScope`; release maps to `releaseClient`. This is what 5.21.1 shipped for, and ignoring it reintroduces the silent cross-project write that PR #258 fixed.
+- **Recall is the fixed orientation card.** `turn-start` → `bootstrapWithHandoff`. Never build a query from prompt text — the defect PR #257 fixed on Hermes. Prompt text may be a signal; it is never the query string.
+- **Exactly one hook publishes the card.** `before_prompt_build` carries it; `agent_turn_prepare` and `heartbeat_prompt_contribution` carry nothing. Context additions concatenate, so two publishers duplicate.
+- **`before_tool_call` is FAIL-CLOSED on a 15 s host budget**, and a timed-out handler keeps running with no cancellation signal. The gate carries its own shorter deadline and answers "accepted" on it. A stalled engine must never deny a user's write.
+- **No handler may float a promise.** Every handler awaits its own work inside its own try/catch. `--unhandled-rejections=throw` is Node's default and a floated rejection kills the gateway. Do **not** install a process-level `unhandledRejection` listener.
+- **The payload allowlist ships with the normaliser.** `readLifecyclePayloadObject` enforces `ROOT_FIELDS` / `MAX_RETAINED_STRING` / `MAX_RETAINED_ARRAY_ITEMS`. Without it a plugin can hand the engine unbounded prompt text and break the "never prompts, never transcripts" promise.
+- Capability is expressed by return value: a profile member that has not been verified is absent, never a flag set to `true`. Read `src/session/hosts/profile.ts` before writing the profile.
+- Verify with `npm run build`, `npm test`, `npx eslint .`, `npm run typecheck`, `npm run docs:check`.
+- Branch `feat/openclaw-plugin` (already exists, holds the spec). Commit after every task.
+- `CHANGELOG.md` has no `## Unreleased` heading after a release — the release commit consumes it. Task 10 recreates it.
+
+## Already done, do not redo
+
+- **Native coexistence is verified** (spec Verification 1, 2026-09-05). libsql, `node:sqlite` and tree-sitter coexist in one process; both engines opened the same file in WAL and saw each other's rows. Do not re-run as a gate.
+- **`openProjectScope` / `withProjectScope` shipped in 5.21.1** (PR #258). Use them; do not rebuild scoping.
+
+---
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `package.json` (modify) | `exports` map with wildcards, `main` retained |
+| `tsup.config.ts` (modify) | add `src/plugin.ts` to `entry` |
+| `src/plugin.ts` (create) | the library door: `openProject`, `ProjectHandle`, re-exports |
+| `src/cli/agents/lifecycle.ts` (modify) | `readLifecyclePayloadObject` beside the stream reader |
+| `src/store/database.ts` (modify) | preserve `SchemaTooNewError` through `initDbPath` |
+| `src/session/hosts/openclaw.ts` (create) | the host profile |
+| `src/session/hosts/index.ts` (modify) | register it |
+| `src/core/host-hook-types.ts` (modify) | `'openclaw'` HookHost |
+| `src/cli/agents/types.ts`, `registry.ts` (modify) | `'openclaw'` AgentName + adapter |
+| `src/cli/agents/openclaw.ts` (create) | adapter: `openclaw.json` merge, gates, timeout |
+| `integrations/openclaw/package.json` (create) | plugin manifest, `openclaw` as **peer** |
+| `integrations/openclaw/openclaw.plugin.json` (create) | `activation.onStartup`, contracts |
+| `integrations/openclaw/src/index.ts` (create) | `register(api)`, six hooks + middleware |
+| `integrations/openclaw/src/engine.ts` (create) | handle cache, deadlines, failure swallowing |
+| `tests/cli/plugin-export.test.ts` (create) | imports the BUILT artifact as a consumer |
+| `tests/cli/hosts/profile-conformance.test.ts` (modify) | `ALL_HOSTS` |
+| `tests/cli/openclaw-adapter.test.ts` (create) | config merge, both gates, timeout |
+| `tests/integrations/openclaw/hooks.test.ts` (create) | hook behaviour with a fake `api` |
+| `README.md`, `docs/hosts.md`, `CHANGELOG.md` (modify) | docs |
+
+---
+
+### Task 0: Branch and OpenClaw checkout
+
+- [ ] **Step 1:** `feat/openclaw-plugin` already exists off `main` and holds the spec (`8a9bda4`, `3858e29`). Confirm `main` is merged in so 5.21.1's `openProjectScope` is present.
+- [ ] **Step 2:** OpenClaw source at `D:/coding/openclaw` (shallow clone) for SDK types. `pnpm install` there; `pnpm@12` is installed. The plugin builds against `openclaw/plugin-sdk/*` types.
+
+---
+
+### Task 1: `readLifecyclePayloadObject` — the allowlist, without a stream
+
+**Files:** modify `src/cli/agents/lifecycle.ts`; test `tests/cli/lifecycle-payload-object.test.ts`
+
+**Interfaces:**
+- Produces: `readLifecyclePayloadObject(raw: unknown): LifecyclePayload` — the same filtering `readLifecyclePayload` applies after parsing, extracted so a non-stdin caller reaches it.
+
+**Why first:** every later task depends on it, and it is the privacy boundary.
+
+- [ ] **Step 1: Write the failing test.** Assert an object with a 5,000-character `prompt` field and a 200-item array comes back truncated to `MAX_RETAINED_STRING` / `MAX_RETAINED_ARRAY_ITEMS`, and that a field outside `ROOT_FIELDS` is dropped entirely. Read the existing constants first; do not restate them as literals.
+- [ ] **Step 2:** Refactor `readLifecyclePayload` so the stream reader parses and then delegates to the new function. One allowlist, two entry points — `hook-over-mcp.ts:118` explains why a second copy is forbidden.
+- [ ] **Step 3:** `npm test -- lifecycle`. Commit.
+
+---
+
+### Task 2: Preserve `SchemaTooNewError` across the library boundary
+
+**Files:** modify `src/store/database.ts`; test `tests/store/schema-error-class.test.ts`
+
+`initDbPath` catches everything and rethrows `DatabaseError`, so the class is lost and a consumer can only string-match.
+
+- [ ] **Step 1: Failing test** — stamp a scratch db `user_version` above `KNOWL_SCHEMA_VERSION`, open it, assert the thrown error is `instanceof SchemaTooNewError` (or carries it as `cause`).
+- [ ] **Step 2:** Preserve the cause. Do not change the CLI's message — `doctor` and `status` render it and their tests assert on it.
+- [ ] **Step 3:** `npm test -- schema`. Commit.
+
+---
+
+### Task 3: The library door — `exports` map and `src/plugin.ts`
+
+**Files:** modify `package.json`, `tsup.config.ts`; create `src/plugin.ts`; test `tests/cli/plugin-export.test.ts`
+
+**Interfaces:**
+- Produces: `openProject(cwd): Promise<ProjectHandle | null>` — `null` on `ProjectNotFoundError`, **throws** on `MissingKnowledgeDatabaseError`. Two different answers, deliberately.
+- Produces: `ProjectHandle { lifecycle, query, store, release }`, every body inside `withProjectScope`, `release` → `releaseClient`.
+- Produces: re-exported `normalizeHostHook`, `readLifecyclePayloadObject`, `KNOWL_MIGRATION_LEVEL`.
+
+- [ ] **Step 1: The exports map must not break the Cline path.** Before writing it, enumerate what resolves today. The verified minimum:
+  ```json
+  { ".": "./dist/index.js", "./plugin": "./dist/plugin.js",
+    "./package.json": "./package.json",
+    "./integrations/*": "./integrations/*", "./dist/*": "./dist/*" }
+  ```
+  Keep `main`. `integrations/cline/knowl-plugin.mjs` is documented in `docs/hosts.md:138`, `docs/reference.md:2390` and `CHANGELOG.md:985` — a three-entry map breaks it.
+- [ ] **Step 2: Failing test that imports the BUILT artifact**, not the source. Pack and install into a scratch dir with OpenClaw's exact flags (`--omit=dev --omit=peer --legacy-peer-deps --ignore-scripts --no-audit --no-fund`), then `import('@dat999zx/knowl/plugin')`. Assert all five paths above still resolve.
+- [ ] **Step 3:** Write `src/plugin.ts`. It must not import the CLI program — check the built chunk does not pull `commander`.
+- [ ] **Step 4: The multi-project regression, at this layer.** Open two projects, write through the first, assert the row landed in the first's file. This is PR #258's test one level up; it is the reason this design is safe.
+- [ ] **Step 5:** `npm run build`, verify `dist/plugin.js` exists and `dist/index.js` still prints the version. Commit.
+
+---
+
+### Task 4: The OpenClaw host profile
+
+**Files:** create `src/session/hosts/openclaw.ts`; modify `src/session/hosts/index.ts`, `src/core/host-hook-types.ts`; test `tests/cli/hosts/profile-conformance.test.ts`
+
+Read `src/session/hosts/hermes.ts` first — its event-map docblock is the model for explaining *why* each mapping is what it is.
+
+- [ ] **Step 1:** Event map: `before_prompt_build` → `turn-start`; `before_tool_call` → `tool-precheck`; `after_tool_call` → `session-event`; `before_compaction` → `checkpoint`; `session_end`/`agent_end` → `turn-stop`; `gateway_stop` → `session-stop`; `session_start` binds.
+- [ ] **Step 2:** No `hookEvents` — like Cline and Hermes, this host has no hook file. Say so in the docblock.
+- [ ] **Step 3:** Add to `ALL_HOSTS`; conformance test passes. Commit.
+
+---
+
+### Task 5: The plugin package skeleton
+
+**Files:** create `integrations/openclaw/{package.json,openclaw.plugin.json,tsconfig.json,src/index.ts}`
+
+- [ ] **Step 1:** `package.json` — `@dat999zx/knowl` as a real **`dependencies`** entry (`--omit=peer` would skip a peer), and `openclaw` as a **`peerDependency`** (the host refuses a second registry copy and relinks it itself). Both, deliberately.
+- [ ] **Step 2:** `openclaw.plugin.json` with `activation.onStartup` and `contracts.agentToolResultMiddleware` listing both runtimes.
+- [ ] **Step 3:** `register(api)` **synchronous**, handlers registered with `api.on(...)` — never `api.registerHook`, which warns and never fires for typed names. Settings from `api.pluginConfig` in the closure.
+- [ ] **Step 4:** Evaluate `openclaw.release.bundleRuntimeDependencies: false` — the documented opt-out native-heavy packages use so npm resolves per-platform binaries at install. Record the decision either way.
+
+---
+
+### Task 6: The engine wrapper — handles, deadlines, and swallowing
+
+**Files:** create `integrations/openclaw/src/engine.ts`; test `tests/integrations/openclaw/engine.test.ts`
+
+The single most important file. Every failure mode the spec accepts is contained here.
+
+- [ ] **Step 1:** A per-workspace handle cache keyed by resolved root, opened at `session_start` (**warm, never lazily inside the gate**), released on `gateway_stop`.
+- [ ] **Step 2:** `withDeadline(ms, work, fallback)` — every engine call goes through it. The gate's deadline is well under the host's 15 s fail-closed budget and its fallback is *accept*.
+- [ ] **Step 3:** `safely(fn)` — awaits inside its own try/catch, logs through the host logger, never rethrows, never floats.
+- [ ] **Step 4:** Migration-level guard. Read `KNOWL_MIGRATION_LEVEL` off the file; if it exceeds the bundled engine's, disable the plugin with a readable reason. `SchemaTooNewError` cannot be the guard — `KNOWL_SCHEMA_VERSION` has moved once in 16 levels.
+- [ ] **Step 5: Test the failure modes, not the happy path.** A throwing engine, a hanging engine (assert the gate still accepts), a stale migration level, and a floated rejection caught by `safely`.
+
+---
+
+### Task 7: The recall card
+
+**Files:** modify `integrations/openclaw/src/index.ts`; test `tests/integrations/openclaw/hooks.test.ts`
+
+- [ ] **Step 1:** `before_prompt_build` → `turn-start` → returns `{ prependContext: card }`.
+- [ ] **Step 2: The regression test for #257, one host over.** Two different prompts in one session produce the **same** card. Assert no prompt substring reaches the engine payload.
+- [ ] **Step 3:** Assert `agent_turn_prepare` and `heartbeat_prompt_contribution` are not registered — one publisher only.
+- [ ] **Step 4:** Requires both `allowConversationAccess` and `allowPromptInjection`. Missing gates are **not** silent: OpenClaw rejects the registration with a `warn` diagnostic, surfaced by `openclaw plugins inspect`. Ship no bespoke doctor line.
+
+---
+
+### Task 8: The write gate
+
+- [ ] **Step 1:** `before_tool_call` with `opts.matcher` on canonical ids (`exec`, `apply_patch`, `spawn_agent`) — wildcards are invalid, and matching keeps a non-write from starting work at all.
+- [ ] **Step 2:** Return `{ block: true, blockReason }` on refusal. `block: false` is *no decision*, not an allow — return nothing to abstain.
+- [ ] **Step 3: Never return `params`.** Codex relays reject rewrites and fail closed, killing the call.
+- [ ] **Step 4:** `event.derivedPaths` is documented as possibly incomplete or over-approximate — a hint, never the sole basis for a refusal.
+- [ ] **Step 5: Test that a stalled engine accepts.** The deadline fires, the gate returns accept, the write proceeds. This is the fail-closed trap, and it is the test that matters most in this task.
+
+---
+
+### Task 9: The impact card and capture
+
+- [ ] **Step 1:** `api.registerAgentToolResultMiddleware(...)` — async, runtime-neutral, and it runs *before* output is fed back to the model. **Not `tool_result_persist`**, which only rewrites the transcript copy; the first draft of the spec got this wrong and the card would never have reached the model.
+- [ ] **Step 2:** Card text goes in `content`, never only `details` — `details` is stripped before provider replay and compaction.
+- [ ] **Step 3:** `after_tool_call` → `session-event` for capture. Observe kind: return value ignored, so it must still `await` inside `safely`.
+- [ ] **Step 4:** `before_compaction` → `checkpoint`, **bounded** — it has a 30 s per-handler timeout and in the Codex harness runs on the serialized notification queue, where a hang freezes `turn/completed`.
+- [ ] **Step 5:** `session_end` closes the turn. It shares a **2-second total drain budget** across all sessions and handlers, so nothing durable may depend on finishing there.
+
+---
+
+### Task 10: `knowl init openclaw`
+
+**Files:** create `src/cli/agents/openclaw.ts`; modify `src/cli/agents/{types,registry}.ts`, `src/cli/program.ts`; test `tests/cli/openclaw-adapter.test.ts`
+
+- [ ] **Step 1:** Merge into `openclaw.json`, never overwrite. Unparseable file → report and leave alone.
+- [ ] **Step 2:** Write the plugin entry, **both** permission gates, and an explicit `plugins.entries.knowl.hooks.timeouts.before_tool_call` rather than inheriting the 15 s default.
+- [ ] **Step 3:** Test that a config with unrelated user keys keeps them.
+
+---
+
+### Task 11: Docs and changelog
+
+- [ ] **Step 1:** `docs/hosts.md` — the OpenClaw row, and that this host runs in-process while the others shell out.
+- [ ] **Step 2:** `README.md` host list.
+- [ ] **Step 3:** `CHANGELOG.md` — create `## Unreleased` (the last release consumed it) above the newest version heading.
+- [ ] **Step 4:** `npm run docs:check`.
+
+---
+
+### Task 12: Full verification
+
+- [ ] **Step 1:** `npm run build`, `npm test`, `npx eslint .`, `npm run typecheck`, `npm run docs:check`.
+- [ ] **Step 2: Install the real way** — `openclaw plugins install npm-pack:<tgz>`, not `--link`. Only that path exercises the managed `--ignore-scripts` install.
+- [ ] **Step 3:** `openclaw plugins inspect knowl --runtime --json` — every hook registered, **no blocked registrations**.
+- [ ] **Step 4: Live gateway checks**, against a real session:
+  - the card appears **once** in the built prompt;
+  - the card is identical for two different prompts in one session;
+  - a blocked write is refused and `blockReason` is visible to the model;
+  - **two workspaces open in one gateway write to their own databases** (PR #258's regression at the plugin layer);
+  - a stalled engine does not deny a write.
+- [ ] **Step 5:** Measure the gate in situ and compare against the 0.68 ms / 118 ms figures in the spec. If the real number is materially worse, that is a finding, not a rounding error — record it.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| libsql abort takes the gateway | Accepted, not mitigated. Native segfault is uncontainable; recorded in the spec. |
+| Engine stall denies a user's write | Task 6 deadline + Task 8 Step 5. The single highest-value test in the plan. |
+| Cross-project write | 5.21.1 scoping + Task 3 Step 4 + Task 12 Step 4. |
+| Version skew on a shared file | Task 6 Step 4 migration-level guard. |
+| `exports` map breaks Cline | Task 3 Step 1 wildcards + Step 2 resolution test. |
+| Prompt text reaching the engine | Task 1 allowlist + Task 7 Step 2. |

--- a/docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md
@@ -1,0 +1,271 @@
+# OpenClaw: an in-process plugin, and the library export it needs
+
+Date: 2026-09-05
+Status: draft for review
+Supersedes: Tasks 4–6 of `docs/superpowers/plans/2026-09-03-harness-integrations.md`, which
+designed a Cline-style subprocess shell-out for OpenClaw.
+Governed by: constraint `6676fd41b5dc410c` — recall is the turn-start hook's fixed orientation
+card, never a query built from the user's prompt text.
+Depends on: nothing unbuilt. The engine exists; only its front door is missing.
+
+## Why this is not the 2026-09-03 design
+
+That plan gave OpenClaw the same shape Cline and Hermes have: a small translator that spawns
+`knowl agent-hook <host> <event> --json` once per event and reads JSON off stdout.
+
+Hermes has that shape because it has no choice. Its plugin is Python — `subprocess.run`,
+`shutil.which("knowl.cmd")` at `integrations/hermes/knowl/__init__.py:233` — and Python cannot
+import TypeScript. The shell-out is its ceiling, not its design.
+
+OpenClaw is TypeScript on Node, the same runtime Knowl is written in. Verified at source
+2026-09-05 (atom `35421756dd5c4dc1`): root `package.json` declares
+`engines.node: ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"`, `packageManager: pnpm@12.1.0`,
+`scripts.start: node openclaw.mjs`. `docs/install/bun.md` states plainly that "Node remains
+OpenClaw's primary, default, and recommended runtime"; Bun 1.4+ is an opt-in that additionally
+requires WAL-reset-safe `node:sqlite`, and `bun install` cannot resolve the repo's pnpm workspace
+at all. That engine range sits entirely inside Knowl's own `>=22`.
+
+Choosing the subprocess here would be adopting Hermes' limitation on purpose. Two things follow
+from being in-process, and neither is available to any subprocess plugin:
+
+- **A returned value, not text.** `integrations/hermes/knowl/__init__.py:893` records the
+  limitation verbatim: Hermes "only reads a bare string here, which a subprocess cannot return."
+- **A warm database.** Measured on the maintainer's machine 2026-09-05: 187 ms median just to
+  spawn `node dist/index.js --version` (5 runs: 182/182/187/188/4739). That is the floor per hook
+  event, paid hundreds of times a session, before any work happens.
+
+The cost is process isolation: an engine fault now lands inside OpenClaw's gateway. The plan's
+existing rule — *a hook failure must allow the action* — stops being defensive and becomes
+load-bearing. Every handler wraps its body and swallows.
+
+## Part 1 — the library export
+
+### The problem, exactly
+
+`@dat999zx/knowl` has no library entry. `package.json` declares `bin: { knowl: "dist/index.js" }`
+and `main: "dist/index.js"`; `exports` is **undefined**. And `dist/index.js` is the CLI: `src/index.ts`
+opens `#!/usr/bin/env node` and its module body dispatches on `process.argv[2]` immediately. Importing
+it does not expose an API — it runs the CLI.
+
+### The engine is already a library
+
+This is not a refactor. `src/mcp/server.ts` already imports `initDb`, `getProjectByRootPath` and
+`registerTools` directly from core modules rather than shelling out; the CLI does the same. Both
+protocol surfaces are already thin adapters over a shared engine, which is what the project's
+"maintain thin protocol boundaries" goal asks for. The work is to name a front door, not to build
+one.
+
+`runAgentHook(host, event)` in `src/cli/agent-hook.ts` is itself a shell: it reads stdin, resolves
+the project (`findProjectRoot` → `assertKnowledgeDatabasePresent` → `initDb` →
+`getProjectByRootPath`), delegates to **`handleHostLifecycleEvent(project.id, normalized)`**, and
+prints JSON. Everything a host plugin needs is that one call; the stdin/stdout wrapper is the only
+thing the CLI adds.
+
+### The surface
+
+Three entries. Parity is not reduced by keeping it small — the Hermes plugin, the most complete
+integration shipped, invokes exactly three CLI verbs across its 1,100 lines
+(`agent-hook` at :387, `query` at :445 and :1000, `store` at :1022) and nothing else.
+
+```ts
+// @dat999zx/knowl  →  exports["./plugin"]
+export async function openProject(cwd: string): Promise<ProjectHandle | null>;
+// resolves the root, asserts the database exists, opens it, returns a handle that keeps
+// the connection warm. null when cwd is not a Knowl project — never throws for that case.
+
+export interface ProjectHandle {
+  lifecycle(event: NormalizedHostHook): Promise<LifecycleResult>;  // handleHostLifecycleEvent
+  query(text: string, opts?: { limit?: number }): Promise<QueryResult[]>;
+  store(atom: StoreInput): Promise<StoreResult>;
+  close(): Promise<void>;
+}
+```
+
+`normalizeHostHook(host, event, payload)` is exported alongside so a plugin builds a payload the
+engine already accepts, rather than reimplementing the shape.
+
+MCP is untouched and stays the channel for the other 33 tools. The library is the automatic
+lifecycle path plus the two tools a plugin offers in-process so a user need not run a second
+server — the same two Hermes bundles.
+
+### Packaging constraints
+
+- **`exports` must be additive.** Adding an `exports` map to a package that had none makes every
+  previously-reachable deep path unreachable. Enumerate what already resolves against `dist/`
+  before writing it, and include `"./package.json": "./package.json"` — omitting it is a known
+  papercut already recorded against `@knowl/ai-sdk`.
+- **`dependencies`, never `peerDependencies`.** OpenClaw installs plugins with
+  `npm install --omit=dev --omit=peer --legacy-peer-deps --ignore-scripts --no-audit --no-fund`
+  into `~/.openclaw/npm/projects/<encoded-package>` (`docs/plugins/dependency-resolution.md`). A
+  peer dependency would simply not be installed.
+- **`--ignore-scripts` is survived, not accidentally.** `tree-sitter@0.21.1` builds with
+  `prebuildify --napi --strip` and resolves at require time through `node-gyp-build` against
+  shipped `prebuilds/{darwin-arm64,darwin-x64,linux-x64,win32-x64}`; `libsql@0.5.29` receives its
+  binaries as ordinary per-platform `optionalDependencies` (`@libsql/win32-x64-msvc` and 8
+  siblings). Neither needs an install script. Any future native dependency that *downloads* a
+  binary in `postinstall` breaks this path.
+- **N-API, so no ABI risk.** Both native dependencies are N-API and therefore ABI-stable across
+  Node majors by contract, not compiled per `MODULE_VERSION`. The earlier concern was overstated.
+- **No competing SQLite addon.** OpenClaw uses Node's built-in `node:sqlite`
+  (`src/infra/node-sqlite.ts`, `src/cron/store/schema.ts`, `src/infra/kysely-sync.ts`), so libsql
+  is the only native SQLite addon in the process. Loading the two side by side remains unproven
+  and is a Task-1 verification, not an assumption.
+- **The engine cannot be bundled flat.** `tsup.config.ts` marks `libsql`, all four tree-sitter
+  packages and `@huggingface/transformers` external, and explains why: libsql reaches its binding
+  through a dynamic `require('@neon-rs/load')` that esbuild cannot follow, and bundling it fails at
+  runtime with *"Dynamic require of \"@neon-rs/load\" is not supported"*. The plugin ships as a
+  package with a dependency tree, not a single file.
+- **tree-sitter and embeddings stay lazy.** A plugin doing only lifecycle/query/store may never
+  load either, leaving libsql as the single native dependency actually in play.
+
+### Version skew, which is new
+
+Today Knowl is a program: one build owns the database. As an importable library it becomes a
+dependency users pin, so a plugin carrying engine 5.21 and a CLI at 5.30 can open the same SQLite
+file. The code anticipates this — `KNOWL_MIGRATION_LEVEL = 16`, `SchemaTooNewError`, and
+`src/store/bootstrap.ts:1243` reasoning explicitly about two builds sharing a file — but the case
+moves from rare to routine. Every future migration must stay honest about it, and
+`SchemaTooNewError` must surface through the plugin as a clean disable with a readable reason,
+never as a gateway crash.
+
+## Part 2 — the plugin
+
+### Shape
+
+`definePluginEntry` from `openclaw/plugin-sdk/plugin-entry`; `package.json` carries
+`openclaw.extensions: ["./index.ts"]` plus an `openclaw.plugin.json` manifest with
+`activation.onStartup`. `register(api)` is **synchronous** and registers every handler; handlers
+themselves may be async except the two synchronous persistence hooks. Plugin settings are read as
+`api.pluginConfig` inside the closure — not `event.context.pluginConfig`.
+
+Use `api.on(...)` for everything. `api.registerHook(...)` is a different internal system:
+registering a typed name there logs a warning and the typed runner never invokes it.
+
+### Both permission gates are required
+
+A non-bundled plugin needs `plugins.entries.knowl.hooks.allowConversationAccess: true` for
+`before_prompt_build`, `agent_turn_prepare`, `before_agent_finalize` and `agent_end`. Separately,
+`allowPromptInjection` (default allowed) gates `before_prompt_build`, `agent_turn_prepare`,
+`heartbeat_prompt_contribution` and durable next-turn injections. `before_prompt_build` needs
+**both**. Without them the plugin registers and silently does nothing — the failure mode to detect
+in `doctor`, not in a bug report.
+
+### Hook map
+
+| Hermes hook | OpenClaw hook | Kind | Notes |
+| --- | --- | --- | --- |
+| `pre_llm_call` | `before_prompt_build` | Modify | Returns `prependContext`. Fixed card only. |
+| `pre_tool_call` | `before_tool_call` | Gate | `{ block: true, blockReason }`. `opts.matcher` on canonical ids. |
+| `post_tool_call` | `after_tool_call` | Observe | Return ignored. Computes and caches the impact card. |
+| `transform_tool_result` | `tool_result_persist` | Sync | Returns `{ message }`. Reads the cache. |
+| `on_pre_compress` | `before_compaction` | Observe | Fire-and-forget checkpoint. |
+| `on_session_end` / `on_session_finalize` | `session_end`, `agent_end`, `gateway_stop` | Observe | `session_end.reason` ∈ new/reset/idle/daily/compaction/deleted/shutdown/restart/unknown. |
+
+`session_start` also exists (Observe) and binds the session.
+
+### The recall card, and the trap
+
+`before_prompt_build` receives the current prompt and session messages, and can return
+`prependContext`, `appendContext`, `systemPrompt`, `prependSystemContext`, `appendSystemContext`
+or `toolsAllow`. It is the obvious place to run a search on what the user just typed. **It must
+not.**
+
+That is exactly the defect PR #257 fixed one host over: Knowl's Hermes MemoryProvider took the
+user's literal sentence and ran `knowl query <sentence> --limit 5`, which is keyword search over
+conversational prose. `src/cli/agents/host-hook.ts` keeps prompt text out of the hook payload
+deliberately — only a derived `correctionSignal` boolean crosses — and the product's "never
+prompts, never transcripts" promise rests on that.
+
+So this hook emits the same fixed orientation card every other host gets: `turn-start` →
+`bootstrapWithHandoff` — the bound session, the pending handoff, recent project state, budget-
+capped. Prompt text may be *passed* as a signal (Hermes forwards it capped at 4000 chars) but
+never becomes the query string.
+
+**Exactly one hook may carry the card.** `before_prompt_build`, `agent_turn_prepare` and
+`heartbeat_prompt_contribution` are three surfaces onto the same slot; two of them publishing the
+same block is how the Hermes rules section appeared in the system prompt twice. This spec chooses
+`before_prompt_build` and the other two carry nothing.
+
+Ordering on embedded/CLI paths is: drain queued injections → `agent_turn_prepare` → heartbeat
+contribution → ordinary `before_prompt_build` → finalized tool policy → authorized prompt
+enrichment. `agent_turn_prepare` and injection draining are **not** wired into the Codex or
+Copilot prompt paths.
+
+`{ requiresToolAuthority: true }` moves the handler into a second post-policy phase with
+`ctx.toolAuthority`. Knowl's card is not tool-backed, so the ordinary phase is correct; noted
+because it is the right slot if retrieval ever must respect the turn's tool policy.
+
+### The impact card: async work, synchronous hook
+
+The one genuinely hard constraint. `tool_result_persist` returns `{ message }` to replace a tool
+result — the true counterpart of Hermes' `transform_tool_result` — but it is **synchronous**:
+"Do not make their handlers `async`: returned promises are ignored with a warning." Knowl's
+engine entry is async, so the card cannot be computed inside it.
+
+Therefore: `after_tool_call` (async, Observe) computes the card and writes it into a small
+per-`toolCallId` cache; `tool_result_persist` (sync) reads that cache and, on a hit, returns the
+message with the card appended to `content`. A miss returns nothing and the turn is unaffected.
+The cache is bounded and evicted on `session_end`.
+
+Two rules for the returned message:
+
+- Model-visible text goes in **`content`**, never only in `details`. OpenClaw strips
+  `toolResult.details` before provider replay and compaction, and caps persisted details
+  (`persistedDetailsTruncated: true`).
+- These hooks operate on OpenClaw-owned transcript writes and do **not** rewrite Codex-native tool
+  records.
+
+### The write veto
+
+`before_tool_call` returns `{ block: true, blockReason }`. `block: true` is terminal and skips
+lower-priority handlers; `block: false` is *no decision*, not an allow. `event.derivedPaths` gives
+best-effort target paths for well-known envelopes such as `apply_patch` — useful, but documented
+as possibly incomplete or over-approximate, so it is a hint and never the sole basis for a
+refusal.
+
+`opts.matcher` takes canonical tool ids (`exec`, `apply_patch`, `spawn_agent`); wildcards and
+blanks are invalid. This is the same "do not even start the work for a non-write" optimisation
+Knowl's `writeTools` matcher already makes.
+
+`requireApproval` is available and deliberately unused: Knowl's refusal is a policy answer, not a
+user prompt.
+
+Codex native tool relays support blocking and observation but **reject parameter rewrites**, so
+the veto must never depend on returning `params`.
+
+### Surfaces available here that Hermes has no equivalent for
+
+Out of scope for v1, recorded so they are not rediscovered:
+`api.session.workflow.enqueueNextTurnInjection(...)` for durable next-turn context (drained before
+prompt hooks, `idempotencyKey` dedupes, dropped when the plugin has prompt injection disabled),
+and `api.session.state.registerSessionExtension(...)` for plugin-owned session state projected
+into Control UI through `pluginExtensions`.
+
+## What ships
+
+- `exports` map and `src/plugin.ts` in this repo, plus tests that import the built artifact the
+  way a consumer will.
+- `integrations/openclaw/` — `package.json`, `openclaw.plugin.json`, `index.ts`.
+- `knowl init openclaw` — merges the plugin entry and both permission gates into `openclaw.json`,
+  never overwriting a user's file; reports a file it cannot parse instead of replacing it.
+- An `openclaw` `HostProfile` in `src/session/hosts/`, registered in `index.ts`, with capability
+  expressed by member presence rather than a boolean.
+
+## Verification
+
+Beyond `npm run build`, `npm test`, `npx eslint .`:
+
+1. **libsql loads beside `node:sqlite` in one process.** The single unproven native assumption.
+   Prove it before anything else.
+2. **The install path, not a link.** `openclaw plugins install npm-pack:<tgz>` — the documented way
+   to prove the managed package install shape, including `--ignore-scripts`. A `--link` install
+   does not exercise it.
+3. **`openclaw plugins inspect knowl --runtime --json`** shows every hook registered.
+4. **The card appears once.** Grep the built prompt for the rules block; two copies means the
+   double-publish bug.
+5. **The card is prompt-independent.** Two different prompts in the same session produce the same
+   orientation card. This is the regression test for #257, one host over.
+6. **A blocked write is refused and the reason reaches the model.**
+7. **Missing permission gates produce an actionable `doctor` line, not silence.**
+
+Default hybrid reload hot-reloads hook *policy*; code changes need a Gateway restart.

--- a/docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md
@@ -1,271 +1,329 @@
 # OpenClaw: an in-process plugin, and the library export it needs
 
-Date: 2026-09-05
+Date: 2026-09-05 (rewritten same day after adversarial review)
 Status: draft for review
-Supersedes: Tasks 4–6 of `docs/superpowers/plans/2026-09-03-harness-integrations.md`, which
-designed a Cline-style subprocess shell-out for OpenClaw.
+Supersedes: Tasks 4–6 of `docs/superpowers/plans/2026-09-03-harness-integrations.md`, and the
+first draft of this file at `347186d`, whose impact-card design was built on a misread hook.
 Governed by: constraint `6676fd41b5dc410c` — recall is the turn-start hook's fixed orientation
 card, never a query built from the user's prompt text.
-Depends on: nothing unbuilt. The engine exists; only its front door is missing.
+Requires: 5.21.1's `openProjectScope` (PR #258), without which this design corrupts data.
 
-## Why this is not the 2026-09-03 design
+## Why in-process
 
-That plan gave OpenClaw the same shape Cline and Hermes have: a small translator that spawns
-`knowl agent-hook <host> <event> --json` once per event and reads JSON off stdout.
+One argument, and it is the write gate.
 
-Hermes has that shape because it has no choice. Its plugin is Python — `subprocess.run`,
-`shutil.which("knowl.cmd")` at `integrations/hermes/knowl/__init__.py:233` — and Python cannot
-import TypeScript. The shell-out is its ceiling, not its design.
+`before_tool_call` is the only hook the agent **blocks on**. `handleHostLifecycleEvent` routes
+`tool-precheck` to `runWriteGate` before every tool call. Measured 2026-09-05:
 
-OpenClaw is TypeScript on Node, the same runtime Knowl is written in. Verified at source
-2026-09-05 (atom `35421756dd5c4dc1`): root `package.json` declares
-`engines.node: ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"`, `packageManager: pnpm@12.1.0`,
-`scripts.start: node openclaw.mjs`. `docs/install/bun.md` states plainly that "Node remains
-OpenClaw's primary, default, and recommended runtime"; Bun 1.4+ is an opt-in that additionally
-requires WAL-reset-safe `node:sqlite`, and `bun install` cannot resolve the repo's pnpm workspace
-at all. That engine range sits entirely inside Knowl's own `>=22`.
+| | subprocess | in-process |
+| --- | --- | --- |
+| write gate (real decision) | 118 ms | 0.68 ms |
+| non-write (nothing to decide) | 118 ms | 0.04 ms |
 
-Choosing the subprocess here would be adopting Hermes' limitation on purpose. Two things follow
-from being in-process, and neither is available to any subprocess plugin:
+The subprocess **cannot short-circuit**. It must boot Node, load the bundle and open SQLite
+before it can discover the tool was a `read` and answer "accepted". At a few hundred tool calls
+per session that is 20–25 seconds of latency sitting directly in front of the user, spent
+overwhelmingly on events that had nothing to decide. In-process, `toolWritesFile` returns before
+the database is touched.
 
-- **A returned value, not text.** `integrations/hermes/knowl/__init__.py:893` records the
-  limitation verbatim: Hermes "only reads a bare string here, which a subprocess cannot return."
-- **A warm database.** Measured on the maintainer's machine 2026-09-05: 187 ms median just to
-  spawn `node dist/index.js --version` (5 runs: 182/182/187/188/4739). That is the floor per hook
-  event, paid hundreds of times a session, before any work happens.
+Two arguments the first draft made, withdrawn:
 
-The cost is process isolation: an engine fault now lands inside OpenClaw's gateway. The plan's
-existing rule — *a hook failure must allow the action* — stops being defensive and becomes
-load-bearing. Every handler wraps its body and swallows.
+- **"187 ms per event."** That benchmarked `node dist/index.js --version`, a command nothing runs.
+  The real per-event cost through `agent-hook` is 118–120 ms, of which 36 ms is the bare `node -e 0`
+  process floor. In-process still pays ~32 ms of real capture work. The honest saving on the common
+  *background* event is ~88 ms, not 187 ms — worth having, not worth restructuring for.
+- **"A subprocess cannot return an object."** It can; `runAgentHook` already returns JSON on stdout.
+  The quote it rested on describes the shape of *Hermes'* Python hook API, not a property of
+  subprocesses. See "the impact card" below, where the premise collapsed entirely.
+
+**The cost.** Process isolation. An engine fault lands inside OpenClaw's gateway. libsql is a
+native addon; a segfault there takes the whole gateway with it, and no amount of try/catch
+prevents that. This is knowingly accepted, not mitigated.
+
+## The prerequisite that already shipped
+
+The first draft assumed independent per-project handles existed. They did not. `initDb()`
+overwrote a module-global context, so a gateway holding two workspaces wrote project A's rows into
+project B's file — silently, no error, no log. `closeDb()` on one handle tore down every other.
+
+Both were fixed in **5.21.1** (`openProjectScope` / `withProjectScope`, refcounted, releasing
+through `releaseClient`). Every handle method in this design runs inside a scope. Nothing here may
+call `initDb`, `initDbPath` or `closeDb` — those own the process-wide context and belong to the CLI.
+
+## Why not `registerMemoryCapability`
+
+OpenClaw ships two exclusive slots — `registerContextEngine(id, factory)` and
+`registerMemoryCapability(capability)` — and `sdk-overview.md` calls the latter "the exclusive
+memory-plugin API". A memory product for OpenClaw appears to belong there. It does not.
+
+**Exclusive means one active at a time.** Registering it would displace whatever the user already
+runs — `memory-core`, Honcho — and take ownership of recall, semantic search, promotion, dreaming
+and the memory runtime. Knowl does not do those jobs. Knowl holds a repository's engineering truth;
+their memory plugin holds the conversation. Displacing one with the other loses a capability the
+user chose and replaces it with something aimed at a different question.
+
+OpenClaw already documents the shape for this. `memory-wiki` is a bundled plugin that "does not
+replace the active memory plugin. Recall, promotion, indexing, and dreaming stay owned by the
+configured memory plugin… `memory-wiki` sits beside it." That is Knowl's position exactly.
+
+So: generic hooks, beside the memory plugin, displacing nothing. Recorded here because silence read
+as an oversight in review.
+
+Two adjacent slots deliberately not used, for the same reason plus one more:
+
+- **`registerTrustedToolPolicy`** — runs before ordinary `before_tool_call` and is documented for
+  "host-trusted gates such as workspace policy". Knowl's write gate is arguably that. Rejected for
+  v1: it requires `contracts.trustedToolPolicies` plus explicit enablement, and a memory tool
+  claiming a trusted policy tier before it has a track record is a bigger ask than the feature is
+  worth. Revisit if users report ordering conflicts.
+- **`registerMemoryPromptSupplement` / `registerMemoryPromptPreparation`** — purpose-built for
+  prompt text depending on async plugin state. Plausible carrier for the orientation card and worth
+  a spike, but it binds Knowl into the memory-plugin surface this section just declined.
 
 ## Part 1 — the library export
 
-### The problem, exactly
+### The problem
 
-`@dat999zx/knowl` has no library entry. `package.json` declares `bin: { knowl: "dist/index.js" }`
-and `main: "dist/index.js"`; `exports` is **undefined**. And `dist/index.js` is the CLI: `src/index.ts`
-opens `#!/usr/bin/env node` and its module body dispatches on `process.argv[2]` immediately. Importing
-it does not expose an API — it runs the CLI.
+`@dat999zx/knowl` has no library entry. `bin` and `main` both point at `dist/index.js`, `exports`
+is undefined, and `src/index.ts` is a `#!/usr/bin/env node` shebang that dispatches on
+`process.argv[2]` in its module body. Importing it runs the CLI.
 
-### The engine is already a library
+### What is already shared, and what is not
 
-This is not a refactor. `src/mcp/server.ts` already imports `initDb`, `getProjectByRootPath` and
-`registerTools` directly from core modules rather than shelling out; the CLI does the same. Both
-protocol surfaces are already thin adapters over a shared engine, which is what the project's
-"maintain thin protocol boundaries" goal asks for. The work is to name a front door, not to build
-one.
+`handleHostLifecycleEvent` (`src/session/host-lifecycle.ts:940`) really is one importable call
+returning `HostLifecycleResult`. `runAgentHook` is a thin shell around it: read stdin, resolve the
+project, delegate, print. For **lifecycle**, this is naming a door.
 
-`runAgentHook(host, event)` in `src/cli/agent-hook.ts` is itself a shell: it reads stdin, resolves
-the project (`findProjectRoot` → `assertKnowledgeDatabasePresent` → `initDb` →
-`getProjectByRootPath`), delegates to **`handleHostLifecycleEvent(project.id, normalized)`**, and
-prints JSON. Everything a host plugin needs is that one call; the stdin/stdout wrapper is the only
-thing the CLI adds.
+For **query and store it is not**, and the first draft was wrong to imply otherwise. There is no
+shared engine function: `src/mcp/tools.ts` holds ~330 lines of query logic — embedder construction,
+layered namespace reads, federation across linked repos, score calibration, foreign-item
+suppression — and `knowl_store` owns category validation, `assertOwnedTargets`, and namespace
+routing. A library `query()` either reimplements that (a second answer to ranking) or is
+deliberately dumber than `knowl_query`.
+
+**Decision: it is deliberately dumber, and says so.** The plugin's in-process `knowl_query` is a
+convenience so a user need not run a second server; anyone wanting federation and vector search
+runs the MCP server, which is unchanged and still carries all 36 tools. The plugin's tool
+description must say which it is.
 
 ### The surface
-
-Three entries. Parity is not reduced by keeping it small — the Hermes plugin, the most complete
-integration shipped, invokes exactly three CLI verbs across its 1,100 lines
-(`agent-hook` at :387, `query` at :445 and :1000, `store` at :1022) and nothing else.
 
 ```ts
 // @dat999zx/knowl  →  exports["./plugin"]
 export async function openProject(cwd: string): Promise<ProjectHandle | null>;
-// resolves the root, asserts the database exists, opens it, returns a handle that keeps
-// the connection warm. null when cwd is not a Knowl project — never throws for that case.
-
 export interface ProjectHandle {
-  lifecycle(event: NormalizedHostHook): Promise<LifecycleResult>;  // handleHostLifecycleEvent
+  lifecycle(event: NormalizedHostHook): Promise<LifecycleResult>;
   query(text: string, opts?: { limit?: number }): Promise<QueryResult[]>;
   store(atom: StoreInput): Promise<StoreResult>;
-  close(): Promise<void>;
+  release(): Promise<void>;   // releaseClient, never closeDb
+}
+export function normalizeHostHook(host, event, payload): NormalizedHostHook;
+export function readLifecyclePayloadObject(raw: unknown): LifecyclePayload;
+```
+
+Every method body runs inside `withProjectScope`. `release()` is per-handle.
+
+**`openProject` must not collapse two errors into one.** `runAgentHook` distinguishes them
+deliberately: `ProjectNotFoundError` is silent (not a Knowl repo — return `null`), while
+`MissingKnowledgeDatabaseError` still speaks up (your database vanished — throw). Returning bare
+`null` for both destroys the distinction `src/cli/database-presence.ts` exists to preserve.
+
+**`readLifecyclePayloadObject` is not optional.** Both existing in-process callers route raw
+payloads through `readLifecyclePayload` before normalising, and `hook-over-mcp.ts:118` says why:
+"it is the allowlist, and a second copy of it here would be a second answer to what a hook may
+carry." It enforces `ROOT_FIELDS`, `MAX_RETAINED_STRING=2000`, `MAX_RETAINED_ARRAY_ITEMS=50`.
+Exporting only the normaliser lets a plugin hand the engine arbitrary unbounded fields — including
+prompt text — which then reach `memory_session_events`, breaking the "never prompts, never
+transcripts" promise this spec invokes below. The existing function takes a stream, so the library
+needs an object-shaped equivalent.
+
+**`hook-over-mcp.ts` is the real precedent** for an in-process caller and the plugin should mirror
+two guards it already has: the self-call guard (skip the hook's own tool event) and the
+project-scope guard (ignore events whose cwd resolves to a sibling checkout).
+
+### The exports map is a breaking change
+
+Verified by experiment, not inspection: packing the repo and installing the tarball with OpenClaw's
+exact flags, `dist/index.js`, `dist/plugin.js`, `package.json` and
+`integrations/cline/knowl-plugin.mjs` all resolve today. A three-entry map breaks the last three
+with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+
+The casualty is real and documented: `integrations/cline/knowl-plugin.mjs` is the published Cline
+install path, named in `docs/hosts.md:138`, `docs/reference.md:2390` and `CHANGELOG.md:985`.
+
+Minimum non-breaking map, verified to restore all five paths:
+
+```json
+{
+  ".": "./dist/index.js",
+  "./plugin": "./dist/plugin.js",
+  "./package.json": "./package.json",
+  "./integrations/*": "./integrations/*",
+  "./dist/*": "./dist/*"
 }
 ```
 
-`normalizeHostHook(host, event, payload)` is exported alongside so a plugin builds a payload the
-engine already accepts, rather than reimplementing the shape.
+Keep `main` for old resolvers. The tsup change is just adding `src/plugin.ts` to `entry`; code
+splitting is already on, so the two entries share chunks and the CLI bundle is unaffected.
 
-MCP is untouched and stays the channel for the other 33 tools. The library is the automatic
-lifecycle path plus the two tools a plugin offers in-process so a user need not run a second
-server — the same two Hermes bundles.
+### Version skew
 
-### Packaging constraints
+Verified safe in both directions. An older engine on a newer schema fails cleanly before any
+migration touches the file (`assertSchemaSupported` runs at `bootstrap.ts:1261`). A newer migration
+level with the same schema version opens, writes, and correctly does not stamp the level down.
 
-- **`exports` must be additive.** Adding an `exports` map to a package that had none makes every
-  previously-reachable deep path unreachable. Enumerate what already resolves against `dist/`
-  before writing it, and include `"./package.json": "./package.json"` — omitting it is a known
-  papercut already recorded against `@knowl/ai-sdk`.
-- **`dependencies`, never `peerDependencies`.** OpenClaw installs plugins with
-  `npm install --omit=dev --omit=peer --legacy-peer-deps --ignore-scripts --no-audit --no-fund`
-  into `~/.openclaw/npm/projects/<encoded-package>` (`docs/plugins/dependency-resolution.md`). A
-  peer dependency would simply not be installed.
-- **`--ignore-scripts` is survived, not accidentally.** `tree-sitter@0.21.1` builds with
-  `prebuildify --napi --strip` and resolves at require time through `node-gyp-build` against
-  shipped `prebuilds/{darwin-arm64,darwin-x64,linux-x64,win32-x64}`; `libsql@0.5.29` receives its
-  binaries as ordinary per-platform `optionalDependencies` (`@libsql/win32-x64-msvc` and 8
-  siblings). Neither needs an install script. Any future native dependency that *downloads* a
-  binary in `postinstall` breaks this path.
-- **N-API, so no ABI risk.** Both native dependencies are N-API and therefore ABI-stable across
-  Node majors by contract, not compiled per `MODULE_VERSION`. The earlier concern was overstated.
-- **No competing SQLite addon.** OpenClaw uses Node's built-in `node:sqlite`
-  (`src/infra/node-sqlite.ts`, `src/cron/store/schema.ts`, `src/infra/kysely-sync.ts`), so libsql
-  is the only native SQLite addon in the process. Loading the two side by side remains unproven
-  and is a Task-1 verification, not an assumption.
-- **The engine cannot be bundled flat.** `tsup.config.ts` marks `libsql`, all four tree-sitter
-  packages and `@huggingface/transformers` external, and explains why: libsql reaches its binding
-  through a dynamic `require('@neon-rs/load')` that esbuild cannot follow, and bundling it fails at
-  runtime with *"Dynamic require of \"@neon-rs/load\" is not supported"*. The plugin ships as a
-  package with a dependency tree, not a single file.
-- **tree-sitter and embeddings stay lazy.** A plugin doing only lifecycle/query/store may never
-  load either, leaving libsql as the single native dependency actually in play.
+**But `SchemaTooNewError` cannot be the guard.** `KNOWL_SCHEMA_VERSION` has been bumped exactly once
+ever while `KNOWL_MIGRATION_LEVEL` has reached 16 — the guard has never fired in practice, and the
+policy is to bump the level. So the plugin reads `KNOWL_MIGRATION_LEVEL` off the file and disables
+itself with a readable reason when the file's level exceeds the bundled engine's.
 
-### Version skew, which is new
-
-Today Knowl is a program: one build owns the database. As an importable library it becomes a
-dependency users pin, so a plugin carrying engine 5.21 and a CLI at 5.30 can open the same SQLite
-file. The code anticipates this — `KNOWL_MIGRATION_LEVEL = 16`, `SchemaTooNewError`, and
-`src/store/bootstrap.ts:1243` reasoning explicitly about two builds sharing a file — but the case
-moves from rare to routine. Every future migration must stay honest about it, and
-`SchemaTooNewError` must surface through the plugin as a clean disable with a readable reason,
-never as a gateway crash.
+Separately: `initDbPath` catches every error and rethrows `DatabaseError`, so the
+`SchemaTooNewError` **class is lost at the library boundary**. Either preserve the cause or
+re-classify at the plugin entry — string-matching an error message is not an answer.
 
 ## Part 2 — the plugin
 
 ### Shape
 
 `definePluginEntry` from `openclaw/plugin-sdk/plugin-entry`; `package.json` carries
-`openclaw.extensions: ["./index.ts"]` plus an `openclaw.plugin.json` manifest with
-`activation.onStartup`. `register(api)` is **synchronous** and registers every handler; handlers
-themselves may be async except the two synchronous persistence hooks. Plugin settings are read as
-`api.pluginConfig` inside the closure — not `event.context.pluginConfig`.
+`openclaw.extensions` and an `openclaw.plugin.json` manifest with `activation.onStartup`.
+`register(api)` is synchronous. Use `api.on(...)` — `api.registerHook(...)` is a different internal
+system that warns and never fires for typed names. Settings come from `api.pluginConfig` inside the
+closure.
 
-Use `api.on(...)` for everything. `api.registerHook(...)` is a different internal system:
-registering a typed name there logs a warning and the typed runner never invokes it.
+**Dependencies, with one exception the first draft got backwards.** OpenClaw installs plugins with
+`npm install --omit=dev --omit=peer --legacy-peer-deps --ignore-scripts --no-audit --no-fund`, so
+ordinary dependencies must be real `dependencies`. But a plugin importing `openclaw/plugin-sdk/*`
+**must** declare `openclaw` as a `peerDependency`: OpenClaw refuses to install a second registry
+copy of the host and relinks `node_modules/openclaw` itself after install.
 
-### Both permission gates are required
+`--ignore-scripts` is survived because tree-sitter ships `prebuildify` prebuilds resolved at require
+time and libsql's binaries arrive as per-platform `optionalDependencies`. Any future dependency that
+*downloads* a binary in `postinstall` breaks this. Evaluate
+`openclaw.release.bundleRuntimeDependencies: false` — the documented opt-out native-heavy packages
+use so npm resolves per-platform binaries at install time.
 
-A non-bundled plugin needs `plugins.entries.knowl.hooks.allowConversationAccess: true` for
-`before_prompt_build`, `agent_turn_prepare`, `before_agent_finalize` and `agent_end`. Separately,
-`allowPromptInjection` (default allowed) gates `before_prompt_build`, `agent_turn_prepare`,
-`heartbeat_prompt_contribution` and durable next-turn injections. `before_prompt_build` needs
-**both**. Without them the plugin registers and silently does nothing — the failure mode to detect
-in `doctor`, not in a bug report.
+### Permissions
+
+`before_prompt_build` needs **both** `allowConversationAccess` (non-bundled plugins) and
+`allowPromptInjection`.
+
+**Missing them is not silent** — the first draft said it was. OpenClaw rejects the registration and
+records a `warn` diagnostic, surfaced by `openclaw plugins inspect <id> --runtime --json`. So the
+plugin ships no bespoke doctor line; `knowl init openclaw` writes both gates and the troubleshooting
+step is the host's existing command.
 
 ### Hook map
 
-| Hermes hook | OpenClaw hook | Kind | Notes |
+| Hermes | OpenClaw | Kind | Note |
 | --- | --- | --- | --- |
-| `pre_llm_call` | `before_prompt_build` | Modify | Returns `prependContext`. Fixed card only. |
-| `pre_tool_call` | `before_tool_call` | Gate | `{ block: true, blockReason }`. `opts.matcher` on canonical ids. |
-| `post_tool_call` | `after_tool_call` | Observe | Return ignored. Computes and caches the impact card. |
-| `transform_tool_result` | `tool_result_persist` | Sync | Returns `{ message }`. Reads the cache. |
-| `on_pre_compress` | `before_compaction` | Observe | Fire-and-forget checkpoint. |
-| `on_session_end` / `on_session_finalize` | `session_end`, `agent_end`, `gateway_stop` | Observe | `session_end.reason` ∈ new/reset/idle/daily/compaction/deleted/shutdown/restart/unknown. |
+| `pre_llm_call` | `before_prompt_build` | Modify | `prependContext`, fixed card only |
+| `pre_tool_call` | `before_tool_call` | Gate | `{ block, blockReason }`, `matcher` on canonical ids |
+| `transform_tool_result` | **`registerAgentToolResultMiddleware`** | async | see below |
+| `post_tool_call` | `after_tool_call` | Observe | capture |
+| `on_pre_compress` | `before_compaction` | Observe | **bounded**, see below |
+| session end | `session_end`, `agent_end`, `gateway_stop` | Observe | 2 s total drain budget |
+| — | `session_start`, `before_reset` | Observe | bind / rebind |
 
-`session_start` also exists (Observe) and binds the session.
+### The impact card — the first draft was wrong
+
+It mapped `transform_tool_result` onto `tool_result_persist` and then built an elaborate
+async-precompute-plus-sync-cache workaround around that hook's synchronicity. **The premise was
+false.** `tool_result_persist` rewrites the *transcript* copy of a tool result, not the copy the
+model reads in the current run: its output feeds `appendMessageAndCacheTranscriptSeq(...)` while the
+model's live context is a separate in-memory array. The card would have reached the model on a later
+turn's replay, if ever. The one shipped consumer uses it to redact secrets from persistence.
+
+The correct seam is **`api.registerAgentToolResultMiddleware(...)`** — "for async tool-result
+transforms that must run before OpenClaw or Codex feeds tool output back into the model." It is
+async and runtime-neutral, so the entire cache workaround is deleted. Cost: declare
+`contracts.agentToolResultMiddleware` and require explicit enablement.
+
+Model-visible text still goes in `content`, never only `details` — OpenClaw strips `details` before
+provider replay and compaction.
 
 ### The recall card, and the trap
 
-`before_prompt_build` receives the current prompt and session messages, and can return
-`prependContext`, `appendContext`, `systemPrompt`, `prependSystemContext`, `appendSystemContext`
-or `toolsAllow`. It is the obvious place to run a search on what the user just typed. **It must
-not.**
+`before_prompt_build` emits the fixed orientation card: `turn-start` → `bootstrapWithHandoff` —
+bound session, pending handoff, recent state, budget-capped. It must **never** build a query from
+the prompt. That is the defect PR #257 fixed on Hermes: the provider slot took the user's literal
+sentence and keyword-searched it. Prompt text may be passed as a signal; it never becomes the query.
 
-That is exactly the defect PR #257 fixed one host over: Knowl's Hermes MemoryProvider took the
-user's literal sentence and ran `knowl query <sentence> --limit 5`, which is keyword search over
-conversational prose. `src/cli/agents/host-hook.ts` keeps prompt text out of the hook payload
-deliberately — only a derived `correctionSignal` boolean crosses — and the product's "never
-prompts, never transcripts" promise rests on that.
+`before_prompt_build`, `agent_turn_prepare` and `heartbeat_prompt_contribution` are three
+independent hooks, not one slot — but their context additions **concatenate in priority order**, so
+two publishers duplicate. This spec uses `before_prompt_build` alone. (`heartbeat_prompt_contribution`
+fires only on heartbeat turns, so it cannot double on an ordinary user turn — but it can on a
+heartbeat.)
 
-So this hook emits the same fixed orientation card every other host gets: `turn-start` →
-`bootstrapWithHandoff` — the bound session, the pending handoff, recent project state, budget-
-capped. Prompt text may be *passed* as a signal (Hermes forwards it capped at 4000 chars) but
-never becomes the query string.
+### The write gate, and the safety contract the first draft had backwards
 
-**Exactly one hook may carry the card.** `before_prompt_build`, `agent_turn_prepare` and
-`heartbeat_prompt_contribution` are three surfaces onto the same slot; two of them publishing the
-same block is how the Hermes rules section appeared in the system prompt twice. This spec chooses
-`before_prompt_build` and the other two carry nothing.
+`before_tool_call` returns `{ block: true, blockReason }`. `block: true` is terminal;
+`block: false` is **no decision**, not an allow. `blockReason` does reach the model — it becomes the
+blocked tool result's text content.
 
-Ordering on embedded/CLI paths is: drain queued injections → `agent_turn_prepare` → heartbeat
-contribution → ordinary `before_prompt_build` → finalized tool policy → authorized prompt
-enrichment. `agent_turn_prepare` and injection draining are **not** wired into the Codex or
-Copilot prompt paths.
+**The plan's rule "a hook failure must allow the action" is not OpenClaw's contract.**
+`before_tool_call` is documented **fail-closed** on a 15-second budget: throw or exceed it and the
+user's write is *blocked*. Worse, a timed-out handler keeps running — hook callbacks get no
+cancellation signal. A cold libsql open or a first-call migration crossing 15 s would deny writes
+while the work continues.
 
-`{ requiresToolAuthority: true }` moves the handler into a second post-policy phase with
-`ctx.toolAuthority`. Knowl's card is not tool-backed, so the ordinary phase is correct; noted
-because it is the right slot if retrieval ever must respect the turn's tool policy.
+Therefore:
 
-### The impact card: async work, synchronous hook
+- The gate handler carries its **own internal deadline**, well under 15 s, and answers "accepted" on
+  its own timeout rather than letting the host's fail-closed budget decide.
+- `knowl init openclaw` writes an explicit `plugins.entries.knowl.hooks.timeouts.before_tool_call`
+  rather than inheriting the default.
+- First open is warmed at `session_start`, not lazily inside the gate.
 
-The one genuinely hard constraint. `tool_result_persist` returns `{ message }` to replace a tool
-result — the true counterpart of Hermes' `transform_tool_result` — but it is **synchronous**:
-"Do not make their handlers `async`: returned promises are ignored with a warning." Knowl's
-engine entry is async, so the card cannot be computed inside it.
+`event.derivedPaths` is documented as possibly incomplete or over-approximate — a hint, never the
+sole basis for a refusal. Codex relays **reject** parameter rewrites and fail closed when one is
+attempted, so the gate must never return `params`.
 
-Therefore: `after_tool_call` (async, Observe) computes the card and writes it into a small
-per-`toolCallId` cache; `tool_result_persist` (sync) reads that cache and, on a hit, returns the
-message with the card appended to `content`. A miss returns nothing and the turn is unaffected.
-The cache is bounded and evicted on `session_end`.
+### Two host budgets that constrain the observers
 
-Two rules for the returned message:
+- **`before_compaction` carries a 30 s per-handler timeout**, and in the Codex harness runs on the
+  serialized notification queue where a hung handler "freezes every later codex notification —
+  including `turn/completed`". The checkpoint must be bounded, not merely fire-and-forget.
+- **`session_end` has a 2-second *total* drain budget** shared across all sessions and handlers.
+  Anything that must survive belongs in the write path, not a flush at the end.
 
-- Model-visible text goes in **`content`**, never only in `details`. OpenClaw strips
-  `toolResult.details` before provider replay and compaction, and caps persisted details
-  (`persistedDetailsTruncated: true`).
-- These hooks operate on OpenClaw-owned transcript writes and do **not** rewrite Codex-native tool
-  records.
+### No handler may float a promise
 
-### The write veto
+`before_compaction` and `after_tool_call` ignore return values, which invites fire-and-forget. A
+floated rejection escapes the enclosing try/catch and Node's default `--unhandled-rejections=throw`
+kills the gateway. Every handler awaits its own work inside its own try/catch, or pushes onto an
+explicitly drained queue with a terminal `.catch()`.
 
-`before_tool_call` returns `{ block: true, blockReason }`. `block: true` is terminal and skips
-lower-priority handlers; `block: false` is *no decision*, not an allow. `event.derivedPaths` gives
-best-effort target paths for well-known envelopes such as `apply_patch` — useful, but documented
-as possibly incomplete or over-approximate, so it is a hint and never the sole basis for a
-refusal.
-
-`opts.matcher` takes canonical tool ids (`exec`, `apply_patch`, `spawn_agent`); wildcards and
-blanks are invalid. This is the same "do not even start the work for a non-write" optimisation
-Knowl's `writeTools` matcher already makes.
-
-`requireApproval` is available and deliberately unused: Knowl's refusal is a policy answer, not a
-user prompt.
-
-Codex native tool relays support blocking and observation but **reject parameter rewrites**, so
-the veto must never depend on returning `params`.
-
-### Surfaces available here that Hermes has no equivalent for
-
-Out of scope for v1, recorded so they are not rediscovered:
-`api.session.workflow.enqueueNextTurnInjection(...)` for durable next-turn context (drained before
-prompt hooks, `idempotencyKey` dedupes, dropped when the plugin has prompt injection disabled),
-and `api.session.state.registerSessionExtension(...)` for plugin-owned session state projected
-into Control UI through `pluginExtensions`.
+The plugin must **not** install a process-level `unhandledRejection` listener. Silently changing
+crash policy inside someone else's gateway is worse than the defect it hides.
 
 ## What ships
 
-- `exports` map and `src/plugin.ts` in this repo, plus tests that import the built artifact the
-  way a consumer will.
+- `exports` map (with the wildcards above) and `src/plugin.ts`, tested by importing the built
+  artifact the way a consumer will.
 - `integrations/openclaw/` — `package.json`, `openclaw.plugin.json`, `index.ts`.
-- `knowl init openclaw` — merges the plugin entry and both permission gates into `openclaw.json`,
-  never overwriting a user's file; reports a file it cannot parse instead of replacing it.
-- An `openclaw` `HostProfile` in `src/session/hosts/`, registered in `index.ts`, with capability
-  expressed by member presence rather than a boolean.
+- `knowl init openclaw` — merges the plugin entry, both permission gates, and the
+  `before_tool_call` timeout into `openclaw.json`, never overwriting a user's file.
+- An `openclaw` `HostProfile` in `src/session/hosts/`.
 
 ## Verification
 
 Beyond `npm run build`, `npm test`, `npx eslint .`:
 
-1. **libsql loads beside `node:sqlite` in one process.** The single unproven native assumption.
-   Prove it before anything else.
-2. **The install path, not a link.** `openclaw plugins install npm-pack:<tgz>` — the documented way
-   to prove the managed package install shape, including `--ignore-scripts`. A `--link` install
-   does not exercise it.
-3. **`openclaw plugins inspect knowl --runtime --json`** shows every hook registered.
-4. **The card appears once.** Grep the built prompt for the rules block; two copies means the
-   double-publish bug.
-5. **The card is prompt-independent.** Two different prompts in the same session produce the same
-   orientation card. This is the regression test for #257, one host over.
-6. **A blocked write is refused and the reason reaches the model.**
-7. **Missing permission gates produce an actionable `doctor` line, not silence.**
+1. **libsql loads beside OpenClaw's built-in `node:sqlite` in one process** — the only unproven
+   native assumption. Must cover both addons holding the same directory under WAL, not just module
+   load. Gates everything else.
+2. **Install via `openclaw plugins install npm-pack:<tgz>`**, not `--link` — only that path
+   exercises the real `--ignore-scripts` managed install.
+3. **`openclaw plugins inspect knowl --runtime --json`** shows every hook registered and no blocked
+   registrations.
+4. **The card appears once** in the built prompt.
+5. **The card is prompt-independent** — two different prompts in one session produce the same card.
+   The regression test for #257, one host over.
+6. **A blocked write is refused and `blockReason` reaches the model.**
+7. **Two workspaces open in one gateway** write to their own databases. The 5.21.1 regression, at
+   the plugin layer.
+8. **A stalled engine does not deny a write** — the internal deadline fires before the host's
+   fail-closed budget.
 
-Default hybrid reload hot-reloads hook *policy*; code changes need a Gateway restart.
+Hybrid reload hot-reloads hook policy; code changes need a Gateway restart.

--- a/docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md
@@ -310,9 +310,16 @@ crash policy inside someone else's gateway is worse than the defect it hides.
 
 Beyond `npm run build`, `npm test`, `npx eslint .`:
 
-1. **libsql loads beside OpenClaw's built-in `node:sqlite` in one process** — the only unproven
-   native assumption. Must cover both addons holding the same directory under WAL, not just module
-   load. Gates everything else.
+1. ~~**libsql loads beside OpenClaw's built-in `node:sqlite` in one process**~~ — **DONE
+   2026-09-05, passed.** Node 24.15.0, knowl 5.21.1 from the registry, `node:sqlite` opened first
+   and held open throughout. Both engines opened their own databases in one directory under WAL
+   (51 interleaved writes each, both intact) and then **the same file**, each seeing the other's
+   row, sidecars correct. Against the real `knowl init` store: 37 tables read, `journal_mode=wal`,
+   200 interleaved gateway-writes + engine-reads in 247 ms, a row written and read back while
+   `node:sqlite` held its own. `tree-sitter` loaded in the same process, and an external `knowl`
+   CLI ran against the same repo concurrently. Clean shutdown.
+   This does **not** prove a libsql *abort* is survivable — a segfault still takes the gateway, and
+   that remains the accepted cost.
 2. **Install via `openclaw plugins install npm-pack:<tgz>`**, not `--link` — only that path
    exercises the real `--ignore-scripts` managed install.
 3. **`openclaw plugins inspect knowl --runtime --json`** shows every hook registered and no blocked

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,86 @@
+# Knowl for OpenClaw
+
+Knowl's repository memory and write gate, running **inside** OpenClaw's gateway rather than as a
+subprocess per lifecycle event.
+
+`before_tool_call` is the only hook the agent blocks on, and it is the reason this plugin is
+in-process: a subprocess pays ~118 ms on *every* tool call because it must boot Node, load the
+bundle and open SQLite before it can even discover the tool was a read. In-process the same gate
+answers in ~0.68 ms, or ~0.04 ms when the tool is not a write at all.
+
+## Install
+
+```bash
+knowl init openclaw
+```
+
+That merges the plugin entry into `openclaw.json` along with both required permission gates
+(`allowConversationAccess`, `allowPromptInjection`) and an explicit
+`timeouts.before_tool_call`, preserving any surrounding configuration.
+
+To install a local build instead:
+
+```bash
+npm pack                     # from this directory — see the warning below
+openclaw plugins install --force npm-pack:/abs/path/to/dat999zx-knowl-openclaw-plugin-<v>.tgz
+openclaw plugins enable knowl
+openclaw plugins inspect knowl --runtime --json    # every hook registered, no blocked registrations
+```
+
+`--force` is required because a local archive sits outside ClawHub trust metadata. The path must be
+absolute and forward-slashed.
+
+## Building — read before publishing
+
+**OpenClaw refuses a plugin that ships TypeScript source.** A managed npm install requires compiled
+runtime output (`./dist/index.js`); TS source is only accepted for local development checkouts. So
+`openclaw.extensions` points at `dist/`, never `src/`.
+
+The compile runs in `prepack`, deliberately: OpenClaw's managed installer runs `npm install
+--ignore-scripts`, so the build cannot happen at install time on the user's machine. It has to be
+baked into the tarball.
+
+**The trap that follows from that:** `npm pack --ignore-scripts` skips `prepack` and produces a
+tarball containing only `package.json` and `openclaw.plugin.json` — two files, no code, and no
+error. Always run a plain `npm pack`, and check the file count is 8, not 2:
+
+```bash
+npm pack && tar -tzf *.tgz | grep dist/index.js
+```
+
+## Dependencies, and why they look inverted
+
+- `@dat999zx/knowl` is a real **dependency**, not a peer: OpenClaw's managed install runs
+  `--omit=peer`, so a peer would simply not be installed.
+- `openclaw` is a **peerDependency**: the host refuses to install a second registry copy of itself
+  and relinks its own `node_modules/openclaw` after install.
+- `openclaw.release.bundleRuntimeDependencies` is `false` because Knowl carries native addons
+  (libsql, tree-sitter) whose per-platform binaries must be resolved by npm at install time.
+
+## Hooks
+
+| Hook | Purpose |
+| --- | --- |
+| `before_prompt_build` | The fixed orientation card. **The only recall channel.** |
+| `before_tool_call` | The write gate, matched to `exec` / `apply_patch` / `spawn_agent`. |
+| `registerAgentToolResultMiddleware` | The impact card, injected before the model sees tool output. |
+| `after_tool_call` | Capture. |
+| `before_compaction` | Checkpoint before the conversation is compressed. |
+| `session_start` / `session_end` / `agent_end` / `gateway_stop` | Bind, close, release. |
+
+Three of these carry constraints that are not obvious from the catalog:
+
+- **Recall never reads the prompt.** `before_prompt_build` emits a *fixed* orientation card. Building
+  a query from the user's sentence is the defect fixed in knowl#257 on another host, and the
+  "never prompts, never transcripts" promise depends on it not recurring here.
+- **Exactly one hook publishes the card.** `agent_turn_prepare` and `heartbeat_prompt_contribution`
+  return the same field names and their contributions *concatenate* — two publishers duplicate the
+  block in the prompt.
+- **`before_tool_call` is fail-closed.** If the handler throws or exceeds OpenClaw's 15-second
+  budget, the user's write is *blocked*. The gate therefore carries its own 5-second deadline whose
+  fallback is **accept**, and the first database open is warmed at `session_start` rather than
+  lazily inside the gate. A stalled or broken Knowl must never deny a write.
+
+The impact card writes into `content`, never only `details`, because OpenClaw strips `details`
+before provider replay and compaction. It does **not** use `tool_result_persist`, which rewrites
+only the transcript copy and would be invisible to the model in the turn that earned it.

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "knowl",
+  "name": "Knowl",
+  "description": "Persistent repository memory and write gate for OpenClaw.",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "agentToolResultMiddleware": [
+      "openclaw",
+      "codex"
+    ]
+  }
+}

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -6,9 +6,60 @@
     "onStartup": true
   },
   "contracts": {
-    "agentToolResultMiddleware": [
-      "openclaw",
-      "codex"
-    ]
+    "agentToolResultMiddleware": ["openclaw", "codex"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "gateDeadlineMs": {
+        "type": "integer",
+        "minimum": 250,
+        "maximum": 14000
+      },
+      "observerDeadlineMs": {
+        "type": "integer",
+        "minimum": 250,
+        "maximum": 29000
+      },
+      "recall": {
+        "type": "boolean"
+      },
+      "writeGate": {
+        "type": "boolean"
+      },
+      "impactCard": {
+        "type": "boolean"
+      }
+    }
+  },
+  "uiHints": {
+    "enabled": {
+      "label": "Knowl Memory",
+      "help": "Enable or pause every Knowl hook. When off the gateway keeps running with no memory card, no write gate and no capture."
+    },
+    "gateDeadlineMs": {
+      "label": "Write Gate Deadline (ms)",
+      "help": "How long the write gate waits for Knowl before allowing the tool call anyway. Default 5000. Capped below OpenClaw's 15s before_tool_call budget on purpose: that budget is FAIL-CLOSED, so a Knowl that hangs past it would block your write. Hitting this deadline allows the call instead."
+    },
+    "observerDeadlineMs": {
+      "label": "Observer Deadline (ms)",
+      "help": "Budget for the non-blocking hooks: capture after a tool call, and the checkpoint before compaction. Default 10000, held under OpenClaw's 30s per-handler compaction timeout."
+    },
+    "recall": {
+      "label": "Recall Card",
+      "help": "Prepend the project orientation card at the start of each turn: bound session, pending handoff, recent decisions. The card is fixed for the session and is never a search built from your prompt."
+    },
+    "writeGate": {
+      "label": "Write Gate",
+      "help": "Let Knowl refuse a write that contradicts recorded project knowledge. Applies to exec, apply_patch and spawn_agent. A refusal carries its reason back to the model."
+    },
+    "impactCard": {
+      "label": "Impact Card",
+      "help": "After a file is written, append what Knowl knows about that file to the tool result, so the model sees it in the same turn rather than the next one."
+    }
   }
 }

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dat999zx/knowl-openclaw-plugin",
+  "version": "5.21.1",
+  "description": "Knowl persistent repository memory and write gate plugin for OpenClaw",
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@dat999zx/knowl": "5.21.1"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.9.1"
+  },
+  "openclaw": {
+    "extensions": [
+      "./src/index.ts"
+    ],
+    "release": {
+      "bundleRuntimeDependencies": false
+    }
+  }
+}

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -3,16 +3,29 @@
   "version": "5.21.1",
   "description": "Knowl persistent repository memory and write gate plugin for OpenClaw",
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
+  },
   "dependencies": {
     "@dat999zx/knowl": "5.21.1"
   },
   "peerDependencies": {
     "openclaw": ">=2026.9.1"
   },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  },
   "openclaw": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ],
     "release": {
       "bundleRuntimeDependencies": false

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,31 +1,19 @@
 {
   "name": "@dat999zx/knowl-openclaw-plugin",
   "version": "5.21.1",
+  "private": true,
   "description": "Knowl persistent repository memory and write gate plugin for OpenClaw",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "openclaw.plugin.json",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "prepack": "npm run build"
-  },
+  "main": "./src/index.ts",
   "dependencies": {
-    "@dat999zx/knowl": "5.21.1"
+    "@dat999zx/knowl": "*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.9.1"
   },
-  "devDependencies": {
-    "typescript": "^5.7.2"
-  },
   "openclaw": {
     "extensions": [
-      "./dist/index.js"
+      "./src/index.ts"
     ],
     "release": {
       "bundleRuntimeDependencies": false

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -1,0 +1,202 @@
+import { createClient } from '@libsql/client';
+import {
+  openProject,
+  KNOWL_MIGRATION_LEVEL,
+  type ProjectHandle,
+} from '@dat999zx/knowl/plugin';
+
+export interface HostLogger {
+  warn(message: string, ...args: unknown[]): void;
+  error?(message: string, ...args: unknown[]): void;
+  info?(message: string, ...args: unknown[]): void;
+  debug?(message: string, ...args: unknown[]): void;
+}
+
+export const DEFAULT_GATE_DEADLINE_MS = 5_000;
+export const DEFAULT_OBSERVER_DEADLINE_MS = 10_000;
+
+/**
+ * Run an async operation bounded by a deadline.
+ *
+ * If the operation does not finish within `ms`, `fallback` is returned.
+ * Used by the write gate so a slow or stalled engine never blocks a user's
+ * write under OpenClaw's 15-second fail-closed host budget.
+ */
+export async function withDeadline<T>(
+  ms: number,
+  work: () => Promise<T>,
+  fallback: T,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timer = setTimeout(() => {
+      onTimeout?.();
+      resolve(fallback);
+    }, ms);
+  });
+
+  try {
+    return await Promise.race([
+      work().then((result) => {
+        if (timer) clearTimeout(timer);
+        return result;
+      }),
+      timeoutPromise,
+    ]);
+  } catch (error) {
+    if (timer) clearTimeout(timer);
+    throw error;
+  }
+}
+
+/**
+ * Execute an async operation safely without floating promises or leaking rejections.
+ *
+ * Node's default --unhandled-rejections=throw will terminate the gateway if an unhandled
+ * rejection escapes. Every hook handler must await inside its own try/catch.
+ * `safely` guarantees that any failure is logged through the host logger and swallowed,
+ * returning `fallback` instead of rethrowing.
+ */
+export async function safely<T>(
+  work: () => Promise<T>,
+  logger?: HostLogger,
+  fallback?: T,
+): Promise<T | undefined> {
+  try {
+    return await work();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (logger?.warn) {
+      logger.warn(`[knowl] Swallowed engine failure: ${message}`, err);
+    } else {
+      console.warn(`[knowl] Swallowed engine failure: ${message}`);
+    }
+    return fallback;
+  }
+}
+
+/**
+ * Check the database's migration level (application_id).
+ *
+ * Returns true if the file is supported (level <= KNOWL_MIGRATION_LEVEL),
+ * or false with the found level if the file was written by a newer Knowl version.
+ */
+export async function checkMigrationLevel(
+  dbPath: string,
+): Promise<{ supported: boolean; found: number; maxSupported: number }> {
+  const client = createClient({ url: `file:${dbPath}` });
+  try {
+    const res = await client.execute('PRAGMA application_id');
+    const found = Number(res.rows[0]?.application_id ?? 0);
+    return {
+      supported: found <= KNOWL_MIGRATION_LEVEL,
+      found,
+      maxSupported: KNOWL_MIGRATION_LEVEL,
+    };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Manages project handles across multiple workspaces in an in-process OpenClaw gateway.
+ *
+ * Handles are keyed by resolved project root.
+ * Workspaces are warmed at `session_start` so the first write gate never pays cold initialization.
+ * Handles are cleanly released on `gateway_stop` without calling `closeDb()`.
+ */
+export class OpenClawEngineManager {
+  private handles = new Map<string, ProjectHandle>();
+  private disabledRoots = new Map<string, string>();
+  private logger?: HostLogger;
+  private gateDeadlineMs: number;
+
+  constructor(options: { logger?: HostLogger; gateDeadlineMs?: number } = {}) {
+    this.logger = options.logger;
+    this.gateDeadlineMs = options.gateDeadlineMs ?? DEFAULT_GATE_DEADLINE_MS;
+  }
+
+  isDisabled(projectRoot: string): boolean {
+    return this.disabledRoots.has(projectRoot);
+  }
+
+  getDisabledReason(projectRoot: string): string | undefined {
+    return this.disabledRoots.get(projectRoot);
+  }
+
+  async getHandle(cwd: string): Promise<ProjectHandle | null> {
+    const cached = Array.from(this.handles.values()).find((h) => cwd.startsWith(h.projectRoot));
+    if (cached) return cached;
+    return await this.warmWorkspace(cwd);
+  }
+
+  async warmWorkspace(cwd: string): Promise<ProjectHandle | null> {
+    if (this.disabledRoots.has(cwd)) {
+      return null;
+    }
+
+    let handle: ProjectHandle | null;
+    try {
+      handle = await openProject(cwd);
+    } catch (err: unknown) {
+      this.logger?.warn?.(`[knowl] Failed to open project at ${cwd}: ${err}`);
+      return null;
+    }
+
+    if (!handle) return null;
+
+    const root = handle.projectRoot;
+    if (this.disabledRoots.has(root)) {
+      await handle.release();
+      return null;
+    }
+
+    if (this.handles.has(root)) {
+      await handle.release();
+      return this.handles.get(root)!;
+    }
+
+    // Check migration level of the opened database
+    try {
+      const migration = await checkMigrationLevel(handle.databasePath);
+      if (!migration.supported) {
+        const reason =
+          `The knowledge database at "${handle.databasePath}" has migration level ${migration.found}, ` +
+          `which is newer than this plugin supports (max level ${migration.maxSupported}). ` +
+          `Please upgrade the Knowl plugin.`;
+        this.disabledRoots.set(root, reason);
+        this.logger?.warn?.(`[knowl] Disabling plugin for workspace ${root}: ${reason}`);
+        await handle.release();
+        return null;
+      }
+    } catch (err: unknown) {
+      this.logger?.warn?.(`[knowl] Could not verify migration level for ${handle.databasePath}: ${err}`);
+    }
+
+    this.handles.set(root, handle);
+    return handle;
+  }
+
+  async releaseWorkspace(cwd: string): Promise<void> {
+    const matching = Array.from(this.handles.entries()).filter(
+      ([root]) => cwd === root || cwd.startsWith(root),
+    );
+    for (const [root, handle] of matching) {
+      this.handles.delete(root);
+      await safely(() => handle.release(), this.logger);
+    }
+  }
+
+  async releaseAll(): Promise<void> {
+    const all = Array.from(this.handles.values());
+    this.handles.clear();
+    for (const handle of all) {
+      await safely(() => handle.release(), this.logger);
+    }
+  }
+
+  getGateDeadlineMs(): number {
+    return this.gateDeadlineMs;
+  }
+}

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -111,10 +111,12 @@ export class OpenClawEngineManager {
   private disabledRoots = new Map<string, string>();
   private logger?: HostLogger;
   private gateDeadlineMs: number;
+  private observerDeadlineMs: number;
 
-  constructor(options: { logger?: HostLogger; gateDeadlineMs?: number } = {}) {
+  constructor(options: { logger?: HostLogger; gateDeadlineMs?: number; observerDeadlineMs?: number } = {}) {
     this.logger = options.logger;
     this.gateDeadlineMs = options.gateDeadlineMs ?? DEFAULT_GATE_DEADLINE_MS;
+    this.observerDeadlineMs = options.observerDeadlineMs ?? DEFAULT_OBSERVER_DEADLINE_MS;
   }
 
   isDisabled(projectRoot: string): boolean {
@@ -198,5 +200,9 @@ export class OpenClawEngineManager {
 
   getGateDeadlineMs(): number {
     return this.gateDeadlineMs;
+  }
+
+  getObserverDeadlineMs(): number {
+    return this.observerDeadlineMs;
   }
 }

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -5,6 +5,30 @@ import { OpenClawEngineManager, safely, withDeadline } from './engine.js';
 
 export { OpenClawEngineManager, safely, withDeadline };
 
+/**
+ * The workspace a hook event belongs to.
+ *
+ * OpenClaw's hook contexts do not all carry a directory: `PluginHookGatewayContext` and
+ * `PluginHookAgentContext` declare `workspaceDir`, but `PluginHookToolContext` and
+ * `PluginHookSessionContext` do not -- they identify a run by `sessionKey`/`agentId` and
+ * nothing else. Reading `ctx.workspaceDir` unconditionally therefore type-errors on half
+ * the hooks and, worse, silently falls through to `process.cwd()` at runtime, which in a
+ * gateway holding several workspaces is whichever directory the gateway happens to be in.
+ *
+ * So the event is asked first (it carries `cwd` on the hooks that know one), the context
+ * second, and `process.cwd()` last -- and the caller decides what an unresolvable workspace
+ * means. `getHandle` answers `null` for a directory that is not a Knowl project, so a wrong
+ * guess degrades to "no memory this turn" rather than to another project's database.
+ */
+function resolveWorkspace(event: unknown, ctx: unknown): string {
+  const fromEvent = (event as { cwd?: unknown } | undefined)?.cwd;
+  if (typeof fromEvent === 'string' && fromEvent) return fromEvent;
+  const c = ctx as { workspaceDir?: unknown; cwd?: unknown } | undefined;
+  if (typeof c?.workspaceDir === 'string' && c.workspaceDir) return c.workspaceDir;
+  if (typeof c?.cwd === 'string' && c.cwd) return c.cwd;
+  return process.cwd();
+}
+
 const MAX_IMPACT_SEEN = 512;
 const impactSeen = new Map<string, true>();
 
@@ -146,10 +170,7 @@ export default definePluginEntry({
     // Fixed orientation card is prepended to context. Never derives queries from prompt prose.
     api.on('before_prompt_build', async (event, ctx) => {
       return await safely(async () => {
-        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
-          ?? ctx?.workspaceDir
-          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
-          ?? process.cwd();
+        const cwd = resolveWorkspace(event, ctx);
 
         const handle = await manager.getHandle(cwd);
         if (!handle) return undefined;
@@ -191,10 +212,7 @@ export default definePluginEntry({
       'before_tool_call',
       async (event, ctx) => {
         return await safely(async () => {
-          const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
-            ?? ctx?.workspaceDir
-            ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
-            ?? process.cwd();
+          const cwd = resolveWorkspace(event, ctx);
 
           const handle = await manager.getHandle(cwd);
           if (!handle) return undefined;
@@ -307,10 +325,7 @@ export default definePluginEntry({
     // Return value is ignored by host, but handler must await inside safely without floating promises.
     api.on('after_tool_call', async (event, ctx) => {
       await safely(async () => {
-        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
-          ?? ctx?.workspaceDir
-          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
-          ?? process.cwd();
+        const cwd = resolveWorkspace(event, ctx);
 
         const handle = await manager.getHandle(cwd);
         if (!handle) return;
@@ -344,10 +359,7 @@ export default definePluginEntry({
     // Bounded under 10s (host has 30s timeout, runs on serialized notification queue in Codex harness).
     api.on('before_compaction', async (event, ctx) => {
       await safely(async () => {
-        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
-          ?? ctx?.workspaceDir
-          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
-          ?? process.cwd();
+        const cwd = resolveWorkspace(event, ctx);
 
         const handle = await manager.getHandle(cwd);
         if (!handle) return;
@@ -375,10 +387,7 @@ export default definePluginEntry({
     // Warms workspace handle in memory so initial write gate avoids cold open latency.
     api.on('session_start', async (event, ctx) => {
       await safely(async () => {
-        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
-          ?? ctx?.workspaceDir
-          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
-          ?? process.cwd();
+        const cwd = resolveWorkspace(event, ctx);
 
         const handle = await manager.warmWorkspace(cwd);
         if (!handle) return;
@@ -404,22 +413,24 @@ export default definePluginEntry({
     // Session / agent shutdown: maps session_end & agent_end -> turn-stop.
     // Bound by 1.5s under OpenClaw's 2-second total shutdown drain budget.
     for (const hookName of ['session_end', 'agent_end'] as const) {
-      api.on(hookName, async (event, ctx) => {
+      // Typed per hook name, so the loop variable does not collapse the handler's
+      // parameters to `any`: `api.on` is overloaded per event and a union of names
+      // widens both arguments. The bodies only read what `resolveWorkspace` accepts.
+      api.on(hookName, async (event: unknown, ctx: unknown) => {
         await safely(async () => {
-          const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
-            ?? ctx?.workspaceDir
-            ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
-            ?? process.cwd();
+          const cwd = resolveWorkspace(event, ctx);
 
           const handle = await manager.getHandle(cwd);
           if (!handle) return;
 
+          const c = ctx as Record<string, unknown> | undefined;
+          const e = event as Record<string, unknown> | undefined;
           const raw: Record<string, unknown> = {
             cwd,
-            sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
-            turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
-            agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
-            agentType: (event as Record<string, unknown>)?.agentType,
+            sessionId: c?.sessionId ?? c?.sessionKey ?? e?.sessionId ?? e?.sessionKey ?? 'openclaw-session',
+            turnId: e?.turnId ?? e?.runId ?? c?.runId,
+            agentId: c?.agentId ?? e?.agentId,
+            agentType: e?.agentType,
           };
 
           const payload = readLifecyclePayloadObject(raw);

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -1,8 +1,113 @@
+import path from 'node:path';
 import { definePluginEntry, type OpenClawPluginApi } from 'openclaw/plugin-sdk/plugin-entry';
 import { normalizeHostHook, readLifecyclePayloadObject } from '@dat999zx/knowl/plugin';
 import { OpenClawEngineManager, safely, withDeadline } from './engine.js';
 
 export { OpenClawEngineManager, safely, withDeadline };
+
+const MAX_IMPACT_SEEN = 512;
+const impactSeen = new Map<string, true>();
+
+export function markImpactSeen(key: string): void {
+  if (impactSeen.size >= MAX_IMPACT_SEEN) {
+    const firstKey = impactSeen.keys().next().value;
+    if (firstKey !== undefined) impactSeen.delete(firstKey);
+  }
+  impactSeen.set(key, true);
+}
+
+export function resetImpactSeenForTest(): void {
+  impactSeen.clear();
+}
+
+function normalizeForCompare(p: string): string {
+  let norm = p.replace(/\\/g, '/');
+  while (norm.startsWith('./')) {
+    norm = norm.slice(2);
+  }
+  return norm.toLowerCase();
+}
+
+export function coversAffectedPath(affected: unknown, rel: string): boolean {
+  if (!Array.isArray(affected) || !rel) return false;
+  const target = normalizeForCompare(rel);
+  for (const entry of affected) {
+    if (typeof entry !== 'string' || !entry.trim()) continue;
+    const e = normalizeForCompare(entry);
+    if (e === target || target.endsWith('/' + e) || e.endsWith('/' + target)) {
+      return true;
+    }
+    if (target.startsWith(e.replace(/\/+$/, '') + '/')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function toRepoRelativePath(rawPath: string, root: string): string {
+  let normalized = rawPath.replace(/\\/g, '/');
+  while (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+  if (path.isAbsolute(rawPath)) {
+    try {
+      const rel = path.relative(root, rawPath);
+      if (!rel.startsWith('..')) {
+        return rel.replace(/\\/g, '/');
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return normalized;
+}
+
+export function extractWrittenPaths(toolName: string, args?: Record<string, unknown>): string[] {
+  if (!args) return [];
+  const paths: string[] = [];
+
+  // Direct path fields
+  for (const key of ['path', 'file_path', 'filePath', 'file', 'target', 'destination']) {
+    const val = args[key];
+    if (typeof val === 'string' && val.trim()) {
+      paths.push(val.trim());
+    }
+  }
+
+  // Changes array (e.g. codex changes: [{ path: '...' }])
+  if (Array.isArray(args.changes)) {
+    for (const change of args.changes) {
+      if (change && typeof change === 'object') {
+        const p = (change as Record<string, unknown>).path
+          ?? (change as Record<string, unknown>).filePath
+          ?? (change as Record<string, unknown>).file;
+        if (typeof p === 'string' && p.trim()) {
+          paths.push(p.trim());
+        }
+      }
+    }
+  }
+
+  // Patch content strings (e.g. apply_patch { patch: '...' } or { input: '...' })
+  for (const patchKey of ['patch', 'input', 'diff']) {
+    const content = args[patchKey];
+    if (typeof content === 'string') {
+      const starMatches = content.matchAll(/\*\*\*\s+(?:Update|Add)\s+File:\s*([^\r\n]+)/g);
+      for (const m of starMatches) {
+        if (m[1]?.trim()) paths.push(m[1].trim());
+      }
+      const diffMatches = content.matchAll(/^\+{3}\s+(?:[ab]\/)?([^\r\n\t]+)/gm);
+      for (const m of diffMatches) {
+        const p = m[1]?.trim();
+        if (p && p !== '/dev/null') paths.push(p);
+      }
+    }
+  }
+
+  return Array.from(new Set(paths));
+}
+
+const DRAIN_BUDGET_MS = 1_500;
 
 /**
  * OpenClaw in-process plugin for Knowl.
@@ -27,10 +132,14 @@ export default definePluginEntry({
     const gateDeadlineMs = typeof config.gateDeadlineMs === 'number'
       ? config.gateDeadlineMs
       : undefined;
+    const observerDeadlineMs = typeof config.observerDeadlineMs === 'number'
+      ? config.observerDeadlineMs
+      : undefined;
 
     const manager = new OpenClawEngineManager({
       logger: api.logger,
       gateDeadlineMs,
+      observerDeadlineMs,
     });
 
     // Exactly one prompt contribution hook: maps before_prompt_build -> turn-start.
@@ -118,6 +227,219 @@ export default definePluginEntry({
       },
       { matcher: ['exec', 'apply_patch', 'spawn_agent'] as const },
     );
+
+    // Impact card middleware: runs before output is fed back to the model.
+    // Not tool_result_persist (which only rewrites the transcript copy).
+    // Appends dependent atom notice into `content` (never only `details`, which OpenClaw
+    // strips before provider replay and compaction).
+    if (typeof api.registerAgentToolResultMiddleware === 'function') {
+      api.registerAgentToolResultMiddleware(
+        async (event, ctx) => {
+          return await safely(async () => {
+            if (event.isError) return undefined;
+
+            const cwd = event.cwd
+              ?? (ctx as Record<string, unknown>)?.workspaceDir as string | undefined
+              ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+              ?? process.cwd();
+
+            const handle = await manager.getHandle(cwd);
+            if (!handle) return undefined;
+
+            const writtenPaths = extractWrittenPaths(event.toolName, event.args);
+            if (writtenPaths.length === 0) return undefined;
+
+            const sessionId = ctx?.sessionId
+              ?? ctx?.sessionKey
+              ?? (event as Record<string, unknown>)?.sessionId as string | undefined
+              ?? (event as Record<string, unknown>)?.sessionKey as string | undefined
+              ?? 'openclaw-session';
+
+            for (const rawPath of writtenPaths) {
+              const rel = toRepoRelativePath(rawPath, handle.projectRoot || cwd);
+              if (!rel) continue;
+
+              const cacheKey = `${sessionId}:${rel.toLowerCase()}`;
+              if (impactSeen.has(cacheKey)) continue;
+
+              const stem = path.basename(rel, path.extname(rel)).replace(/[-_]/g, ' ');
+              const items = await withDeadline(
+                manager.getGateDeadlineMs(),
+                () => handle.query(`${rel} ${stem}`, { limit: 8 }),
+                [],
+              );
+
+              const hits = items.filter((item) => coversAffectedPath(item.affectedPaths, rel));
+              if (hits.length === 0) continue;
+
+              markImpactSeen(cacheKey);
+
+              const lines = [
+                `[Knowl] ${hits.length} stored item(s) depend on ${rel}. Check them before you move on:`,
+                ...hits.slice(0, 5).map((item) => `- ${item.title} (${item.category} ${item.id})`),
+                'Read one in full with knowl_query and its id.',
+              ];
+              const cardText = lines.join('\n').slice(0, 1500);
+
+              const existingContent = Array.isArray(event.result?.content) ? event.result.content : [];
+              return {
+                result: {
+                  ...event.result,
+                  content: [
+                    ...existingContent,
+                    { type: 'text', text: cardText },
+                  ],
+                },
+              };
+            }
+
+            return undefined;
+          }, api.logger);
+        },
+        {
+          matcher: ['exec', 'apply_patch', 'spawn_agent'] as const,
+          runtimes: ['openclaw', 'codex'],
+        },
+      );
+    }
+
+    // Capture observer: maps after_tool_call -> session-event.
+    // Return value is ignored by host, but handler must await inside safely without floating promises.
+    api.on('after_tool_call', async (event, ctx) => {
+      await safely(async () => {
+        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
+          ?? ctx?.workspaceDir
+          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+          ?? process.cwd();
+
+        const handle = await manager.getHandle(cwd);
+        if (!handle) return;
+
+        const raw: Record<string, unknown> = {
+          cwd,
+          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
+          agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
+          agentType: (event as Record<string, unknown>)?.agentType,
+          tool_name: event.toolName,
+          tool_input: event.params,
+          status: event.error ? 'failed' : 'finished',
+          duration_ms: event.durationMs,
+          exit_code: event.error ? 1 : 0,
+          ...(event.error ? { error: event.error } : {}),
+        };
+
+        const payload = readLifecyclePayloadObject(raw);
+        const normalized = normalizeHostHook('openclaw', 'after_tool_call', payload as Record<string, unknown>);
+
+        await withDeadline(
+          manager.getObserverDeadlineMs(),
+          () => handle.lifecycle(normalized),
+          null,
+        );
+      }, api.logger);
+    });
+
+    // Compaction checkpoint: maps before_compaction -> checkpoint.
+    // Bounded under 10s (host has 30s timeout, runs on serialized notification queue in Codex harness).
+    api.on('before_compaction', async (event, ctx) => {
+      await safely(async () => {
+        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
+          ?? ctx?.workspaceDir
+          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+          ?? process.cwd();
+
+        const handle = await manager.getHandle(cwd);
+        if (!handle) return;
+
+        const raw: Record<string, unknown> = {
+          cwd,
+          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
+          agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
+          agentType: (event as Record<string, unknown>)?.agentType,
+        };
+
+        const payload = readLifecyclePayloadObject(raw);
+        const normalized = normalizeHostHook('openclaw', 'before_compaction', payload as Record<string, unknown>);
+
+        await withDeadline(
+          manager.getObserverDeadlineMs(),
+          () => handle.lifecycle(normalized),
+          null,
+        );
+      }, api.logger);
+    });
+
+    // Session start: maps session_start -> session-start.
+    // Warms workspace handle in memory so initial write gate avoids cold open latency.
+    api.on('session_start', async (event, ctx) => {
+      await safely(async () => {
+        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
+          ?? ctx?.workspaceDir
+          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+          ?? process.cwd();
+
+        const handle = await manager.warmWorkspace(cwd);
+        if (!handle) return;
+
+        const raw: Record<string, unknown> = {
+          cwd,
+          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
+          agentType: (event as Record<string, unknown>)?.agentType,
+        };
+
+        const payload = readLifecyclePayloadObject(raw);
+        const normalized = normalizeHostHook('openclaw', 'session_start', payload as Record<string, unknown>);
+
+        await withDeadline(
+          manager.getObserverDeadlineMs(),
+          () => handle.lifecycle(normalized),
+          null,
+        );
+      }, api.logger);
+    });
+
+    // Session / agent shutdown: maps session_end & agent_end -> turn-stop.
+    // Bound by 1.5s under OpenClaw's 2-second total shutdown drain budget.
+    for (const hookName of ['session_end', 'agent_end'] as const) {
+      api.on(hookName, async (event, ctx) => {
+        await safely(async () => {
+          const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
+            ?? ctx?.workspaceDir
+            ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+            ?? process.cwd();
+
+          const handle = await manager.getHandle(cwd);
+          if (!handle) return;
+
+          const raw: Record<string, unknown> = {
+            cwd,
+            sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+            turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
+            agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
+            agentType: (event as Record<string, unknown>)?.agentType,
+          };
+
+          const payload = readLifecyclePayloadObject(raw);
+          const normalized = normalizeHostHook('openclaw', hookName, payload as Record<string, unknown>);
+
+          await withDeadline(
+            DRAIN_BUDGET_MS,
+            () => handle.lifecycle(normalized),
+            null,
+          );
+        }, api.logger);
+      });
+    }
+
+    // Gateway stop: releases all handles cleanly on full gateway shutdown.
+    api.on('gateway_stop', async () => {
+      await safely(async () => {
+        await manager.releaseAll();
+      }, api.logger);
+    });
   },
 });
 

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -1,0 +1,22 @@
+import { definePluginEntry, type OpenClawPluginApi } from 'openclaw/plugin-sdk/plugin-entry';
+
+/**
+ * OpenClaw in-process plugin for Knowl.
+ *
+ * Runs inside OpenClaw's gateway process to evaluate write gates in sub-millisecond
+ * latency and supply turn orientation and tool-result impact cards in the turn that earned them.
+ *
+ * All handlers register through synchronous `register(api)` using `api.on(...)`.
+ * `api.registerHook` is avoided because it is a legacy internal system that warns and never fires
+ * for typed host event names.
+ */
+export default definePluginEntry({
+  id: 'knowl',
+  name: 'Knowl',
+  description: 'Persistent repository memory and write gate for OpenClaw.',
+  register(api: OpenClawPluginApi) {
+    const _config = api.pluginConfig ?? {};
+    // Hook registrations (before_prompt_build, before_tool_call, etc.) will be wired
+    // in subsequent tasks via the engine manager.
+  },
+});

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -1,4 +1,8 @@
 import { definePluginEntry, type OpenClawPluginApi } from 'openclaw/plugin-sdk/plugin-entry';
+import { normalizeHostHook, readLifecyclePayloadObject } from '@dat999zx/knowl/plugin';
+import { OpenClawEngineManager, safely, withDeadline } from './engine.js';
+
+export { OpenClawEngineManager, safely, withDeadline };
 
 /**
  * OpenClaw in-process plugin for Knowl.
@@ -9,14 +13,59 @@ import { definePluginEntry, type OpenClawPluginApi } from 'openclaw/plugin-sdk/p
  * All handlers register through synchronous `register(api)` using `api.on(...)`.
  * `api.registerHook` is avoided because it is a legacy internal system that warns and never fires
  * for typed host event names.
+ *
+ * Exactly one hook publishes prompt context: `before_prompt_build`.
+ * `agent_turn_prepare` and `heartbeat_prompt_contribution` are deliberately not registered
+ * because prompt contributions concatenate and multiple publishers would duplicate cards.
  */
 export default definePluginEntry({
   id: 'knowl',
   name: 'Knowl',
   description: 'Persistent repository memory and write gate for OpenClaw.',
   register(api: OpenClawPluginApi) {
-    const _config = api.pluginConfig ?? {};
-    // Hook registrations (before_prompt_build, before_tool_call, etc.) will be wired
-    // in subsequent tasks via the engine manager.
+    const manager = new OpenClawEngineManager({
+      logger: api.logger,
+    });
+
+    // Exactly one prompt contribution hook: maps before_prompt_build -> turn-start.
+    // Fixed orientation card is prepended to context. Never derives queries from prompt prose.
+    api.on('before_prompt_build', async (event, ctx) => {
+      return await safely(async () => {
+        const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
+          ?? ctx?.workspaceDir
+          ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+          ?? process.cwd();
+
+        const handle = await manager.getHandle(cwd);
+        if (!handle) return undefined;
+
+        const raw: Record<string, unknown> = {
+          cwd,
+          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId ?? ctx?.jobId,
+          agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
+          agentType: (event as Record<string, unknown>)?.agentType,
+          prompt: event.prompt,
+        };
+
+        const payload = readLifecyclePayloadObject(raw);
+        const normalized = normalizeHostHook('openclaw', 'before_prompt_build', payload as Record<string, unknown>);
+
+        const result = await withDeadline(
+          manager.getGateDeadlineMs(),
+          () => handle.lifecycle(normalized),
+          null,
+        );
+
+        if (!result) return undefined;
+
+        const card = (result.hostOutput?.prependContext as string | undefined) ?? result.context;
+        if (card) {
+          return { prependContext: card };
+        }
+        return undefined;
+      }, api.logger);
+    });
   },
 });
+

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -23,8 +23,14 @@ export default definePluginEntry({
   name: 'Knowl',
   description: 'Persistent repository memory and write gate for OpenClaw.',
   register(api: OpenClawPluginApi) {
+    const config = (api.pluginConfig ?? {}) as Record<string, unknown>;
+    const gateDeadlineMs = typeof config.gateDeadlineMs === 'number'
+      ? config.gateDeadlineMs
+      : undefined;
+
     const manager = new OpenClawEngineManager({
       logger: api.logger,
+      gateDeadlineMs,
     });
 
     // Exactly one prompt contribution hook: maps before_prompt_build -> turn-start.
@@ -66,6 +72,52 @@ export default definePluginEntry({
         return undefined;
       }, api.logger);
     });
+
+    // Write gate: maps before_tool_call -> tool-precheck for canonical write tools.
+    // Answers { block: true, blockReason } on refusal.
+    // Abstains (returns undefined) on allow, never returns params (Codex rejects rewrites).
+    // Uses internal deadline under OpenClaw's 15s fail-closed budget so a stalled engine
+    // allows the write instead of denying it.
+    api.on(
+      'before_tool_call',
+      async (event, ctx) => {
+        return await safely(async () => {
+          const cwd = (event as Record<string, unknown>)?.cwd as string | undefined
+            ?? ctx?.workspaceDir
+            ?? (ctx as Record<string, unknown>)?.cwd as string | undefined
+            ?? process.cwd();
+
+          const handle = await manager.getHandle(cwd);
+          if (!handle) return undefined;
+
+          const raw: Record<string, unknown> = {
+            cwd,
+            sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+            turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
+            agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
+            agentType: (event as Record<string, unknown>)?.agentType,
+            tool_name: event.toolName,
+            tool_input: event.params,
+            ...(Array.isArray(event.derivedPaths) ? { changed_paths: event.derivedPaths } : {}),
+          };
+
+          const payload = readLifecyclePayloadObject(raw);
+          const normalized = normalizeHostHook('openclaw', 'before_tool_call', payload as Record<string, unknown>);
+
+          const result = await withDeadline(
+            manager.getGateDeadlineMs(),
+            () => handle.lifecycle(normalized),
+            null,
+          );
+
+          if (result?.hostOutput?.block === true && typeof result.hostOutput.blockReason === 'string') {
+            return { block: true, blockReason: result.hostOutput.blockReason };
+          }
+          return undefined;
+        }, api.logger);
+      },
+      { matcher: ['exec', 'apply_patch', 'spawn_agent'] as const },
+    );
   },
 });
 

--- a/integrations/openclaw/tsconfig.json
+++ b/integrations/openclaw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/integrations/openclaw/tsconfig.json
+++ b/integrations/openclaw/tsconfig.json
@@ -6,7 +6,15 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@dat999zx/knowl/plugin": ["../../dist/plugin.d.ts"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/node": "^22.10.7",
         "drizzle-kit": "^0.31.10",
         "eslint": "^10.9.1",
-        "openclaw": "^2026.9.1",
         "tsup": "^8.3.5",
         "tsx": "^4.23.8",
         "typescript": "^5.7.3",
@@ -50,16 +49,6 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0"
-      }
-    },
-    "node_modules/@agentclientprotocol/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -142,49 +131,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
-      "integrity": "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@borewit/text-codec": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/@clack/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
@@ -219,20 +165,6 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
-      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
@@ -838,86 +770,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@google/genai": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.18.0.tgz",
-      "integrity": "sha512-uy9gWVTAZXuA/2tld0QJl/QNiGEn4QOmfX4PiRgZQmeFQRQhojpD/Gf41SPnBJmjEnT83a+h4AdU1HHYaYvVDw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@grammyjs/runner": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
-      "integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.20.0 || >=14.13.1"
-      },
-      "peerDependencies": {
-        "grammy": "^1.13.1"
-      }
-    },
-    "node_modules/@grammyjs/transformer-throttler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
-      "integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bottleneck": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || >=14.13.1"
-      },
-      "peerDependencies": {
-        "grammy": "^1.0.0"
-      }
-    },
-    "node_modules/@grammyjs/types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-5.0.0.tgz",
-      "integrity": "sha512-iq1Qrq1iPKkB8yAa0qSuIURMZOCuqTY5pWy5gHpCeL1oQ+GPadGhw/cDTVE8waJwuCzacUzuIjRv1sESvk7u7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@homebridge/ciao": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.12.tgz",
-      "integrity": "sha512-84/0u0kqKy4qcKupIDaTtbkmk+3qFDuMzxTC0NPfVlHcUT+jHGdP+QCqwEw94/GJxRezDeBLwxaclkBZgCdeUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "fast-deep-equal": "^3.1.3",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.8.1"
-      },
-      "bin": {
-        "ciao-bcs": "lib/bonjour-conformance-testing.js"
-      }
-    },
     "node_modules/@hono/node-server": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
@@ -1139,9 +991,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1157,9 +1006,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1177,9 +1023,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1195,9 +1038,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1215,9 +1055,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1233,9 +1070,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1253,9 +1087,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1272,9 +1103,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1290,9 +1118,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1316,9 +1141,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1340,9 +1162,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1366,9 +1185,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1390,9 +1206,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1416,9 +1229,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1441,9 +1251,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1465,9 +1272,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1576,19 +1380,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1626,261 +1417,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@koromix/koffi-darwin-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
-      "integrity": "sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-darwin-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
-      "integrity": "sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-freebsd-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
-      "integrity": "sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-freebsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-freebsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
-      "integrity": "sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
-      "integrity": "sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
-      "integrity": "sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-loong64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
-      "integrity": "sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-riscv64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
-      "integrity": "sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
-      "integrity": "sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-openbsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-openbsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
-      "integrity": "sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-win32-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
-      "integrity": "sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-win32-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
-      "integrity": "sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-win32-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
-      "integrity": "sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@libsql/client": {
@@ -2042,138 +1578,6 @@
         "win32"
       ]
     },
-    "node_modules/@lydell/node-pty": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.15.tgz",
-      "integrity": "sha512-Br8wBxzbxFwdWgk9uQ+rdzE0xfoxOK4QuGH54swhRwc5IxP6H9Y1/bcyazRGvNUs6XkB5qNVkezuKSRxUwZe7A==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.15",
-        "@lydell/node-pty-darwin-x64": "1.2.0-beta.15",
-        "@lydell/node-pty-linux-arm64": "1.2.0-beta.15",
-        "@lydell/node-pty-linux-x64": "1.2.0-beta.15",
-        "@lydell/node-pty-win32-arm64": "1.2.0-beta.15",
-        "@lydell/node-pty-win32-x64": "1.2.0-beta.15"
-      }
-    },
-    "node_modules/@lydell/node-pty-darwin-arm64": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.15.tgz",
-      "integrity": "sha512-6TSBbzdcLiNTHl1mTuzflqXrkmcC36USVGvERoDgvHk2ItEDaMaFZuAJ1CqPmwYj0DyhCS16TVS8OGK9xZnjyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lydell/node-pty-darwin-x64": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.15.tgz",
-      "integrity": "sha512-yDT2oqPqYMBScyuk1U9Rg5VKcrbMOD9o9jWYYamDADA3NSbUISroPChrqYRQ74Y7BQtNH4gqYAiWOZRi5uQZ0Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lydell/node-pty-linux-arm64": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.15.tgz",
-      "integrity": "sha512-wkbNF7dYAmtJv+o2+iztVlNwnUB4B0uX0wh/UD+mwMcmE2gNMnW9GChXO7fEE5XJokD0vB5idiHpGegaN+G/sg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lydell/node-pty-linux-x64": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.15.tgz",
-      "integrity": "sha512-+U/5AVvHT6W+8OCYcnJgN0Qgc0ycO3TfD6aaFJHK+WHij797f8gsi5dV1HEO9l6YQmWCD+VL5gaLDhx3mxHwCA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lydell/node-pty-win32-arm64": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.15.tgz",
-      "integrity": "sha512-pyAk91w7wnnKrD4mrHXtIXRfmzSWV5bEzvRhurXcMCtCc2TJ424ciUskIgWMhAPP6y3KyUnqElj+U6kY3iOt0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@lydell/node-pty-win32-x64": {
-      "version": "1.2.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.15.tgz",
-      "integrity": "sha512-2f8twEmDVxZ7drchAXjtevpmSPhFok0avAnzXro4t5gmz0xsPNKkoZvymwtuIS3xo7PzQqZOPQ/YzwEMb7oIzQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.6.4.tgz",
-      "integrity": "sha512-PPt4GyJqs2hEsWrYCJZK5f0ORmT+L2MSm75LVGD7kBLf6ZKsoDpld/FRBQXr8xG6iFCBOFJFYzvGYhUb+UCkbw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
-        "@opentelemetry/resources": "^2.9.0",
-        "@opentelemetry/sdk-trace-base": "^2.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-http": {
-          "optional": true
-        },
-        "@opentelemetry/resources": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -2214,16 +1618,6 @@
         }
       }
     },
-    "node_modules/@mozilla/readability": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
-      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
@@ -2242,186 +1636,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@openclaw/ai": {
-      "version": "2026.9.1",
-      "resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.9.1.tgz",
-      "integrity": "sha512-Am/7miiZZjbXv0MxzmOsaCAB9YXlz3vHl1Nuq1j1rOWj+7MwO83P5rnXdk10vc3jXxaXq2snlDl/La8xkd2IeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.120.0",
-        "@google/genai": "2.18.0",
-        "@mistralai/mistralai": "2.6.4",
-        "openai": "7.5.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.3.17"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@openclaw/fs-safe": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.7.0.tgz",
-      "integrity": "sha512-i+0a4yQYa4ThUahaSLMledG99AL38XdAn8q/ppVMr49zr0dsOO+1gf8Jz6jgI0ggdcq6U4IhgsNunACsSymjyA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      },
-      "optionalDependencies": {
-        "@openclaw/fs-safe-darwin-arm64": "0.7.0",
-        "@openclaw/fs-safe-darwin-x64": "0.7.0",
-        "@openclaw/fs-safe-linux-arm64-gnu": "0.7.0",
-        "@openclaw/fs-safe-linux-arm64-musl": "0.7.0",
-        "@openclaw/fs-safe-linux-x64-gnu": "0.7.0",
-        "@openclaw/fs-safe-linux-x64-musl": "0.7.0",
-        "@openclaw/fs-safe-win32-x64-msvc": "0.7.0",
-        "jszip": "^3.10.1",
-        "tar": "7.5.22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-darwin-arm64": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-darwin-arm64/-/fs-safe-darwin-arm64-0.7.0.tgz",
-      "integrity": "sha512-11z1Tv1ZVa31M+aoC56EX/DUACVuq4GiYSOpbv/ZDqwFPCdy+N/Vi2x/hcwCLjhb6UOsMWRsMsIAMjQAR2qHmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-darwin-x64": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-darwin-x64/-/fs-safe-darwin-x64-0.7.0.tgz",
-      "integrity": "sha512-LS89eU+x7Kq0kugOR1HLsdVcuTNwCeMU+UQoWZUsWbWg9XTtw5ohOTU7bqewPNVGmB0cdihPfdorKc5wZgLTVw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-linux-arm64-gnu": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-arm64-gnu/-/fs-safe-linux-arm64-gnu-0.7.0.tgz",
-      "integrity": "sha512-3UZDqtYJSMMN4Rid68EuTmCYjHyGHilQ7BFfm+ZKGloJoJLEvXoaAbDAqsazvWjrQKecfxlXJTC9qbLa5RYJEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-linux-arm64-musl": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-arm64-musl/-/fs-safe-linux-arm64-musl-0.7.0.tgz",
-      "integrity": "sha512-rX1m2ft84KOb61/EhJmkiC0hqH4QCd1knQFcDU8tiA49sbiXsghNfSXRd2K07GlA7spXtqQfSX3ZvMh4f7JhBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-linux-x64-gnu": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-x64-gnu/-/fs-safe-linux-x64-gnu-0.7.0.tgz",
-      "integrity": "sha512-lTn5h0lkJjL1yiOxh+kgY2L4JDAXo2fNHXXZqxKACQdhB1+YFcc8YyUPTjK2b8aWlsgpRwfq/7JJ1eDHRbDcrg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-linux-x64-musl": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-x64-musl/-/fs-safe-linux-x64-musl-0.7.0.tgz",
-      "integrity": "sha512-e/LcF75zEQzg9yII5jv7WBZ3w7dNGBVpiOxlbm1dpy5XX+ap8pjsqWC0c0UGJdIbwWQInzKpb4/B0mwED/obYw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@openclaw/fs-safe-win32-x64-msvc": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-win32-x64-msvc/-/fs-safe-win32-x64-msvc-0.7.0.tgz",
-      "integrity": "sha512-FiVNgckcHBuRov6vRytRjx8AdRBPxl56qZ8Dr0aAaAxfo+yhSJCGPmhnpgqUirBxkKQyrABIrP3LdIyscJMgWA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.146.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
@@ -2436,36 +1650,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
@@ -2474,29 +1688,29 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
@@ -2608,9 +1822,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2628,9 +1839,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2648,9 +1856,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2668,9 +1873,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,9 +1890,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,9 +1907,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2870,9 +2066,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2887,9 +2080,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2904,9 +2094,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,9 +2108,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,9 +2122,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2955,9 +2136,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2972,9 +2150,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2989,9 +2164,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3006,9 +2178,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3023,9 +2192,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3040,9 +2206,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3057,9 +2220,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3074,9 +2234,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3167,179 +2324,11 @@
         "win32"
       ]
     },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
-    },
-    "node_modules/@tokenizer/inflate": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
-      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "token-types": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@trycua/cua-driver": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver/-/cua-driver-0.22.0.tgz",
-      "integrity": "sha512-NElsgryvNTl7arPdx7trvYhz4geMhPztsi8RFeECY2XhuuhWWzSPPPHTC4cBVsb/gprqqPtb+Hy2I1kGGEGddg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ubjs/core": "0.31.0-3",
-        "@ubjs/node": "0.31.0-3"
-      },
-      "optionalDependencies": {
-        "@trycua/cua-driver-darwin-arm64": "0.22.0",
-        "@trycua/cua-driver-darwin-x64": "0.22.0",
-        "@trycua/cua-driver-linux-arm64-gnu": "0.22.0",
-        "@trycua/cua-driver-linux-x64-gnu": "0.22.0",
-        "@trycua/cua-driver-win32-arm64-msvc": "0.22.0",
-        "@trycua/cua-driver-win32-x64-msvc": "0.22.0"
-      }
-    },
-    "node_modules/@trycua/cua-driver-darwin-arm64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-darwin-arm64/-/cua-driver-darwin-arm64-0.22.0.tgz",
-      "integrity": "sha512-CD83Bvwx5XQtds+nxDOcY2CxKqSxr6spjjdpwYDb/34jtTt46jedt1A73QEEP/xkf9Ckw9Z7CWs68bt+bmGMYA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT AND MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@trycua/cua-driver-darwin-x64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-darwin-x64/-/cua-driver-darwin-x64-0.22.0.tgz",
-      "integrity": "sha512-uHqMAbYRqLs8MUHyODrAR0kX7rmgwFINcSGVGgrULr5E2OmeJHx6F/THQk/1lLV6jtrKX/bZsqxROehRJmtPNg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT AND MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@trycua/cua-driver-linux-arm64-gnu": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-linux-arm64-gnu/-/cua-driver-linux-arm64-gnu-0.22.0.tgz",
-      "integrity": "sha512-UCGS0LRnySNwAYqymH+jShoyDUtqAkVPEMbCDDALu5R4BqtsyGfawxKYAYg9/tBya48Dkf4NcjE5lGDKs2ku9g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT AND MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@trycua/cua-driver-linux-x64-gnu": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-linux-x64-gnu/-/cua-driver-linux-x64-gnu-0.22.0.tgz",
-      "integrity": "sha512-9wtKFGaDbQk0BHXnyWMLKKgkTvhNi0Qv8y39inbXL5mfhQoUvUUx1QnhD5SZiImE0GoGvLq/BcwoizmjO3pLNw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT AND MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@trycua/cua-driver-win32-arm64-msvc": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-win32-arm64-msvc/-/cua-driver-win32-arm64-msvc-0.22.0.tgz",
-      "integrity": "sha512-zJJuFJAYCchablDpgDv4ybbBaBVUiPNvt38XeoTKwIkZZHqfAYXUO0gWQ6tU2PpTfZHZAdidpwjln+xO0OUE5w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT AND MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@trycua/cua-driver-win32-x64-msvc": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-win32-x64-msvc/-/cua-driver-win32-x64-msvc-0.22.0.tgz",
-      "integrity": "sha512-32E9FZCrXKgXV9vg+2wsdJUarsrn3cj0nBMxcY8z1QyfXjuYKYX0J5XJUlxbNC8PJRbYPEBnd09F1qb05Rv64w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT AND MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3388,13 +2377,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3635,154 +2617,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ubjs/core": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/core/-/core-0.31.0-3.tgz",
-      "integrity": "sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==",
-      "dev": true,
-      "license": "MPL-2.0"
-    },
-    "node_modules/@ubjs/node": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node/-/node-0.31.0-3.tgz",
-      "integrity": "sha512-qNMpi2LICNwxGXZyRF8fSDBSpbezyZbEsydrbiMPJOmtOWr4tmZIEl7jkWGHVGShoBvHfFo4eHp5B4UVP928Cg==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optionalDependencies": {
-        "@ubjs/node-darwin-arm64": "0.31.0-3",
-        "@ubjs/node-darwin-x64": "0.31.0-3",
-        "@ubjs/node-linux-arm64-gnu": "0.31.0-3",
-        "@ubjs/node-linux-arm64-musl": "0.31.0-3",
-        "@ubjs/node-linux-x64-gnu": "0.31.0-3",
-        "@ubjs/node-linux-x64-musl": "0.31.0-3",
-        "@ubjs/node-win32-arm64-msvc": "0.31.0-3",
-        "@ubjs/node-win32-x64-msvc": "0.31.0-3"
-      }
-    },
-    "node_modules/@ubjs/node-darwin-arm64": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-darwin-arm64/-/node-darwin-arm64-0.31.0-3.tgz",
-      "integrity": "sha512-GGQVPLkVo4Gc8qVLW4IGvS8bjl8eHXyeP4a97ntGmsAdXwE5gsS29o8xUEFROjhwHKD+9sgVeblCSWVG3CpHsw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@ubjs/node-darwin-x64": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-darwin-x64/-/node-darwin-x64-0.31.0-3.tgz",
-      "integrity": "sha512-2sc47u4XFYOsbmP5EW+Gx8m/yGrYnfFDFQm6+kz7goSWTNg84eEiz3COs9HKJDVuNJ5Khv5XipTO8CFadMLXCw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@ubjs/node-linux-arm64-gnu": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-arm64-gnu/-/node-linux-arm64-gnu-0.31.0-3.tgz",
-      "integrity": "sha512-YStVXhYz/5jvlWf/p4fhiVT72unYAbGugifFC9QmO/+hnroQDAQ5t8SARbsc15G4olMcamdIB+GETiUB7gmaYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ubjs/node-linux-arm64-musl": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-arm64-musl/-/node-linux-arm64-musl-0.31.0-3.tgz",
-      "integrity": "sha512-Izp4nvfy/LmibzFowAztkoDOksCR2fb2zl6fh1ojR1HEsg0rAGruxtI8d3fn8DI0lBXwqmn6SF///oD4mFNJPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ubjs/node-linux-x64-gnu": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-x64-gnu/-/node-linux-x64-gnu-0.31.0-3.tgz",
-      "integrity": "sha512-Xdm21blyg5U/kW6s7OMvgrr8coGTkUlt26DVR9x8gKISif+E3YwdEskbFScWqystAiJnfjw7xHEc8UMu0Qlz7Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ubjs/node-linux-x64-musl": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-x64-musl/-/node-linux-x64-musl-0.31.0-3.tgz",
-      "integrity": "sha512-fFQ9BWS6i2LUH9SJgD9oEiKXXo/say59vHy7usFe1t7C2xvwvP34f5SuxXmWP9R8fHyA0aC4kIZ+TTwyHSv1Kw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ubjs/node-win32-arm64-msvc": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-win32-arm64-msvc/-/node-win32-arm64-msvc-0.31.0-3.tgz",
-      "integrity": "sha512-ID6rSz1NmPsWTNBBNAw4OnJ5Dj8pcbtNJtdPB3OxcGigLBd/e0x7buhSI7os6Mo5iYtEdCynBRQHFJwub5XSPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@ubjs/node-win32-x64-msvc": {
-      "version": "0.31.0-3",
-      "resolved": "https://registry.npmjs.org/@ubjs/node-win32-x64-msvc/-/node-win32-x64-msvc-0.31.0-3.tgz",
-      "integrity": "sha512-wevs+Y+szwcCUT8IJFbB4/1nfxyRv/51l8oG7FGUPWD1xLPyuHfJBG27C+PDeC7KRzes/2n6aLo4DGZbr/LYTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@vercel/oidc": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
@@ -3911,19 +2745,6 @@
       "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3938,9 +2759,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3968,16 +2789,6 @@
       "optional": true,
       "engines": {
         "node": ">=14.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/ai": {
@@ -4030,51 +2841,12 @@
         }
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -4095,44 +2867,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -4171,20 +2905,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/boolbase": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
-      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -4192,13 +2912,6 @@
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/bottleneck": {
-      "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -4212,13 +2925,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4291,16 +2997,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4309,19 +3005,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
-      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -4339,64 +3022,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/clawpdf": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/clawpdf/-/clawpdf-0.3.1.tgz",
-      "integrity": "sha512-HZ8gz3cm8arzT/V2CnMZlHlRJbsrUYQ71u+A4nymeyvNnYzpZ8RQwkr2EIZiXCOzRkzFy8sOiHBXBuSUDDcXqQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "clawpdf": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -4471,13 +3096,6 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -4495,26 +3113,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/croner": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
-      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "other",
-          "url": "https://paypal.me/hexagonpp"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/hexagon"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4527,58 +3125,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
-      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^2.0.0",
-        "css-what": "^8.0.0",
-        "domhandler": "^6.0.1",
-        "domutils": "^4.0.2",
-        "nth-check": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
-      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -4596,16 +3142,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-is": {
@@ -4675,94 +3211,6 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/diff": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dijkstrajs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
-      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dom-serializer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
-      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0",
-        "entities": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
-      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/domhandler": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
-      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
-      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^3.0.0",
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -4931,27 +3379,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4961,19 +3392,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -5060,16 +3478,6 @@
         "@esbuild/win32-arm64": "0.28.2",
         "@esbuild/win32-ia32": "0.28.2",
         "@esbuild/win32-x64": "0.28.2"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -5289,16 +3697,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -5318,33 +3716,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/execa": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
-      "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.1",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.3.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "which-command": "^0.1.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/expect-type": {
@@ -5418,13 +3789,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5444,13 +3808,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "dev": true,
-      "license": "Unlicense"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -5510,46 +3867,6 @@
         }
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5561,25 +3878,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.2.tgz",
-      "integrity": "sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/inflate": "^0.4.1",
-        "strtok3": "^10.3.5",
-        "token-types": "^6.1.2",
-        "uint8array-extras": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/finalhandler": {
@@ -5660,19 +3958,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5715,59 +4000,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gaxios": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
-      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5803,23 +4035,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -5883,34 +4098,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/google-auth-library": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
-      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5921,43 +4108,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/grammy": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.46.0.tgz",
-      "integrity": "sha512-/8Qw+iisrUdOMk+p2mjEHouMm/BBdBEN1DHh16wiTpRUZkxDG3PxexdjCvR+wvK3LWPdrEvnQbdrwpU954sPhg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@grammyjs/types": "5.0.0",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.4.3",
-        "node-fetch": "^2.7.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || >=14.13.1"
-      }
-    },
-    "node_modules/grammy/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/guid-typescript": {
@@ -6004,16 +4154,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
-      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/hono": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
@@ -6021,141 +4161,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
-      "integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/htmlparser2/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/http_ece": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
-      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/http-errors": {
@@ -6178,34 +4183,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
     "node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6218,27 +4199,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6248,13 +4208,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -6300,16 +4253,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6323,56 +4266,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
-    "node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6380,16 +4277,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
     },
     "node_modules/jose": {
       "version": "6.2.3",
@@ -6416,16 +4303,6 @@
       "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6438,20 +4315,6 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -6479,55 +4342,6 @@
       "license": "ISC",
       "optional": true
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6536,44 +4350,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/koffi": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.6.tgz",
-      "integrity": "sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      },
-      "optionalDependencies": {
-        "@koromix/koffi-darwin-arm64": "3.1.6",
-        "@koromix/koffi-darwin-x64": "3.1.6",
-        "@koromix/koffi-freebsd-arm64": "3.1.6",
-        "@koromix/koffi-freebsd-ia32": "3.1.6",
-        "@koromix/koffi-freebsd-x64": "3.1.6",
-        "@koromix/koffi-linux-arm64": "3.1.6",
-        "@koromix/koffi-linux-ia32": "3.1.6",
-        "@koromix/koffi-linux-loong64": "3.1.6",
-        "@koromix/koffi-linux-riscv64": "3.1.6",
-        "@koromix/koffi-linux-x64": "3.1.6",
-        "@koromix/koffi-openbsd-ia32": "3.1.6",
-        "@koromix/koffi-openbsd-x64": "3.1.6",
-        "@koromix/koffi-win32-arm64": "3.1.6",
-        "@koromix/koffi-win32-ia32": "3.1.6",
-        "@koromix/koffi-win32-x64": "3.1.6"
-      }
-    },
-    "node_modules/kysely": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.5.tgz",
-      "integrity": "sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/levn": {
@@ -6620,16 +4396,6 @@
         "@libsql/linux-x64-gnu": "0.5.29",
         "@libsql/linux-x64-musl": "0.5.29",
         "@libsql/win32-x64-msvc": "0.5.29"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6775,9 +4541,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6799,9 +4562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6823,9 +4583,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6847,9 +4604,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6935,31 +4689,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/linkedom": {
-      "version": "0.18.13",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
-      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "css-select": "^7.0.0",
-        "cssom": "^0.5.0",
-        "html-escaper": "^3.0.3",
-        "htmlparser2": "^10.1.0",
-        "uhyphen": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "canvas": ">= 2"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -6990,18 +4719,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -7011,19 +4730,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/matcher": {
@@ -7094,13 +4800,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -7115,39 +4814,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -7225,61 +4891,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-edge-tts": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
-      "integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "https-proxy-agent": "^7.0.1",
-        "ws": "^8.13.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "node-edge-tts": "bin.js"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -7289,53 +4900,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
-      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {
@@ -7451,270 +5015,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/openai": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-7.5.0.tgz",
-      "integrity": "sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
-        "@smithy/hash-node": ">=4.3.0 <5",
-        "@smithy/signature-v4": ">=5.4.0 <6",
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-provider-node": {
-          "optional": true
-        },
-        "@smithy/hash-node": {
-          "optional": true
-        },
-        "@smithy/signature-v4": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openclaw": {
-      "version": "2026.9.1",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.9.1.tgz",
-      "integrity": "sha512-0Ve0631CdgkJDwd4NNG1BawIdF5yCL2sO+Tts8amStw+H6vKURTj0K4rOa4+hFpJk1Dnw5LyKl5twzwX1VtA2w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@agentclientprotocol/sdk": "1.4.0",
-        "@anthropic-ai/sdk": "0.120.0",
-        "@clack/core": "1.4.3",
-        "@clack/prompts": "1.7.0",
-        "@earendil-works/pi-tui": "0.84.2",
-        "@google/genai": "2.18.0",
-        "@grammyjs/runner": "2.0.3",
-        "@grammyjs/transformer-throttler": "1.2.1",
-        "@homebridge/ciao": "1.3.12",
-        "@lydell/node-pty": "1.2.0-beta.15",
-        "@mistralai/mistralai": "2.6.4",
-        "@modelcontextprotocol/sdk": "1.30.0",
-        "@mozilla/readability": "0.6.0",
-        "@openclaw/ai": "2026.9.1",
-        "@openclaw/fs-safe": "0.7.0",
-        "@openclaw/proxyline": "0.3.7",
-        "@silvia-odwyer/photon-node": "0.3.4",
-        "@trycua/cua-driver": "0.22.0",
-        "acorn": "8.18.0",
-        "chalk": "6.0.0",
-        "chokidar": "5.0.0",
-        "clawpdf": "0.3.1",
-        "commander": "15.0.0",
-        "croner": "10.0.1",
-        "diff": "9.0.0",
-        "dotenv": "17.4.2",
-        "entities": "8.0.0",
-        "execa": "10.0.1",
-        "express": "5.2.1",
-        "file-type": "22.0.2",
-        "grammy": "1.46.0",
-        "highlight.js": "11.12.0",
-        "hosted-git-info": "10.1.1",
-        "iconv-lite": "0.7.3",
-        "ignore": "7.0.6",
-        "jiti": "2.7.0",
-        "json5": "2.2.3",
-        "jszip": "3.10.1",
-        "koffi": "3.1.6",
-        "kysely": "0.29.5",
-        "linkedom": "0.18.13",
-        "minimatch": "10.2.6",
-        "ms": "2.1.3",
-        "node-edge-tts": "1.2.10",
-        "openai": "7.5.0",
-        "p-limit": "7.3.1",
-        "p-map": "7.0.6",
-        "partial-json": "0.1.7",
-        "playwright-core": "1.62.1",
-        "pretty-ms": "9.3.0",
-        "qrcode": "1.5.4",
-        "quickjs-wasi": "3.5.0",
-        "rastermill": "0.3.2",
-        "semver": "7.8.5",
-        "tar": "7.5.22",
-        "tree-sitter-bash": "0.25.1",
-        "tslog": "4.11.0",
-        "typebox": "1.3.17",
-        "typescript": "6.0.3",
-        "undici": "8.10.0",
-        "web-push": "3.6.7",
-        "web-tree-sitter": "0.26.13",
-        "ws": "8.21.3",
-        "yaml": "2.9.0",
-        "zod": "4.4.3"
-      },
-      "bin": {
-        "openclaw": "openclaw.mjs"
-      },
-      "engines": {
-        "node": ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
-      },
-      "optionalDependencies": {
-        "sqlite-vec": "0.1.9"
-      }
-    },
-    "node_modules/openclaw/node_modules/@openclaw/proxyline": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openclaw/proxyline/-/proxyline-0.3.7.tgz",
-      "integrity": "sha512-RWkt4mPcBOj7E8euyeqynkIFXvEIxVStYH0YHDC08feq5qFyBXGmfdWC+MTMVJXfHN2ituoxLlrIyjpyJpW7ew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      },
-      "peerDependencies": {
-        "undici": ">=8.5.0 <9"
-      }
-    },
-    "node_modules/openclaw/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/openclaw/node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/openclaw/node_modules/p-limit": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
-      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openclaw/node_modules/readdirp": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
-      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/openclaw/node_modules/tree-sitter-bash": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
-      "integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.25.0"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openclaw/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/openclaw/node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openclaw/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7765,63 +5065,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
-      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
-    "node_modules/parse-ms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7830,13 +5073,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7931,29 +5167,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -8036,29 +5249,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
@@ -8069,9 +5259,9 @@
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
       "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8112,151 +5302,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qrcode": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
-      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dijkstrajs": "^1.0.1",
-        "pngjs": "^5.0.0",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "qrcode": "bin/qrcode"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/qrcode/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qs": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
@@ -8273,13 +5318,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/quickjs-wasi": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-3.5.0.tgz",
-      "integrity": "sha512-/4LKs62eqqqQyr0uVEgSvB3QeOlIpM0Wc4XPgomOfucVurDWssH2eNfDS0Y4NjQoIzoD8jVO7qWvR5drkgnRVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8287,19 +5325,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/rastermill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/rastermill/-/rastermill-0.3.2.tgz",
-      "integrity": "sha512-Qr4Q+PKsAyAPn4sHwY+hJ2P7rv+WJ4HZ8X+KjwVmm0tOpkb1IrtCb7sbwDZ8iJLUgiYafhmG4VHwo7Pjej0pgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@silvia-odwyer/photon-node": "0.3.4"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/raw-body": {
@@ -8317,29 +5342,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -8354,16 +5356,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8372,13 +5364,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -8398,16 +5383,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/roarr": {
@@ -8523,27 +5498,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8630,20 +5584,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8811,19 +5751,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8880,108 +5807,12 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
-    "node_modules/sqlite-vec": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
-      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
-      "dev": true,
-      "license": "MIT OR Apache",
-      "optional": true,
-      "optionalDependencies": {
-        "sqlite-vec-darwin-arm64": "0.1.9",
-        "sqlite-vec-darwin-x64": "0.1.9",
-        "sqlite-vec-linux-arm64": "0.1.9",
-        "sqlite-vec-linux-x64": "0.1.9",
-        "sqlite-vec-windows-x64": "0.1.9"
-      }
-    },
-    "node_modules/sqlite-vec-darwin-arm64": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
-      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/sqlite-vec-darwin-x64": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
-      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/sqlite-vec-linux-arm64": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
-      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/sqlite-vec-linux-x64": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
-      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/sqlite-vec-windows-x64": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
-      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT OR Apache",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
-      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -9026,81 +5857,6 @@
         "url": "https://github.com/sponsors/uhop"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strtok3": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
-      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -9132,23 +5888,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.5.22",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
-      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -9223,32 +5962,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/token-types": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
-      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@borewit/text-codec": "^0.2.1",
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -9348,13 +6061,6 @@
         }
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -9379,21 +6085,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
-      "license": "0BSD"
-    },
-    "node_modules/tslog": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.11.0.tgz",
-      "integrity": "sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
-      }
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -9534,13 +6227,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/typebox": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.17.tgz",
-      "integrity": "sha512-20PsSaZV1pN7pIfM/YEUHZNTv8X21+1ilPo/HN+6GtFbhCaQhLrIoKCkAkcBwIva3nYI+Ao0MxM1iDj5H3SOhw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -9586,26 +6272,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uhyphen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
-      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -9620,19 +6286,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -9652,13 +6305,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -9847,61 +6493,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/web-push": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
-      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "asn1.js": "^5.3.0",
-        "http_ece": "1.2.0",
-        "https-proxy-agent": "^7.0.0",
-        "jws": "^4.0.0",
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "web-push": "src/cli.js"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/web-tree-sitter": {
-      "version": "0.26.13",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.13.tgz",
-      "integrity": "sha512-5bUZ7vbQ1kcondet96wzP974+JfCZDeQ7bTpacICm2nnvHpa5cO0ByRsoMcAhUP+743vpkb4m0BFlVSm+Ye9VA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9916,29 +6507,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/which-command": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
-      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "which-command": "cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
-      }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -9967,24 +6535,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9992,9 +6542,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
-      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10012,26 +6562,6 @@
         }
       }
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -10047,35 +6577,6 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.7.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -10084,19 +6585,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
-      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/node": "^22.10.7",
         "drizzle-kit": "^0.31.10",
         "eslint": "^10.9.1",
+        "openclaw": "^2026.9.1",
         "tsup": "^8.3.5",
         "tsx": "^4.23.8",
         "typescript": "^5.7.3",
@@ -49,6 +50,16 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -131,6 +142,49 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
+      "integrity": "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
@@ -165,6 +219,20 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.3",
@@ -768,6 +836,86 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.18.0.tgz",
+      "integrity": "sha512-uy9gWVTAZXuA/2tld0QJl/QNiGEn4QOmfX4PiRgZQmeFQRQhojpD/Gf41SPnBJmjEnT83a+h4AdU1HHYaYvVDw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@grammyjs/runner": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
+      "integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.13.1"
+      }
+    },
+    "node_modules/@grammyjs/transformer-throttler": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
+      "integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bottleneck": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.0.0"
+      }
+    },
+    "node_modules/@grammyjs/types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-5.0.0.tgz",
+      "integrity": "sha512-iq1Qrq1iPKkB8yAa0qSuIURMZOCuqTY5pWy5gHpCeL1oQ+GPadGhw/cDTVE8waJwuCzacUzuIjRv1sESvk7u7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@homebridge/ciao": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.12.tgz",
+      "integrity": "sha512-84/0u0kqKy4qcKupIDaTtbkmk+3qFDuMzxTC0NPfVlHcUT+jHGdP+QCqwEw94/GJxRezDeBLwxaclkBZgCdeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1428,6 +1576,19 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1465,6 +1626,261 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
+      "integrity": "sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
+      "integrity": "sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
+      "integrity": "sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
+      "integrity": "sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
+      "integrity": "sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
+      "integrity": "sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
+      "integrity": "sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
+      "integrity": "sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
+      "integrity": "sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
+      "integrity": "sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
+      "integrity": "sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
+      "integrity": "sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
+      "integrity": "sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
+      "integrity": "sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
+      "integrity": "sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@libsql/client": {
@@ -1626,6 +2042,138 @@
         "win32"
       ]
     },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "integrity": "sha512-Br8wBxzbxFwdWgk9uQ+rdzE0xfoxOK4QuGH54swhRwc5IxP6H9Y1/bcyazRGvNUs6XkB5qNVkezuKSRxUwZe7A==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.15",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.15",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.15",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.15",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.15",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.15"
+      }
+    },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.15.tgz",
+      "integrity": "sha512-6TSBbzdcLiNTHl1mTuzflqXrkmcC36USVGvERoDgvHk2ItEDaMaFZuAJ1CqPmwYj0DyhCS16TVS8OGK9xZnjyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.15.tgz",
+      "integrity": "sha512-yDT2oqPqYMBScyuk1U9Rg5VKcrbMOD9o9jWYYamDADA3NSbUISroPChrqYRQ74Y7BQtNH4gqYAiWOZRi5uQZ0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-arm64": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.15.tgz",
+      "integrity": "sha512-wkbNF7dYAmtJv+o2+iztVlNwnUB4B0uX0wh/UD+mwMcmE2gNMnW9GChXO7fEE5XJokD0vB5idiHpGegaN+G/sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.15.tgz",
+      "integrity": "sha512-+U/5AVvHT6W+8OCYcnJgN0Qgc0ycO3TfD6aaFJHK+WHij797f8gsi5dV1HEO9l6YQmWCD+VL5gaLDhx3mxHwCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.15.tgz",
+      "integrity": "sha512-pyAk91w7wnnKrD4mrHXtIXRfmzSWV5bEzvRhurXcMCtCc2TJ424ciUskIgWMhAPP6y3KyUnqElj+U6kY3iOt0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.15.tgz",
+      "integrity": "sha512-2f8twEmDVxZ7drchAXjtevpmSPhFok0avAnzXro4t5gmz0xsPNKkoZvymwtuIS3xo7PzQqZOPQ/YzwEMb7oIzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.6.4.tgz",
+      "integrity": "sha512-PPt4GyJqs2hEsWrYCJZK5f0ORmT+L2MSm75LVGD7kBLf6ZKsoDpld/FRBQXr8xG6iFCBOFJFYzvGYhUb+UCkbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+        "@opentelemetry/resources": "^2.9.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -1666,6 +2214,16 @@
         }
       }
     },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
@@ -1684,6 +2242,186 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@openclaw/ai": {
+      "version": "2026.9.1",
+      "resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.9.1.tgz",
+      "integrity": "sha512-Am/7miiZZjbXv0MxzmOsaCAB9YXlz3vHl1Nuq1j1rOWj+7MwO83P5rnXdk10vc3jXxaXq2snlDl/La8xkd2IeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.120.0",
+        "@google/genai": "2.18.0",
+        "@mistralai/mistralai": "2.6.4",
+        "openai": "7.5.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.17"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@openclaw/fs-safe": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.7.0.tgz",
+      "integrity": "sha512-i+0a4yQYa4ThUahaSLMledG99AL38XdAn8q/ppVMr49zr0dsOO+1gf8Jz6jgI0ggdcq6U4IhgsNunACsSymjyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@openclaw/fs-safe-darwin-arm64": "0.7.0",
+        "@openclaw/fs-safe-darwin-x64": "0.7.0",
+        "@openclaw/fs-safe-linux-arm64-gnu": "0.7.0",
+        "@openclaw/fs-safe-linux-arm64-musl": "0.7.0",
+        "@openclaw/fs-safe-linux-x64-gnu": "0.7.0",
+        "@openclaw/fs-safe-linux-x64-musl": "0.7.0",
+        "@openclaw/fs-safe-win32-x64-msvc": "0.7.0",
+        "jszip": "^3.10.1",
+        "tar": "7.5.22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-darwin-arm64": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-darwin-arm64/-/fs-safe-darwin-arm64-0.7.0.tgz",
+      "integrity": "sha512-11z1Tv1ZVa31M+aoC56EX/DUACVuq4GiYSOpbv/ZDqwFPCdy+N/Vi2x/hcwCLjhb6UOsMWRsMsIAMjQAR2qHmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-darwin-x64": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-darwin-x64/-/fs-safe-darwin-x64-0.7.0.tgz",
+      "integrity": "sha512-LS89eU+x7Kq0kugOR1HLsdVcuTNwCeMU+UQoWZUsWbWg9XTtw5ohOTU7bqewPNVGmB0cdihPfdorKc5wZgLTVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-linux-arm64-gnu": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-arm64-gnu/-/fs-safe-linux-arm64-gnu-0.7.0.tgz",
+      "integrity": "sha512-3UZDqtYJSMMN4Rid68EuTmCYjHyGHilQ7BFfm+ZKGloJoJLEvXoaAbDAqsazvWjrQKecfxlXJTC9qbLa5RYJEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-linux-arm64-musl": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-arm64-musl/-/fs-safe-linux-arm64-musl-0.7.0.tgz",
+      "integrity": "sha512-rX1m2ft84KOb61/EhJmkiC0hqH4QCd1knQFcDU8tiA49sbiXsghNfSXRd2K07GlA7spXtqQfSX3ZvMh4f7JhBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-linux-x64-gnu": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-x64-gnu/-/fs-safe-linux-x64-gnu-0.7.0.tgz",
+      "integrity": "sha512-lTn5h0lkJjL1yiOxh+kgY2L4JDAXo2fNHXXZqxKACQdhB1+YFcc8YyUPTjK2b8aWlsgpRwfq/7JJ1eDHRbDcrg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-linux-x64-musl": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-linux-x64-musl/-/fs-safe-linux-x64-musl-0.7.0.tgz",
+      "integrity": "sha512-e/LcF75zEQzg9yII5jv7WBZ3w7dNGBVpiOxlbm1dpy5XX+ap8pjsqWC0c0UGJdIbwWQInzKpb4/B0mwED/obYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@openclaw/fs-safe-win32-x64-msvc": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe-win32-x64-msvc/-/fs-safe-win32-x64-msvc-0.7.0.tgz",
+      "integrity": "sha512-FiVNgckcHBuRov6vRytRjx8AdRBPxl56qZ8Dr0aAaAxfo+yhSJCGPmhnpgqUirBxkKQyrABIrP3LdIyscJMgWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.146.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
@@ -1698,36 +2436,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
@@ -1736,29 +2474,29 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
@@ -2429,11 +3167,179 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@trycua/cua-driver": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver/-/cua-driver-0.22.0.tgz",
+      "integrity": "sha512-NElsgryvNTl7arPdx7trvYhz4geMhPztsi8RFeECY2XhuuhWWzSPPPHTC4cBVsb/gprqqPtb+Hy2I1kGGEGddg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ubjs/core": "0.31.0-3",
+        "@ubjs/node": "0.31.0-3"
+      },
+      "optionalDependencies": {
+        "@trycua/cua-driver-darwin-arm64": "0.22.0",
+        "@trycua/cua-driver-darwin-x64": "0.22.0",
+        "@trycua/cua-driver-linux-arm64-gnu": "0.22.0",
+        "@trycua/cua-driver-linux-x64-gnu": "0.22.0",
+        "@trycua/cua-driver-win32-arm64-msvc": "0.22.0",
+        "@trycua/cua-driver-win32-x64-msvc": "0.22.0"
+      }
+    },
+    "node_modules/@trycua/cua-driver-darwin-arm64": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-darwin-arm64/-/cua-driver-darwin-arm64-0.22.0.tgz",
+      "integrity": "sha512-CD83Bvwx5XQtds+nxDOcY2CxKqSxr6spjjdpwYDb/34jtTt46jedt1A73QEEP/xkf9Ckw9Z7CWs68bt+bmGMYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-darwin-x64": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-darwin-x64/-/cua-driver-darwin-x64-0.22.0.tgz",
+      "integrity": "sha512-uHqMAbYRqLs8MUHyODrAR0kX7rmgwFINcSGVGgrULr5E2OmeJHx6F/THQk/1lLV6jtrKX/bZsqxROehRJmtPNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-linux-arm64-gnu": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-linux-arm64-gnu/-/cua-driver-linux-arm64-gnu-0.22.0.tgz",
+      "integrity": "sha512-UCGS0LRnySNwAYqymH+jShoyDUtqAkVPEMbCDDALu5R4BqtsyGfawxKYAYg9/tBya48Dkf4NcjE5lGDKs2ku9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-linux-x64-gnu": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-linux-x64-gnu/-/cua-driver-linux-x64-gnu-0.22.0.tgz",
+      "integrity": "sha512-9wtKFGaDbQk0BHXnyWMLKKgkTvhNi0Qv8y39inbXL5mfhQoUvUUx1QnhD5SZiImE0GoGvLq/BcwoizmjO3pLNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-win32-arm64-msvc": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-win32-arm64-msvc/-/cua-driver-win32-arm64-msvc-0.22.0.tgz",
+      "integrity": "sha512-zJJuFJAYCchablDpgDv4ybbBaBVUiPNvt38XeoTKwIkZZHqfAYXUO0gWQ6tU2PpTfZHZAdidpwjln+xO0OUE5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-win32-x64-msvc": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-win32-x64-msvc/-/cua-driver-win32-x64-msvc-0.22.0.tgz",
+      "integrity": "sha512-32E9FZCrXKgXV9vg+2wsdJUarsrn3cj0nBMxcY8z1QyfXjuYKYX0J5XJUlxbNC8PJRbYPEBnd09F1qb05Rv64w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2482,6 +3388,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2722,6 +3635,154 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ubjs/core": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/core/-/core-0.31.0-3.tgz",
+      "integrity": "sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==",
+      "dev": true,
+      "license": "MPL-2.0"
+    },
+    "node_modules/@ubjs/node": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node/-/node-0.31.0-3.tgz",
+      "integrity": "sha512-qNMpi2LICNwxGXZyRF8fSDBSpbezyZbEsydrbiMPJOmtOWr4tmZIEl7jkWGHVGShoBvHfFo4eHp5B4UVP928Cg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "optionalDependencies": {
+        "@ubjs/node-darwin-arm64": "0.31.0-3",
+        "@ubjs/node-darwin-x64": "0.31.0-3",
+        "@ubjs/node-linux-arm64-gnu": "0.31.0-3",
+        "@ubjs/node-linux-arm64-musl": "0.31.0-3",
+        "@ubjs/node-linux-x64-gnu": "0.31.0-3",
+        "@ubjs/node-linux-x64-musl": "0.31.0-3",
+        "@ubjs/node-win32-arm64-msvc": "0.31.0-3",
+        "@ubjs/node-win32-x64-msvc": "0.31.0-3"
+      }
+    },
+    "node_modules/@ubjs/node-darwin-arm64": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-darwin-arm64/-/node-darwin-arm64-0.31.0-3.tgz",
+      "integrity": "sha512-GGQVPLkVo4Gc8qVLW4IGvS8bjl8eHXyeP4a97ntGmsAdXwE5gsS29o8xUEFROjhwHKD+9sgVeblCSWVG3CpHsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ubjs/node-darwin-x64": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-darwin-x64/-/node-darwin-x64-0.31.0-3.tgz",
+      "integrity": "sha512-2sc47u4XFYOsbmP5EW+Gx8m/yGrYnfFDFQm6+kz7goSWTNg84eEiz3COs9HKJDVuNJ5Khv5XipTO8CFadMLXCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-arm64-gnu": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-arm64-gnu/-/node-linux-arm64-gnu-0.31.0-3.tgz",
+      "integrity": "sha512-YStVXhYz/5jvlWf/p4fhiVT72unYAbGugifFC9QmO/+hnroQDAQ5t8SARbsc15G4olMcamdIB+GETiUB7gmaYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-arm64-musl": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-arm64-musl/-/node-linux-arm64-musl-0.31.0-3.tgz",
+      "integrity": "sha512-Izp4nvfy/LmibzFowAztkoDOksCR2fb2zl6fh1ojR1HEsg0rAGruxtI8d3fn8DI0lBXwqmn6SF///oD4mFNJPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-x64-gnu": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-x64-gnu/-/node-linux-x64-gnu-0.31.0-3.tgz",
+      "integrity": "sha512-Xdm21blyg5U/kW6s7OMvgrr8coGTkUlt26DVR9x8gKISif+E3YwdEskbFScWqystAiJnfjw7xHEc8UMu0Qlz7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-x64-musl": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-x64-musl/-/node-linux-x64-musl-0.31.0-3.tgz",
+      "integrity": "sha512-fFQ9BWS6i2LUH9SJgD9oEiKXXo/say59vHy7usFe1t7C2xvwvP34f5SuxXmWP9R8fHyA0aC4kIZ+TTwyHSv1Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-win32-arm64-msvc": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-win32-arm64-msvc/-/node-win32-arm64-msvc-0.31.0-3.tgz",
+      "integrity": "sha512-ID6rSz1NmPsWTNBBNAw4OnJ5Dj8pcbtNJtdPB3OxcGigLBd/e0x7buhSI7os6Mo5iYtEdCynBRQHFJwub5XSPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ubjs/node-win32-x64-msvc": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-win32-x64-msvc/-/node-win32-x64-msvc-0.31.0-3.tgz",
+      "integrity": "sha512-wevs+Y+szwcCUT8IJFbB4/1nfxyRv/51l8oG7FGUPWD1xLPyuHfJBG27C+PDeC7KRzes/2n6aLo4DGZbr/LYTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@vercel/oidc": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
@@ -2850,6 +3911,19 @@
       "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2864,9 +3938,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2894,6 +3968,16 @@
       "optional": true,
       "engines": {
         "node": ">=14.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ai": {
@@ -2946,12 +4030,51 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2972,6 +4095,44 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -3010,6 +4171,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -3017,6 +4192,13 @@
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -3030,6 +4212,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3102,6 +4291,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3110,6 +4309,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -3127,6 +4339,64 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/clawpdf": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/clawpdf/-/clawpdf-0.3.1.tgz",
+      "integrity": "sha512-HZ8gz3cm8arzT/V2CnMZlHlRJbsrUYQ71u+A4nymeyvNnYzpZ8RQwkr2EIZiXCOzRkzFy8sOiHBXBuSUDDcXqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "clawpdf": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -3201,6 +4471,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3218,6 +4495,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3230,6 +4527,58 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -3247,6 +4596,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-is": {
@@ -3316,6 +4675,94 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -3484,10 +4931,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -3497,6 +4961,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3583,6 +5060,16 @@
         "@esbuild/win32-arm64": "0.28.2",
         "@esbuild/win32-ia32": "0.28.2",
         "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3802,6 +5289,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -3821,6 +5318,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
+      "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.1",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.3.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/expect-type": {
@@ -3894,6 +5418,13 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3913,6 +5444,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -3972,6 +5510,46 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3983,6 +5561,25 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.2.tgz",
+      "integrity": "sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/finalhandler": {
@@ -4063,6 +5660,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -4105,6 +5715,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4140,6 +5803,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4203,6 +5883,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4213,6 +5921,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grammy": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.46.0.tgz",
+      "integrity": "sha512-/8Qw+iisrUdOMk+p2mjEHouMm/BBdBEN1DHh16wiTpRUZkxDG3PxexdjCvR+wvK3LWPdrEvnQbdrwpU954sPhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "5.0.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/grammy/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/guid-typescript": {
@@ -4259,6 +6004,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hono": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
@@ -4266,6 +6021,141 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
+      "integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/http-errors": {
@@ -4288,10 +6178,34 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4304,6 +6218,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4313,6 +6248,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -4358,6 +6300,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4371,10 +6323,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4382,6 +6380,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.3",
@@ -4408,6 +6416,16 @@
       "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -4420,6 +6438,20 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4447,6 +6479,55 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4455,6 +6536,44 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.6.tgz",
+      "integrity": "sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.6",
+        "@koromix/koffi-darwin-x64": "3.1.6",
+        "@koromix/koffi-freebsd-arm64": "3.1.6",
+        "@koromix/koffi-freebsd-ia32": "3.1.6",
+        "@koromix/koffi-freebsd-x64": "3.1.6",
+        "@koromix/koffi-linux-arm64": "3.1.6",
+        "@koromix/koffi-linux-ia32": "3.1.6",
+        "@koromix/koffi-linux-loong64": "3.1.6",
+        "@koromix/koffi-linux-riscv64": "3.1.6",
+        "@koromix/koffi-linux-x64": "3.1.6",
+        "@koromix/koffi-openbsd-ia32": "3.1.6",
+        "@koromix/koffi-openbsd-x64": "3.1.6",
+        "@koromix/koffi-win32-arm64": "3.1.6",
+        "@koromix/koffi-win32-ia32": "3.1.6",
+        "@koromix/koffi-win32-x64": "3.1.6"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.5.tgz",
+      "integrity": "sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/levn": {
@@ -4501,6 +6620,16 @@
         "@libsql/linux-x64-gnu": "0.5.29",
         "@libsql/linux-x64-musl": "0.5.29",
         "@libsql/win32-x64-msvc": "0.5.29"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -4806,6 +6935,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -4836,8 +6990,18 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -4847,6 +7011,19 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {
@@ -4917,6 +7094,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -4931,6 +7115,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -5008,6 +7225,61 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-edge-tts": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
+      "integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.1",
+        "ws": "^8.13.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "node-edge-tts": "bin.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -5017,6 +7289,53 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {
@@ -5132,6 +7451,270 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/openai": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.5.0.tgz",
+      "integrity": "sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openclaw": {
+      "version": "2026.9.1",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.9.1.tgz",
+      "integrity": "sha512-0Ve0631CdgkJDwd4NNG1BawIdF5yCL2sO+Tts8amStw+H6vKURTj0K4rOa4+hFpJk1Dnw5LyKl5twzwX1VtA2w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "1.4.0",
+        "@anthropic-ai/sdk": "0.120.0",
+        "@clack/core": "1.4.3",
+        "@clack/prompts": "1.7.0",
+        "@earendil-works/pi-tui": "0.84.2",
+        "@google/genai": "2.18.0",
+        "@grammyjs/runner": "2.0.3",
+        "@grammyjs/transformer-throttler": "1.2.1",
+        "@homebridge/ciao": "1.3.12",
+        "@lydell/node-pty": "1.2.0-beta.15",
+        "@mistralai/mistralai": "2.6.4",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "@mozilla/readability": "0.6.0",
+        "@openclaw/ai": "2026.9.1",
+        "@openclaw/fs-safe": "0.7.0",
+        "@openclaw/proxyline": "0.3.7",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "@trycua/cua-driver": "0.22.0",
+        "acorn": "8.18.0",
+        "chalk": "6.0.0",
+        "chokidar": "5.0.0",
+        "clawpdf": "0.3.1",
+        "commander": "15.0.0",
+        "croner": "10.0.1",
+        "diff": "9.0.0",
+        "dotenv": "17.4.2",
+        "entities": "8.0.0",
+        "execa": "10.0.1",
+        "express": "5.2.1",
+        "file-type": "22.0.2",
+        "grammy": "1.46.0",
+        "highlight.js": "11.12.0",
+        "hosted-git-info": "10.1.1",
+        "iconv-lite": "0.7.3",
+        "ignore": "7.0.6",
+        "jiti": "2.7.0",
+        "json5": "2.2.3",
+        "jszip": "3.10.1",
+        "koffi": "3.1.6",
+        "kysely": "0.29.5",
+        "linkedom": "0.18.13",
+        "minimatch": "10.2.6",
+        "ms": "2.1.3",
+        "node-edge-tts": "1.2.10",
+        "openai": "7.5.0",
+        "p-limit": "7.3.1",
+        "p-map": "7.0.6",
+        "partial-json": "0.1.7",
+        "playwright-core": "1.62.1",
+        "pretty-ms": "9.3.0",
+        "qrcode": "1.5.4",
+        "quickjs-wasi": "3.5.0",
+        "rastermill": "0.3.2",
+        "semver": "7.8.5",
+        "tar": "7.5.22",
+        "tree-sitter-bash": "0.25.1",
+        "tslog": "4.11.0",
+        "typebox": "1.3.17",
+        "typescript": "6.0.3",
+        "undici": "8.10.0",
+        "web-push": "3.6.7",
+        "web-tree-sitter": "0.26.13",
+        "ws": "8.21.3",
+        "yaml": "2.9.0",
+        "zod": "4.4.3"
+      },
+      "bin": {
+        "openclaw": "openclaw.mjs"
+      },
+      "engines": {
+        "node": ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+      },
+      "optionalDependencies": {
+        "sqlite-vec": "0.1.9"
+      }
+    },
+    "node_modules/openclaw/node_modules/@openclaw/proxyline": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@openclaw/proxyline/-/proxyline-0.3.7.tgz",
+      "integrity": "sha512-RWkt4mPcBOj7E8euyeqynkIFXvEIxVStYH0YHDC08feq5qFyBXGmfdWC+MTMVJXfHN2ituoxLlrIyjpyJpW7ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "undici": ">=8.5.0 <9"
+      }
+    },
+    "node_modules/openclaw/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/openclaw/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/openclaw/node_modules/p-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openclaw/node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/openclaw/node_modules/tree-sitter-bash": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
+      "integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openclaw/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/openclaw/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openclaw/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5182,6 +7765,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5190,6 +7830,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5284,6 +7931,29 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -5366,6 +8036,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
@@ -5376,9 +8069,9 @@
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
       "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5419,6 +8112,151 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
@@ -5435,6 +8273,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quickjs-wasi": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-3.5.0.tgz",
+      "integrity": "sha512-/4LKs62eqqqQyr0uVEgSvB3QeOlIpM0Wc4XPgomOfucVurDWssH2eNfDS0Y4NjQoIzoD8jVO7qWvR5drkgnRVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5442,6 +8287,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rastermill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/rastermill/-/rastermill-0.3.2.tgz",
+      "integrity": "sha512-Qr4Q+PKsAyAPn4sHwY+hJ2P7rv+WJ4HZ8X+KjwVmm0tOpkb1IrtCb7sbwDZ8iJLUgiYafhmG4VHwo7Pjej0pgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@silvia-odwyer/photon-node": "0.3.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/raw-body": {
@@ -5459,6 +8317,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -5473,6 +8354,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5481,6 +8372,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -5500,6 +8398,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/roarr": {
@@ -5615,6 +8523,27 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5701,6 +8630,20 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -5868,6 +8811,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5924,12 +8880,108 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "dev": true,
+      "license": "MIT OR Apache",
+      "optional": true,
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -5974,6 +9026,81 @@
         "url": "https://github.com/sponsors/uhop"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -6005,6 +9132,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -6079,6 +9223,32 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -6178,6 +9348,13 @@
         }
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6202,8 +9379,21 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "devOptional": true,
+      "license": "0BSD"
+    },
+    "node_modules/tslog": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.11.0.tgz",
+      "integrity": "sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+      }
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -6344,6 +9534,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typebox": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.17.tgz",
+      "integrity": "sha512-20PsSaZV1pN7pIfM/YEUHZNTv8X21+1ilPo/HN+6GtFbhCaQhLrIoKCkAkcBwIva3nYI+Ao0MxM1iDj5H3SOhw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6389,6 +9586,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -6403,6 +9620,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -6422,6 +9652,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -6610,6 +9847,61 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.13",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.13.tgz",
+      "integrity": "sha512-5bUZ7vbQ1kcondet96wzP974+JfCZDeQ7bTpacICm2nnvHpa5cO0ByRsoMcAhUP+743vpkb4m0BFlVSm+Ye9VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6624,6 +9916,29 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -6652,6 +9967,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -6659,9 +9992,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6679,6 +10012,26 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -6694,6 +10047,35 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6702,6 +10084,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "version": "5.21.1",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./plugin": "./dist/plugin.js",
+    "./package.json": "./package.json",
+    "./integrations/*": "./integrations/*",
+    "./dist/*": "./dist/*"
+  },
   "type": "module",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "@types/node": "^22.10.7",
     "drizzle-kit": "^0.31.10",
     "eslint": "^10.9.1",
-    "openclaw": "^2026.9.1",
     "tsup": "^8.3.5",
     "tsx": "^4.23.8",
     "typescript": "^5.7.3",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@types/node": "^22.10.7",
     "drizzle-kit": "^0.31.10",
     "eslint": "^10.9.1",
+    "openclaw": "^2026.9.1",
     "tsup": "^8.3.5",
     "tsx": "^4.23.8",
     "typescript": "^5.7.3",

--- a/src/cli/agents/lifecycle.ts
+++ b/src/cli/agents/lifecycle.ts
@@ -1,6 +1,5 @@
-import { Readable, Transform } from 'node:stream';
+import { Readable } from 'node:stream';
 import chain from 'stream-chain';
-import { ignore } from 'stream-json/filters/ignore.js';
 import { parser } from 'stream-json';
 import { streamObject } from 'stream-json/streamers/stream-object.js';
 import { SessionEventType } from '../../core/types.js';
@@ -9,9 +8,9 @@ import { LifecycleCapability, LifecycleEvent } from './types.js';
 const capabilities: LifecycleCapability[] = ['supported', 'unsupported', 'degraded'];
 const events: LifecycleEvent[] = ['session-start', 'session-event', 'session-stop', 'session-recover'];
 const sessionEventTypes: SessionEventType[] = ['start', 'command', 'test', 'error', 'git', 'decision', 'checkpoint', 'stop'];
-const MAX_RETAINED_STRING = 2_000;
-const MAX_RETAINED_ARRAY_ITEMS = 50;
-const ROOT_FIELDS = new Set([
+export const MAX_RETAINED_STRING = 2_000;
+export const MAX_RETAINED_ARRAY_ITEMS = 50;
+export const ROOT_FIELDS = new Set([
   // `cascade_id` is Windsurf's third identity fallback and was read by its profile while this
   // list dropped it -- harmless only for as long as Windsurf also sends one of the first two.
   'session_id', 'sessionId', 'thread_id', 'turn_id', 'turnId', 'conversation_id', 'cascade_id', 'generation_id',
@@ -44,18 +43,18 @@ const ROOT_FIELDS = new Set([
  * head of `stdout` is the list of files that passed. These keep the tail instead, at the same
  * bound, so the line that names the failure survives.
  */
-const TAIL_FIELDS = new Set(['error', 'stdout', 'stderr']);
+export const TAIL_FIELDS = new Set(['error', 'stdout', 'stderr']);
 // Knowl write-tool arguments are retained so a new commit can be recognised as the
 // caller's own work. They are compared in memory and never persisted: only summary,
 // command, and changedPaths reach the stored event payload.
-const KNOWL_WRITE_ARGS = ['title', 'id', 'supersedeId', 'supersedes', 'atoms'];
+export const KNOWL_WRITE_ARGS = ['title', 'id', 'supersedeId', 'supersedes', 'atoms'];
 // What tells one call of a search tool from the next. Without these, every Grep in a
 // session normalises to the same event -- the payload keeps only `summary: "Grep
 // completed"` -- so two searches inside the debounce window counted as one and the
 // second was dropped unprocessed, taking its change card with it. Short strings, bounded
 // by MAX_RETAINED_STRING like every other retained field, and compared in memory only.
-const TOOL_DISCRIMINATORS = ['pattern', 'glob', 'query', 'url'];
-const NESTED_FIELDS: Record<string, Set<string>> = {
+export const TOOL_DISCRIMINATORS = ['pattern', 'glob', 'query', 'url'];
+export const NESTED_FIELDS: Record<string, Set<string>> = {
   tool_input: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path', 'notebook_path', ...TOOL_DISCRIMINATORS, ...KNOWL_WRITE_ARGS]),
   toolInput: new Set(['command', 'changedPaths', 'changed_paths', 'file_path', 'filePath', 'path', 'notebook_path', ...TOOL_DISCRIMINATORS, ...KNOWL_WRITE_ARGS]),
   // `stdout`/`stderr` are kept here, tail-bounded, for the fleet's error signature and never
@@ -69,10 +68,10 @@ const NESTED_FIELDS: Record<string, Set<string>> = {
 // Fields kept inside an allowlisted array of objects, e.g. tool_input.atoms[i].
 // Without this, allowing `atoms` above would retain whole atom bodies; only the
 // title is needed to recognise a commit as the caller's own.
-const NESTED_ARRAY_ITEM_FIELDS: Record<string, Set<string>> = {
+export const NESTED_ARRAY_ITEM_FIELDS: Record<string, Set<string>> = {
   atoms: new Set(['title']),
 };
-const ARRAY_FIELDS = new Set(['workspace_roots', 'workspacePaths', 'changedPaths', 'changed_paths', 'file_paths', 'filePaths']);
+export const ARRAY_FIELDS = new Set(['workspace_roots', 'workspacePaths', 'changedPaths', 'changed_paths', 'file_paths', 'filePaths']);
 /**
  * The `toolCall.args` leaves Antigravity's normalizer reads, and nothing else.
  *
@@ -81,73 +80,89 @@ const ARRAY_FIELDS = new Set(['workspace_roots', 'workspacePaths', 'changedPaths
  * arguments are allowlisted down to the fields that are actually read; letting one host's
  * arguments through by their parent would put whole file bodies in this process for no reader.
  */
-const TOOL_CALL_ARG_FIELDS = new Set(['TargetFile', 'AbsolutePath', 'CommandLine', 'Query']);
+export const TOOL_CALL_ARG_FIELDS = new Set(['TargetFile', 'AbsolutePath', 'CommandLine', 'Query']);
 
-function shouldDiscardPath(stack: Array<string | number | null>): boolean {
-  if (stack.length === 0) return false;
-  if (stack.length === 1) return !ROOT_FIELDS.has(String(stack[0]));
-  if (typeof stack.at(-1) === 'number') {
-    const index = Number(stack.at(-1));
-    if (stack.length === 2) return !ARRAY_FIELDS.has(String(stack[0])) || index >= MAX_RETAINED_ARRAY_ITEMS;
-    if (stack.length === 3) return !NESTED_FIELDS[String(stack[0])]?.has(String(stack[1])) || index >= MAX_RETAINED_ARRAY_ITEMS;
-    return true;
+export type LifecyclePayload = Record<string, unknown>;
+
+function boundString(key: string, val: string): string {
+  if (TAIL_FIELDS.has(key)) {
+    return val.length > MAX_RETAINED_STRING ? val.slice(-MAX_RETAINED_STRING) : val;
   }
-  const parent = String(stack[0]);
-  if (stack.length >= 4 && typeof stack[2] === 'number') {
-    // A field of an object inside an allowlisted array. Nothing deeper is ever kept.
-    return stack.length > 4 || !NESTED_ARRAY_ITEM_FIELDS[String(stack[1])]?.has(String(stack[3]));
-  }
-  // `toolCall.args` is the one allowlisted pair with a third level worth keeping, and the one
-  // whose siblings are file contents. Everything under it is named or dropped.
-  if (parent === 'toolCall' && stack.length > 2) {
-    return stack.length > 3 || stack[1] !== 'args' || !TOOL_CALL_ARG_FIELDS.has(String(stack[2]));
-  }
-  if (NESTED_FIELDS[parent]) return !NESTED_FIELDS[parent].has(String(stack[1]));
-  return true;
+  return val.length > MAX_RETAINED_STRING ? val.slice(0, MAX_RETAINED_STRING) : val;
 }
 
-function retainOnlyBoundedStrings() {
-  let chunks: string[] | undefined;
-  // The key the next string value belongs to. Keys arrive packed (`packKeys: true`) as one
-  // `keyValue` token ahead of their value, so this is exact rather than inferred.
-  let currentKey: string | undefined;
-  let keepTail = false;
-  return new Transform({
-    objectMode: true,
-    transform(token, _encoding, callback) {
-      if (token.name === 'keyValue') currentKey = String(token.value);
-      if (token.name === 'startString') {
-        chunks = [];
-        keepTail = currentKey !== undefined && TAIL_FIELDS.has(currentKey);
-        callback();
-        return;
-      }
-      if (chunks) {
-        if (token.name === 'stringChunk') {
-          if (keepTail) {
-            // Rolling window: never hold more than twice the bound, never lose the end.
-            chunks.push(String(token.value));
-            const joined = chunks.join('');
-            if (joined.length > 2 * MAX_RETAINED_STRING) chunks = [joined.slice(-MAX_RETAINED_STRING)];
+export function readLifecyclePayloadObject(raw: unknown): LifecyclePayload {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+  const source = raw as Record<string, unknown>;
+  const payload: LifecyclePayload = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (!ROOT_FIELDS.has(key)) continue;
+
+    if (typeof value === 'string') {
+      payload[key] = boundString(key, value);
+    } else if (Array.isArray(value)) {
+      if (!ARRAY_FIELDS.has(key)) continue;
+      payload[key] = value.slice(0, MAX_RETAINED_ARRAY_ITEMS).map((item) => {
+        if (typeof item === 'string') return boundString(key, item);
+        return item;
+      });
+    } else if (value !== null && typeof value === 'object') {
+      const allowedNested = NESTED_FIELDS[key];
+      if (!allowedNested) continue;
+
+      const nestedSource = value as Record<string, unknown>;
+      const nestedResult: Record<string, unknown> = {};
+
+      for (const [nestedKey, nestedValue] of Object.entries(nestedSource)) {
+        if (!allowedNested.has(nestedKey)) continue;
+
+        if (key === 'toolCall' && nestedKey === 'args') {
+          if (nestedValue !== null && typeof nestedValue === 'object' && !Array.isArray(nestedValue)) {
+            const argsObj = nestedValue as Record<string, unknown>;
+            const filteredArgs: Record<string, unknown> = {};
+            for (const [argKey, argValue] of Object.entries(argsObj)) {
+              if (TOOL_CALL_ARG_FIELDS.has(argKey)) {
+                filteredArgs[argKey] = typeof argValue === 'string' ? boundString(argKey, argValue) : argValue;
+              }
+            }
+            nestedResult[nestedKey] = filteredArgs;
           } else {
-            const retained = chunks.join('').length;
-            if (retained < MAX_RETAINED_STRING) chunks.push(String(token.value).slice(0, MAX_RETAINED_STRING - retained));
+            nestedResult[nestedKey] = typeof nestedValue === 'string' ? boundString(nestedKey, nestedValue) : nestedValue;
           }
-          callback();
-          return;
+        } else if (Array.isArray(nestedValue)) {
+          const itemFields = NESTED_ARRAY_ITEM_FIELDS[nestedKey];
+          nestedResult[nestedKey] = nestedValue.slice(0, MAX_RETAINED_ARRAY_ITEMS).map((item) => {
+            if (item !== null && typeof item === 'object' && !Array.isArray(item) && itemFields) {
+              const itemObj = item as Record<string, unknown>;
+              const filteredItem: Record<string, unknown> = {};
+              for (const [itemKey, itemVal] of Object.entries(itemObj)) {
+                if (itemFields.has(itemKey)) {
+                  filteredItem[itemKey] = typeof itemVal === 'string' ? boundString(itemKey, itemVal) : itemVal;
+                }
+              }
+              return filteredItem;
+            }
+            if (typeof item === 'string') {
+              return boundString(nestedKey, item);
+            }
+            return item;
+          });
+        } else if (typeof nestedValue === 'string') {
+          nestedResult[nestedKey] = boundString(nestedKey, nestedValue);
+        } else {
+          nestedResult[nestedKey] = nestedValue;
         }
-        if (token.name === 'endString') {
-          const joined = chunks.join('');
-          const value = keepTail ? joined.slice(-MAX_RETAINED_STRING) : joined.slice(0, MAX_RETAINED_STRING);
-          chunks = undefined;
-          callback(null, { name: 'stringValue', value });
-          return;
-        }
-        chunks = undefined;
       }
-      callback(null, token);
-    },
-  });
+      payload[key] = nestedResult;
+    } else {
+      payload[key] = value;
+    }
+  }
+
+  return payload;
 }
 
 export function isLifecycleCapability(value: string): value is LifecycleCapability {
@@ -189,7 +204,7 @@ function stripByteOrderMark(chunk: unknown): unknown {
   return chunk;
 }
 
-export async function readLifecyclePayload(stdin = process.stdin): Promise<Record<string, unknown>> {
+export async function readLifecyclePayload(stdin = process.stdin): Promise<LifecyclePayload> {
   if (stdin.isTTY) return {};
   const iterator = stdin[Symbol.asyncIterator]();
   let first = await iterator.next();
@@ -206,16 +221,14 @@ export async function readLifecyclePayload(stdin = process.stdin): Promise<Recor
   })());
   const stream = chain([
     source,
-    parser({ packStrings: false, packKeys: true }),
-    ignore({ filter: shouldDiscardPath, streamKeys: false }),
-    retainOnlyBoundedStrings(),
+    parser(),
     streamObject(),
   ]);
-  const payload: Record<string, unknown> = {};
+  const raw: Record<string, unknown> = {};
   for await (const entry of stream as AsyncIterable<{ key: string; value: unknown }>) {
-    payload[entry.key] = entry.value;
+    raw[entry.key] = entry.value;
   }
-  return payload;
+  return readLifecyclePayloadObject(raw);
 }
 
 export function stringPayloadValue(payload: Record<string, unknown>, key: string): string | undefined {

--- a/src/cli/agents/openclaw.ts
+++ b/src/cli/agents/openclaw.ts
@@ -1,0 +1,209 @@
+import fsSync from 'node:fs';
+import path from 'node:path';
+import { MergeStatus, readTextIfExists, writeWithBackup } from './files.js';
+import {
+  AgentAdapter,
+  AgentDetection,
+  AgentEnvironment,
+  AgentIntegrationResult,
+  IntegrationScope,
+} from './types.js';
+
+/**
+ * Resolves the configuration path for OpenClaw.
+ * Priority:
+ * 1. OPENCLAW_CONFIG_PATH environment variable override.
+ * 2. Project-scoped `openclaw.json` if it exists in projectRoot.
+ * 3. Global `~/.openclaw/openclaw.json`.
+ */
+export function openclawConfigPath(environment: AgentEnvironment, projectRoot?: string): string {
+  if (process.env.OPENCLAW_CONFIG_PATH) {
+    return process.env.OPENCLAW_CONFIG_PATH;
+  }
+  if (projectRoot && fsSync.existsSync(path.join(projectRoot, 'openclaw.json'))) {
+    return path.join(projectRoot, 'openclaw.json');
+  }
+  return path.join(environment.homeDir, '.openclaw', 'openclaw.json');
+}
+
+export function openclawConfigScope(configPath: string, projectRoot?: string): IntegrationScope {
+  if (projectRoot && path.resolve(configPath) === path.resolve(projectRoot, 'openclaw.json')) {
+    return 'project';
+  }
+  return 'global';
+}
+
+/**
+ * Checks whether the OpenClaw configuration has the Knowl plugin enabled with:
+ * - `enabled: true`
+ * - `allowConversationAccess: true`
+ * - `allowPromptInjection: true`
+ * - explicit `timeouts.before_tool_call: 5000` (ms)
+ */
+export function isOpenClawConfigured(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const config = data as Record<string, any>;
+  const knowl = config.plugins?.entries?.knowl;
+  if (!knowl || typeof knowl !== 'object' || Array.isArray(knowl)) return false;
+  if (knowl.enabled !== true) return false;
+  const hooks = knowl.hooks;
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) return false;
+  if (hooks.allowConversationAccess !== true) return false;
+  if (hooks.allowPromptInjection !== true) return false;
+  if (hooks.timeouts?.before_tool_call !== 5000) return false;
+  return true;
+}
+
+/**
+ * Mutates an OpenClaw config object in-place to ensure Knowl plugin configuration,
+ * preserving all unrelated user keys across top-level, plugins, entries, and hooks.
+ */
+export function mutateOpenClawConfig(data: Record<string, unknown>): { changed: boolean; status: MergeStatus } {
+  if (isOpenClawConfigured(data)) {
+    return { changed: false, status: 'unchanged' };
+  }
+
+  const hadKnowl = typeof (data as any)?.plugins?.entries?.knowl === 'object'
+    && (data as any)?.plugins?.entries?.knowl !== null;
+  const status: MergeStatus = hadKnowl ? 'updated' : 'configured';
+
+  if (!data.plugins || typeof data.plugins !== 'object' || Array.isArray(data.plugins)) {
+    data.plugins = {};
+  }
+  const plugins = data.plugins as Record<string, unknown>;
+
+  if (!plugins.entries || typeof plugins.entries !== 'object' || Array.isArray(plugins.entries)) {
+    plugins.entries = {};
+  }
+  const entries = plugins.entries as Record<string, unknown>;
+
+  const existingKnowl = entries.knowl && typeof entries.knowl === 'object' && !Array.isArray(entries.knowl)
+    ? (entries.knowl as Record<string, unknown>)
+    : {};
+
+  const existingHooks = existingKnowl.hooks && typeof existingKnowl.hooks === 'object' && !Array.isArray(existingKnowl.hooks)
+    ? (existingKnowl.hooks as Record<string, unknown>)
+    : {};
+
+  const existingTimeouts = existingHooks.timeouts && typeof existingHooks.timeouts === 'object' && !Array.isArray(existingHooks.timeouts)
+    ? (existingHooks.timeouts as Record<string, unknown>)
+    : {};
+
+  entries.knowl = {
+    ...existingKnowl,
+    enabled: true,
+    hooks: {
+      ...existingHooks,
+      allowConversationAccess: true,
+      allowPromptInjection: true,
+      timeouts: {
+        ...existingTimeouts,
+        before_tool_call: 5000,
+      },
+    },
+  };
+
+  return { changed: true, status };
+}
+
+/**
+ * Merges OpenClaw plugin configuration into `openclaw.json`.
+ * Never overwrites unrelated keys. If the file is unparseable JSON, throws an error
+ * leaving the file untouched.
+ */
+export async function mergeOpenClawConfig(configPath: string): Promise<MergeStatus> {
+  const existing = await readTextIfExists(configPath);
+  let config: Record<string, unknown>;
+  if (existing === undefined || existing.trim() === '') {
+    config = {};
+  } else {
+    try {
+      config = JSON.parse(existing);
+      if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+        throw new Error('Config root is not an object');
+      }
+    } catch (error: any) {
+      throw new Error(`Could not parse ${configPath}: ${error.message}`, { cause: error });
+    }
+  }
+
+  const { changed, status } = mutateOpenClawConfig(config);
+  if (!changed) {
+    return 'unchanged';
+  }
+
+  const json = `${JSON.stringify(config, null, 2)}\n`;
+  const output = existing?.includes('\r\n') ? json.replace(/\n/g, '\r\n') : json;
+  await writeWithBackup(configPath, output, existing);
+  return status;
+}
+
+export function createOpenClawAdapter(environment: AgentEnvironment): AgentAdapter {
+  return {
+    name: 'openclaw',
+    label: 'OpenClaw',
+    async detect(root: string): Promise<AgentDetection> {
+      const pathname = openclawConfigPath(environment, root);
+      const scope = openclawConfigScope(pathname, root);
+      const configured = await this.verify(root);
+      return {
+        installed: await environment.commandExists('openclaw'),
+        configured,
+        scope,
+        configPath: pathname,
+      };
+    },
+    async configure(root: string): Promise<AgentIntegrationResult> {
+      const pathname = openclawConfigPath(environment, root);
+      const scope = openclawConfigScope(pathname, root);
+      try {
+        const status = await mergeOpenClawConfig(pathname);
+        return {
+          agent: 'openclaw',
+          status,
+          scope,
+          configPath: pathname,
+          message: 'OpenClaw plugin enabled with required hook permissions and timeout.',
+        };
+      } catch (error: any) {
+        return {
+          agent: 'openclaw',
+          status: 'failed',
+          scope,
+          configPath: pathname,
+          message: `Could not configure ${pathname}: ${error.message}`,
+        };
+      }
+    },
+    async verify(root: string): Promise<boolean> {
+      const pathname = openclawConfigPath(environment, root);
+      try {
+        const text = await readTextIfExists(pathname);
+        if (!text || text.trim() === '') return false;
+        return isOpenClawConfigured(JSON.parse(text));
+      } catch {
+        return false;
+      }
+    },
+    async lifecycleCapability() {
+      return 'supported';
+    },
+    async configureLifecycle(root: string): Promise<AgentIntegrationResult> {
+      const pathname = openclawConfigPath(environment, root);
+      const scope = openclawConfigScope(pathname, root);
+      const isConfigured = await this.verify(root);
+      return {
+        agent: 'openclaw',
+        status: isConfigured ? 'unchanged' : 'failed',
+        scope,
+        configPath: pathname,
+        message: isConfigured
+          ? 'Lifecycle runs through the in-process plugin.'
+          : 'OpenClaw plugin is not configured in openclaw.json.',
+      };
+    },
+    async verifyLifecycle(root: string): Promise<boolean> {
+      return this.verify(root);
+    },
+  };
+}

--- a/src/cli/agents/openclaw.ts
+++ b/src/cli/agents/openclaw.ts
@@ -226,13 +226,15 @@ export function createOpenClawAdapter(environment: AgentEnvironment): AgentAdapt
           scope,
           configPath: pathname,
           message: `Plugin copied to ${target}. Two steps remain, both once:\n`
-            + `  cd "${target}" && npm install @dat999zx/knowl @libsql/client\n`
+            + `  cd "${target}" && npm install @dat999zx/knowl @libsql/client --install-links\n`
             + `  openclaw plugins install --link "${target}" --force --accept-capabilities\n`
-            + 'then restart the gateway. The install is not optional: a linked directory resolves '
-            + 'its own imports, and libsql stays external to the Knowl bundle, so without it the '
-            + "plugin loads to \"Cannot find module\". Both install flags are required too -- "
-            + '--force because the directory is outside ClawHub trust metadata, '
-            + '--accept-capabilities because the plugin declares tool-result middleware.',
+            + 'then restart the gateway. None of that is optional. A linked directory resolves its '
+            + 'own imports and libsql stays external to the Knowl bundle, so without the install '
+            + 'the plugin loads to "Cannot find module". --install-links is required because '
+            + "OpenClaw's safety scan refuses a plugin whose node_modules symlinks outside the "
+            + 'install root, which is exactly what a plain `npm link` produces. --force covers the '
+            + 'directory being outside ClawHub trust metadata, and --accept-capabilities covers '
+            + 'the declared tool-result middleware.',
         };
       } catch (error: any) {
         return {

--- a/src/cli/agents/openclaw.ts
+++ b/src/cli/agents/openclaw.ts
@@ -1,6 +1,7 @@
 import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
-import { MergeStatus, readTextIfExists, writeWithBackup } from './files.js';
+import { MergeStatus, packageRootDir, readTextIfExists, writeWithBackup } from './files.js';
 import {
   AgentAdapter,
   AgentDetection,
@@ -8,6 +9,34 @@ import {
   AgentIntegrationResult,
   IntegrationScope,
 } from './types.js';
+
+/** Where this package keeps the plugin it ships, the way Hermes' adapter reads its own. */
+export function openclawPluginSourceDir(): string {
+  return path.join(packageRootDir(), 'integrations', 'openclaw');
+}
+
+/** Where the plugin is copied to, so OpenClaw can link a directory this package does not own. */
+export function openclawPluginTargetDir(environment: AgentEnvironment): string {
+  return path.join(environment.homeDir, '.openclaw', 'knowl-plugin');
+}
+
+/**
+ * The files that make a loadable plugin: manifest, package manifest, and the TypeScript entry.
+ *
+ * TypeScript, deliberately, and it is not an oversight that nothing is compiled. OpenClaw
+ * refuses a `.ts` entry on the MANAGED npm path (`plugins install npm-pack:…` wants
+ * `./dist/index.js`), but a **link** install of a local directory loads the source directly --
+ * its own error text says the source fallback exists for "source checkouts and local
+ * development paths". Copying source is therefore the same shape `knowl init hermes` already
+ * uses for its Python plugin, and it keeps Knowl to one published package rather than a second
+ * one that would have to be released before this one could depend on it.
+ */
+const PLUGIN_FILES = [
+  'openclaw.plugin.json',
+  'package.json',
+  path.join('src', 'index.ts'),
+  path.join('src', 'engine.ts'),
+];
 
 /**
  * Resolves the configuration path for OpenClaw.
@@ -52,6 +81,35 @@ export function isOpenClawConfigured(data: unknown): boolean {
   if (hooks.allowPromptInjection !== true) return false;
   if (hooks.timeouts?.before_tool_call !== 5000) return false;
   return true;
+}
+
+/** Every plugin file present at the target. Config alone is not an installed plugin. */
+export async function openclawPluginInstalled(environment: AgentEnvironment): Promise<boolean> {
+  const target = openclawPluginTargetDir(environment);
+  try {
+    await Promise.all(PLUGIN_FILES.map(file => fs.access(path.join(target, file))));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copies the plugin out of this package and into a directory OpenClaw can link.
+ *
+ * Copied rather than linked straight at `node_modules/@dat999zx/knowl/integrations/openclaw`
+ * for the reason the Hermes adapter gives: npm may replace that tree on any update, and a
+ * plugin registered at a path npm owns is a plugin that disappears. Only the files Knowl ships
+ * are written; anything else in the target is left alone.
+ */
+export async function installOpenClawPlugin(environment: AgentEnvironment): Promise<string> {
+  const source = openclawPluginSourceDir();
+  const target = openclawPluginTargetDir(environment);
+  await fs.mkdir(path.join(target, 'src'), { recursive: true });
+  for (const file of PLUGIN_FILES) {
+    await fs.copyFile(path.join(source, file), path.join(target, file));
+  }
+  return target;
 }
 
 /**
@@ -158,12 +216,23 @@ export function createOpenClawAdapter(environment: AgentEnvironment): AgentAdapt
       const scope = openclawConfigScope(pathname, root);
       try {
         const status = await mergeOpenClawConfig(pathname);
+        // Config alone enables a plugin OpenClaw has never been told about. The files have to
+        // land somewhere linkable first, exactly as the Hermes adapter copies its plugin before
+        // the config that references it means anything.
+        const target = await installOpenClawPlugin(environment);
         return {
           agent: 'openclaw',
           status,
           scope,
           configPath: pathname,
-          message: 'OpenClaw plugin enabled with required hook permissions and timeout.',
+          message: `Plugin copied to ${target}. Two steps remain, both once:\n`
+            + `  cd "${target}" && npm install @dat999zx/knowl @libsql/client\n`
+            + `  openclaw plugins install --link "${target}" --force --accept-capabilities\n`
+            + 'then restart the gateway. The install is not optional: a linked directory resolves '
+            + 'its own imports, and libsql stays external to the Knowl bundle, so without it the '
+            + "plugin loads to \"Cannot find module\". Both install flags are required too -- "
+            + '--force because the directory is outside ClawHub trust metadata, '
+            + '--accept-capabilities because the plugin declares tool-result middleware.',
         };
       } catch (error: any) {
         return {
@@ -180,7 +249,8 @@ export function createOpenClawAdapter(environment: AgentEnvironment): AgentAdapt
       try {
         const text = await readTextIfExists(pathname);
         if (!text || text.trim() === '') return false;
-        return isOpenClawConfigured(JSON.parse(text));
+        if (!isOpenClawConfigured(JSON.parse(text))) return false;
+        return await openclawPluginInstalled(environment);
       } catch {
         return false;
       }

--- a/src/cli/agents/registry.ts
+++ b/src/cli/agents/registry.ts
@@ -5,13 +5,14 @@ import { createClaudeDesktopAdapter } from './desktop-adapter.js';
 import { createCursorAdapter } from './cursor.js';
 import { createClaudeCodeAdapter, createClineAdapter, createCodexAdapter, createOpenCodeAdapter } from './project-adapters.js';
 import { createHermesAdapter } from './hermes.js';
+import { createOpenClawAdapter } from './openclaw.js';
 import { createHookHostAdapter, hookHostSpecs } from './hook-host-adapter.js';
 import { AgentAdapter, AgentDetection, AgentEnvironment, AgentName } from './types.js';
 
 export const SUPPORTED_AGENT_NAMES: AgentName[] = [
   'codex', 'claude', 'cursor', 'claude-desktop', 'cline', 'opencode',
   'copilot', 'openhands', 'antigravity', 'windsurf',
-  'hermes',
+  'hermes', 'openclaw',
 ];
 
 function defaultEnvironment(): AgentEnvironment {
@@ -33,6 +34,7 @@ export function createAgentRegistry(overrides: Partial<AgentEnvironment> = {}): 
     ['cline', createClineAdapter(environment)],
     ['opencode', createOpenCodeAdapter(environment)],
     ['hermes', createHermesAdapter(environment)],
+    ['openclaw', createOpenClawAdapter(environment)],
     // Every host whose integration is "an MCP entry plus a hooks file" comes from one spec
     // list, so a new one is a row there rather than a factory here.
     ...hookHostSpecs(environment).map(spec =>

--- a/src/cli/agents/types.ts
+++ b/src/cli/agents/types.ts
@@ -1,7 +1,7 @@
 export type AgentName =
   | 'codex' | 'claude' | 'cursor' | 'claude-desktop'
   | 'copilot' | 'openhands' | 'antigravity' | 'windsurf' | 'cline' | 'opencode'
-  | 'hermes';
+  | 'hermes' | 'openclaw';
 export type IntegrationScope = 'project' | 'global';
 export type IntegrationStatus = 'configured' | 'updated' | 'unchanged' | 'skipped' | 'failed';
 export type LifecycleCapability = 'supported' | 'unsupported' | 'degraded';

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -3903,7 +3903,7 @@ program
 program
   .command('agent-hook')
   .description('Translate a project-local agent host hook into bounded Knowl memory events')
-  .argument('<host>', 'claude, codex, copilot, cursor, openhands, antigravity, windsurf, cline, hermes, claude-desktop, or generic')
+  .argument('<host>', 'claude, codex, copilot, cursor, openhands, antigravity, windsurf, cline, hermes, claude-desktop, openclaw, or generic')
   .argument('<event>', 'host lifecycle event name')
   .option('--json')
   // Registered so `knowl --help` still describes it, but a real hook invocation never

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,6 +1,6 @@
 export class KnowlError extends Error {
-  constructor(message: string, public readonly code: string) {
-    super(message);
+  constructor(message: string, public readonly code: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'KnowlError';
   }
 }
@@ -13,8 +13,8 @@ export class ConfigError extends KnowlError {
 }
 
 export class DatabaseError extends KnowlError {
-  constructor(message: string) {
-    super(message, 'DATABASE_ERROR');
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, 'DATABASE_ERROR', options);
     this.name = 'DatabaseError';
   }
 }

--- a/src/core/host-hook-types.ts
+++ b/src/core/host-hook-types.ts
@@ -13,7 +13,7 @@ import { SessionEventType } from './types.js';
 export type HookHost =
   | 'codex' | 'claude' | 'cursor' | 'claude-desktop' | 'generic'
   | 'copilot' | 'openhands' | 'antigravity' | 'windsurf' | 'cline'
-  | 'hermes';
+  | 'hermes' | 'openclaw';
 
 export type NormalizedHookEventName =
   | 'session-start'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,108 @@
+import { findProjectRoot } from './core/config.js';
+import { ProjectNotFoundError } from './core/errors.js';
+import { assertKnowledgeDatabasePresent } from './cli/database-presence.js';
+import { openProjectScope } from './store/database.js';
+import { getProjectByRootPath } from './store/repository.js';
+import { handleHostLifecycleEvent, HostLifecycleResult } from './session/host-lifecycle.js';
+import { queryKnowledgeForAgent } from './store/agent-query.js';
+import { storeKnowledgeItemDeduped, StoreKnowledgeInput, StoreKnowledgeResult } from './store/knowledge-writer.js';
+import { KnowledgeItem } from './core/types.js';
+import { NormalizedHostHook } from './core/host-hook-types.js';
+
+export interface ProjectHandle {
+  readonly projectRoot: string;
+  readonly databasePath: string;
+  lifecycle(event: NormalizedHostHook): Promise<HostLifecycleResult>;
+  query(text: string, opts?: { limit?: number }): Promise<KnowledgeItem[]>;
+  store(atom: StoreKnowledgeInput): Promise<StoreKnowledgeResult>;
+  release(): Promise<void>;
+}
+
+export type LifecycleResult = HostLifecycleResult;
+export type StoreInput = StoreKnowledgeInput;
+export type StoreResult = StoreKnowledgeResult;
+export type QueryResult = KnowledgeItem;
+
+/**
+ * Open a scoped handle to a Knowl project.
+ *
+ * Returns `null` when `cwd` does not resolve to a Knowl repository (`ProjectNotFoundError`).
+ * Throws `MissingKnowledgeDatabaseError` when the repository is initialized and registered
+ * but its database file is missing.
+ *
+ * Every operation on the returned `ProjectHandle` runs inside `withProjectScope` / `scope.run`,
+ * guaranteeing that concurrent operations across different projects in the same process do not
+ * overwrite each other's connection or write to the wrong database.
+ *
+ * `handle.release()` decrements the scope refcount and releases the client connection via
+ * `releaseClient`. Never calls `closeDb` or `initDb`.
+ */
+export async function openProject(cwd: string): Promise<ProjectHandle | null> {
+  let root: string;
+  try {
+    root = await findProjectRoot(cwd);
+  } catch (error) {
+    if (error instanceof ProjectNotFoundError) {
+      return null;
+    }
+    throw error;
+  }
+
+  // Before opening the scope, verify the database file exists if this repo is registered.
+  // Throws MissingKnowledgeDatabaseError if the file vanished.
+  assertKnowledgeDatabasePresent(root);
+
+  const scope = await openProjectScope(root);
+
+  let project;
+  try {
+    project = await scope.run(async () => {
+      return await getProjectByRootPath(root);
+    });
+  } catch (error) {
+    await scope.release();
+    throw error;
+  }
+
+  if (!project) {
+    await scope.release();
+    return null;
+  }
+
+  const projectId = project.id;
+
+  return {
+    projectRoot: root,
+    databasePath: scope.databasePath,
+    async lifecycle(event: NormalizedHostHook): Promise<HostLifecycleResult> {
+      return await scope.run(async () => {
+        return await handleHostLifecycleEvent(projectId, event);
+      });
+    },
+    async query(text: string, opts?: { limit?: number }): Promise<KnowledgeItem[]> {
+      return await scope.run(async () => {
+        return await queryKnowledgeForAgent(projectId, {
+          query: text,
+          limit: opts?.limit ?? 10,
+          surface: 'plugin',
+        });
+      });
+    },
+    async store(atom: StoreKnowledgeInput): Promise<StoreKnowledgeResult> {
+      return await scope.run(async () => {
+        return await storeKnowledgeItemDeduped(projectId, atom);
+      });
+    },
+    async release(): Promise<void> {
+      await scope.release();
+    },
+  };
+}
+
+export { normalizeHostHook } from './cli/agents/host-hook.js';
+export { readLifecyclePayloadObject } from './cli/agents/lifecycle.js';
+export { KNOWL_MIGRATION_LEVEL } from './store/schema-version.js';
+export { ProjectNotFoundError } from './core/errors.js';
+export { MissingKnowledgeDatabaseError } from './cli/database-presence.js';
+export type { NormalizedHostHook, NormalizedHookEventName, HookHost } from './core/host-hook-types.js';
+export type { LifecyclePayload } from './cli/agents/lifecycle.js';

--- a/src/session/hosts/index.ts
+++ b/src/session/hosts/index.ts
@@ -14,6 +14,7 @@ import { antigravityProfile } from './antigravity.js';
 import { windsurfProfile } from './windsurf.js';
 import { clineProfile } from './cline.js';
 import { hermesProfile } from './hermes.js';
+import { openclawProfile } from './openclaw.js';
 
 export type { HostIdentity, HostOutput, HostProfile } from './profile.js';
 
@@ -29,6 +30,7 @@ export const HOST_PROFILES: Record<HookHost, HostProfile> = {
   windsurf: windsurfProfile,
   cline: clineProfile,
   hermes: hermesProfile,
+  openclaw: openclawProfile,
 };
 
 export function hostProfile(host: HookHost): HostProfile {

--- a/src/session/hosts/openclaw.ts
+++ b/src/session/hosts/openclaw.ts
@@ -1,0 +1,83 @@
+import type { NormalizedHookEventName } from '../../core/host-hook-types.js';
+import type { HostIdentity, HostOutput, HostProfile } from './profile.js';
+import { hostString, toolNameIsShell } from './profile.js';
+
+/**
+ * OpenClaw's hook events mapped onto Knowl's engine lifecycle.
+ *
+ * `before_prompt_build` maps to `turn-start`: OpenClaw's prompt contribution hook where
+ * the fixed orientation card is injected via `prependContext`. Exactly one hook publishes
+ * the card; `agent_turn_prepare` and `heartbeat_prompt_contribution` do not publish context
+ * because context contributions concatenate and multiple publishers would duplicate cards.
+ *
+ * `before_tool_call` maps to `tool-precheck`: The only blocking hook the host blocks on.
+ * Evaluates the write gate before write tools (`exec`, `apply_patch`, `spawn_agent`) and
+ * answers `{ block: true, blockReason }` when refused.
+ *
+ * `after_tool_call` maps to `session-event`: Observational hook for recording tool execution
+ * outcomes and capturing file change events.
+ *
+ * `before_compaction` maps to `checkpoint`: Fires before conversation history compaction.
+ * Runs under a 30-second budget to ensure memory is persisted before transcript truncation.
+ *
+ * `session_end` and `agent_end` map to `turn-stop`: Closes the current turn binding under
+ * OpenClaw's 2-second total shutdown drain budget.
+ *
+ * `gateway_stop` maps to `session-stop`: Full gateway shutdown closing the active session
+ * and releasing cached project handles.
+ *
+ * `session_start` maps to `session-start`: Binds session identity and warms the project
+ * handle cache in memory so subsequent write gates never suffer cold client initialization.
+ */
+const OPENCLAW_EVENT_MAP: Record<string, NormalizedHookEventName> = {
+  before_prompt_build: 'turn-start',
+  before_tool_call: 'tool-precheck',
+  after_tool_call: 'session-event',
+  before_compaction: 'checkpoint',
+  session_end: 'turn-stop',
+  agent_end: 'turn-stop',
+  gateway_stop: 'session-stop',
+  session_start: 'session-start',
+};
+
+const openclawBlock = (blockReason: string): HostOutput => ({ block: true, blockReason });
+
+/**
+ * OpenClaw host profile for in-process gateway execution.
+ *
+ * Like Cline and Hermes, OpenClaw has no hooks file: its lifecycle hooks are registered
+ * in-process via `api.on(...)` through an extension plugin (`integrations/openclaw/`)
+ * loaded by the gateway, rather than writing shell hook commands into user config.
+ */
+export const openclawProfile: HostProfile = {
+  host: 'openclaw',
+  hookEvents: [],
+  promptEvent: 'before_prompt_build',
+  sharesSessionBinding: true,
+  nativeOutput: true,
+  midTurnDeliveryVerified: false,
+  hookConfigStyle: 'none',
+  lifecycleClaimable: false,
+  writeTools: ['exec', 'apply_patch', 'spawn_agent'],
+  identity(raw): HostIdentity {
+    return {
+      externalSessionId: hostString(raw.session_id) ?? hostString(raw.sessionId) ?? hostString(raw.conversationId),
+      externalTurnId: hostString(raw.turn_id) ?? hostString(raw.turnId),
+      agentId: hostString(raw.agent_id) ?? hostString(raw.agentId),
+      agentType: hostString(raw.agent_type) ?? hostString(raw.agentType),
+    };
+  },
+  normalizedEvent(hostEvent) {
+    return OPENCLAW_EVENT_MAP[hostEvent];
+  },
+  isShellEvent(_hostEvent, toolName) {
+    return toolNameIsShell(toolName) || toolName === 'exec';
+  },
+  startContext(event, context) {
+    return event === 'turn-start' ? { prependContext: context } : undefined;
+  },
+  midTurnContext() {
+    return undefined;
+  },
+  denyToolCall: openclawBlock,
+};

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -114,7 +114,7 @@ export async function initDbPath(dbPath: string, options: InitDbOptions = {}): P
     };
     return globalContext.db;
   } catch (error: any) {
-    throw new DatabaseError(`Failed to initialize database at "${dbPath}": ${error.message}`);
+    throw new DatabaseError(`Failed to initialize database at "${dbPath}": ${error.message}`, { cause: error });
   }
 }
 

--- a/tests/cli/hosts/profile-conformance.test.ts
+++ b/tests/cli/hosts/profile-conformance.test.ts
@@ -5,7 +5,7 @@ import { HookHost } from '../../../src/cli/agents/host-hook.js';
 const ALL_HOSTS: HookHost[] = [
   'codex', 'claude', 'cursor', 'claude-desktop', 'generic',
   'copilot', 'openhands', 'antigravity', 'windsurf', 'cline',
-  'hermes',
+  'hermes', 'openclaw',
 ];
 
 describe('host profile registry', () => {

--- a/tests/cli/lifecycle-payload-object.test.ts
+++ b/tests/cli/lifecycle-payload-object.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_RETAINED_ARRAY_ITEMS,
+  MAX_RETAINED_STRING,
+  ROOT_FIELDS,
+  readLifecyclePayloadObject,
+} from '../../src/cli/agents/lifecycle.js';
+
+describe('readLifecyclePayloadObject', () => {
+  it('truncates strings to MAX_RETAINED_STRING and arrays to MAX_RETAINED_ARRAY_ITEMS and drops non-ROOT_FIELDS', () => {
+    const raw = {
+      prompt: 'a'.repeat(5_000),
+      changedPaths: Array.from({ length: 200 }, (_, i) => `path/to/file-${i}.ts`),
+      unrecognized_field: 'should be dropped',
+      another_ignored: { nested: true },
+    };
+
+    const result = readLifecyclePayloadObject(raw);
+
+    // Root fields allowlist
+    expect(ROOT_FIELDS.has('prompt')).toBe(true);
+    expect(ROOT_FIELDS.has('unrecognized_field')).toBe(false);
+    expect(result).toHaveProperty('prompt');
+    expect(result).toHaveProperty('changedPaths');
+    expect(result).not.toHaveProperty('unrecognized_field');
+    expect(result).not.toHaveProperty('another_ignored');
+
+    // String truncation
+    expect(result.prompt).toBe('a'.repeat(MAX_RETAINED_STRING));
+    expect((result.prompt as string).length).toBe(MAX_RETAINED_STRING);
+
+    // Array truncation
+    expect(Array.isArray(result.changedPaths)).toBe(true);
+    expect((result.changedPaths as unknown[]).length).toBe(MAX_RETAINED_ARRAY_ITEMS);
+    expect((result.changedPaths as unknown[])[0]).toBe('path/to/file-0.ts');
+    expect((result.changedPaths as unknown[])[MAX_RETAINED_ARRAY_ITEMS - 1]).toBe(`path/to/file-${MAX_RETAINED_ARRAY_ITEMS - 1}.ts`);
+  });
+
+  it('tail-truncates fields in TAIL_FIELDS like stdout', () => {
+    const raw = {
+      session_id: 'test-session',
+      tool_response: {
+        stdout: `prefix-discarded-${'x'.repeat(3000)}tail-kept`,
+        exit_code: 0,
+      },
+    };
+
+    const result = readLifecyclePayloadObject(raw);
+    const response = result.tool_response as Record<string, unknown>;
+    expect(response.exit_code).toBe(0);
+    expect(typeof response.stdout).toBe('string');
+    expect((response.stdout as string).length).toBe(MAX_RETAINED_STRING);
+    expect((response.stdout as string).endsWith('tail-kept')).toBe(true);
+    expect(response.stdout as string).not.toContain('prefix-discarded');
+  });
+
+  it('filters nested objects and arrays correctly', () => {
+    const raw = {
+      session_id: 's1',
+      tool_input: {
+        command: 'npm test',
+        disallowed: 'drop-me',
+        atoms: [
+          { title: 'Atom 1', body: 'drop body' },
+          { title: 'Atom 2', notes: 'drop notes' },
+        ],
+      },
+      toolCall: {
+        name: 'testTool',
+        args: {
+          CommandLine: 'git status',
+          ForbiddenContent: 'drop this large file content',
+        },
+      },
+    };
+
+    const result = readLifecyclePayloadObject(raw);
+    expect(result.tool_input).toEqual({
+      command: 'npm test',
+      atoms: [
+        { title: 'Atom 1' },
+        { title: 'Atom 2' },
+      ],
+    });
+    expect(result.toolCall).toEqual({
+      name: 'testTool',
+      args: {
+        CommandLine: 'git status',
+      },
+    });
+  });
+
+  it('returns empty object for non-object inputs', () => {
+    expect(readLifecyclePayloadObject(null)).toEqual({});
+    expect(readLifecyclePayloadObject(undefined)).toEqual({});
+    expect(readLifecyclePayloadObject('string')).toEqual({});
+    expect(readLifecyclePayloadObject(123)).toEqual({});
+    expect(readLifecyclePayloadObject([])).toEqual({});
+  });
+});

--- a/tests/cli/openclaw-adapter.test.ts
+++ b/tests/cli/openclaw-adapter.test.ts
@@ -1,0 +1,368 @@
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import pathPosix from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createOpenClawAdapter,
+  isOpenClawConfigured,
+  mergeOpenClawConfig,
+  mutateOpenClawConfig,
+  openclawConfigPath,
+  openclawConfigScope,
+} from '../../src/cli/agents/openclaw.js';
+import { parseAgentNames } from '../../src/cli/agents/registry.js';
+import { AgentEnvironment } from '../../src/cli/agents/types.js';
+
+const dirs: string[] = [];
+const workspace = async () => {
+  const d = await mkdtemp(pathPosix.join(tmpdir(), 'knowl-openclaw-'));
+  dirs.push(d);
+  return d;
+};
+afterAll(async () => {
+  for (const d of dirs) await rm(d, { recursive: true, force: true });
+});
+
+describe('openclaw adapter', () => {
+  let home: string;
+  const savedConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+
+  beforeEach(async () => {
+    home = await workspace();
+    delete process.env.OPENCLAW_CONFIG_PATH;
+  });
+
+  afterEach(() => {
+    if (savedConfigPath === undefined) delete process.env.OPENCLAW_CONFIG_PATH;
+    else process.env.OPENCLAW_CONFIG_PATH = savedConfigPath;
+  });
+
+  const env = (installed: boolean): AgentEnvironment => ({
+    platform: process.platform,
+    homeDir: home,
+    appDataDir: pathPosix.join(home, 'appdata'),
+    commandExists: async cmd => cmd === 'openclaw' && installed,
+  });
+
+  it('is a supported agent name', () => {
+    expect(parseAgentNames(['openclaw'])).toEqual(['openclaw']);
+  });
+
+  describe('openclawConfigPath and scope resolution', () => {
+    it('honors process.env.OPENCLAW_CONFIG_PATH override first', async () => {
+      const custom = pathPosix.join(home, 'custom', 'openclaw.json');
+      process.env.OPENCLAW_CONFIG_PATH = custom;
+      expect(openclawConfigPath(env(true), '/some/repo')).toBe(custom);
+    });
+
+    it('uses project-scoped openclaw.json if it exists in projectRoot', async () => {
+      const projectRoot = await workspace();
+      const projectConfig = pathPosix.join(projectRoot, 'openclaw.json');
+      await writeFile(projectConfig, '{}', 'utf8');
+
+      const resolved = openclawConfigPath(env(true), projectRoot);
+      expect(resolved).toBe(projectConfig);
+      expect(openclawConfigScope(resolved, projectRoot)).toBe('project');
+    });
+
+    it('falls back to global ~/.openclaw/openclaw.json when project has no openclaw.json', async () => {
+      const projectRoot = await workspace();
+      const expected = pathPosix.join(home, '.openclaw', 'openclaw.json');
+
+      const resolved = openclawConfigPath(env(true), projectRoot);
+      expect(resolved).toBe(expected);
+      expect(openclawConfigScope(resolved, projectRoot)).toBe('global');
+    });
+  });
+
+  describe('isOpenClawConfigured', () => {
+    it('returns false for non-objects or empty structures', () => {
+      expect(isOpenClawConfigured(null)).toBe(false);
+      expect(isOpenClawConfigured(undefined)).toBe(false);
+      expect(isOpenClawConfigured({})).toBe(false);
+      expect(isOpenClawConfigured({ plugins: {} })).toBe(false);
+      expect(isOpenClawConfigured({ plugins: { entries: {} } })).toBe(false);
+    });
+
+    it('returns false if knowl plugin is disabled', () => {
+      expect(isOpenClawConfigured({
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: false,
+              hooks: {
+                allowConversationAccess: true,
+                allowPromptInjection: true,
+                timeouts: { before_tool_call: 5000 },
+              },
+            },
+          },
+        },
+      })).toBe(false);
+    });
+
+    it('returns false if permission gates are missing or false', () => {
+      expect(isOpenClawConfigured({
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: true,
+              hooks: {
+                allowConversationAccess: false,
+                allowPromptInjection: true,
+                timeouts: { before_tool_call: 5000 },
+              },
+            },
+          },
+        },
+      })).toBe(false);
+
+      expect(isOpenClawConfigured({
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: true,
+              hooks: {
+                allowConversationAccess: true,
+                allowPromptInjection: false,
+                timeouts: { before_tool_call: 5000 },
+              },
+            },
+          },
+        },
+      })).toBe(false);
+    });
+
+    it('returns false if before_tool_call timeout is missing or not 5000', () => {
+      expect(isOpenClawConfigured({
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: true,
+              hooks: {
+                allowConversationAccess: true,
+                allowPromptInjection: true,
+              },
+            },
+          },
+        },
+      })).toBe(false);
+
+      expect(isOpenClawConfigured({
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: true,
+              hooks: {
+                allowConversationAccess: true,
+                allowPromptInjection: true,
+                timeouts: { before_tool_call: 15000 },
+              },
+            },
+          },
+        },
+      })).toBe(false);
+    });
+
+    it('returns true when all required settings are present', () => {
+      expect(isOpenClawConfigured({
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: true,
+              hooks: {
+                allowConversationAccess: true,
+                allowPromptInjection: true,
+                timeouts: { before_tool_call: 5000 },
+              },
+            },
+          },
+        },
+      })).toBe(true);
+    });
+  });
+
+  describe('mutateOpenClawConfig', () => {
+    it('returns unchanged if already configured', () => {
+      const data: Record<string, any> = {
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: true,
+              hooks: {
+                allowConversationAccess: true,
+                allowPromptInjection: true,
+                timeouts: { before_tool_call: 5000 },
+              },
+            },
+          },
+        },
+      };
+      const result = mutateOpenClawConfig(data);
+      expect(result.changed).toBe(false);
+      expect(result.status).toBe('unchanged');
+    });
+
+    it('returns configured for empty object and writes all fields', () => {
+      const data: Record<string, any> = {};
+      const result = mutateOpenClawConfig(data);
+      expect(result.changed).toBe(true);
+      expect(result.status).toBe('configured');
+      expect(isOpenClawConfigured(data)).toBe(true);
+    });
+
+    it('returns updated for partially configured object', () => {
+      const data: Record<string, any> = {
+        plugins: {
+          entries: {
+            knowl: {
+              enabled: false,
+            },
+          },
+        },
+      };
+      const result = mutateOpenClawConfig(data);
+      expect(result.changed).toBe(true);
+      expect(result.status).toBe('updated');
+      expect(isOpenClawConfigured(data)).toBe(true);
+    });
+  });
+
+  describe('mergeOpenClawConfig', () => {
+    it('creates a new config file when none exists', async () => {
+      const configPath = pathPosix.join(home, 'openclaw.json');
+      const status = await mergeOpenClawConfig(configPath);
+      expect(status).toBe('configured');
+
+      const saved = JSON.parse(await readFile(configPath, 'utf8'));
+      expect(saved.plugins.entries.knowl).toEqual({
+        enabled: true,
+        hooks: {
+          allowConversationAccess: true,
+          allowPromptInjection: true,
+          timeouts: {
+            before_tool_call: 5000,
+          },
+        },
+      });
+    });
+
+    it('preserves unrelated user keys at all levels and creates a backup file', async () => {
+      const configPath = pathPosix.join(home, 'openclaw.json');
+      const initial = {
+        model: 'claude-3-7-sonnet',
+        gateway: {
+          port: 18789,
+          auth: 'token',
+        },
+        plugins: {
+          loadPath: ['/opt/plugins'],
+          entries: {
+            custom_plugin: {
+              enabled: true,
+              setting: 42,
+            },
+            knowl: {
+              customNote: 'keep me',
+              hooks: {
+                otherHookSetting: true,
+                timeouts: {
+                  session_start: 3000,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await writeFile(configPath, JSON.stringify(initial, null, 2), 'utf8');
+
+      const status = await mergeOpenClawConfig(configPath);
+      expect(status).toBe('updated');
+
+      const saved = JSON.parse(await readFile(configPath, 'utf8'));
+      // Unrelated top-level keys preserved
+      expect(saved.model).toBe('claude-3-7-sonnet');
+      expect(saved.gateway).toEqual({ port: 18789, auth: 'token' });
+      // Unrelated plugin keys preserved
+      expect(saved.plugins.loadPath).toEqual(['/opt/plugins']);
+      expect(saved.plugins.entries.custom_plugin).toEqual({ enabled: true, setting: 42 });
+      // Existing knowl options preserved
+      expect(saved.plugins.entries.knowl.customNote).toBe('keep me');
+      expect(saved.plugins.entries.knowl.hooks.otherHookSetting).toBe(true);
+      expect(saved.plugins.entries.knowl.hooks.timeouts.session_start).toBe(3000);
+      // Required knowl configuration applied
+      expect(saved.plugins.entries.knowl.enabled).toBe(true);
+      expect(saved.plugins.entries.knowl.hooks.allowConversationAccess).toBe(true);
+      expect(saved.plugins.entries.knowl.hooks.allowPromptInjection).toBe(true);
+      expect(saved.plugins.entries.knowl.hooks.timeouts.before_tool_call).toBe(5000);
+
+      // Backup created
+      await expect(access(`${configPath}.backup`)).resolves.toBeUndefined();
+    });
+
+    it('is idempotent and returns unchanged on repeated execution', async () => {
+      const configPath = pathPosix.join(home, 'openclaw.json');
+      await mergeOpenClawConfig(configPath);
+      const textBefore = await readFile(configPath, 'utf8');
+
+      const status = await mergeOpenClawConfig(configPath);
+      expect(status).toBe('unchanged');
+      const textAfter = await readFile(configPath, 'utf8');
+      expect(textAfter).toBe(textBefore);
+    });
+
+    it('leaves unparseable JSON file untouched and throws an error', async () => {
+      const configPath = pathPosix.join(home, 'openclaw.json');
+      const invalidJson = '{\n  "corrupt": true,\n';
+      await writeFile(configPath, invalidJson, 'utf8');
+
+      await expect(mergeOpenClawConfig(configPath)).rejects.toThrow(/Could not parse/);
+
+      // File was left untouched
+      const textAfter = await readFile(configPath, 'utf8');
+      expect(textAfter).toBe(invalidJson);
+    });
+  });
+
+  describe('createOpenClawAdapter', () => {
+    it('detects installation status and configuration', async () => {
+      const adapter = createOpenClawAdapter(env(true));
+      const root = await workspace();
+
+      // Initially not configured
+      const detection1 = await adapter.detect(root);
+      expect(detection1.installed).toBe(true);
+      expect(detection1.configured).toBe(false);
+
+      // Configure
+      const result = await adapter.configure(root);
+      expect(result.status).toBe('configured');
+      expect(result.agent).toBe('openclaw');
+
+      // Now configured
+      const detection2 = await adapter.detect(root);
+      expect(detection2.configured).toBe(true);
+      expect(await adapter.verify(root)).toBe(true);
+      expect(await adapter.lifecycleCapability!(root)).toBe('supported');
+      expect(await adapter.verifyLifecycle!(root)).toBe(true);
+      expect((await adapter.configureLifecycle!(root)).status).toBe('unchanged');
+    });
+
+    it('fails safely when configuring an unparseable file without crashing', async () => {
+      const adapter = createOpenClawAdapter(env(true));
+      const root = await workspace();
+      const projectConfig = pathPosix.join(root, 'openclaw.json');
+      const malformed = '{"unclosed": "brace"';
+      await writeFile(projectConfig, malformed, 'utf8');
+
+      const result = await adapter.configure(root);
+      expect(result.status).toBe('failed');
+      expect(result.message).toContain('Could not configure');
+
+      // Verify file is still untouched
+      expect(await readFile(projectConfig, 'utf8')).toBe(malformed);
+      expect(await adapter.verify(root)).toBe(false);
+    });
+  });
+});

--- a/tests/cli/plugin-export.test.ts
+++ b/tests/cli/plugin-export.test.ts
@@ -57,7 +57,12 @@ describe('plugin export and built artifact verification', () => {
     const consumerRequire = createRequire(path.join(consumerDir, 'package.json'));
     const pluginResolvedPath = consumerRequire.resolve('@dat999zx/knowl/plugin');
     pluginModule = await import(pathToFileURL(pluginResolvedPath).href);
-  }, 120_000);
+    // 300s, not the default: this hook runs a real `npm pack` and a real `npm install` of the
+    // resulting tarball into a scratch consumer, which is the only way to prove the exports map
+    // resolves the way it will for a user. That is ~54s on an idle machine and comfortably past
+    // 120s once the rest of the suite is running in parallel, where it timed out. The budget is
+    // for the package manager, not for anything this test asserts.
+  }, 300_000);
 
   afterAll(async () => {
     if (scratchDir && existsSync(scratchDir)) {

--- a/tests/cli/plugin-export.test.ts
+++ b/tests/cli/plugin-export.test.ts
@@ -1,0 +1,207 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { createClient } from '@libsql/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI_PATH = path.resolve('dist/index.js');
+const ROOT_DIR = path.resolve('.');
+const NPM_CMD = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+describe('plugin export and built artifact verification', () => {
+  let scratchDir: string;
+  let consumerDir: string;
+  let tgzPath: string;
+  let pluginModule: typeof import('../../src/plugin.js');
+
+  beforeAll(async () => {
+    // 1. Pack the built artifact into scratch directory
+    scratchDir = path.join(os.tmpdir(), `knowl-pack-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+
+    const packOutput = execFileSync(NPM_CMD, ['pack', '--pack-destination', scratchDir], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    }).trim().split(/\r?\n/).pop()!;
+    tgzPath = path.join(scratchDir, packOutput);
+
+    // 2. Install into consumer scratch directory with OpenClaw's exact flags
+    consumerDir = path.join(scratchDir, 'consumer');
+    await fs.mkdir(consumerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(consumerDir, 'package.json'),
+      JSON.stringify({ name: 'consumer', type: 'module' }, null, 2),
+      'utf8',
+    );
+
+    execFileSync(
+      NPM_CMD,
+      [
+        'install',
+        tgzPath,
+        '--omit=dev',
+        '--omit=peer',
+        '--legacy-peer-deps',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+      ],
+      { cwd: consumerDir, encoding: 'utf8', shell: process.platform === 'win32' },
+    );
+
+    const consumerRequire = createRequire(path.join(consumerDir, 'package.json'));
+    const pluginResolvedPath = consumerRequire.resolve('@dat999zx/knowl/plugin');
+    pluginModule = await import(pathToFileURL(pluginResolvedPath).href);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (scratchDir && existsSync(scratchDir)) {
+      await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('still prints version from dist/index.js', () => {
+    const versionOutput = execFileSync(process.execPath, [CLI_PATH, '--version'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+    }).trim();
+    const pkg = JSON.parse(readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'));
+    expect(versionOutput).toBe(pkg.version);
+  });
+
+  it('resolves all 5 exported paths without breaking Cline', () => {
+    const consumerRequire = createRequire(path.join(consumerDir, 'package.json'));
+
+    // 1. Root export (.)
+    expect(consumerRequire.resolve('@dat999zx/knowl')).toBeTruthy();
+
+    // 2. Plugin export (./plugin)
+    expect(consumerRequire.resolve('@dat999zx/knowl/plugin')).toBeTruthy();
+
+    // 3. Package.json export (./package.json)
+    expect(consumerRequire.resolve('@dat999zx/knowl/package.json')).toBeTruthy();
+
+    // 4. Cline integration export (./integrations/*)
+    const clinePath = consumerRequire.resolve('@dat999zx/knowl/integrations/cline/knowl-plugin.mjs');
+    expect(existsSync(clinePath)).toBe(true);
+
+    // 5. Dist wildcard export (./dist/*)
+    const distIndexPath = consumerRequire.resolve('@dat999zx/knowl/dist/index.js');
+    expect(existsSync(distIndexPath)).toBe(true);
+  });
+
+  it('exports openProject, normalizeHostHook, readLifecyclePayloadObject, and KNOWL_MIGRATION_LEVEL', () => {
+    expect(typeof pluginModule.openProject).toBe('function');
+    expect(typeof pluginModule.normalizeHostHook).toBe('function');
+    expect(typeof pluginModule.readLifecyclePayloadObject).toBe('function');
+    expect(typeof pluginModule.KNOWL_MIGRATION_LEVEL).toBe('number');
+    expect(pluginModule.KNOWL_MIGRATION_LEVEL).toBeGreaterThan(0);
+  });
+
+  it('built plugin chunk does not pull commander into its module tree', () => {
+    const distPluginPath = path.resolve('dist/plugin.js');
+    const visited = new Set<string>();
+
+    function inspect(file: string) {
+      if (visited.has(file)) return;
+      visited.add(file);
+      const content = readFileSync(file, 'utf8');
+      expect(content).not.toContain('commander');
+      const matches = content.matchAll(/from\s+['"](\.[^'"]+)['"]/g);
+      for (const match of matches) {
+        const dep = path.resolve(path.dirname(file), match[1]);
+        inspect(dep);
+      }
+    }
+
+    inspect(distPluginPath);
+    expect(visited.size).toBeGreaterThan(0);
+  });
+
+  it('returns null on ProjectNotFoundError and throws MissingKnowledgeDatabaseError on missing db', async () => {
+    const nonExistentDir = path.join(scratchDir, 'non-existent-repo');
+    await fs.mkdir(nonExistentDir, { recursive: true });
+
+    // Non-repo directory returns null
+    const handle = await pluginModule.openProject(nonExistentDir);
+    expect(handle).toBeNull();
+
+    // Initialized repo with deleted database file throws MissingKnowledgeDatabaseError
+    const missingDbDir = path.join(scratchDir, 'missing-db-repo');
+    await fs.mkdir(missingDbDir, { recursive: true });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: missingDbDir, encoding: 'utf8' });
+    const dbFile = path.join(missingDbDir, '.knowl', 'knowl.db');
+    await fs.rm(dbFile, { force: true });
+
+    await expect(pluginModule.openProject(missingDbDir)).rejects.toThrow(
+      pluginModule.MissingKnowledgeDatabaseError,
+    );
+  });
+
+  it('multi-project regression: writes to project A land in project A and never in project B', async () => {
+    const projectADir = path.join(scratchDir, 'projectA');
+    const projectBDir = path.join(scratchDir, 'projectB');
+    await fs.mkdir(projectADir, { recursive: true });
+    await fs.mkdir(projectBDir, { recursive: true });
+
+    // Initialize both projects using the CLI
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: projectADir, encoding: 'utf8' });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: projectBDir, encoding: 'utf8' });
+
+    // Open handles to both projects concurrently in this single process
+    const handleA = await pluginModule.openProject(projectADir);
+    const handleB = await pluginModule.openProject(projectBDir);
+
+    expect(handleA).not.toBeNull();
+    expect(handleB).not.toBeNull();
+
+    try {
+      expect(path.resolve(handleA!.projectRoot)).toBe(path.resolve(projectADir));
+      expect(path.resolve(handleB!.projectRoot)).toBe(path.resolve(projectBDir));
+      expect(path.resolve(handleA!.databasePath)).not.toBe(path.resolve(handleB!.databasePath));
+
+      // Write strictly through handleA
+      const writeResult = await handleA!.store({
+        category: 'decision',
+        title: 'Project A Architectural Isolation',
+        content: 'Verification row asserting project A isolation in in-process execution.',
+      });
+      expect(writeResult.action).toBe('inserted');
+
+      // Verify handleA can retrieve it
+      const resultsA = await handleA!.query('Project A Architectural Isolation');
+      expect(resultsA.some((item) => item.title === 'Project A Architectural Isolation')).toBe(true);
+
+      // Verify handleB CANNOT retrieve it
+      const resultsB = await handleB!.query('Project A Architectural Isolation');
+      expect(resultsB.some((item) => item.title === 'Project A Architectural Isolation')).toBe(false);
+
+      // Verify at the SQLite level directly
+      const clientA = createClient({ url: `file:${handleA!.databasePath}` });
+      const clientB = createClient({ url: `file:${handleB!.databasePath}` });
+
+      const rowsA = await clientA.execute({
+        sql: 'SELECT id, title FROM knowledge_items WHERE title = ?',
+        args: ['Project A Architectural Isolation'],
+      });
+      const rowsB = await clientB.execute({
+        sql: 'SELECT id, title FROM knowledge_items WHERE title = ?',
+        args: ['Project A Architectural Isolation'],
+      });
+
+      clientA.close();
+      clientB.close();
+
+      expect(rowsA.rows.length).toBe(1);
+      expect(rowsB.rows.length).toBe(0);
+    } finally {
+      await handleA!.release();
+      await handleB!.release();
+    }
+  }, 60_000);
+});

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { createClient } from '@libsql/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  OpenClawEngineManager,
+  checkMigrationLevel,
+  safely,
+  withDeadline,
+  type HostLogger,
+} from '../../../integrations/openclaw/src/engine.js';
+import { KNOWL_MIGRATION_LEVEL } from '@dat999zx/knowl/plugin';
+
+const CLI_PATH = path.resolve('dist/index.js');
+
+describe('OpenClaw engine wrapper failure modes', () => {
+  let scratchDir: string;
+
+  beforeEach(async () => {
+    scratchDir = path.join(os.tmpdir(), `knowl-engine-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('safely catches a throwing engine call, logs it, and returns fallback without rethrowing', async () => {
+    const logger: HostLogger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const throwingEngineCall = async () => {
+      throw new Error('LibSQL disk I/O error or engine crash');
+    };
+
+    const fallback = { block: false };
+    const result = await safely(throwingEngineCall, logger, fallback);
+
+    expect(result).toBe(fallback);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Swallowed engine failure: LibSQL disk I/O error or engine crash'),
+      expect.any(Error),
+    );
+  });
+
+  it('safely prevents floated rejections from escaping and crashing Node', async () => {
+    const logger: HostLogger = {
+      warn: vi.fn(),
+    };
+
+    let rejectedPromiseSettled = false;
+    const floatedPromiseFn = () =>
+      new Promise<void>((_, reject) => {
+        setTimeout(() => {
+          rejectedPromiseSettled = true;
+          reject(new Error('Delayed async explosion'));
+        }, 10);
+      });
+
+    const result = await safely(floatedPromiseFn, logger, 'swallowed');
+    expect(rejectedPromiseSettled).toBe(true);
+    expect(result).toBe('swallowed');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('hanging engine: withDeadline fires and accepts the write before the host budget expires', async () => {
+    let timeoutFired = false;
+    const hangingEngineWork = () =>
+      new Promise<{ block: boolean }>((_resolve) => {
+        // Stalled indefinitely: simulating an SQLite lock hang or cold model stall
+      });
+
+    const fallback = { block: false };
+    const start = Date.now();
+    const decision = await withDeadline(
+      50,
+      hangingEngineWork,
+      fallback,
+      () => {
+        timeoutFired = true;
+      },
+    );
+    const duration = Date.now() - start;
+
+    expect(decision).toEqual({ block: false });
+    expect(timeoutFired).toBe(true);
+    expect(duration).toBeLessThan(1_000);
+  });
+
+  it('stale migration level: disables plugin for workspace when database level exceeds bundled engine', async () => {
+    const projectDir = path.join(scratchDir, 'stale-migration-repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    // Initialize real repo
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: projectDir, encoding: 'utf8' });
+
+    // Stamp application_id to a newer migration level
+    const dbPath = path.join(projectDir, '.knowl', 'knowl.db');
+    const newerLevel = KNOWL_MIGRATION_LEVEL + 5;
+    const rawClient = createClient({ url: `file:${dbPath}` });
+    await rawClient.execute(`PRAGMA application_id = ${newerLevel}`);
+    rawClient.close();
+
+    // Check migration check helper
+    const check = await checkMigrationLevel(dbPath);
+    expect(check.supported).toBe(false);
+    expect(check.found).toBe(newerLevel);
+    expect(check.maxSupported).toBe(KNOWL_MIGRATION_LEVEL);
+
+    // Engine manager should refuse and disable workspace
+    const logger: HostLogger = { warn: vi.fn() };
+    const manager = new OpenClawEngineManager({ logger });
+
+    const handle = await manager.warmWorkspace(projectDir);
+    expect(handle).toBeNull();
+    expect(manager.isDisabled(projectDir)).toBe(true);
+    expect(manager.getDisabledReason(projectDir)).toContain(`migration level ${newerLevel}`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`Disabling plugin for workspace`),
+    );
+
+    // Subsequent handle request returns null immediately without attempting to open
+    const cachedAttempt = await manager.getHandle(projectDir);
+    expect(cachedAttempt).toBeNull();
+  });
+});

--- a/tests/integrations/openclaw/hooks.test.ts
+++ b/tests/integrations/openclaw/hooks.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import knowlPlugin from '../../../integrations/openclaw/src/index.js';
+import knowlPlugin, { resetImpactSeenForTest } from '../../../integrations/openclaw/src/index.js';
 import type { NormalizedHostHook } from '../../../src/core/host-hook-types.js';
 import * as pluginModule from '@dat999zx/knowl/plugin';
 
@@ -321,6 +321,299 @@ describe('OpenClaw hooks: write gate', () => {
       expect.stringContaining('Swallowed engine failure: Native LibSQL crash or disk corruption'),
       expect.any(Error),
     );
+  });
+});
+
+describe('OpenClaw hooks: impact card and capture (Task 9)', () => {
+  let scratchDir: string;
+  let registeredHooks: Map<string, Array<{ handler: (...args: unknown[]) => Promise<unknown> | unknown; opts?: unknown }>>;
+  let registeredMiddleware: Array<{ handler: (...args: unknown[]) => Promise<unknown> | unknown; opts?: unknown }>;
+  let api: any;
+
+  beforeEach(async () => {
+    resetImpactSeenForTest();
+    scratchDir = path.join(os.tmpdir(), `knowl-openclaw-impact-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+
+    registeredHooks = new Map();
+    registeredMiddleware = [];
+    api = {
+      id: 'knowl',
+      name: 'Knowl',
+      logger: {
+        warn: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      pluginConfig: {},
+      on: vi.fn((hookName: string, handler: any, opts: any) => {
+        if (!registeredHooks.has(hookName)) {
+          registeredHooks.set(hookName, []);
+        }
+        registeredHooks.get(hookName)!.push({ handler, opts });
+      }),
+      registerAgentToolResultMiddleware: vi.fn((handler: any, opts: any) => {
+        registeredMiddleware.push({ handler, opts });
+      }),
+    };
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('Step 1: registers agent tool result middleware with write tool matcher and runtimes', () => {
+    knowlPlugin.register(api);
+
+    expect(registeredMiddleware.length).toBe(1);
+    const { opts } = registeredMiddleware[0];
+    expect(opts).toEqual({
+      matcher: ['exec', 'apply_patch', 'spawn_agent'],
+      runtimes: ['openclaw', 'codex'],
+    });
+  });
+
+  it('Step 2: appends impact card to result.content (never only details) and cards once per (session, file)', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    // Store an atom whose affectedPaths covers src/core.ts
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.query = async () => [
+        {
+          id: 'atom-core-invariant',
+          title: 'Database connection pooling invariant',
+          category: 'architecture',
+          affectedPaths: ['src/core.ts'],
+          scope: 'project',
+          confidence: 0.95,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          source: 'test',
+          content: 'Details here',
+        } as any,
+      ];
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const middleware = registeredMiddleware[0]?.handler;
+    expect(middleware).toBeDefined();
+
+    const event = {
+      toolName: 'apply_patch',
+      args: { patch: '*** Update File: src/core.ts\n@@\n+const x = 1;', path: 'src/core.ts' },
+      cwd: scratchDir,
+      result: {
+        content: [{ type: 'text', text: 'Patch applied successfully' }],
+        details: { exitCode: 0, appliedFiles: ['src/core.ts'] },
+      },
+      toolCallId: 'call-1',
+    };
+    const ctx = {
+      runtime: 'openclaw',
+      sessionId: 'sess-impact-1',
+    };
+
+    const firstRun = (await middleware!(event, ctx)) as any;
+    expect(firstRun).toBeDefined();
+    expect(firstRun?.result).toBeDefined();
+
+    // Step 2 invariant: Card text goes in content, never only details
+    const content = firstRun.result.content;
+    expect(Array.isArray(content)).toBe(true);
+    expect(content.length).toBe(2);
+    expect(content[0]).toEqual({ type: 'text', text: 'Patch applied successfully' });
+    expect(content[1].type).toBe('text');
+    expect(content[1].text).toContain('[Knowl] 1 stored item(s) depend on src/core.ts');
+    expect(content[1].text).toContain('Database connection pooling invariant');
+
+    // Details is preserved, not replaced
+    expect(firstRun.result.details).toEqual({ exitCode: 0, appliedFiles: ['src/core.ts'] });
+
+    // Second call in the same session for the same file: returns undefined (no duplicate card)
+    const secondRun = (await middleware!(event, ctx)) as any;
+    expect(secondRun).toBeUndefined();
+  });
+
+  it('impact card returns undefined when no stored items cover the file', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.query = async () => [
+        {
+          id: 'atom-unrelated',
+          title: 'Unrelated fact',
+          category: 'fact',
+          affectedPaths: ['docs/other.md'],
+        } as any,
+      ];
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const middleware = registeredMiddleware[0]?.handler;
+
+    const event = {
+      toolName: 'apply_patch',
+      args: { path: 'src/unrelated.ts' },
+      cwd: scratchDir,
+      result: { content: [{ type: 'text', text: 'ok' }] },
+      toolCallId: 'call-2',
+    };
+    const ctx = { runtime: 'openclaw', sessionId: 'sess-impact-2' };
+
+    const result = await middleware!(event, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it('impact card returns undefined on tool error', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    knowlPlugin.register(api);
+    const middleware = registeredMiddleware[0]?.handler;
+
+    const event = {
+      toolName: 'apply_patch',
+      args: { path: 'src/core.ts' },
+      cwd: scratchDir,
+      isError: true,
+      result: { content: [{ type: 'text', text: 'error applying patch' }] },
+      toolCallId: 'call-err',
+    };
+    const ctx = { runtime: 'openclaw', sessionId: 'sess-impact-3' };
+
+    const result = await middleware!(event, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it('Step 3: after_tool_call maps to session-event and maps status correctly without floating promises', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    const capturedEvents: NormalizedHostHook[] = [];
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      const origLifecycle = handle.lifecycle.bind(handle);
+      handle.lifecycle = async (hook: NormalizedHostHook) => {
+        capturedEvents.push(hook);
+        return await origLifecycle(hook);
+      };
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const afterToolHook = registeredHooks.get('after_tool_call')?.[0]?.handler;
+    expect(afterToolHook).toBeDefined();
+
+    // Success call
+    await afterToolHook!(
+      { toolName: 'exec', params: { command: 'npm test' }, durationMs: 120 },
+      { workspaceDir: scratchDir, sessionId: 's-after-1' },
+    );
+
+    // Failed call
+    await afterToolHook!(
+      { toolName: 'exec', params: { command: 'false' }, error: 'Command exited with 1', durationMs: 45 },
+      { workspaceDir: scratchDir, sessionId: 's-after-1' },
+    );
+
+    expect(capturedEvents.length).toBe(2);
+    expect(capturedEvents[0].event).toBe('session-event');
+    expect(capturedEvents[0].status).not.toBe('failed');
+    expect(capturedEvents[1].event).toBe('session-event');
+    expect(capturedEvents[1].status).toBe('failed');
+  });
+
+  it('Step 4: before_compaction maps to checkpoint and runs bounded', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    let checkpointFired = false;
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.lifecycle = async (hook: NormalizedHostHook) => {
+        if (hook.event === 'checkpoint') {
+          checkpointFired = true;
+        }
+        return { accepted: true };
+      };
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const compactionHook = registeredHooks.get('before_compaction')?.[0]?.handler;
+    expect(compactionHook).toBeDefined();
+
+    await compactionHook!({}, { workspaceDir: scratchDir, sessionId: 's-compact-1' });
+    expect(checkpointFired).toBe(true);
+  });
+
+  it('Step 5: session_end and agent_end map to turn-stop under shutdown drain budget', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    const stopEvents: NormalizedHostHook[] = [];
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.lifecycle = async (hook: NormalizedHostHook) => {
+        stopEvents.push(hook);
+        return { accepted: true };
+      };
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const sessionEndHook = registeredHooks.get('session_end')?.[0]?.handler;
+    const agentEndHook = registeredHooks.get('agent_end')?.[0]?.handler;
+    expect(sessionEndHook).toBeDefined();
+    expect(agentEndHook).toBeDefined();
+
+    await sessionEndHook!({ sessionId: 's-end-1' }, { workspaceDir: scratchDir });
+    await agentEndHook!({}, { workspaceDir: scratchDir, sessionId: 's-end-1' });
+
+    expect(stopEvents.length).toBe(2);
+    expect(stopEvents[0].event).toBe('turn-stop');
+    expect(stopEvents[1].event).toBe('turn-stop');
+  });
+
+  it('session_start warms workspace and gateway_stop releases all handles', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    let released = false;
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      const origRelease = handle.release.bind(handle);
+      handle.release = async () => {
+        released = true;
+        return await origRelease();
+      };
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const sessionStartHook = registeredHooks.get('session_start')?.[0]?.handler;
+    const gatewayStopHook = registeredHooks.get('gateway_stop')?.[0]?.handler;
+    expect(sessionStartHook).toBeDefined();
+    expect(gatewayStopHook).toBeDefined();
+
+    await sessionStartHook!({ sessionId: 's-start-1' }, { workspaceDir: scratchDir });
+    expect(released).toBe(false);
+
+    await gatewayStopHook!({}, {});
+    expect(released).toBe(true);
   });
 });
 

--- a/tests/integrations/openclaw/hooks.test.ts
+++ b/tests/integrations/openclaw/hooks.test.ts
@@ -147,3 +147,180 @@ describe('OpenClaw hooks: recall card', () => {
     expect(result).toBeUndefined();
   });
 });
+
+describe('OpenClaw hooks: write gate', () => {
+  let scratchDir: string;
+  let registeredHooks: Map<string, Array<{ handler: (...args: unknown[]) => Promise<unknown> | unknown; opts?: unknown }>>;
+  let api: any;
+
+  beforeEach(async () => {
+    scratchDir = path.join(os.tmpdir(), `knowl-openclaw-gate-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+
+    registeredHooks = new Map();
+    api = {
+      id: 'knowl',
+      name: 'Knowl',
+      logger: {
+        warn: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      pluginConfig: {},
+      on: vi.fn((hookName: string, handler: any, opts: any) => {
+        if (!registeredHooks.has(hookName)) {
+          registeredHooks.set(hookName, []);
+        }
+        registeredHooks.get(hookName)!.push({ handler, opts });
+      }),
+      registerAgentToolResultMiddleware: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('registers before_tool_call with canonical write tool matcher', () => {
+    knowlPlugin.register(api);
+
+    const gateEntries = registeredHooks.get('before_tool_call');
+    expect(gateEntries).toBeDefined();
+    expect(gateEntries?.length).toBe(1);
+
+    const opts = gateEntries![0].opts as { matcher: string[] };
+    expect(opts).toBeDefined();
+    expect(opts.matcher).toEqual(['exec', 'apply_patch', 'spawn_agent']);
+  });
+
+  it('allows write when engine has no objection (returns undefined, never params or block: false)', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    knowlPlugin.register(api);
+    const gateHook = registeredHooks.get('before_tool_call')?.[0]?.handler;
+    expect(gateHook).toBeDefined();
+
+    const event = {
+      toolName: 'apply_patch',
+      params: { patch: '*** test patch ***', path: 'src/index.ts' },
+      derivedPaths: ['src/index.ts'],
+    };
+    const ctx = {
+      workspaceDir: scratchDir,
+      sessionId: 'gate-session-1',
+    };
+
+    const result = (await gateHook!(event, ctx)) as any;
+    // Decision is abstain (undefined) so host allows the write
+    expect(result).toBeUndefined();
+    expect(result?.params).toBeUndefined();
+    expect(result?.block).toBeUndefined();
+  });
+
+  it('blocks write when engine lifecycle refuses, returning blockReason and never params', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    // Mock lifecycle to return a refusal
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.lifecycle = async () => ({
+        accepted: true,
+        hostOutput: {
+          block: true,
+          blockReason: 'Modifying src/core.ts contradicts a verified invariant from Task 2.',
+        },
+      });
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const gateHook = registeredHooks.get('before_tool_call')?.[0]?.handler;
+
+    const event = {
+      toolName: 'apply_patch',
+      params: { patch: '*** bad patch ***', path: 'src/core.ts' },
+      derivedPaths: ['src/core.ts'],
+    };
+    const ctx = {
+      workspaceDir: scratchDir,
+      sessionId: 'gate-session-refusal',
+    };
+
+    const result = (await gateHook!(event, ctx)) as any;
+    expect(result).toBeDefined();
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe('Modifying src/core.ts contradicts a verified invariant from Task 2.');
+    // Invariant: Codex relays reject rewrites and fail closed, so never return params
+    expect(result?.params).toBeUndefined();
+  });
+
+  it('Step 5: test that a stalled engine accepts — deadline fires, returns accept, write proceeds', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    // Configure a short gate deadline to test deadline expiry
+    api.pluginConfig = { gateDeadlineMs: 40 };
+
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      // Stalled engine: simulates a hung sqlite query or blocked native worker
+      handle.lifecycle = async () => new Promise<any>(() => {});
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const gateHook = registeredHooks.get('before_tool_call')?.[0]?.handler;
+
+    const start = Date.now();
+    const event = {
+      toolName: 'exec',
+      params: { command: 'rm -rf /tmp/data' },
+    };
+    const ctx = {
+      workspaceDir: scratchDir,
+      sessionId: 'gate-session-stall',
+    };
+
+    const result = (await gateHook!(event, ctx)) as any;
+    const elapsed = Date.now() - start;
+
+    // The gate must resolve well under the host's 15s budget (here in ~40-150ms)
+    expect(elapsed).toBeLessThan(1_000);
+    // On timeout, gate abstains / accepts rather than failing closed
+    expect(result).toBeUndefined();
+  });
+
+  it('throwing engine safely accepts the write without crashing the gateway', async () => {
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.lifecycle = async () => {
+        throw new Error('Native LibSQL crash or disk corruption');
+      };
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const gateHook = registeredHooks.get('before_tool_call')?.[0]?.handler;
+
+    const result = (await gateHook!(
+      { toolName: 'spawn_agent', params: { task: 'run' } },
+      { workspaceDir: scratchDir, sessionId: 's-err' },
+    )) as any;
+
+    expect(result).toBeUndefined();
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Swallowed engine failure: Native LibSQL crash or disk corruption'),
+      expect.any(Error),
+    );
+  });
+});
+

--- a/tests/integrations/openclaw/hooks.test.ts
+++ b/tests/integrations/openclaw/hooks.test.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import knowlPlugin from '../../../integrations/openclaw/src/index.js';
+import type { NormalizedHostHook } from '../../../src/core/host-hook-types.js';
+import * as pluginModule from '@dat999zx/knowl/plugin';
+
+const CLI_PATH = path.resolve('dist/index.js');
+
+describe('OpenClaw hooks: recall card', () => {
+  let scratchDir: string;
+  let registeredHooks: Map<string, Array<{ handler: (...args: unknown[]) => Promise<unknown> | unknown; opts?: unknown }>>;
+  let api: any;
+
+  beforeEach(async () => {
+    scratchDir = path.join(os.tmpdir(), `knowl-openclaw-hooks-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+
+    registeredHooks = new Map();
+    api = {
+      id: 'knowl',
+      name: 'Knowl',
+      logger: {
+        warn: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      pluginConfig: {},
+      on: vi.fn((hookName: string, handler: any, opts: any) => {
+        if (!registeredHooks.has(hookName)) {
+          registeredHooks.set(hookName, []);
+        }
+        registeredHooks.get(hookName)!.push({ handler, opts });
+      }),
+      registerAgentToolResultMiddleware: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('registers before_prompt_build and asserts no secondary prompt publishers are registered', () => {
+    knowlPlugin.register(api);
+
+    expect(registeredHooks.has('before_prompt_build')).toBe(true);
+    // PR #257 invariant: exactly one hook publishes prompt context
+    expect(registeredHooks.has('agent_turn_prepare')).toBe(false);
+    expect(registeredHooks.has('heartbeat_prompt_contribution')).toBe(false);
+  });
+
+  it('regression test for #257: two different prompts produce the identical recall card and no prompt text reaches the engine payload', async () => {
+    const repo1 = path.join(scratchDir, 'repo1');
+    const repo2 = path.join(scratchDir, 'repo2');
+    await fs.mkdir(repo1, { recursive: true });
+    await fs.mkdir(repo2, { recursive: true });
+
+    // Initialize real knowl database in both scratch directories
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: repo1, encoding: 'utf8' });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: repo2, encoding: 'utf8' });
+
+    // Disable fleet roster in both repos so fleet peer banners do not differentiate the orientation cards
+    const noFleetConfig = JSON.stringify({ fleet: { enabled: false } }, null, 2);
+    await fs.writeFile(path.join(repo1, '.knowl', 'config.json'), noFleetConfig, 'utf8');
+    await fs.writeFile(path.join(repo2, '.knowl', 'config.json'), noFleetConfig, 'utf8');
+
+    // Spy on openProject to intercept lifecycle calls and inspect the exact hook passed to the engine
+    const capturedHooks: NormalizedHostHook[] = [];
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      const origLifecycle = handle.lifecycle.bind(handle);
+      handle.lifecycle = async (hook: NormalizedHostHook) => {
+        capturedHooks.push(hook);
+        return await origLifecycle(hook);
+      };
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+
+    const promptHook = registeredHooks.get('before_prompt_build')?.[0]?.handler;
+    expect(promptHook).toBeDefined();
+
+    const promptA = 'Can you describe the architectural layers and memory layout of this system?';
+    const promptB = 'What is the population of Tokyo in 2026?';
+
+    const ctxSession1 = {
+      workspaceDir: repo1,
+      sessionId: 'openclaw-session-1',
+      sessionKey: 'main',
+    };
+
+    const ctxSession2 = {
+      workspaceDir: repo2,
+      sessionId: 'openclaw-session-2',
+      sessionKey: 'main',
+    };
+
+    // Prompt A in Repo 1
+    const resultA = (await promptHook!({ prompt: promptA }, ctxSession1)) as { prependContext?: string } | undefined;
+    expect(resultA).toBeDefined();
+    expect(resultA?.prependContext).toBeDefined();
+    expect(resultA?.prependContext?.length).toBeGreaterThan(0);
+
+    // Prompt B in Repo 2
+    const resultB = (await promptHook!({ prompt: promptB }, ctxSession2)) as { prependContext?: string } | undefined;
+    expect(resultB).toBeDefined();
+    expect(resultB?.prependContext).toBeDefined();
+
+    // Invariant 1 (regression test for #257): Two different prompts produce the IDENTICAL orientation card
+    expect(resultA?.prependContext).toBe(resultB?.prependContext);
+
+    // Subsequent prompt in Session 1 delivers context once per session (not duplicated)
+    const resultA2 = (await promptHook!({ prompt: 'Another follow-up message' }, ctxSession1)) as { prependContext?: string } | undefined;
+    expect(resultA2).toBeUndefined();
+
+    // Invariant 2: Assert no prompt substring reaches the engine payload
+    expect(capturedHooks.length).toBe(3);
+    for (const hook of capturedHooks) {
+      expect(hook.event).toBe('turn-start');
+      expect(hook.payload).not.toHaveProperty('prompt');
+
+      const payloadStr = JSON.stringify(hook.payload);
+      expect(payloadStr).not.toContain('architectural layers');
+      expect(payloadStr).not.toContain('population of Tokyo');
+      expect(payloadStr).not.toContain('Another follow-up message');
+    }
+  });
+
+  it('returns undefined cleanly when run outside a knowl project directory', async () => {
+    knowlPlugin.register(api);
+
+    const promptHook = registeredHooks.get('before_prompt_build')?.[0]?.handler;
+    expect(promptHook).toBeDefined();
+
+    const result = await promptHook!(
+      { prompt: 'Some prompt' },
+      { workspaceDir: scratchDir, sessionId: 's1' },
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/tests/integrations/openclaw/plugin-entry-stub.ts
+++ b/tests/integrations/openclaw/plugin-entry-stub.ts
@@ -1,0 +1,21 @@
+/**
+ * A stand-in for `openclaw/plugin-sdk/plugin-entry` under vitest.
+ *
+ * The real module is a **peer dependency** of `integrations/openclaw` and is deliberately not
+ * installed in this repository: OpenClaw refuses to let npm place a second registry copy of the
+ * host inside a managed plugin project, and relinks its own `node_modules/openclaw` after
+ * install. So the specifier resolves on a machine that happens to have OpenClaw installed and
+ * fails everywhere else — which is exactly what happened on CI, where the suite passed locally
+ * and died with `Cannot find package 'openclaw/plugin-sdk/plugin-entry'` on ubuntu and macOS.
+ *
+ * `definePluginEntry` is an identity-shaped registrar: it takes the plugin definition and hands
+ * back something the gateway can load. Nothing in these tests exercises the host's side of that
+ * contract — they drive `register(api)` directly with a fake `api` — so returning the definition
+ * unchanged is a faithful stub rather than a simplification that hides a behaviour.
+ *
+ * Typed against the real shape loosely on purpose: tightening it here would duplicate OpenClaw's
+ * declarations into this repo, and they are already the authority (`npm view openclaw`).
+ */
+export function definePluginEntry<T>(definition: T): T {
+  return definition;
+}

--- a/tests/store/schema-error-class.test.ts
+++ b/tests/store/schema-error-class.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDbPath } from '../../src/store/database.js';
+import { KNOWL_SCHEMA_VERSION, SchemaTooNewError } from '../../src/store/schema-version.js';
+
+describe('preserve SchemaTooNewError across library boundary', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `knowl-schema-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    dbPath = path.join(tmpDir, 'knowl.db');
+
+    // Create a database and stamp user_version higher than supported
+    const rawClient = createClient({ url: `file:${dbPath}` });
+    await rawClient.execute(`PRAGMA user_version = ${KNOWL_SCHEMA_VERSION + 1}`);
+    rawClient.close();
+  });
+
+  afterEach(async () => {
+    await closeDb().catch(() => {});
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('preserves SchemaTooNewError as cause when initDbPath throws', async () => {
+    let thrownError: any = null;
+    try {
+      await initDbPath(dbPath, { configRoot: tmpDir });
+    } catch (err: any) {
+      thrownError = err;
+    }
+
+    expect(thrownError).toBeDefined();
+    const causeOrSelf = thrownError instanceof SchemaTooNewError ? thrownError : thrownError?.cause;
+    expect(causeOrSelf).toBeInstanceOf(SchemaTooNewError);
+    expect(causeOrSelf.name).toBe('SchemaTooNewError');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,7 +26,7 @@ import { defineConfig } from 'tsup';
  * without a `require` in scope an ESM bundle throws on it.
  */
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/plugin.ts'],
   format: ['esm'],
   clean: true,
   dts: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,12 @@ import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@dat999zx/knowl/plugin': path.resolve('./dist/plugin.js'),
+      '@dat999zx/knowl': path.resolve('./dist/index.js'),
+    },
+  },
   test: {
     // Benchmark harness lives under benchmarks/ with its own vitest project (`npm run
     // test:bench`). Excluding it keeps `npm test` scoped to the product, so research tooling can

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,13 @@ export default defineConfig({
     alias: {
       '@dat999zx/knowl/plugin': path.resolve('./dist/plugin.js'),
       '@dat999zx/knowl': path.resolve('./dist/index.js'),
+      // `openclaw` is a PEER dependency of integrations/openclaw and is deliberately absent
+      // here: the host refuses a second registry copy of itself inside a managed plugin
+      // project and relinks its own node_modules after install. Without this alias the
+      // OpenClaw suite passes only on a machine that happens to have OpenClaw installed --
+      // it died on CI's ubuntu and macOS legs with ERR_MODULE_NOT_FOUND while passing on the
+      // developer's Windows box, which had it left over from a live install.
+      'openclaw/plugin-sdk/plugin-entry': path.resolve('./tests/integrations/openclaw/plugin-entry-stub.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## What

OpenClaw joins as a host, but not the way the other ten did. Every existing integration is a thin translator that spawns `knowl agent-hook <host> <event> --json` per lifecycle event. This one runs **inside** OpenClaw's gateway and imports the engine directly.

Spec: `docs/superpowers/specs/2026-09-05-openclaw-plugin-design.md`
Plan: `docs/superpowers/plans/2026-09-05-openclaw-plugin.md`

## Why in-process, and why only one argument survives

`before_tool_call` is the only hook the agent **blocks on**. Measured:

| | subprocess | in-process |
| --- | --- | --- |
| write gate (real decision) | 118 ms | 0.68 ms |
| non-write (nothing to decide) | 118 ms | 0.04 ms |

The subprocess cannot short-circuit — it must boot Node, load the bundle and open SQLite before discovering the tool was a `read`. At a few hundred tool calls per session that is 20–25 s of latency in front of the user, spent mostly on events with nothing to decide.

Three arguments from the first draft of the spec were **withdrawn** after adversarial review, and the spec records them as withdrawn rather than quietly dropping them:

- *"187 ms per event"* benchmarked `node dist/index.js --version`, a command nothing runs. Real `agent-hook` cost is 118–120 ms, ~36 ms of which is the bare process floor. The background saving is ~88 ms, not 187 ms.
- *"A subprocess cannot return an object."* It can; `runAgentHook` already returns JSON on stdout.
- The whole synchronous-hook workaround — see below.

## The correction that mattered most

The first draft built the impact card on `tool_result_persist`, then designed an async-precompute-plus-sync-cache workaround around that hook's synchronicity. **The premise was false.** That hook rewrites the *transcript* copy, not what the model reads in the current run — confirmed in OpenClaw source at `src/agents/session-tool-result-guard.ts:685`, where the function is named `persistToolResult` and its output flows only into `appendMessageAndCacheTranscriptSeq`. The card would never have reached the model.

The correct seam is `api.registerAgentToolResultMiddleware(...)` — async, runtime-neutral, and documented as running *before* tool output is fed back to the model. Verified at the type level in the shipped `.d.ts`. The entire cache workaround is deleted.

## The safety contract was backwards

The 2026-09-03 plan's rule was "a hook failure must allow the action." OpenClaw documents `before_tool_call` as **fail-closed** on a 15-second budget: throw or exceed it and the user's write is *blocked*. A timed-out handler also keeps running, with no cancellation signal.

So the gate carries its own **5-second deadline** whose fallback is *accept*, `safely()` swallows to a fallback rather than rethrowing, the first open is warmed at `session_start` rather than lazily inside the gate, and `knowl init openclaw` writes an explicit `timeouts.before_tool_call` instead of inheriting the default.

## Prerequisite, already shipped

5.21.1 (#258) added `openProjectScope` / `withProjectScope`. Before it, `initDb()` overwrote a module-global context, so a gateway holding two workspaces wrote project A's rows into project B's file — silently. Nothing in this PR calls `initDb`, `initDbPath` or `closeDb`; every handle body runs inside a scope and releases via `releaseClient`.

## Why not `registerMemoryCapability`

It is an **exclusive** slot — one active at a time — so registering there would displace whatever memory plugin the user runs (`memory-core`, Honcho) and take ownership of recall, semantic search, promotion and dreaming. Knowl does none of those. OpenClaw's own `memory-wiki` is the precedent for sitting *beside* the active memory plugin. Recorded in the spec so the omission does not read as an oversight.

## Verification

Native coexistence was proven before any code was written: libsql, `node:sqlite` and tree-sitter all load in one process, both engines opened the **same file** under WAL and saw each other's rows, and an external `knowl` CLI ran concurrently against the same repo.

- `npm run build`, `npx tsc --noEmit`, `npx eslint .`, `npm run docs:check` — all clean
- Full suite: **415 files, 3925 passed, 5 skipped**

The two tests that are the point of the exercise:

- `tests/cli/plugin-export.test.ts:146` — two projects open in one process, write through the first, asserted at the **raw SQLite level** (`rowsA=1, rowsB=0`), not just through the query API.
- `tests/integrations/openclaw/hooks.test.ts:261` — a **stalled** engine still accepts the write, with a companion test for a throwing engine.

Plus a regression for #257: two different prompts in one session produce an identical card, and no prompt text reaches the engine payload.

The `exports` map uses `./integrations/*` and `./dist/*` wildcards deliberately — a three-entry map would break `integrations/cline/knowl-plugin.mjs`, the documented Cline install path.

## Not in this PR

Task 12, the live-gateway checks against a running OpenClaw instance: the card appearing exactly once in a real prompt, a blocked write surfacing `blockReason` to the model, and two workspaces isolated in one gateway. Those need a real install and are being run separately.

## Known

CI's `test (windows-latest, node 22)` leg intermittently dies with `status: 3221225477` (0xC0000005) — a worker crash with zero failing assertions. It is already failing this way on `main` for the 5.21.1 release and pre-dates this branch.
