### PR TITLE
docs: move the Discord invite into the badge row, drop Product Hunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![node](https://img.shields.io/badge/node-%E2%89%A522-70b6fd)](package.json)
 [![MCP](https://img.shields.io/badge/protocol-MCP-cab049)](https://modelcontextprotocol.io)
 
-<a href="https://www.producthunt.com/products/knowl?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-knowl" target="_blank" rel="noopener noreferrer"><img alt="Knowl - Agent memory that knows when to forget | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1228671&amp;theme=light&amp;t=1787366617137"></a>
+<a href="https://discord.gg/YrWbHe8FBB"><img src="https://img.shields.io/badge/Discord-Join%20the%20server-5865F2?logo=discord&logoColor=white&style=for-the-badge" alt="Join the Knowl Discord" height="40" /></a>
 
 <p align="center">
   <a href="#the-idea-memory-that-retires-itself"><picture><source media="(prefers-color-scheme: light)" srcset="docs/assets/chips/light/stat-supersession.svg"><img src="docs/assets/chips/stat-supersession.svg" alt="Scores 90 on MemoryAgentBench FactConsolidation single-hop at 262K" height="38" /></picture></a>
@@ -25,7 +25,6 @@
 [Features](#features) ·
 [Agent setup](#connecting-an-agent) ·
 [Viewer](#see-it-the-local-viewer) ·
-[Discord](#community) ·
 [Requirements](#requirements-and-local-data) ·
 **[Full reference →](docs/reference.md)**
 
@@ -296,15 +295,6 @@ hosted layer for when one machine is not enough:
 </p>
 
 Local-only remains a first-class way to run Knowl. Nothing here is required to use anything above.
-
-## Community
-
-<p align="center">
-  <a href="https://discord.gg/YrWbHe8FBB"><img src="https://img.shields.io/badge/Discord-Join%20the%20server-5865F2?logo=discord&logoColor=white&style=for-the-badge" alt="Join the Knowl Discord" height="40" /></a>
-</p>
-
-Questions, bug reports, and what you are building with it — the fastest place to reach us is
-**[the Knowl Discord](https://discord.gg/YrWbHe8FBB)**.
 
 ## What gets stored
 


### PR DESCRIPTION
Follow-up to #262, which put the invite in a `## Community` section two thirds down the page — past the point where the reader who would actually join has stopped reading.

- Discord badge moves into the header, taking the Product Hunt slot directly under the shields row.
- Product Hunt badge removed; it had done its launch-week job.
- `## Community` section and its nav entry removed, so there is one invite, not two.

README-only. `tests/core/knowl-guidance.test.ts` passes against the edited file.