### PR TITLE
chore: release 5.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.21.1",
+  "version": "5.22.0",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.22.0 — 2026-09-06
 
 **OpenClaw in-process plugin integration.** OpenClaw is supported via an in-process plugin package (`@dat999zx/knowl/plugin` and `integrations/openclaw`) rather than shell hooks. Running inside the OpenClaw gateway evaluates the write gate at `before_tool_call` in sub-millisecond time (~0.68ms vs ~118ms subprocess) with an explicit matcher filtering write tools (`exec`, `apply_patch`, `spawn_agent`). The write gate carries an internal 5-second deadline and swallows engine errors to uphold OpenClaw's fail-closed host contract without blocking user writes on memory degradation.
 
@@ -13,7 +13,7 @@ Prompt recall is delivered at `before_prompt_build` returning `{ prependContext:
 
 **Namespace reads now reach the store that writes reach.** The global store is addressed by its known path, but every namespace list was built from project config — and `knowl init` writes no `memory.global` block. So in every repository Knowl creates, an atom written with `namespace: 'global'` was unreadable by the surface that wrote it: `knowl query` and `knowl_query` keyword search both missed it, and every id-addressed operation failed on an id search had just printed — `knowl supersede` and `knowl reviewed` with "Knowledge item not found", `knowl_query --id` reporting it did not exist, `knowl_timeline` answering `[]`. Reported as "Knowl is bad at superseding". `withItemNamespace` now resolves an id in whichever namespace holds it and runs the caller's entire operation there, write included; both keyword search paths union the global store's known path.
 
-`knowl init openclaw` merges the plugin entry into `openclaw.json` (project-scoped or `~/.openclaw/openclaw.json`), writing both required permission gates (`allowConversationAccess` and `allowPromptInjection`) and explicitly setting `timeouts.before_tool_call: 5000` while preserving all surrounding user configuration.
+`knowl init openclaw` merges the plugin entry into `openclaw.json` (project-scoped or `~/.openclaw/openclaw.json`), writing both required permission gates (`allowConversationAccess` and `allowPromptInjection`) and explicitly setting `timeouts.before_tool_call: 5000` while preserving all surrounding user configuration. It also **copies the plugin** into `~/.openclaw/knowl-plugin`, the way `knowl init hermes` has always copied its own — previously the command wrote config enabling a plugin OpenClaw had never been told about, reported success, and left a dead install that `verify()` agreed was configured because it only read the config file. The printed instructions name the two remaining steps and why each is mandatory: the dependency install needs `--install-links`, because OpenClaw's safety scan refuses a plugin whose `node_modules` symlink outside the install root and a plain `npm install <path>` produces exactly that; the registration needs `--force` (the directory is outside ClawHub trust metadata) and `--accept-capabilities` (the plugin declares tool-result middleware).
 
 ## 5.21.1 — 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ works.
 <sub>MCP · lifecycle · gate</sub>
 </td>
 <td align="center" width="14%">
+<a href="https://github.com/openclaw/openclaw"><img src="docs/assets/logos/openclaw.svg" alt="OpenClaw" width="40" height="40" /></a><br/>
+<strong>OpenClaw</strong><br/>
+<sub>in-process · plugin · gate</sub>
+</td>
+<td align="center" width="14%">
 <a href="https://github.com/features/copilot"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/logos/githubcopilot-dark.svg" /><img src="docs/assets/logos/githubcopilot.svg" alt="Copilot" width="40" height="40" /></picture></a><br/>
 <strong>Copilot</strong><br/>
 <sub>MCP · lifecycle · gate</sub>
@@ -124,13 +129,13 @@ works.
 <strong>OpenHands</strong><br/>
 <sub>MCP · lifecycle · gate</sub>
 </td>
+</tr>
+<tr>
 <td align="center" width="14%">
 <a href="https://antigravity.google"><img src="docs/assets/logos/antigravity.svg" alt="Antigravity" width="40" height="40" /></a><br/>
 <strong>Antigravity</strong><br/>
 <sub>MCP · lifecycle · gate</sub>
 </td>
-</tr>
-<tr>
 <td align="center" width="14%">
 <a href="https://windsurf.com"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/logos/windsurf-dark.svg" /><img src="docs/assets/logos/windsurf.svg" alt="Windsurf" width="40" height="40" /></picture></a><br/>
 <strong>Windsurf</strong><br/>
@@ -161,11 +166,6 @@ works.
 <strong>Claude Desktop</strong><br/>
 <sub>MCP · manual loop</sub>
 </td>
-<td align="center" width="14%">
-<a href="https://github.com/openclaw/openclaw"><img src="docs/assets/logos/openclaw.svg" alt="OpenClaw" width="40" height="40" /></a><br/>
-<strong>OpenClaw</strong><br/>
-<sub>in-process · plugin · gate</sub>
-</td>
 </tr>
 </table>
 
@@ -177,7 +177,8 @@ Neovim and Kiro work the same way as Zed and JetBrains, through `knowl acp`. Cli
 line pointing it at the shipped plugin. Hermes Agent gets a Python plugin, installed for you,
 that works in the terminal and in Hermes Desktop alike, and can additionally be picked as
 Hermes' memory provider. OpenClaw runs in-process inside its gateway via an extension plugin,
-evaluating write gates without subprocess overhead. Any other MCP client works with
+evaluating write gates without subprocess overhead — `knowl init openclaw` copies it and prints
+the two commands that register it. Any other MCP client works with
 no integration at all.
 
 Running agents in parallel? Every **git worktree** resolves to the main checkout's store —

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -79,6 +79,8 @@ knowl init --global hermes      # install the plugin, enable it, add the MCP ser
 cd my-repo && knowl init
 ```
 
