### PR TITLE
chore: release 5.22.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowl",
   "description": "Persistent memory for Claude Code. Facts are typed, sourced, and retired when they change, so a query returns the current answer rather than every answer it has ever held. Local SQLite in your repository — no API key, nothing uploaded.",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "author": {
     "name": "Knowl"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
-## Unreleased
+## 5.22.1 — 2026-09-07
 
 **The skill run banner no longer corrupts the MCP transport.** `runSkillPackage` wrote its banner with `console.log`, and it has two callers that disagree about what stdout is: on the CLI it is the operator's terminal, under `knowl serve` it is the JSON-RPC frame stream. `knowl_skill_run` calls the same function inside a stdio MCP server, so the banner was interleaved into the protocol and the client failed to parse the response to a call whose skill had actually run — an action taken, reported as a transport error. It goes to stderr now, the choice `knowl serve` already makes for its own startup banner.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dat999zx/knowl",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dat999zx/knowl",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dat999zx/knowl",
   "mcpName": "io.github.dat999zx/knowl",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts are typed, sourced, and retired when they change. Local SQLite, no API keys.",
   "main": "dist/index.js",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dat999zx/knowl",
   "title": "Knowl",
   "description": "Persistent memory for Claude Code, Cursor and Codex. Facts retire when they change.",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "websiteUrl": "https://knowl.cloud",
   "repository": {
     "url": "https://github.com/dat999zx/knowl",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "@dat999zx/knowl",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Patch release for the four audit fixes merged in #266, plus the fifth this repo found while reviewing it.

- the skill run banner no longer corrupts the MCP transport
- creating the global store no longer rebinds the process
- a caller-chosen revision reaches git as an operand, not an option
- `--local` excludes in the store that holds the atom, on both the CLI and MCP surfaces

Version bumped in all four files (6 sites); `check-version-sync` clean. `## Unreleased` renamed in place to `## 5.22.1`.

Verified locally: build, 421 files / 3955 tests, eslint, tsc --noEmit, docs:check, check-version-sync.