### PR TITLE
ci(deps): bump the plugin scanner action, and keep the scan scoped

### DIFF
--- a/.github/workflows/plugin-scan.yml
+++ b/.github/workflows/plugin-scan.yml
@@ -5,8 +5,10 @@ name: Plugin Scan
 # same scanner here means a regression fails on our pull request instead of on theirs, and
 # a project that maintains the scanner in its own CI keeps the full trust score.
 #
-# Scope and suppressions live in .plugin-scanner.toml, which the scanner discovers on its
-# own -- so this workflow and their gate see the same result.
+# Scope and suppressions live in .plugin-scanner.toml. Since scanner-action v1.2.601 the
+# scanner only discovers that file when trust_repository_policy is set, and their gate does
+# not set it -- so this workflow no longer predicts their verdict. Ours reads the scope and
+# passes; theirs ignores it and sees the fixtures the scope exists to exclude.
 on:
   push:
     branches:
@@ -25,9 +27,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: HOL Guard plugin scanner
-        uses: hashgraph-online/ai-plugin-scanner-action@7e420247177d5beebbd3747ed16e4b29a1e41f57 # v1.2.551
+        uses: hashgraph-online/ai-plugin-scanner-action@92356daf90a3df7bbdd323222a448a6bb79bc823 # v1.2.601
         with:
           plugin_dir: '.'
-          # The same bar their listing gate applies, so a pass here is a pass there.
+          # v1.2.601 added this input, defaulted to false, and it gates auto-discovery of
+          # .plugin-scanner.toml -- so without it the scanner ignores the scope above and this
+          # repository scores 75 on 33 findings that are all the known false positives.
+          trust_repository_policy: 'true'
           min_score: '80'
           fail_on_severity: 'high'


### PR DESCRIPTION
Supersedes #269.

Dependabot bumped `ai-plugin-scanner-action` 1.2.551 -> 1.2.601 and the scan job failed: **75/100, 33 high findings**, down from 100/100 with none.

## Why

v1.2.601 added an input:

```yaml
trust_repository_policy:
  description: "Allow repository-owned scanner config and baselines to affect Action verdicts"
  default: "false"
```

It gates `auto_discover` in `load_scanner_config` (`_scanner_commands.py:69-74`), so at the default the scanner never reads `.plugin-scanner.toml` and the scope in it stops applying. The 33 findings are exactly what that scope excludes: 23 `HARDCODED_SECRET` (the secret detector's own real-shaped fixtures), 9 `SHELL_INJECTION_PATTERN` (`execSync` template literals in CLI tests), 1 `DANGEROUS_DYNAMIC_EXECUTION` (`new Function` asserting the viewer script parses). None of it ships — `package.json#files` publishes `dist/`, `integrations/` and three docs.

Verified locally against a clean `git archive` of `main`, scanner 3.0.78:

| | score | findings |
|---|---|---|
| with `.plugin-scanner.toml` | 100/100 (A) | 0 |
| without it | 75/100 (C) | 33 high |

The second row reproduces CI exactly.

## What this does not fix

The listing gate in `hashgraph-online/awesome-ai-plugins` (`validate-contribution.yml`) runs v1.2.635 and does **not** pass `trust_repository_policy`, so it is on the untrusted default too and now scores this repository 75 against its own threshold of 80. Our workflow and their gate no longer agree, and the header comment is updated to say so. Passing there again means the findings have to genuinely go away rather than be scoped out — tracked separately.