+OpenClaw is machine-wide the same way, with one difference worth knowing before you start: `knowl init openclaw` copies the plugin but leaves the dependency install and the `openclaw plugins install --link` registration for you to run, and prints both. Neither is optional, and the flags on them are not decoration — see [Why some hosts get less](#why-some-hosts-get-less) below.
+
 | Host | MCP config | Hooks |
 | --- | --- | --- |
 | Claude Code | `.mcp.json` | `.claude/settings.local.json` |
@@ -90,7 +92,7 @@ cd my-repo && knowl init
 | Cursor | `.cursor/mcp.json` | `.cursor/hooks.json` |
 | Claude Desktop | platform config directory | — |
 | Hermes Agent | `config.yaml` in the Hermes home (global) | a plugin in `<Hermes home>/plugins/knowl/` |
-| OpenClaw | — | in-process plugin in `openclaw.json` (`plugins.entries.knowl`) |
+| OpenClaw | — | in-process plugin in `openclaw.json` (`plugins.entries.knowl`), plus a copy in `~/.openclaw/knowl-plugin` |
 
 † Antigravity is two products reading two files. The IDE's "View raw config" opens `~/.gemini/antigravity/mcp_config.json`; the `agy` CLI reads `~/.gemini/config/mcp_config.json`, which Gemini CLI's migration often leaves at 0 bytes — an empty file, not a broken one. Both are confirmed against real installs, and `knowl init antigravity` writes both.
 
@@ -174,6 +176,26 @@ stops injecting once it sees `memory.provider: knowl`, though it still fires, be
 what binds the session and carries capture.
 
 **One thing to know about the MCP tools on Desktop.** `knowl serve` resolves the project by walking up from its own process directory, and every other host launches one server per project, so it inherits the right one. Hermes Desktop runs a single server for every project, started from the Hermes process directory — so its `mcp__knowl__*` tools report *No Knowl project found* on a machine whose store is perfectly healthy. Setting `mcp_servers.knowl.cwd` fixes one project and then silently answers from **that** project in every other session, which is worse than the error, so `knowl init hermes` does not set it; pin it yourself only if you use Hermes for a single repository. Because of this the plugin registers `knowl_query` and `knowl_store` as its own tools, run in the session's own directory, so the query-then-store loop is correct in every session no matter how many projects are open. The rest of the tool surface stays reachable the way any command is — `knowl timeline`, `knowl conflicts`, `knowl drift` and the others, run from the repository in the agent's terminal. A per-session MCP server needs something Hermes does not have yet: project-local config, or MCP roots.
+
+**OpenClaw** takes the same shape as Hermes — a plugin copied out of the Knowl package rather than a shell hook — but it runs *inside the gateway process*, so the write gate costs ~0.68ms instead of the ~118ms a subprocess pays, and 0.04ms on a tool that cannot write. `knowl init openclaw` merges `plugins.entries.knowl` into `openclaw.json` (the repository's own file if it has one, otherwise `~/.openclaw/openclaw.json`) and copies [`integrations/openclaw/`](../integrations/openclaw/README.md) into `~/.openclaw/knowl-plugin`.
+
+It then prints two commands and does not run them, because both need to be your decision:
+
+```bash
+cd ~/.openclaw/knowl-plugin && npm install @dat999zx/knowl @libsql/client --install-links
+openclaw plugins install --link ~/.openclaw/knowl-plugin --force --accept-capabilities
+# then restart the gateway
+```
+
+Every flag there is load-bearing, and each one was found by an install that failed without it:
+
+- **`--install-links` is not optional.** A plain `npm install <path>` symlinks the dependency back to its source, and OpenClaw's safety scan refuses any plugin whose `node_modules` point outside the install root — *"dependency boundary scan found node_modules symlink target outside install root"*. `--install-links` copies instead. The dependencies themselves are required because a linked directory resolves its own imports and libsql stays external to the Knowl bundle; without them the plugin loads to *"Cannot find module"*.
+- **`--force`** covers the directory being outside ClawHub trust metadata, and **`--accept-capabilities`** covers the tool-result middleware the plugin declares. Miss either and the install stops.
+- **A refused install leaves the config entry behind.** The next run reports `plugins.entries.knowl: plugin not found (stale config entry ignored)`, which reads like a missing plugin rather than a rejected one. If you see it, the registration step is what failed.
+
+Check the result with `openclaw plugins inspect knowl --runtime`: `status: loaded` and a non-zero `hookCount` mean the plugin registered. `knowl init openclaw` re-run afterwards reports *configured* only when both the config entry and the copied files are present, so a half-finished install cannot report success.
+
+**A caveat worth reading before you rely on the prompt card.** The card is delivered from `before_prompt_build`, and on OpenClaw 2026.9.1 that hook is not dispatched on every surface: it fires under the `claude-cli` backend and does not fire on the embedded runner, for bundled and non-bundled plugins alike. `plugins inspect` still reports the hook registered, and no warning is emitted either way. Upstream discussion is [openclaw#134579](https://github.com/openclaw/openclaw/issues/134579), where the generic `openclaw agent` command is also documented as not being a contracted surface for prompt hooks. The write gate, the capture observers and the impact card are unaffected; treat automatic recall as working where that hook runs and verify it on the surface you actually use.
 
 **Gemini CLI is gone.** Discontinued upstream; its adapter was instructions-only and was removed. Antigravity replaces it. An existing `GEMINI.md` is left on disk.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2369,12 +2369,12 @@ one `knowl_store` or one hook capture is a single write — and better under con
 ## Agent setup
 
 `knowl init` detects Claude Code, Codex, GitHub Copilot, Cursor, OpenHands, Antigravity,
-Windsurf, Cline, Hermes Agent, OpenCode and Claude Desktop. Run it interactively or name the integrations
+Windsurf, Cline, Hermes Agent, OpenClaw, OpenCode and Claude Desktop. Run it interactively or name the integrations
 explicitly:
 
 ```bash
 knowl init
-knowl init claude codex copilot cursor openhands antigravity windsurf cline hermes opencode claude-desktop
+knowl init claude codex copilot cursor openhands antigravity windsurf cline hermes openclaw opencode claude-desktop
 knowl doctor
 ```
 
@@ -2384,7 +2384,7 @@ Codex, Copilot, OpenHands and Hermes — the installed prompt hook invokes `know
 --json`. Existing unrelated MCP servers and host rules are preserved, and changed configuration
 files are backed up.
 
-Three hosts need one extra step:
+Four hosts need one extra step:
 
 - **Cline** loads lifecycle as a plugin. Point it at the shipped file:
   `ClineCore.start({ pluginPaths: ['./node_modules/@dat999zx/knowl/integrations/cline/knowl-plugin.mjs'] })`
@@ -2396,6 +2396,18 @@ Three hosts need one extra step:
   memory providers, so Knowl also appears under **Settings > Memory & Context > Memory
   Provider**; picking it there (or setting `memory.provider: knowl`) is optional and additive
   — see [hosts](hosts.md).
+- **OpenClaw** runs in-process inside the gateway. `knowl init openclaw` merges
+  `plugins.entries.knowl` into `openclaw.json` with both permission gates and copies the plugin
+  to `~/.openclaw/knowl-plugin`, then prints two commands it deliberately does not run:
+  `npm install @dat999zx/knowl @libsql/client --install-links` in that directory, and
+  `openclaw plugins install --link <dir> --force --accept-capabilities`. All three flags are
+  required — `--install-links` because OpenClaw's safety scan refuses a plugin whose
+  `node_modules` symlink outside the install root, `--force` because the directory is outside
+  ClawHub trust metadata, `--accept-capabilities` because the plugin declares tool-result
+  middleware. Restart the gateway, then confirm with
+  `openclaw plugins inspect knowl --runtime`. One caveat: `before_prompt_build`, which carries
+  the recall card, is not dispatched on every OpenClaw surface as of 2026.9.1 — see
+  [hosts](hosts.md) and [openclaw#134579](https://github.com/openclaw/openclaw/issues/134579).
 - **Zed, JetBrains, Neovim and Kiro** speak the Agent Client Protocol, whose traffic runs
   agent-to-client with no hook to register. Point the editor at `knowl acp -- <agent-command>`
   instead of at the agent.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -16,37 +16,47 @@ knowl init openclaw
 
 That merges the plugin entry into `openclaw.json` along with both required permission gates
 (`allowConversationAccess`, `allowPromptInjection`) and an explicit
-`timeouts.before_tool_call`, preserving any surrounding configuration.
-
-To install a local build instead:
-
-```bash
-npm pack                     # from this directory — see the warning below
-openclaw plugins install --force npm-pack:/abs/path/to/dat999zx-knowl-openclaw-plugin-<v>.tgz
-openclaw plugins enable knowl
-openclaw plugins inspect knowl --runtime --json    # every hook registered, no blocked registrations
-```
-
-`--force` is required because a local archive sits outside ClawHub trust metadata. The path must be
-absolute and forward-slashed.
-
-## Building — read before publishing
-
-**OpenClaw refuses a plugin that ships TypeScript source.** A managed npm install requires compiled
-runtime output (`./dist/index.js`); TS source is only accepted for local development checkouts. So
-`openclaw.extensions` points at `dist/`, never `src/`.
-
-The compile runs in `prepack`, deliberately: OpenClaw's managed installer runs `npm install
---ignore-scripts`, so the build cannot happen at install time on the user's machine. It has to be
-baked into the tarball.
-
-**The trap that follows from that:** `npm pack --ignore-scripts` skips `prepack` and produces a
-tarball containing only `package.json` and `openclaw.plugin.json` — two files, no code, and no
-error. Always run a plain `npm pack`, and check the file count is 8, not 2:
+`timeouts.before_tool_call`, preserving any surrounding configuration. It also copies this
+directory to `~/.openclaw/knowl-plugin` and prints the two commands that finish the install:
 
 ```bash
-npm pack && tar -tzf *.tgz | grep dist/index.js
+cd ~/.openclaw/knowl-plugin && npm install @dat999zx/knowl @libsql/client --install-links
+openclaw plugins install --link ~/.openclaw/knowl-plugin --force --accept-capabilities
+openclaw plugins inspect knowl --runtime            # status: loaded, hookCount non-zero
+# restart the gateway
 ```
+
+Each flag is there because the install fails without it:
+
+- **`--install-links`** copies the dependency rather than symlinking it. A plain
+  `npm install <path>` symlinks back to the source, and OpenClaw's safety scan refuses a plugin
+  whose `node_modules` escape the install root: *"dependency boundary scan found node_modules
+  symlink target outside install root"*. The dependencies are needed at all because a linked
+  directory resolves its own imports and libsql stays external to the Knowl bundle.
+- **`--force`** covers the directory sitting outside ClawHub trust metadata.
+- **`--accept-capabilities`** covers the tool-result middleware declared in the manifest.
+
+A refused install still leaves the config entry behind, so the next run reports
+`plugins.entries.knowl: plugin not found (stale config entry ignored)` — that message means the
+registration failed, not that the plugin is missing.
+
+## Shipping — TypeScript source, and why that is fine
+
+**`openclaw.extensions` points at `./src/index.ts`, and OpenClaw loads it directly.** The rule
+that a plugin must ship compiled JavaScript applies to the *managed npm install* path
+(`npm-pack:` archives, ClawHub packages) — a `--link` install of a local directory accepts a
+TypeScript entry, which is what OpenClaw's own error text means by a development checkout. Since
+`knowl init openclaw` copies this directory and links it, there is no build step, no `dist/`, and
+no second npm package to publish.
+
+That also removes an ordering problem worth recording: a published plugin package would depend on
+`@dat999zx/knowl` for the `/plugin` subpath export, which only exists from 5.22.0 — so the plugin
+could not be installed until a release that did not yet exist. Copy-and-link has no such cycle.
+
+If you ever do need a packed archive, the compile runs in `prepack`, because OpenClaw's managed
+installer runs `npm install --ignore-scripts` and cannot build on the user's machine. The trap
+there: `npm pack --ignore-scripts` skips `prepack` and produces a tarball containing only
+`package.json` and `openclaw.plugin.json` — two files, no code, no error.
 
 ## Dependencies, and why they look inverted
 
@@ -61,12 +71,21 @@ npm pack && tar -tzf *.tgz | grep dist/index.js
 
 | Hook | Purpose |
 | --- | --- |
-| `before_prompt_build` | The fixed orientation card. **The only recall channel.** |
+| `before_prompt_build` | The fixed orientation card. **The only recall channel.** See the dispatch caveat below. |
 | `before_tool_call` | The write gate, matched to `exec` / `apply_patch` / `spawn_agent`. |
 | `registerAgentToolResultMiddleware` | The impact card, injected before the model sees tool output. |
 | `after_tool_call` | Capture. |
 | `before_compaction` | Checkpoint before the conversation is compressed. |
 | `session_start` / `session_end` / `agent_end` / `gateway_stop` | Bind, close, release. |
+
+**`before_prompt_build` does not dispatch on every surface.** On OpenClaw 2026.9.1 it fires under
+the `claude-cli` backend and does not fire on the embedded runner — for bundled and non-bundled
+plugins alike, verified with a control plugin whose only job was to return a marker string.
+`plugins inspect` reports the hook registered in both cases and no warning is emitted, so the
+failure is silent in both directions. Upstream: [openclaw#134579](https://github.com/openclaw/openclaw/issues/134579),
+which also records that the generic `openclaw agent` command is not a contracted surface for
+prompt hooks. Nothing else in the table is affected; the write gate, capture and impact card all
+run normally.
 
 Three of these carry constraints that are not obvious from the catalog:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.21.1",
+  "version": "5.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.21.1",
+      "version": "5.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.21.1",
+  "version": "5.22.0",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.21.1",
+  "version": "5.22.0",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.21.1",
+      "version": "5.22.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Ships the OpenClaw in-process plugin (#260), the namespace read fix (#264), and mid-turn card delivery on plugin hosts.

Version bumped across all four sites; `check-version-sync.mjs` passes. `## Unreleased` renamed to `## 5.22.0 — 2026-09-06`.

**Docs.** OpenClaw is now documented the way Hermes is, in `docs/hosts.md`, `docs/reference.md` and `integrations/openclaw/README.md`, plus the README host grid (logo moved beside Hermes). Three things the previous docs got wrong or left out:

- The install is **not** fully automatic. `knowl init openclaw` copies the plugin and prints two commands it deliberately does not run. Every flag on them is required and each is documented with the failure it prevents — notably `--install-links`, without which OpenClaw's safety scan refuses the plugin outright.
- The plugin README claimed OpenClaw refuses TypeScript source. True for managed `npm-pack` installs, false for the `--link` install we use, which loads `src/index.ts` directly. Corrected, along with the release-ordering cycle that removes.
- **Caveat now recorded:** `before_prompt_build` does not dispatch on every OpenClaw surface as of 2026.9.1 — it fires under `claude-cli`, not the embedded runner, for bundled and non-bundled plugins alike. `plugins inspect` still reports it registered and nothing warns. Upstream: [openclaw#134579](https://github.com/openclaw/openclaw/issues/134579).

Local gate: build, typecheck, eslint, docs:check all clean. Suite 3940 passed / 415 files; one file failed on a `dist/` rebuilt underneath a running suite and passes 35/35 on a clean re-run.