### PR TITLE
feat(workspace): dissent — contest a linked repo's item without editing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; s
 
 ## Unreleased
 
+### A repo can say a linked repo's item is wrong
+
+One repo owns an item and only that repo may change it. That rule is what stops a neighbour
+silently retiring knowledge its owner had good reason to hold — but on its own it left the repo
+that *noticed* an error with nowhere to put what it found. The write was refused, and the finding
+was lost.
+
+`knowl dissent record` is that place:
+
+```
+knowl dissent record 5fdbe969633c418d --claim "The TTL is five minutes; measured on staging."
+```
+
+Nothing in the other repo is touched. What changes is that every query returning that item — in
+any repo in the workspace — now carries the dispute beside it, so the next agent to rely on it
+reads the objection first instead of discovering it later. That is the whole point: a dissent that
+only sat in a queue would leave the system knowingly serving a fact one of its own repos has
+flagged as wrong.
+
+The owner sees it with `knowl dissent list --incoming` and ends it in one of two ways. **Accept**
+by superseding the item, exactly as they always could — the dispute clears itself, which is why
+there is no accept verb. **Reject** with `knowl dissent reject`, and the item stands and stops
+reading as disputed; the other repo keeps its own record of disagreeing, because rejecting answers
+it rather than deleting it. A rejection can be undone with `knowl dissent reopen`, since it is a
+judgement made on partial information and reconsidering has to stay possible.
+
+A dispute also ends quietly when the owner simply rewrites the item: a dissent is pinned to the
+revision it was raised against, because the objection was to what the item *said*.
+
+**Neither repo ever writes the other's database.** The dissent lives in the store of the repo that
+raised it and the resolution in the store of the repo that owns the item, joined only when
+something is read. The single-owner rule is not weakened anywhere — `knowl_update` on another
+repo's item is refused exactly as before, and now says what to do instead.
+
+Dissent is workspace-local. An item owned by a cloud workspace is refused rather than recorded,
+because that dissent could never reach its owner and would sit on one machine looking as though
+something had been done.
+
+Agents get `knowl_dissent` in a linked repo, and a `disputed` block on every query result that has
+one.
+
 **The OpenClaw bootstrap card was being thrown away, on every session.** The profile registered `session_start`, so the engine bound the session and spent the bootstrap card on an event whose return value OpenClaw discards — and the first real turn (`before_prompt_build`) then arrived on a session the engine had already seen, with nothing to say. Measured: a fresh session whose first event is `before_prompt_build` gets the orientation card; the same session preceded by `session_start` got an empty answer with zero prepend context. That event is no longer mapped to the engine lifecycle, so the first `before_prompt_build` binds the session and carries the card. The plugin continues to register `session_start` solely to warm the workspace handle cache in memory so the initial write gate avoids cold open latency.
 
 **A workspace is a path, not a prefix.** `OpenClawEngineManager` matched cached workspace handles by string prefix (`cwd.startsWith(root)`), so sibling directories that share a name prefix (such as `knowl` and `knowl-cloud`) collided on lookup: whichever warmed first captured subsequent requests for the other, reading and writing atoms to the wrong project's database. Workspace matching in `getHandle` and `releaseWorkspace` now enforces a path boundary via `path.relative`, ensuring a workspace matches only itself or directories beneath it.

--- a/KNOWL.md
+++ b/KNOWL.md
@@ -41,6 +41,7 @@ Casual conversation, a single memory lookup, and trivial non-resumable work do n
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while `--default-visibility repo` keeps writes private. `knowl workspace set` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs `knowl workspace promote`. Only the owning repo can promote, update, or retire its own items.
 - When the work you are doing belongs to a LINKED repo, pass `repo: "<name>"` on the call instead of writing it here. The call then applies to that repo exactly as if it had been run there -- what you write is stamped as its own, and retiring its knowledge is allowed, because the repo is correcting itself. Without it a write lands here, attributed here, which is how a finding ends up in the wrong drawer.
+- A result carrying `disputed` is contested by the repo named there: read the claim before relying on it. When a linked repo's item is wrong, record a dissent rather than trying to edit it -- the write is refused, and the dissent reaches the owner, who resolves it by superseding the item or rejecting the dissent.
 
 ### Safety and freshness
 

--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ answered from your personal defaults.
 ### Everything else
 
 <!-- generated:tool-count -->
-**28 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 1 when linked into a local workspace, 1 when change impact is on, 1 for fleet awareness unless it is switched off, and 1 when hooks run over MCP)
+**28 MCP tools** (plus 3 when transcript search is on, 1 when connected to a cloud workspace, 2 when linked into a local workspace, 1 when change impact is on, 1 for fleet awareness unless it is switched off, and 1 when hooks run over MCP)
 <!-- /generated:tool-count -->
 and two resource URIs · the
 **complete CLI**, from `knowl status` to `knowl audit` · a **read-only integrity audit** ·

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1738,7 +1738,8 @@ The owning repo sees it with `knowl dissent list --incoming` and ends it in one 
   retired item is no longer returned. There is deliberately no `accept` verb.
 - **Reject** — `knowl dissent reject <dissentId> --target <itemId>`. The item stands and stops
   reading as disputed. The other repo keeps its own record of disagreeing; rejecting answers it
-  rather than deleting it.
+  rather than deleting it. Reversible with `knowl dissent reopen <dissentId>`, because a
+  rejection is a judgement made on partial information and reconsidering has to stay possible.
 
 A dispute also ends quietly when the owner simply rewrites the item, because a dissent is pinned
 to the revision it was raised against — the objection was to what the item *said*.
@@ -1799,16 +1800,27 @@ for knowledge that is only true of this machine.
 
 #### The local workspace, from an agent
 
-A repository linked into a local workspace offers one more tool:
+A repository linked into a local workspace offers two more tools:
 
 - **`knowl_workspace`** — `action: "status"` names the workspace, this repo's name in it, and every
   linked repo with whether its database is present. `action: "demand"` reports what the linked
   repos have queried each other for, most-repeated first — the readout that says which knowledge
   this repo owes its peers.
+- **`knowl_dissent`** — contest a linked repo's item without editing it. `action: "record"` states
+  that another repo's item is wrong and why; `action: "list"` (the default) shows disputes against
+  this repo's items and disputes it has raised; `action: "reject"` says one of this repo's items
+  stands as written; `action: "withdraw"` takes back a dissent this repo raised; `action: "reopen"`
+  undoes a rejection. There is no `accept`: accepting is superseding the item, which the owner
+  could always do, and the dispute clears itself once the item is retired or rewritten.
 
-Read-only, on the same line the cloud tool draws. `knowl workspace promote` is absent because it
-shares in one step with no second command to complete, so it stays yours; linking and unlinking
-repos are machine setup and stay yours for the reason `knowl init` does.
+`knowl_workspace` is read-only, on the same line the cloud tool draws. `knowl workspace promote` is
+absent because it shares in one step with no second command to complete, so it stays yours; linking
+and unlinking repos are machine setup and stay yours for the reason `knowl init` does.
+
+`knowl_dissent` writes, and is an agent's to run for the reason `promote` is not: it changes only
+this repo's store, reaches no network, and every action it takes has an inverse. Recording a
+dissent is precisely the "record an intent, let the owner complete it" shape — the finding lands
+where the owner will see it, and what happens to their item stays their decision.
 
 #### Doing a linked repo's work from here
 
@@ -2693,6 +2705,7 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl dissent record <itemId> --claim <text> [--replacement <id>]` | Record that a linked repo's item is wrong, without editing it. The item is not changed; only its owner can supersede or retire it |
 | `knowl dissent list [--incoming] [--outgoing]` | Disputes raised against this repo's items, and disputes this repo has raised. Neither flag shows both |
 | `knowl dissent reject <dissentId> --target <itemId> [--reason <text>]` | Reject a dispute raised against one of this repo's items. The item stands and stops reading as disputed |
+| `knowl dissent reopen <dissentId>` | Undo a rejection and put the dispute back in front of this repo |
 | `knowl dissent withdraw <dissentId>` | Take back a dispute this repo raised |
 
 ### Memory and retrieval

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1715,6 +1715,38 @@ setting its `visibility`. Nothing leaves the machine.
 `knowl cloud stage` and `knowl cloud push` share it with **the team, over the network**, and that
 state lives in a local ledger rather than in `visibility`.
 
+### Contesting a linked repo's knowledge
+
+One repo owns an item and only that repo may change it. That rule is what keeps a neighbour from
+silently retiring knowledge its owner had good reason to hold — but on its own it leaves the repo
+that *noticed* an error with nowhere to put what it found.
+
+`knowl dissent record` is that place. It writes one row, in **your** store, saying which of
+another repo's items you believe is wrong and why:
+
+```
+knowl dissent record 5fdbe969633c418d --claim "The TTL is five minutes; measured on the staging box."
+```
+
+Nothing in the other repo is touched. What changes is that every query returning that item — in
+any repo in the workspace — now carries the dispute beside it, so the next agent to rely on it
+reads your objection first rather than discovering it later.
+
+The owning repo sees it with `knowl dissent list --incoming` and ends it in one of two ways:
+
+- **Accept** — supersede the item, as it always could. The dispute clears itself, because a
+  retired item is no longer returned. There is deliberately no `accept` verb.
+- **Reject** — `knowl dissent reject <dissentId> --target <itemId>`. The item stands and stops
+  reading as disputed. The other repo keeps its own record of disagreeing; rejecting answers it
+  rather than deleting it.
+
+A dispute also ends quietly when the owner simply rewrites the item, because a dissent is pinned
+to the revision it was raised against — the objection was to what the item *said*.
+
+Dissent is workspace-local. An item owned by a cloud workspace is refused rather than recorded,
+because a dissent that cannot reach its owner would sit on one machine forever while reading as
+though something had been done.
+
 Neither implies the other. Promoting publishes nothing, and publishing does not make your other
 local repositories see it.
 
@@ -2658,6 +2690,10 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl workspace demand [--limit <n>] [--json]` | What the linked repos have queried each other for — the readout that says which knowledge this repo owes its peers |
 | `knowl workspace repin-embedding [--yes]` | Repoint the workspace at this repository's embedding profile |
 | `knowl workspace set [--role <text>] [--default-visibility <repo\|workspace>] [--kin <group>]` | Change this repo's recorded nature in the workspace manifest; bare prints the current values |
+| `knowl dissent record <itemId> --claim <text> [--replacement <id>]` | Record that a linked repo's item is wrong, without editing it. The item is not changed; only its owner can supersede or retire it |
+| `knowl dissent list [--incoming] [--outgoing]` | Disputes raised against this repo's items, and disputes this repo has raised. Neither flag shows both |
+| `knowl dissent reject <dissentId> --target <itemId> [--reason <text>]` | Reject a dispute raised against one of this repo's items. The item stands and stops reading as disputed |
+| `knowl dissent withdraw <dissentId>` | Take back a dispute this repo raised |
 
 ### Memory and retrieval
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,6 +1472,7 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
       "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.4",
         "@libsql/hrana-client": "^0.10.0",
@@ -2515,6 +2516,7 @@
       "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.69.0",
         "@typescript-eslint/types": "8.69.0",
@@ -2782,6 +2784,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3470,6 +3473,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3530,6 +3534,7 @@
       "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3758,6 +3763,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4192,6 +4198,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
       "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5181,6 +5188,7 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6054,6 +6062,7 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -6308,6 +6317,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6674,6 +6684,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -45,6 +45,9 @@ import { formatCrossRepoNotice } from './cross-repo-notice.js';
 import { formatWorkspaceBlock } from './workspace-report.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
 import { assertOwnedItem } from '../workspace/ownership.js';
+import {
+  createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent, withdrawDissent,
+} from '../workspace/dissents.js';
 import { storeKnowledgeItemDeduped } from '../store/knowledge-writer.js';
 import { formatDoctorReport, runDoctor } from './doctor-report.js';
 import { upgradeExistingRepository, type UpgradeResult } from './upgrade.js';
@@ -4730,6 +4733,135 @@ program
       process.exit(1);
     }
     console.log(formatStartupReport(hours));
+  });
+
+/**
+ * `knowl dissent` -- say that a linked repo's atom is wrong, without editing it.
+ *
+ * Every verb is explicit rather than `knowl dissent <id>` with subcommands beside it: an item id
+ * is opaque, so a bare argument could not be told apart from a subcommand name, and the failure
+ * would be a user typing an id that happens to read like a verb.
+ *
+ * The layer is deliberately thin. Everything with a rule in it lives in `workspace/dissents.ts`,
+ * so the CLI and the MCP tool cannot drift into two different sets of guards.
+ */
+const dissentCommand = program
+  .command('dissent')
+  .description("Contest a linked repo's knowledge item without editing it");
+
+dissentCommand
+  .command('record')
+  .argument('<itemId>', 'The item, owned by another repo in this workspace, that you believe is wrong')
+  .requiredOption('--claim <text>', 'What is wrong with it. This is what the owner reads.')
+  .option('--replacement <id>', 'An item in THIS repo that says what you believe instead')
+  .description("Record disagreement with another repo's item")
+  .action(async (itemId: string, options: { claim: string; replacement?: string }) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const config = await loadConfig(root);
+      await initDb(root);
+      try {
+        const workspace = await resolveWorkspace(root, config);
+        const { id, targetRepo } = await createDissent(
+          { targetItemId: itemId, claim: options.claim, replacementItemId: options.replacement, provenance: 'user_stated' },
+          workspace,
+        );
+        console.log(`Recorded dissent ${id} against ${itemId}, owned by "${targetRepo}".`);
+        console.log(`"${targetRepo}" sees it on its next \`knowl dissent list\`, and every query that returns that item now carries the dispute.`);
+        console.log('Nothing in that repo was changed -- only its owner can supersede or retire it.');
+      } finally {
+        await closeDb();
+      }
+    } catch (error: any) {
+      console.error(`Error recording dissent: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+dissentCommand
+  .command('list')
+  .description('Disputes raised against this repo, and disputes this repo has raised')
+  .option('--incoming', "Only disputes against this repo's items")
+  .option('--outgoing', 'Only disputes this repo has raised')
+  .action(async (options: { incoming?: boolean; outgoing?: boolean }) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      const config = await loadConfig(root);
+      await initDb(root);
+      try {
+        // Neither flag means both, which is the useful default: the question "what is disputed
+        // around here" does not naturally pick a direction.
+        const both = !options.incoming && !options.outgoing;
+        if (options.incoming || both) {
+          const incoming = await listIncomingDissents(await resolveWorkspace(root, config));
+          console.log(`INCOMING (${incoming.length})`);
+          for (const entry of incoming) {
+            const stale = entry.staleAgainstCurrentRevision ? ' [raised against an older revision]' : '';
+            console.log(`  ${entry.dissentId}  "${entry.targetTitle}" (${entry.targetItemId}) -- ${entry.fromRepo} says: ${entry.claim}${stale}`);
+          }
+          if (incoming.length > 0) {
+            console.log('  Accept one by superseding the item; that clears it. Or: knowl dissent reject <dissentId> --target <itemId>');
+          }
+        }
+        if (options.outgoing || both) {
+          const outgoing = await listOutgoingDissents();
+          console.log(`OUTGOING (${outgoing.length})`);
+          for (const entry of outgoing) {
+            console.log(`  ${entry.id}  ${entry.targetItemId} @ ${entry.targetRepo} [${entry.status}] -- ${entry.claim}`);
+          }
+        }
+      } finally {
+        await closeDb();
+      }
+    } catch (error: any) {
+      console.error(`Error listing dissents: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+dissentCommand
+  .command('reject')
+  .argument('<dissentId>', 'The dissent to reject, as shown by `knowl dissent list --incoming`')
+  .requiredOption('--target <itemId>', 'The item of yours it was raised against')
+  .option('--reason <text>', 'Why the item stands as written')
+  .description("Reject a dispute raised against one of this repo's items")
+  .action(async (dissentId: string, options: { target: string; reason?: string }) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      await initDb(root);
+      try {
+        await rejectDissent(dissentId, options.target, options.reason);
+        console.log(`Rejected dissent ${dissentId}. ${options.target} stands as written and no longer reads as disputed.`);
+        // Said plainly, because the row is deliberately one-sided and that looks like a bug
+        // otherwise.
+        console.log('The other repo keeps its own record of disagreeing -- rejecting answers it, it does not delete it.');
+      } finally {
+        await closeDb();
+      }
+    } catch (error: any) {
+      console.error(`Error rejecting dissent: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+dissentCommand
+  .command('withdraw')
+  .argument('<dissentId>', 'A dissent THIS repo raised')
+  .description('Take back a dispute this repo raised')
+  .action(async (dissentId: string) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      await initDb(root);
+      try {
+        await withdrawDissent(dissentId);
+        console.log(`Withdrew dissent ${dissentId}. It no longer marks the item it named.`);
+      } finally {
+        await closeDb();
+      }
+    } catch (error: any) {
+      console.error(`Error withdrawing dissent: ${error.message}`);
+      process.exit(1);
+    }
   });
 
 return program;

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -46,7 +46,8 @@ import { formatWorkspaceBlock } from './workspace-report.js';
 import { resolveWorkspace } from '../workspace/resolve.js';
 import { assertOwnedItem } from '../workspace/ownership.js';
 import {
-  createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent, withdrawDissent,
+  createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent, reopenDissent,
+  withdrawDissent,
 } from '../workspace/dissents.js';
 import { storeKnowledgeItemDeduped } from '../store/knowledge-writer.js';
 import { formatDoctorReport, runDoctor } from './doctor-report.js';
@@ -4840,6 +4841,26 @@ dissentCommand
       }
     } catch (error: any) {
       console.error(`Error rejecting dissent: ${error.message}`);
+      process.exit(1);
+    }
+  });
+
+dissentCommand
+  .command('reopen')
+  .argument('<dissentId>', 'A dissent this repo previously rejected')
+  .description('Undo a rejection and put the dispute back in front of this repo')
+  .action(async (dissentId: string) => {
+    try {
+      const root = await findProjectRoot(process.cwd());
+      await initDb(root);
+      try {
+        await reopenDissent(dissentId);
+        console.log(`Reopened dissent ${dissentId}. It marks the item again and is back in \`knowl dissent list --incoming\`.`);
+      } finally {
+        await closeDb();
+      }
+    } catch (error: any) {
+      console.error(`Error reopening dissent: ${error.message}`);
       process.exit(1);
     }
   });

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -4829,9 +4829,10 @@ dissentCommand
   .action(async (dissentId: string, options: { target: string; reason?: string }) => {
     try {
       const root = await findProjectRoot(process.cwd());
+      const config = await loadConfig(root);
       await initDb(root);
       try {
-        await rejectDissent(dissentId, options.target, options.reason);
+        await rejectDissent(dissentId, options.target, options.reason, await resolveWorkspace(root, config));
         console.log(`Rejected dissent ${dissentId}. ${options.target} stands as written and no longer reads as disputed.`);
         // Said plainly, because the row is deliberately one-sided and that looks like a bug
         // otherwise.

--- a/src/core/knowl-guidance.ts
+++ b/src/core/knowl-guidance.ts
@@ -112,7 +112,8 @@ const WORKSPACE = `### Linked repositories
 - A \`WORKSPACE:\` notice names linked repos that matched but were not shown, with counts. Re-query with \`repos\` to read them.
 - Whether a new write is shared is this repo's recorded default, not a fixed rule: joining a linked workspace sets it to workspace visibility, while \`--default-visibility repo\` keeps writes private. \`knowl workspace set\` with no flags prints the current value.
 - Knowledge already written privately stays private until someone runs \`knowl workspace promote\`. Only the owning repo can promote, update, or retire its own items.
-- When the work you are doing belongs to a LINKED repo, pass \`repo: "<name>"\` on the call instead of writing it here. The call then applies to that repo exactly as if it had been run there -- what you write is stamped as its own, and retiring its knowledge is allowed, because the repo is correcting itself. Without it a write lands here, attributed here, which is how a finding ends up in the wrong drawer.`;
+- When the work you are doing belongs to a LINKED repo, pass \`repo: "<name>"\` on the call instead of writing it here. The call then applies to that repo exactly as if it had been run there -- what you write is stamped as its own, and retiring its knowledge is allowed, because the repo is correcting itself. Without it a write lands here, attributed here, which is how a finding ends up in the wrong drawer.
+- A result carrying \`disputed\` is contested by the repo named there: read the claim before relying on it. When a linked repo's item is wrong, record a dissent rather than trying to edit it -- the write is refused, and the dissent reaches the owner, who resolves it by superseding the item or rejecting the dissent.`;
 
 export function renderFullKnowlGuidance(): string {
   const table = [

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -290,6 +290,43 @@ export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
             },
           },
         },
+        {
+          name: 'knowl_dissent',
+          description: "Contest a linked repo's knowledge item without editing it. Use when a query returns another repo's item you believe is wrong: editing it is refused, and a dissent is the way the finding reaches its owner instead of being lost. Recording one writes only in THIS repo and changes nothing in theirs, but from then on every query returning that item -- in any repo here -- carries the dispute, so the next reader sees the objection before relying on it. The owner ends it by superseding the item (which is why there is no accept action) or by rejecting the dissent. Workspace-local: an item owned by a cloud workspace is refused, because that dissent could never reach its owner.",
+          inputSchema: {
+            type: 'object',
+            properties: {
+              action: {
+                type: 'string', enum: ['record', 'list', 'reject', 'withdraw', 'reopen'],
+                description: "list (default): disputes against this repo's items and disputes it has raised. record: state that another repo's item is wrong. reject: this repo's item stands as written. withdraw: take back a dissent this repo raised. reopen: undo a rejection and put the dispute back.",
+              },
+              itemId: {
+                type: 'string', minLength: 1,
+                description: "record: the other repo's item you believe is wrong. Full id -- a truncated one matches nothing.",
+              },
+              claim: {
+                type: 'string', minLength: 1,
+                description: 'record: what is wrong with it. This is what the owning repo reads and what every later reader of that item sees, so state the correction, not that there is one.',
+              },
+              replacement: {
+                type: 'string', minLength: 1,
+                description: 'record, optional: an item in THIS repo saying what you believe instead, so the owner can read the correction rather than reconstruct it.',
+              },
+              dissentId: {
+                type: 'string', minLength: 1,
+                description: 'reject, withdraw, reopen: the dissent, as returned by the list action.',
+              },
+              targetItemId: {
+                type: 'string', minLength: 1,
+                description: 'reject: the item of yours the dissent was raised against.',
+              },
+              reason: {
+                type: 'string',
+                description: 'reject, optional: why the item stands as written.',
+              },
+            },
+          },
+        },
 ];
 
 /**

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -292,6 +292,11 @@ export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_dissent',
+          // Not `readOnlyHint`: `list` reads, but `record`, `reject`, `withdraw` and `reopen`
+          // all write rows, and annotations are read before arguments -- a hint that is true
+          // for only some actions is a hint that lies. `destructiveHint` is left at its
+          // default: every action is additive, and nothing here retires or deletes an atom.
+          annotations: { title: "Contest a linked repo's item", openWorldHint: false },
           description: "Contest a linked repo's knowledge item without editing it. Use when a query returns another repo's item you believe is wrong: editing it is refused, and a dissent is the way the finding reaches its owner instead of being lost. Recording one writes only in THIS repo and changes nothing in theirs, but from then on every query returning that item -- in any repo here -- carries the dispute, so the next reader sees the objection before relying on it. The owner ends it by superseding the item (which is why there is no accept action) or by rejecting the dissent. Workspace-local: an item owned by a cloud workspace is refused, because that dissent could never reach its owner.",
           inputSchema: {
             type: 'object',

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1549,7 +1549,7 @@ export function registerTools(
             return { content: [{ type: 'text', text: `Recorded dissent ${result.id} against ${itemId}, owned by "${inlineUntrusted(result.targetRepo)}". Nothing in that repo changed -- only its owner can supersede or retire the item. Every query returning it now carries this dispute.` }] };
           }
           if (verb === 'reject') {
-            await rejectDissent(String(dissentId), String(targetItemId), reason ? String(reason) : undefined);
+            await rejectDissent(String(dissentId), String(targetItemId), reason ? String(reason) : undefined, active);
             return { content: [{ type: 'text', text: `Rejected dissent ${dissentId}. ${targetItemId} stands as written and no longer reads as disputed. The other repo keeps its own record of disagreeing; this answered it rather than deleting it. Undo with action "reopen".` }] };
           }
           if (verb === 'withdraw') {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -10,6 +10,10 @@ import { assertOwnedItem, findForeignItem } from '../workspace/ownership.js';
 import { withRepoContext } from '../workspace/act-as.js';
 import { getProjectRoot as ambientProjectRoot, withDbPath } from '../store/database.js';
 import { globalStorePath, knowlHome } from '../core/paths.js';
+import {
+  annotateDisputes, createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent,
+  reopenDissent, withdrawDissent, type Dispute,
+} from '../workspace/dissents.js';
 import { flattenGroups, queryFederated, type FederatedResult } from '../workspace/federated-query.js';
 import { recordDemandEventBestEffort } from '../workspace/demand-ledger.js';
 import { hasAiConfigured } from '../core/config.js';
@@ -815,13 +819,11 @@ export function registerTools(
               const { getKnowledgeItem } = await import('../store/repository.js');
               return getKnowledgeItem(String(id));
             });
-          // Resolved only on a local miss, so an ordinary fetch pays nothing for the workspace
-          // lookup -- the property `assertOwnedTargets` keeps on the write side, for the same
-          // reason. `findForeignItem` returns null for a null workspace, so the hit path needs
-          // no second guard of its own.
-          const active = local === null && projectRoot
-            ? await resolveWorkspace(projectRoot, config ?? undefined)
-            : null;
+          // Resolved on both paths now, where reaching a linked repo alone would only need it on
+          // a miss: a LOCAL item can be disputed too, and its owner fetching it whole is exactly
+          // who needs to be told. `findForeignItem` returns null for a null workspace, so the
+          // hit path still needs no second guard of its own.
+          const active = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
           const foreign = await findForeignItem(String(id), active);
           const item = local ?? foreign?.item ?? null;
           if (!item) {
@@ -877,6 +879,10 @@ export function registerTools(
               },
             } : {}),
           };
+          // Whoever is reading this atom whole is the reader most likely to act on it, so a
+          // standing objection belongs here more than anywhere.
+          const [disputed] = await annotateDisputes([{ id: item.id }], active);
+          const withDisputes = disputed.disputed?.length ? { ...full, disputed: disputed.disputed } : full;
           const evidenceWithStale = async (itemId: string) => Promise.all(
             (await listEvidenceForItem(itemId)).map(async evidence => ({
               ...evidence,
@@ -889,8 +895,8 @@ export function registerTools(
           // list and a staleness verdict about the wrong checkout. Omitting beats answering
           // wrongly, and the `foreign` note above says which it is.
           const payload = includeEvidence && !foreign
-            ? [{ ...full, evidence: boundedEvidence(await evidenceWithStale(item.id)) }]
-            : [full];
+            ? [{ ...withDisputes, evidence: boundedEvidence(await evidenceWithStale(item.id)) }]
+            : [withDisputes];
           // An array of one, not a bare object: every existing caller parses the first block as
           // an array, and a fetch that changed the shape would break each of them.
           return { content: [{ type: 'text', text: compactMcpJson(payload) }] };
@@ -1153,6 +1159,17 @@ export function registerTools(
             }
           })).catch(() => {});
         }
+        // What the linked repos are contesting about these exact rows. Resolved once for the
+        // result set rather than per item, and attached after compaction the same way
+        // `affectedPaths` and `explanation` are -- the compact shape is an allowlist, so a field
+        // set on the item alone never reaches the agent.
+        //
+        // Never reorders anything. `annotateDisputes` preserves input order and this only reads
+        // the map it returns; a dispute adds a line to a result and must not move it.
+        const disputeMap = new Map<string, Dispute[]>();
+        for (const annotated of await annotateDisputes(resolvedItems.map((item: any) => ({ id: String(item.id) })), active)) {
+          if (annotated.disputed?.length) disputeMap.set(annotated.id, annotated.disputed);
+        }
         const compact = (item: any) => {
           const score = scoreOf(item);
           const cosine = cosineOf(item);
@@ -1171,6 +1188,7 @@ export function registerTools(
             ...(affectedPaths && !isForeign(item) ? { affectedPaths } : {}),
             // Absent when clean, so a row that says nothing still means what it always meant.
             ...(pathsChangedNotes.has(item.id) ? { pathsChanged: pathsChangedNotes.get(item.id) } : {}),
+            ...(disputeMap.has(String(item.id)) ? { disputed: disputeMap.get(String(item.id)) } : {}),
             ...(explain && item.explanation ? { explanation: item.explanation } : {}),
           };
         };
@@ -1514,6 +1532,39 @@ export function registerTools(
           conflictBlocks.push({ type: 'text', text: `CONFLICTS TRUNCATED: ${hidden.join(', ')} not shown.` });
         }
         return { content: conflictBlocks };
+      }
+
+      else if (name === 'knowl_dissent') {
+        const { action, itemId, claim, replacement, dissentId, targetItemId, reason } = args as any;
+        const active = projectRoot ? await resolveWorkspace(projectRoot, config ?? undefined) : null;
+        try {
+          // Read-only by default. Every other action changes something, and an omitted enum
+          // should never be the one that writes.
+          const verb = String(action ?? 'list');
+          if (verb === 'record') {
+            const result = await createDissent(
+              { targetItemId: String(itemId), claim: String(claim), replacementItemId: replacement ? String(replacement) : undefined, provenance: 'inferred' },
+              active,
+            );
+            return { content: [{ type: 'text', text: `Recorded dissent ${result.id} against ${itemId}, owned by "${inlineUntrusted(result.targetRepo)}". Nothing in that repo changed -- only its owner can supersede or retire the item. Every query returning it now carries this dispute.` }] };
+          }
+          if (verb === 'reject') {
+            await rejectDissent(String(dissentId), String(targetItemId), reason ? String(reason) : undefined);
+            return { content: [{ type: 'text', text: `Rejected dissent ${dissentId}. ${targetItemId} stands as written and no longer reads as disputed. The other repo keeps its own record of disagreeing; this answered it rather than deleting it. Undo with action "reopen".` }] };
+          }
+          if (verb === 'withdraw') {
+            await withdrawDissent(String(dissentId));
+            return { content: [{ type: 'text', text: `Withdrew dissent ${dissentId}. It no longer marks the item it named.` }] };
+          }
+          if (verb === 'reopen') {
+            await reopenDissent(String(dissentId));
+            return { content: [{ type: 'text', text: `Reopened dissent ${dissentId}. It is in front of this repo again and marks the item once more.` }] };
+          }
+          const [incoming, outgoing] = await Promise.all([listIncomingDissents(active), listOutgoingDissents()]);
+          return { content: [{ type: 'text', text: compactMcpJson({ incoming, outgoing }) }] };
+        } catch (error: any) {
+          return { isError: true, content: [{ type: 'text', text: String(error?.message ?? error) }] };
+        }
       }
 
       else if (name === 'knowl_context') {

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -232,6 +232,59 @@ const SCHEMA_STATEMENTS = [
     bytes INTEGER
   );`,
 
+  /**
+   * A dissent: this repo's recorded disagreement with an atom ANOTHER repo owns.
+   *
+   * Held here, in the writer's own store, and never in the owner's. That is the whole design:
+   * a repo may say what it believes without reaching into a database it does not own, so the
+   * single-writer rule `assertOwnedItem` enforces is not bent to allow disagreement.
+   *
+   * No foreign key on `target_item_id`, and there cannot be one -- the row it names lives in a
+   * different SQLite file. That is also why `target_repo` is stored rather than resolved later:
+   * the manifest can change, and a dissent has to keep saying who it was aimed at.
+   *
+   * `target_content_hash` pins the revision. A dissent is against what the atom SAID, so the
+   * owner rewriting it is a response, and the dissent stales out of the overlay rather than
+   * silently carrying to text nobody has objected to.
+   *
+   * `replacement_item_id` is local and optional: the correction itself, written where the
+   * dissenting repo can own it. Nothing dereferences it across stores.
+   */
+  `CREATE TABLE IF NOT EXISTS dissents (
+    id TEXT PRIMARY KEY,
+    target_repo TEXT NOT NULL,
+    target_item_id TEXT NOT NULL,
+    target_content_hash TEXT NOT NULL,
+    claim TEXT NOT NULL,
+    replacement_item_id TEXT,
+    provenance TEXT,
+    created_at TEXT NOT NULL,
+    withdrawn_at TEXT,
+    status TEXT NOT NULL DEFAULT 'open'
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_dissents_target ON dissents(target_item_id);`,
+
+  /**
+   * The owning repo's answer to a dissent raised against one of its atoms.
+   *
+   * Written HERE, by the owner, about a `dissent_id` that lives in a peer's store -- the mirror
+   * image of the table above, and the reason neither repo ever writes the other's database.
+   *
+   * There is no `accept` resolution and deliberately so. Accepting means superseding the atom,
+   * which is an ordinary local write the owner could always make; the dissent then goes silent
+   * because retired atoms are not returned, and no cross-store bookkeeping is needed to make
+   * that happen. Only a rejection needs recording, because it is the one outcome that leaves
+   * the disputed atom standing and must still clear the dispute.
+   */
+  `CREATE TABLE IF NOT EXISTS dissent_resolutions (
+    dissent_id TEXT PRIMARY KEY,
+    target_item_id TEXT NOT NULL,
+    resolution TEXT NOT NULL,
+    reason TEXT,
+    resolved_at TEXT NOT NULL
+  );`,
+  `CREATE INDEX IF NOT EXISTS idx_dissent_resolutions_target ON dissent_resolutions(target_item_id);`,
+
   `CREATE TABLE IF NOT EXISTS skill_steps (
     id TEXT PRIMARY KEY,
     knowledge_item_id TEXT NOT NULL REFERENCES knowledge_items(id) ON DELETE CASCADE,

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -208,8 +208,23 @@ export const KNOWL_SCHEMA_VERSION = 1;
  *
  * `KNOWL_SCHEMA_VERSION` again does not move: an older build selects the columns it knows and is
  * unaffected by one it never names.
+ *
+ * Level 17 adds `dissents` and `dissent_resolutions` with their two target indexes -- one repo's
+ * recorded disagreement with an atom another repo owns, and the owning repo's answer to it. Two
+ * new tables, no altered column, no backfill, so `KNOWL_SCHEMA_VERSION` stays at 1 on the same
+ * reasoning as levels 3, 4, 7 and 9: an older build opens this database, finds every table it
+ * knows intact, and never looks at these two.
+ *
+ * A backfill is not merely skipped but meaningless -- a dissent is an act someone performs, and
+ * no past act of disagreement was ever recorded anywhere to recover.
+ *
+ * The bump is load-bearing rather than bookkeeping, and in the direction level 6 records. Both
+ * tables are read on the hot path: `annotateDisputes` runs over every returned atom in a
+ * workspace. A store already stamped at level 16 by an installed build would skip
+ * `SCHEMA_STATEMENTS`, never create them, and every read would then hit "no such table" -- on
+ * ordinary queries, not just on the new command.
  */
-export const KNOWL_MIGRATION_LEVEL = 16;
+export const KNOWL_MIGRATION_LEVEL = 17;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/snapshot-tables.ts
+++ b/src/store/snapshot-tables.ts
@@ -47,6 +47,18 @@ export const SNAPSHOT_TABLE_POLICY: Readonly<Record<string, SnapshotTablePolicy>
   // since -- which is precisely the window someone asking "was that threshold right?" is
   // asking about. An audit trail a restore can silently truncate is not one.
   knowledge_forget_log: 'preserved',
+  // What this repo currently believes is wrong about a NEIGHBOUR's item, and its answers to what
+  // neighbours believe about its own. Both are live positions rather than knowledge, and both
+  // belong to now rather than to the snapshot: restoring older knowledge is not a statement that
+  // anyone changed their mind, so `restored` would resurrect dissents already withdrawn and
+  // un-reject disputes the owner had already settled -- re-marking atoms as disputed on the
+  // strength of a file that predates the answer.
+  //
+  // A dissent left pointing at an item the restore removed costs nothing: the overlay drops a
+  // dispute whose target it cannot find. And one whose target reverts to the disputed text
+  // becomes live again, which is correct -- the objection was to what the item said.
+  dissents: 'preserved',
+  dissent_resolutions: 'preserved',
   // Sessions and their events belong to hosts that are running now. A restored session is a
   // session no host is in.
   memory_sessions: 'preserved',

--- a/src/workspace/dissents.ts
+++ b/src/workspace/dissents.ts
@@ -1,0 +1,213 @@
+import crypto from 'node:crypto';
+import { getClient } from '../store/database.js';
+import { getKnowledgeItem } from '../store/repository.js';
+import { openPeerStore } from '../store/store-handle.js';
+import { isImportedOrigin } from '../store/portability.js';
+import { hashKnowledgeContent } from '../store/freshness.js';
+import { validateKnowledgeWrite } from '../core/knowledge-validation.js';
+import { peerVerdictFor, UnverifiedOwnerError } from './ownership.js';
+import type { KnowledgeItem } from '../core/types.js';
+import type { ActiveWorkspace } from './resolve.js';
+
+/**
+ * A dissent: this repo's recorded disagreement with an atom another repo owns.
+ *
+ * The rule the rest of the product enforces is that one repo owns an item and only that repo
+ * may change it -- `assertOwnedItem`. That rule is right and this does not weaken it. What it
+ * adds is the thing a single-owner rule leaves missing: a way for the repo that noticed the
+ * error to say so, where the owner will see it, without editing anything it does not own.
+ *
+ * Two rows in two stores, joined when something is read:
+ *
+ * - the dissent lives HERE, written by the repo that disagrees
+ * - the resolution lives THERE, written by the repo that owns the atom
+ *
+ * Neither ever writes the other's database. That is what makes this safe to allow at all, and
+ * it is why the upstream workspace-v2 plan stalled: it promised cross-owner editing and forbade
+ * it in the same document, because the only shape it considered was one repo reaching into
+ * another's rows.
+ */
+
+export class NotInWorkspaceError extends Error {
+  constructor() {
+    super(
+      'A dissent is addressed to another repo, so there has to be one. This repo is not in a ' +
+      'workspace -- link it with `knowl workspace add`, or correct the item directly if it is yours.',
+    );
+    this.name = 'NotInWorkspaceError';
+  }
+}
+
+export class OwnItemError extends Error {
+  constructor(itemId: string) {
+    super(
+      `Item ${itemId} is yours to change: supersede or update it directly. A dissent is for an ` +
+      'atom another repo owns and you cannot edit.',
+    );
+    this.name = 'OwnItemError';
+  }
+}
+
+/**
+ * A dissent that could never reach its owner is worse than no dissent at all.
+ *
+ * The team replica is a local copy of rows other people's machines wrote. Recording a dissent
+ * against one would leave it sitting here forever, invisible to the person who could act on it,
+ * while reading as though something had been done. That is the failure mode this whole design
+ * exists to avoid -- knowledge filed where nobody will look for it -- so it is refused rather
+ * than allowed to look like it worked.
+ */
+export class CloudOwnedItemError extends Error {
+  constructor(itemId: string, workspaceName: string) {
+    super(
+      `Item ${itemId} belongs to team workspace "${workspaceName}", not to a repo on this ` +
+      'machine. A dissent is workspace-local and would never reach its owner, so it was not ' +
+      'recorded. Team corrections go through the cloud path.',
+    );
+    this.name = 'CloudOwnedItemError';
+  }
+}
+
+export class UnknownItemError extends Error {
+  constructor(itemId: string) {
+    super(
+      `No knowledge item "${itemId}" in this repo's store or in any linked repo readable from ` +
+      'here. Ids must be given in full -- a truncated one matches nothing.',
+    );
+    this.name = 'UnknownItemError';
+  }
+}
+
+export class NoSuchDissentError extends Error {
+  constructor(dissentId: string) {
+    super(
+      `No dissent "${dissentId}" in this repo's store. A dissent is held by the repo that raised ` +
+      'it, so withdraw it from there.',
+    );
+    this.name = 'NoSuchDissentError';
+  }
+}
+
+export type DissentTarget = { repo: string; item: KnowledgeItem };
+
+function generateId(): string {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+}
+
+/**
+ * Whether the cloud replica holds this id.
+ *
+ * Consulted only after every local peer has said no, because it answers a different question --
+ * "is this someone else's, on another machine" -- and the answer changes the refusal rather than
+ * the outcome. Failure to read the replica is treated as "not there": it downgrades a precise
+ * refusal to a vaguer one, and never turns a refusal into a write.
+ */
+async function heldByCloudReplica(itemId: string, workspace: ActiveWorkspace): Promise<boolean> {
+  const replica = workspace.cloud;
+  if (!replica?.present) return false;
+  try {
+    const store = await openPeerStore(replica.databasePath);
+    return (await getKnowledgeItem(itemId, store.db)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Who owns the atom being dissented against, or a refusal explaining why nobody can be named.
+ *
+ * The local lookup comes first and can end two ways. A row here that this repo originated --
+ * including a null origin, which predates ownership stamping, and an `import:` origin, which is
+ * a copy with no live database behind it -- is ours, and the answer is to edit it. A row here
+ * stamped with another repo's origin is a legitimate target: it is held locally but owned
+ * elsewhere, exactly the case `assertOne` refuses writes for.
+ */
+async function resolveTarget(itemId: string, workspace: ActiveWorkspace): Promise<DissentTarget> {
+  const local = await getKnowledgeItem(itemId);
+  if (local && (local.originRepo == null || isImportedOrigin(local.originRepo) || local.originRepo === workspace.repo)) {
+    throw new OwnItemError(itemId);
+  }
+  if (local?.originRepo) return { repo: local.originRepo, item: local };
+
+  const verdict = await peerVerdictFor(itemId, workspace);
+  if (verdict.repo && verdict.item) return { repo: verdict.repo, item: verdict.item };
+
+  if (await heldByCloudReplica(itemId, workspace)) {
+    throw new CloudOwnedItemError(itemId, workspace.cloud!.workspaceName);
+  }
+  // A peer that could not be read was never asked. Reporting the id as unknown would send
+  // someone to correct an id that was never wrong.
+  if (verdict.unverified.length > 0) throw new UnverifiedOwnerError(itemId, verdict.unverified);
+  throw new UnknownItemError(itemId);
+}
+
+/**
+ * The revision a dissent was raised against.
+ *
+ * Computed rather than read off `content_hash`, so the pin and every later comparison come from
+ * one function over one set of fields. Reading the stored column here and recomputing it there
+ * would make a null column, or any drift between the two, present as a permanently stale dissent.
+ */
+export function revisionPin(item: KnowledgeItem): string {
+  return hashKnowledgeContent({
+    title: item.title,
+    content: item.content,
+    reasoning: item.reasoning,
+    source: item.source,
+    affectedPaths: item.affectedPaths,
+  });
+}
+
+/**
+ * Record this repo's disagreement with an atom another repo owns.
+ *
+ * Writes one row, into this repo's own store. The owning repo's database is opened read-only to
+ * read the revision being disputed and is not written to at any point.
+ */
+export async function createDissent(
+  input: { targetItemId: string; claim: string; replacementItemId?: string; provenance?: string },
+  workspace: ActiveWorkspace | null,
+): Promise<{ id: string; targetRepo: string }> {
+  if (!workspace) throw new NotInWorkspaceError();
+
+  // The caller's own text, checked before anything is looked up: it is the cheapest refusal
+  // available and the only one that depends on nothing but the input. Every knowledge write is
+  // secret-validated and a claim is knowledge, so it goes through the same gate.
+  validateKnowledgeWrite({ content: input.claim });
+
+  const target = await resolveTarget(input.targetItemId, workspace);
+
+  const id = generateId();
+  await getClient().execute({
+    sql: `INSERT INTO dissents
+            (id, target_repo, target_item_id, target_content_hash, claim, replacement_item_id, provenance, created_at, status)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open')`,
+    args: [
+      id,
+      target.repo,
+      input.targetItemId,
+      revisionPin(target.item),
+      input.claim,
+      input.replacementItemId ?? null,
+      input.provenance ?? null,
+      new Date().toISOString(),
+    ],
+  });
+  return { id, targetRepo: target.repo };
+}
+
+/**
+ * Take back a dissent this repo raised.
+ *
+ * Status rather than deletion, and `withdrawn_at` beside it, because "we said this and stopped
+ * saying it" is a different fact from never having said it -- and the owner may have already
+ * read it. Only rows in this store can be withdrawn, which needs no ownership check: a peer's
+ * dissent is not in this database to find.
+ */
+export async function withdrawDissent(dissentId: string): Promise<void> {
+  const result = await getClient().execute({
+    sql: `UPDATE dissents SET status = 'withdrawn', withdrawn_at = ? WHERE id = ? AND status = 'open'`,
+    args: [new Date().toISOString(), dissentId],
+  });
+  if (Number(result.rowsAffected ?? 0) === 0) throw new NoSuchDissentError(dissentId);
+}

--- a/src/workspace/dissents.ts
+++ b/src/workspace/dissents.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import type { Client } from '@libsql/client';
 import { getClient } from '../store/database.js';
 import { getKnowledgeItem } from '../store/repository.js';
 import { openPeerStore } from '../store/store-handle.js';
@@ -318,6 +319,129 @@ export async function rejectDissent(dissentId: string, targetItemId: string, rea
           ON CONFLICT (dissent_id) DO UPDATE SET
             resolution = excluded.resolution, reason = excluded.reason, resolved_at = excluded.resolved_at`,
     args: [dissentId, targetItemId, reason ?? null, new Date().toISOString()],
+  });
+}
+
+export type Dispute = {
+  /** The repo that raised it. */
+  by: string;
+  claim: string;
+  at: string;
+  replacementItemId?: string;
+};
+
+/** Every store this machine can read in the workspace: this repo's own, then each present peer. */
+async function readableStores(workspace: ActiveWorkspace): Promise<Array<{ repo: string; client: Client }>> {
+  const stores: Array<{ repo: string; client: Client }> = [{ repo: workspace.repo, client: getClient() }];
+  for (const peer of workspace.peers) {
+    if (!peer.present) continue;
+    try {
+      stores.push({ repo: peer.name, client: (await openPeerStore(peer.databasePath)).client });
+    } catch {
+      // Unreadable is not "has nothing", but on the read path it has to behave like it.
+    }
+  }
+  return stores;
+}
+
+/**
+ * Attach the disputes standing against each returned atom.
+ *
+ * **Annotation only.** The order of `items` is preserved exactly and no score is touched. A
+ * dispute adds a line to a result; it never demotes one. Demoting on dissent would let a
+ * neighbouring repo push another's knowledge down the ranking, which is the blast radius the
+ * single-owner rule exists to prevent -- arriving by a quieter route. If disputed atoms should
+ * one day rank lower, that is a separate change with its own measurement, and this makes it
+ * cheap to try rather than making it happen by accident.
+ *
+ * **Both halves of a dispute are read, from wherever they live.** The dissent is in the raising
+ * repo's store and the resolution in the owning repo's, so a THIRD repo holds neither. Reading
+ * only this store would leave every settled dispute looking open to everyone except the two
+ * repos involved.
+ *
+ * Staleness is judged against the owner's current row rather than against the item passed in:
+ * callers hand this compact search results whose content is truncated, and hashing that would
+ * make every atom read as rewritten.
+ */
+export async function annotateDisputes<T extends { id: string }>(
+  items: T[],
+  workspace: ActiveWorkspace | null,
+): Promise<Array<T & { disputed?: Dispute[] }>> {
+  if (!workspace || items.length === 0) return items;
+
+  const ids = [...new Set(items.map(item => item.id))];
+  const placeholders = ids.map(() => '?').join(', ');
+  const stores = await readableStores(workspace);
+
+  const open: Array<{ by: string; row: Record<string, unknown> }> = [];
+  for (const store of stores) {
+    try {
+      const rows = await store.client.execute({
+        sql: `SELECT id, target_repo, target_item_id, target_content_hash, claim, replacement_item_id, created_at
+              FROM dissents WHERE status = 'open' AND target_item_id IN (${placeholders})`,
+        args: ids,
+      });
+      for (const row of rows.rows) open.push({ by: store.repo, row: row as Record<string, unknown> });
+    } catch {
+      // No `dissents` table: a store written by a build that predates them. Nothing to add.
+    }
+  }
+  if (open.length === 0) return items;
+
+  const resolved = new Set<string>();
+  for (const store of stores) {
+    try {
+      const rows = await store.client.execute({
+        sql: `SELECT dissent_id FROM dissent_resolutions WHERE target_item_id IN (${placeholders})`,
+        args: ids,
+      });
+      for (const row of rows.rows) resolved.add(String(row.dissent_id));
+    } catch {
+      // Same tolerance, and it matters more here: failing to read a resolution would show a
+      // dispute that is already settled, so this must not become an error either.
+    }
+  }
+
+  const current = new Map<string, KnowledgeItem | null>();
+  const currentItem = async (itemId: string, ownerRepo: string): Promise<KnowledgeItem | null> => {
+    if (current.has(itemId)) return current.get(itemId)!;
+    let item: KnowledgeItem | null = null;
+    try {
+      if (ownerRepo === workspace.repo) {
+        item = await getKnowledgeItem(itemId);
+      } else {
+        const peer = workspace.peers.find(entry => entry.name === ownerRepo && entry.present);
+        if (peer) item = await getKnowledgeItem(itemId, (await openPeerStore(peer.databasePath)).db);
+      }
+    } catch {
+      item = null;
+    }
+    current.set(itemId, item);
+    return item;
+  };
+
+  const byItem = new Map<string, Dispute[]>();
+  for (const { by, row } of open) {
+    if (resolved.has(String(row.id))) continue;
+    const itemId = String(row.target_item_id);
+    const item = await currentItem(itemId, String(row.target_repo));
+    // Retired, unreachable, or rewritten since the objection was raised. A dissent is against
+    // what the atom SAID, so the owner changing it is an answer, not something to keep flagging.
+    if (!item || item.status !== 'active') continue;
+    if (String(row.target_content_hash) !== revisionPin(item)) continue;
+    const dispute: Dispute = {
+      by,
+      claim: String(row.claim),
+      at: String(row.created_at),
+      ...(row.replacement_item_id ? { replacementItemId: String(row.replacement_item_id) } : {}),
+    };
+    byItem.set(itemId, [...(byItem.get(itemId) ?? []), dispute]);
+  }
+  if (byItem.size === 0) return items;
+
+  return items.map(item => {
+    const disputes = byItem.get(item.id);
+    return disputes?.length ? { ...item, disputed: disputes } : item;
   });
 }
 

--- a/src/workspace/dissents.ts
+++ b/src/workspace/dissents.ts
@@ -445,6 +445,26 @@ export async function annotateDisputes<T extends { id: string }>(
   });
 }
 
+/**
+ * Undo a rejection, putting the dispute back in front of this repo.
+ *
+ * Deliberately present from the start. A rejection is a judgement made on partial information --
+ * that is the normal case, since the other repo is the one that saw the problem -- and an
+ * irreversible one would make reconsidering impossible for no gain. `workspace promote` shipped
+ * without its inverse and the cost has been paid ever since; there is no reason to repeat the
+ * shape in a feature whose entire subject is disagreement being revisable.
+ *
+ * Safe because the resolution is local and additive: deleting the row restores exactly the state
+ * before the rejection, and the peer's dissent was never touched by either operation.
+ */
+export async function reopenDissent(dissentId: string): Promise<void> {
+  const result = await getClient().execute({
+    sql: 'DELETE FROM dissent_resolutions WHERE dissent_id = ?',
+    args: [dissentId],
+  });
+  if (Number(result.rowsAffected ?? 0) === 0) throw new NoSuchDissentError(dissentId);
+}
+
 /** What this repo has raised against its neighbours. Own store only; no peer is consulted. */
 export async function listOutgoingDissents(): Promise<OutgoingDissent[]> {
   const rows = await getClient().execute({

--- a/src/workspace/dissents.ts
+++ b/src/workspace/dissents.ts
@@ -6,7 +6,7 @@ import { openPeerStore } from '../store/store-handle.js';
 import { isImportedOrigin } from '../store/portability.js';
 import { hashKnowledgeContent } from '../store/freshness.js';
 import { validateKnowledgeWrite } from '../core/knowledge-validation.js';
-import { peerVerdictFor, UnverifiedOwnerError } from './ownership.js';
+import { assertOwnedItem, peerVerdictFor, UnverifiedOwnerError } from './ownership.js';
 import type { KnowledgeItem } from '../core/types.js';
 import type { ActiveWorkspace } from './resolve.js';
 
@@ -310,9 +310,18 @@ export async function listIncomingDissents(workspace: ActiveWorkspace | null): P
  *
  * There is no matching `accept`: accepting is superseding the atom, which needs no new verb.
  */
-export async function rejectDissent(dissentId: string, targetItemId: string, reason?: string): Promise<void> {
+export async function rejectDissent(
+  dissentId: string,
+  targetItemId: string,
+  reason: string | undefined,
+  workspace: ActiveWorkspace | null,
+): Promise<void> {
   const target = await getKnowledgeItem(targetItemId);
   if (!target) throw new UnknownItemError(targetItemId);
+  // The same guard every write to an item passes. A row held here but stamped with another
+  // repo's origin is exactly what `resolveTarget` accepts as a dissent TARGET, and a rejection
+  // written from here would be an answer its owner never gave.
+  await assertOwnedItem(targetItemId, workspace);
   await getClient().execute({
     sql: `INSERT INTO dissent_resolutions (dissent_id, target_item_id, resolution, reason, resolved_at)
           VALUES (?, ?, 'rejected', ?, ?)
@@ -388,14 +397,17 @@ export async function annotateDisputes<T extends { id: string }>(
   }
   if (open.length === 0) return items;
 
-  const resolved = new Set<string>();
+  // Keyed by the store a resolution was read from. Only the OWNER's answer settles a dispute;
+  // a resolution row in any other store is not that repo's to give, so it is not consulted.
+  // Without this, one row in a third repo's database could silence a dispute between two others.
+  const resolvedBy = new Map<string, Set<string>>();
   for (const store of stores) {
     try {
       const rows = await store.client.execute({
         sql: `SELECT dissent_id FROM dissent_resolutions WHERE target_item_id IN (${placeholders})`,
         args: ids,
       });
-      for (const row of rows.rows) resolved.add(String(row.dissent_id));
+      resolvedBy.set(store.repo, new Set(rows.rows.map(row => String(row.dissent_id))));
     } catch {
       // Same tolerance, and it matters more here: failing to read a resolution would show a
       // dispute that is already settled, so this must not become an error either.
@@ -422,9 +434,10 @@ export async function annotateDisputes<T extends { id: string }>(
 
   const byItem = new Map<string, Dispute[]>();
   for (const { by, row } of open) {
-    if (resolved.has(String(row.id))) continue;
+    const ownerRepo = String(row.target_repo);
+    if (resolvedBy.get(ownerRepo)?.has(String(row.id))) continue;
     const itemId = String(row.target_item_id);
-    const item = await currentItem(itemId, String(row.target_repo));
+    const item = await currentItem(itemId, ownerRepo);
     // Retired, unreachable, or rewritten since the objection was raised. A dissent is against
     // what the atom SAID, so the owner changing it is an answer, not something to keep flagging.
     if (!item || item.status !== 'active') continue;

--- a/src/workspace/dissents.ts
+++ b/src/workspace/dissents.ts
@@ -211,3 +211,128 @@ export async function withdrawDissent(dissentId: string): Promise<void> {
   });
   if (Number(result.rowsAffected ?? 0) === 0) throw new NoSuchDissentError(dissentId);
 }
+
+export type IncomingDissent = {
+  dissentId: string;
+  fromRepo: string;
+  targetItemId: string;
+  targetTitle: string;
+  claim: string;
+  replacementItemId: string | null;
+  createdAt: string;
+  /** The atom has been rewritten since the objection was raised. */
+  staleAgainstCurrentRevision: boolean;
+};
+
+export type OutgoingDissent = {
+  id: string;
+  targetRepo: string;
+  targetItemId: string;
+  claim: string;
+  status: string;
+  createdAt: string;
+};
+
+/** Dissent rows a peer holds against atoms this repo owns. Unreadable peers contribute nothing. */
+async function openDissentsFromPeers(workspace: ActiveWorkspace): Promise<Array<{ fromRepo: string; row: Record<string, unknown> }>> {
+  const found: Array<{ fromRepo: string; row: Record<string, unknown> }> = [];
+  for (const peer of workspace.peers) {
+    if (!peer.present) continue;
+    try {
+      const store = await openPeerStore(peer.databasePath);
+      const rows = await store.client.execute({
+        sql: `SELECT id, target_item_id, target_content_hash, claim, replacement_item_id, created_at
+              FROM dissents WHERE target_repo = ? AND status = 'open'`,
+        args: [workspace.repo],
+      });
+      for (const row of rows.rows) found.push({ fromRepo: peer.name, row: row as Record<string, unknown> });
+    } catch {
+      // A peer written by an older build has no `dissents` table, and one that is corrupt or
+      // locked cannot be asked. Neither may fail the caller: this runs on the read path, so an
+      // unreadable neighbour must cost a missing annotation and never a failed query.
+    }
+  }
+  return found;
+}
+
+/**
+ * What the linked repos are disputing about this repo's atoms.
+ *
+ * Three things drop a dissent out of this list, and each corresponds to one of the ways a
+ * dispute genuinely ends:
+ *
+ * - the dissenter withdrew it (its own row is no longer `open`)
+ * - this repo rejected it (a local resolution row)
+ * - this repo answered it by rewriting or retiring the atom -- the revision pin no longer
+ *   matches, or the item is no longer active
+ *
+ * Accepting therefore needs no API. Superseding the atom is an ordinary local write, and the
+ * dispute clears itself because a retired atom is not scanned.
+ */
+export async function listIncomingDissents(workspace: ActiveWorkspace | null): Promise<IncomingDissent[]> {
+  if (!workspace) return [];
+  const candidates = await openDissentsFromPeers(workspace);
+  if (candidates.length === 0) return [];
+
+  const resolved = new Set<string>();
+  const resolutions = await getClient().execute({ sql: 'SELECT dissent_id FROM dissent_resolutions', args: [] });
+  for (const row of resolutions.rows) resolved.add(String(row.dissent_id));
+
+  const incoming: IncomingDissent[] = [];
+  for (const { fromRepo, row } of candidates) {
+    const dissentId = String(row.id);
+    if (resolved.has(dissentId)) continue;
+    const target = await getKnowledgeItem(String(row.target_item_id));
+    // Not ours, or no longer standing. Either way there is nothing here left to defend.
+    if (!target || target.status !== 'active') continue;
+    incoming.push({
+      dissentId,
+      fromRepo,
+      targetItemId: target.id,
+      targetTitle: target.title,
+      claim: String(row.claim),
+      replacementItemId: row.replacement_item_id === null ? null : String(row.replacement_item_id),
+      createdAt: String(row.created_at),
+      staleAgainstCurrentRevision: String(row.target_content_hash) !== revisionPin(target),
+    });
+  }
+  return incoming;
+}
+
+/**
+ * Reject a dissent raised against one of this repo's atoms.
+ *
+ * The row is written HERE, keyed by a `dissent_id` that lives in the peer's store. That
+ * asymmetry is the design rather than an oversight: the dissenter keeps its record of what it
+ * believes, this repo keeps its record of having answered, and neither writes the other's
+ * database. The peer's row stays `open` because it still describes that repo's position.
+ *
+ * There is no matching `accept`: accepting is superseding the atom, which needs no new verb.
+ */
+export async function rejectDissent(dissentId: string, targetItemId: string, reason?: string): Promise<void> {
+  const target = await getKnowledgeItem(targetItemId);
+  if (!target) throw new UnknownItemError(targetItemId);
+  await getClient().execute({
+    sql: `INSERT INTO dissent_resolutions (dissent_id, target_item_id, resolution, reason, resolved_at)
+          VALUES (?, ?, 'rejected', ?, ?)
+          ON CONFLICT (dissent_id) DO UPDATE SET
+            resolution = excluded.resolution, reason = excluded.reason, resolved_at = excluded.resolved_at`,
+    args: [dissentId, targetItemId, reason ?? null, new Date().toISOString()],
+  });
+}
+
+/** What this repo has raised against its neighbours. Own store only; no peer is consulted. */
+export async function listOutgoingDissents(): Promise<OutgoingDissent[]> {
+  const rows = await getClient().execute({
+    sql: `SELECT id, target_repo, target_item_id, claim, status, created_at FROM dissents ORDER BY created_at DESC`,
+    args: [],
+  });
+  return rows.rows.map(row => ({
+    id: String(row.id),
+    targetRepo: String(row.target_repo),
+    targetItemId: String(row.target_item_id),
+    claim: String(row.claim),
+    status: String(row.status),
+    createdAt: String(row.created_at),
+  }));
+}

--- a/src/workspace/ownership.ts
+++ b/src/workspace/ownership.ts
@@ -7,7 +7,13 @@ import type { ActiveWorkspace } from './resolve.js';
 
 export class ForeignItemError extends Error {
   constructor(itemId: string, repo: string) {
-    super(`Item ${itemId} belongs to repo "${repo}" and was not changed. Run this from that repo.`);
+    super(
+      `Item ${itemId} belongs to repo "${repo}" and was not changed. Run this from that repo. ` +
+      // A refusal that only says no leaves the caller holding a finding with nowhere to put it,
+      // which is the gap dissent exists to close. Named here rather than at each call site so
+      // the CLI and the tool surface cannot end up offering different remedies.
+      'To record that it is wrong without editing it, raise a dissent -- the owner decides.',
+    );
     this.name = 'ForeignItemError';
   }
 }

--- a/src/workspace/ownership.ts
+++ b/src/workspace/ownership.ts
@@ -172,3 +172,22 @@ export async function findForeignItem(
   if (item.visibility !== 'workspace') return null;
   return { repo: owner, item };
 }
+
+/**
+ * The same walk, with the peers that could not answer.
+ *
+ * `findForeignItem` collapses "no peer holds it" and "the peer that might was unreadable" into
+ * one null, which is right for a read: the caller's not-found path words both. It is wrong for
+ * anything durable. Telling someone their id does not exist, when the truth is that the repo
+ * owning it is not checked out on this machine, invites them to go and correct an id that was
+ * never wrong -- the mistake `UnverifiedOwnerError` exists to prevent on the write side.
+ */
+export async function peerVerdictFor(
+  itemId: string,
+  workspace: ActiveWorkspace,
+): Promise<{ repo: string | null; item: KnowledgeItem | null; unverified: string[] }> {
+  const { owner, item, unverified } = await ownerFromPeers(itemId, workspace);
+  // One shape rather than a union: `repo` is not a literal, so a union could not be narrowed on
+  // it, and every caller would have to re-test what it had already tested.
+  return owner && item ? { repo: owner, item, unverified } : { repo: null, item: null, unverified };
+}

--- a/tests/cli/dissent.test.ts
+++ b/tests/cli/dissent.test.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+
+/**
+ * The `knowl dissent` verbs, driven through the built CLI.
+ *
+ * Every verb is explicit -- `record`, not a bare `knowl dissent <id>` beside subcommands -- so
+ * an item id can never be mistaken for a verb. The layer itself is thin on purpose: the rules
+ * live in `workspace/dissents.ts`, and these assertions are that the CLI reaches them and shows
+ * what came back.
+ */
+
+const HOME = path.resolve('./.knowl-dissent-cli-home');
+const A = path.resolve('./.knowl-dissent-cli-a');
+const B = path.resolve('./.knowl-dissent-cli-b');
+const CLI = path.resolve('./dist/index.js');
+
+function knowl(cwd: string, ...args: string[]) {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, KNOWL_HOME: HOME },
+  });
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
+}
+
+async function seed(root: string, name: string, title: string, content: string): Promise<string> {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  const projectId = (await repo.createProject(root, name)).id;
+  const stored = await storeKnowledgeItemDeduped(projectId, { category: 'decision', title, content });
+  await getClient().execute({
+    sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ? WHERE id = ?',
+    args: ['workspace', name, stored.item.id],
+  });
+  await closeDb();
+  return stored.item.id;
+}
+
+// Each assertion spawns the real built CLI: several seconds of node start-up per invocation.
+describe('knowl dissent CLI', { timeout: 180_000 }, () => {
+  let ownedByB = '';
+  let ownedByA = '';
+
+  beforeAll(async () => {
+    // The manifest and the membership rows are written in-process here but read by a spawned
+    // CLI, and both sides resolve the workspace through `knowlHome()`. Without this the setup
+    // would land in the real home directory and the CLI would correctly report no workspace.
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('cliws'), createManifest('cliws', null));
+    ownedByA = await seed(A, 'clia', 'Local note', 'Something only this repo knows.');
+    ownedByB = await seed(B, 'clib', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'cliws', repoName: 'clia' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'cliws', repoName: 'clib' });
+    await closeDb();
+    await releaseAll();
+  });
+
+  it('records a dissent and says who now sees it', () => {
+    const result = knowl(A, 'dissent', 'record', ownedByB, '--claim', 'The TTL is five minutes, not fifteen.');
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('clib');
+    // The reassurance that matters: contesting an item did not edit it.
+    expect(result.stdout).toMatch(/only its owner can supersede or retire it/i);
+  });
+
+  it('the owning repo sees it as incoming, with the claim and what to do', () => {
+    const result = knowl(B, 'dissent', 'list', '--incoming');
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('INCOMING (1)');
+    expect(result.stdout).toContain('Auth token TTL');
+    expect(result.stdout).toContain('five minutes');
+    expect(result.stdout).toMatch(/superseding the item/i);
+  });
+
+  it('the raising repo sees it as outgoing', () => {
+    const result = knowl(A, 'dissent', 'list', '--outgoing');
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('OUTGOING (1)');
+    expect(result.stdout).toContain('clib');
+    expect(result.stdout).toContain('[open]');
+  });
+
+  it('refuses to dissent against this repo\'s own item, and says what to do instead', () => {
+    const result = knowl(A, 'dissent', 'record', ownedByA, '--claim', 'Wrong.');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/yours to change/i);
+  });
+
+  it('refuses an id no repo holds', () => {
+    const result = knowl(A, 'dissent', 'record', 'no-such-item-000', '--claim', 'Wrong.');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/No knowledge item/i);
+  });
+
+  it('rejecting clears the dispute and says the other repo keeps its own record', () => {
+    const listed = knowl(B, 'dissent', 'list', '--incoming');
+    const dissentId = /\s{2}([0-9a-f]{16})\s{2}/.exec(listed.stdout)?.[1] ?? '';
+    expect(dissentId).toMatch(/^[0-9a-f]{16}$/);
+
+    const rejected = knowl(B, 'dissent', 'reject', dissentId, '--target', ownedByB, '--reason', 'Measured at fifteen.');
+    expect(rejected.status, rejected.stderr).toBe(0);
+    expect(rejected.stdout).toMatch(/stands as written/i);
+    expect(rejected.stdout).toMatch(/keeps its own record/i);
+
+    expect(knowl(B, 'dissent', 'list', '--incoming').stdout).toContain('INCOMING (0)');
+  });
+
+  it('withdrawing refuses an id this repo does not hold', () => {
+    const result = knowl(B, 'dissent', 'withdraw', 'not-a-dissent-x');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/No dissent/i);
+  });
+
+  it('the raising repo can withdraw its own', () => {
+    const outgoing = knowl(A, 'dissent', 'list', '--outgoing');
+    const dissentId = /\s{2}([0-9a-f]{16})\s{2}/.exec(outgoing.stdout)?.[1] ?? '';
+    const result = knowl(A, 'dissent', 'withdraw', dissentId);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toMatch(/no longer marks the item/i);
+  });
+});

--- a/tests/cli/dissent.test.ts
+++ b/tests/cli/dissent.test.ts
@@ -118,6 +118,16 @@ describe('knowl dissent CLI', { timeout: 180_000 }, () => {
     expect(rejected.stdout).toMatch(/keeps its own record/i);
 
     expect(knowl(B, 'dissent', 'list', '--incoming').stdout).toContain('INCOMING (0)');
+
+    // A rejection is a judgement on partial information -- the other repo is the one that saw
+    // the problem -- so reconsidering has to stay possible. `promote` shipped without its
+    // inverse and the cost has been paid ever since.
+    const reopened = knowl(B, 'dissent', 'reopen', dissentId);
+    expect(reopened.status, reopened.stderr).toBe(0);
+    expect(knowl(B, 'dissent', 'list', '--incoming').stdout).toContain('INCOMING (1)');
+
+    // Left rejected, so the withdraw case below reads a settled fixture.
+    knowl(B, 'dissent', 'reject', dissentId, '--target', ownedByB, '--reason', 'Measured at fifteen.');
   });
 
   it('withdrawing refuses an id this repo does not hold', () => {

--- a/tests/mcp/dissent-tool.test.ts
+++ b/tests/mcp/dissent-tool.test.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * `knowl_dissent`, and the `disputed` mark it puts on every later read.
+ *
+ * The mark is the whole product decision. A dissent that only sat in a queue would leave the
+ * system knowingly serving a fact one of its repos has flagged as wrong; marking it means the
+ * correction reaches whoever is about to rely on it, at the moment they ask.
+ */
+
+const HOME = path.join(os.tmpdir(), 'knowl-dtool-home');
+const A = path.join(os.tmpdir(), 'knowl-dtool-a');
+const B = path.join(os.tmpdir(), 'knowl-dtool-b');
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+async function callTool(root: string, config: ProjectConfig, name: string, args: Record<string, unknown>) {
+  const server = createMcpServer('local', root, config);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as any);
+  const initialized = new Promise<any>(resolve => { transport.onSend = m => { if (m.id === 'init') resolve(m); }; });
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const response = new Promise<any>(resolve => { transport.onSend = m => { if (m.id === 'call') resolve(m); }; });
+  transport.onmessage!({ jsonrpc: '2.0', id: 'call', method: 'tools/call', params: { name, arguments: args } });
+  const result = await response;
+  await server.close();
+  return result.result;
+}
+
+async function seed(root: string, name: string, title: string, content: string): Promise<string> {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  await getClient().execute('DELETE FROM knowledge_commits');
+  await getClient().execute('DELETE FROM knowledge_items');
+  const projectId = (await repo.createProject(root, name)).id;
+  const stored = await storeKnowledgeItemDeduped(projectId, { category: 'decision', title, content });
+  await getClient().execute({
+    sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ? WHERE id = ?',
+    args: ['workspace', name, stored.item.id],
+  });
+  await closeDb();
+  return stored.item.id;
+}
+
+describe('knowl_dissent', { timeout: 180_000 }, () => {
+  let ownedByB = '';
+
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('dws'), createManifest('dws', null));
+    await seed(A, 'a', 'Local note', 'Something only this repo knows.');
+    ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'dws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'dws', repoName: 'b' });
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function recordFromA(claim = 'The TTL is five minutes, not fifteen.') {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_dissent', {
+      action: 'record', itemId: ownedByB, claim,
+    });
+    await closeDb();
+    return result;
+  }
+
+  it('records, and says plainly that the other repo was not edited', async () => {
+    const result = await recordFromA();
+    expect(result.isError).toBeFalsy();
+    const text = String(result.content[0].text);
+    expect(text).toContain('"b"');
+    expect(text).toMatch(/Nothing in that repo changed/i);
+    expect(text).toMatch(/only its owner can supersede or retire/i);
+  });
+
+  it('marks the disputed atom on a later fetch by id — the whole point of the feature', async () => {
+    await recordFromA();
+    await initDb(B);
+    const result = await callTool(B, await loadConfig(B), 'knowl_query', { id: ownedByB });
+    await closeDb();
+
+    const [item] = JSON.parse(result.content[0].text);
+    expect(item.disputed).toHaveLength(1);
+    expect(item.disputed[0].by).toBe('a');
+    expect(item.disputed[0].claim).toContain('five minutes');
+  });
+
+  it('the owner lists it, rejects it, and it stops marking the atom', async () => {
+    await recordFromA();
+    await initDb(B);
+    const config = await loadConfig(B);
+    const listed = await callTool(B, config, 'knowl_dissent', { action: 'list' });
+    const { incoming } = JSON.parse(listed.content[0].text);
+    expect(incoming).toHaveLength(1);
+
+    const rejected = await callTool(B, config, 'knowl_dissent', {
+      action: 'reject', dissentId: incoming[0].dissentId, targetItemId: ownedByB, reason: 'Measured at fifteen.',
+    });
+    expect(rejected.isError).toBeFalsy();
+    expect(String(rejected.content[0].text)).toMatch(/reopen/i);
+
+    const after = await callTool(B, config, 'knowl_query', { id: ownedByB });
+    await closeDb();
+    expect(JSON.parse(after.content[0].text)[0]).not.toHaveProperty('disputed');
+  });
+
+  it('a rejection can be undone, so reconsidering stays possible', async () => {
+    await recordFromA();
+    await initDb(B);
+    const config = await loadConfig(B);
+    const { incoming } = JSON.parse((await callTool(B, config, 'knowl_dissent', { action: 'list' })).content[0].text);
+    await callTool(B, config, 'knowl_dissent', { action: 'reject', dissentId: incoming[0].dissentId, targetItemId: ownedByB });
+    await callTool(B, config, 'knowl_dissent', { action: 'reopen', dissentId: incoming[0].dissentId });
+    const after = await callTool(B, config, 'knowl_query', { id: ownedByB });
+    await closeDb();
+
+    expect(JSON.parse(after.content[0].text)[0].disputed).toHaveLength(1);
+  });
+
+  it('defaults to listing, so an omitted action never writes', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_dissent', {});
+    await closeDb();
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0].text)).toHaveProperty('incoming');
+  });
+
+  it('refuses this repo\'s own item through the tool surface too', async () => {
+    await initDb(B);
+    const result = await callTool(B, await loadConfig(B), 'knowl_dissent', {
+      action: 'record', itemId: ownedByB, claim: 'Wrong.',
+    });
+    await closeDb();
+    expect(result.isError).toBe(true);
+    expect(String(result.content[0].text)).toMatch(/yours to change/i);
+  });
+
+  it('the refused foreign update now points at the remedy instead of only refusing', async () => {
+    await initDb(A);
+    const result = await callTool(A, await loadConfig(A), 'knowl_update', {
+      id: ownedByB, content: 'Rewritten from the wrong repo.',
+    });
+    await closeDb();
+    expect(String(result.content[0].text)).toMatch(/belongs to repo "b"/);
+    expect(String(result.content[0].text)).toMatch(/dissent/i);
+  });
+});

--- a/tests/mcp/tool-annotations.test.ts
+++ b/tests/mcp/tool-annotations.test.ts
@@ -57,6 +57,8 @@ const READ_ONLY: Record<string, boolean> = {
   knowl_ingest_atoms: false,
   knowl_store: false,
   knowl_decide: false,
+  // `list` reads; `record`, `reject`, `withdraw` and `reopen` all write.
+  knowl_dissent: false,
   knowl_update: false,
   knowl_synthesize: false,
   knowl_feedback: false,

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -90,6 +90,12 @@ const SCHEMA_PINS: Record<number, string> = {
   // parent's external session id and a dozen other counters key on that same function. Additive,
   // so `KNOWL_SCHEMA_VERSION` again does not move.
   16: '232a05446e8fcd4ed32861db0c97b8be',
+  // 17 adds `dissents` and `dissent_resolutions` with their two target indexes: one repo's
+  // recorded disagreement with an atom another repo owns, and the owning repo's answer. Two new
+  // tables, no altered column, no backfill, so `KNOWL_SCHEMA_VERSION` again does not move. The
+  // level does, and load-bearingly: `annotateDisputes` reads both on every workspace query, so a
+  // store left at 16 would skip the DDL and fail ordinary reads, not just the new command.
+  17: '7a690fc55d186b8106ea27c647685bd3',
 };
 
 let root: string;

--- a/tests/workspace/dissents-cloud.test.ts
+++ b/tests/workspace/dissents-cloud.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import { withTeamStore } from '../../src/cloud/team-store.js';
+import { applySyncRows } from '../../src/cloud/sync-apply.js';
+import { resolveWorkspace } from '../../src/workspace/resolve.js';
+import { createDissent } from '../../src/workspace/dissents.js';
+import type { ProjectConfig } from '../../src/core/config.js';
+import type { SyncAtom } from '../../src/cloud/sync-contract.js';
+
+/**
+ * A dissent against an item the team replica holds is refused, not recorded. The replica is a
+ * copy of rows written on other machines: a dissent filed here would never reach the owner while
+ * reading as though something had been done.
+ */
+
+const HOME = path.join(os.tmpdir(), 'knowl-dissent-cloud-home');
+const ROOT = path.join(os.tmpdir(), 'knowl-dissent-cloud-root');
+const WS = 'ws-dissent-cloud';
+
+const config: ProjectConfig = {
+  version: 1,
+  cloud: {
+    apiHost: 'https://api.knowl.test', workspaceId: WS, workspaceName: 'Acme',
+    repo: 'github.com/acme/web', remote: 'origin',
+  },
+};
+
+function atom(id: string, originRepo: string, title: string): SyncAtom {
+  return {
+    id, category: 'decision', title, content: `${title} body`,
+    status: 'active', freshness: 'fresh', contentHash: `hash-${id}`, originRepo,
+    authorUserId: 'u1', supersededById: null, version: 1, visibility: 'workspace', review: null,
+    publishedAt: '2026-08-09T10:00:00.000Z', createdAt: '2026-08-09T10:00:00.000Z',
+    updatedAt: '2026-08-09T10:00:00.000Z',
+  };
+}
+
+describe('createDissent against the cloud replica', () => {
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, ROOT]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await fs.writeFile(path.join(ROOT, '.knowl', 'config.json'), JSON.stringify({ version: 1 }), 'utf8');
+    await initDb(ROOT);
+    await closeDb();
+    await withTeamStore(WS, ROOT, async () => {
+      await applySyncRows([{ op: 'upsert', seq: '1', item: atom('t1', 'github.com/acme/api', 'API rollback') }]);
+    });
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, ROOT]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('refuses a cloud-owned item by name, and writes nothing', async () => {
+    const workspace = (await resolveWorkspace(ROOT, config))!;
+    expect(workspace.cloud?.present).toBe(true);
+    await initDb(ROOT);
+    await expect(createDissent({ targetItemId: 't1', claim: 'Wrong.' }, workspace))
+      .rejects.toThrow(/team workspace "Acme"/);
+    await closeDb();
+  });
+});

--- a/tests/workspace/dissents.test.ts
+++ b/tests/workspace/dissents.test.ts
@@ -325,7 +325,7 @@ describe('the owner side', () => {
   it('rejecting it clears it, and the rejection is written in the owner\'s own store', async () => {
     const id = await dissentFromA();
     const workspace = await inB();
-    await rejectDissent(id, ownedByB, 'Measured at fifteen; the five-minute figure is the refresh window.');
+    await rejectDissent(id, ownedByB, 'Measured at fifteen; the five-minute figure is the refresh window.', workspace);
     const incoming = await listIncomingDissents(workspace);
     const local = await getClient().execute({ sql: 'SELECT * FROM dissent_resolutions', args: [] });
     await closeDb();
@@ -341,7 +341,7 @@ describe('the owner side', () => {
   it('the rejection did not reach the dissenting repo\'s store', async () => {
     const id = await dissentFromA();
     const workspace = await inB();
-    await rejectDissent(id, ownedByB, 'Measured at fifteen.');
+    await rejectDissent(id, ownedByB, 'Measured at fifteen.', workspace);
     await closeDb();
     void workspace;
 
@@ -369,8 +369,42 @@ describe('the owner side', () => {
   it('rejecting refuses a target this repo does not own', async () => {
     const id = await dissentFromA();
     await initDb(A);
-    await expect(rejectDissent(id, 'no-such-item-000', 'nope')).rejects.toThrow(/No knowledge item|not yours/i);
+    await expect(rejectDissent(id, 'no-such-item-000', 'nope', null)).rejects.toThrow(/No knowledge item|not yours/i);
     await closeDb();
+  });
+
+  it('rejecting refuses a copy held locally but owned by another repo', async () => {
+    // A row stamped with another repo's origin sits here -- the exact shape `resolveTarget`
+    // accepts as a dissent target. Rejecting from here would write a resolution the owner never
+    // made, and every reader would drop the dispute on its strength.
+    const id = await dissentFromA();
+    await initDb(A);
+    // Same shape `resolveTarget` accepts as a target: held here, stamped as b's.
+    await getClient().execute({
+      sql: `UPDATE knowledge_items SET origin_repo = 'b', visibility = 'workspace'`,
+      args: [],
+    });
+    const held = await getClient().execute({ sql: `SELECT id FROM knowledge_items LIMIT 1`, args: [] });
+    await expect(rejectDissent(id, String(held.rows[0].id), 'nope', await resolveWorkspace(A, await loadConfig(A)))).rejects.toThrow(/belongs to repo "b"/);
+    await closeDb();
+    expect(await peerRowCount(A, 'dissent_resolutions')).toBe(0);
+  });
+
+  it('a resolution row in a non-owner store does not silence the dispute', async () => {
+    const id = await dissentFromA();
+    await initDb(A);
+    await getClient().execute({
+      sql: `INSERT INTO dissent_resolutions (dissent_id, target_item_id, resolution, reason, resolved_at) VALUES (?, ?, 'rejected', NULL, ?)`,
+      args: [id, ownedByB, new Date().toISOString()],
+    });
+    await closeDb();
+
+    const workspace = await inB();
+    const [annotated] = await annotateDisputes([{ id: ownedByB }], workspace);
+    const incoming = await listIncomingDissents(workspace);
+    await closeDb();
+    expect(annotated.disputed).toHaveLength(1);
+    expect(incoming).toHaveLength(1);
   });
 
   it('the dissenting repo can list what it has raised', async () => {
@@ -479,7 +513,7 @@ describe('annotateDisputes', () => {
   it('a rejected dissent no longer marks the atom, as seen from the owning repo', async () => {
     const id = await dissentFromA();
     const workspace = await inB();
-    await rejectDissent(id, ownedByB, 'Measured at fifteen.');
+    await rejectDissent(id, ownedByB, 'Measured at fifteen.', workspace);
     const [annotated] = await annotateDisputes([{ id: ownedByB }], workspace);
     await closeDb();
     expect(annotated).not.toHaveProperty('disputed');
@@ -490,9 +524,8 @@ describe('annotateDisputes', () => {
     // so without reading the owner's resolutions it would keep showing a dispute that is over.
     const id = await dissentFromA();
     const workspaceB = await inB();
-    await rejectDissent(id, ownedByB, 'Measured at fifteen.');
+    await rejectDissent(id, ownedByB, 'Measured at fifteen.', workspaceB);
     await closeDb();
-    void workspaceB;
 
     await initDb(A);
     const workspaceA = await resolveWorkspace(A, await loadConfig(A));

--- a/tests/workspace/dissents.test.ts
+++ b/tests/workspace/dissents.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+
+/**
+ * A dissent is one repo's recorded disagreement with an atom another repo owns.
+ *
+ * Two single-writer rows, joined at read time: the dissent lives in the DISSENTING repo's store
+ * and the resolution in the OWNING repo's. Nothing here ever writes another repo's database,
+ * which is the invariant `assertOwnedItem` enforces and the one this feature exists not to bend.
+ */
+
+const ROOT = path.join(os.tmpdir(), 'knowl-dissent-schema');
+
+describe('dissent schema', () => {
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('bootstrap creates both tables', async () => {
+    const tables = await getClient().execute({
+      sql: `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('dissents', 'dissent_resolutions') ORDER BY name`,
+      args: [],
+    });
+    expect(tables.rows.map(row => String(row.name))).toEqual(['dissent_resolutions', 'dissents']);
+  });
+
+  it('the overlay lookup is indexed, because it runs per returned atom', async () => {
+    const plan = await getClient().execute({
+      sql: `EXPLAIN QUERY PLAN SELECT * FROM dissents WHERE target_item_id = 'x'`,
+      args: [],
+    });
+    expect(JSON.stringify(plan.rows)).toContain('idx_dissents_target');
+  });
+
+  it('resolutions are looked up the same way, by the atom being defended', async () => {
+    const plan = await getClient().execute({
+      sql: `EXPLAIN QUERY PLAN SELECT * FROM dissent_resolutions WHERE target_item_id = 'x'`,
+      args: [],
+    });
+    expect(JSON.stringify(plan.rows)).toContain('idx_dissent_resolutions_target');
+  });
+
+  it('re-opening an existing store is idempotent', async () => {
+    await closeDb();
+    await expect(initDb(ROOT)).resolves.not.toThrow();
+    const tables = await getClient().execute({
+      sql: `SELECT count(*) AS n FROM sqlite_master WHERE type = 'table' AND name IN ('dissents', 'dissent_resolutions')`,
+      args: [],
+    });
+    expect(Number(tables.rows[0].n)).toBe(2);
+  });
+
+  it('a dissent pins the revision it was raised against, so a rewrite can stale it out', async () => {
+    // Not decoration: without the pinned hash, a dissent raised against revision N would still
+    // read as live against N+1, and the owner's rewrite -- the most likely response -- could
+    // never clear it.
+    const columns = await getClient().execute({ sql: `PRAGMA table_info(dissents)`, args: [] });
+    const names = columns.rows.map(row => String(row.name));
+    expect(names).toContain('target_content_hash');
+    expect(names).toContain('target_repo');
+    expect(names).toContain('claim');
+    expect(names).toContain('replacement_item_id');
+    expect(names).toContain('status');
+  });
+});

--- a/tests/workspace/dissents.test.ts
+++ b/tests/workspace/dissents.test.ts
@@ -12,7 +12,8 @@ import { joinWorkspace } from '../../src/workspace/membership.js';
 import { resolveWorkspace } from '../../src/workspace/resolve.js';
 import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
 import {
-  createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent, withdrawDissent,
+  annotateDisputes, createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent,
+  withdrawDissent,
 } from '../../src/workspace/dissents.js';
 
 /**
@@ -119,6 +120,28 @@ async function peerRowCount(root: string, table: string): Promise<number> {
     const rows = await getClient().execute({ sql: `SELECT count(*) AS n FROM ${table}`, args: [] });
     return Number(rows.rows[0].n);
   } finally {
+    await closeDb();
+  }
+}
+
+/**
+ * Run `body` with `root`'s `dissents` table invisible, then put it back.
+ *
+ * Renamed rather than dropped, and restored rather than left. The store is stamped at the
+ * current migration level, so `bootstrapSchema` skips `SCHEMA_STATEMENTS` entirely on the next
+ * open and would never recreate a dropped table -- and on Windows a fixture directory routinely
+ * survives its own removal while libSQL holds the sidecar. A dropped table therefore outlives
+ * the test that dropped it and breaks every later case in the file.
+ */
+async function withDissentsTableHidden(root: string, body: () => Promise<void>): Promise<void> {
+  await initDb(root);
+  await getClient().execute('ALTER TABLE dissents RENAME TO dissents_hidden');
+  await closeDb();
+  try {
+    await body();
+  } finally {
+    await initDb(root);
+    await getClient().execute('ALTER TABLE dissents_hidden RENAME TO dissents');
     await closeDb();
   }
 }
@@ -368,12 +391,139 @@ describe('the owner side', () => {
   it('a peer with no dissents table contributes nothing rather than failing the listing', async () => {
     // An older build's store, or one never used. The overlay runs on every workspace read, so
     // this must degrade to "no dissents" and never to an error.
+    await withDissentsTableHidden(A, async () => {
+      const workspace = await inB();
+      await expect(listIncomingDissents(workspace)).resolves.toEqual([]);
+      await closeDb();
+    });
+  });
+});
+
+describe('annotateDisputes', () => {
+  let ownedByB = '';
+
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
+    await seed(A, 'a', 'Local auth note', 'Auth tokens expire locally.');
+    ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'ws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'ws', repoName: 'b' });
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function dissentFromA(claim = 'The TTL is five minutes, not fifteen.'): Promise<string> {
     await initDb(A);
-    await getClient().execute('DROP TABLE dissents');
+    const workspace = await resolveWorkspace(A, await loadConfig(A));
+    const { id } = await createDissent({ targetItemId: ownedByB, claim }, workspace);
+    await closeDb();
+    return id;
+  }
+
+  const inB = async () => {
+    await initDb(B);
+    return resolveWorkspace(B, await loadConfig(B));
+  };
+
+  it('marks a disputed atom, naming the repo that disputes it', async () => {
+    await dissentFromA();
+    const workspace = await inB();
+    const [annotated] = await annotateDisputes([{ id: ownedByB }], workspace);
+    await closeDb();
+
+    expect(annotated.disputed).toHaveLength(1);
+    expect(annotated.disputed![0].by).toBe('a');
+    expect(annotated.disputed![0].claim).toContain('five minutes');
+  });
+
+  it('leaves an undisputed atom exactly as it arrived', async () => {
+    const workspace = await inB();
+    const [annotated] = await annotateDisputes([{ id: ownedByB, keep: 'me' }], workspace);
+    await closeDb();
+
+    expect(annotated).not.toHaveProperty('disputed');
+    expect(annotated.keep).toBe('me');
+  });
+
+  it('preserves order exactly — the overlay annotates and never ranks', async () => {
+    await dissentFromA();
+    const workspace = await inB();
+    const input = [{ id: 'x1' }, { id: ownedByB }, { id: 'x2' }, { id: 'x3' }];
+    const annotated = await annotateDisputes(input, workspace);
+    await closeDb();
+
+    expect(annotated.map(entry => entry.id)).toEqual(['x1', ownedByB, 'x2', 'x3']);
+  });
+
+  it('a withdrawn dissent no longer marks the atom', async () => {
+    const id = await dissentFromA();
+    await initDb(A);
+    await withdrawDissent(id);
     await closeDb();
 
     const workspace = await inB();
-    await expect(listIncomingDissents(workspace)).resolves.toEqual([]);
+    const [annotated] = await annotateDisputes([{ id: ownedByB }], workspace);
     await closeDb();
+    expect(annotated).not.toHaveProperty('disputed');
+  });
+
+  it('a rejected dissent no longer marks the atom, as seen from the owning repo', async () => {
+    const id = await dissentFromA();
+    const workspace = await inB();
+    await rejectDissent(id, ownedByB, 'Measured at fifteen.');
+    const [annotated] = await annotateDisputes([{ id: ownedByB }], workspace);
+    await closeDb();
+    expect(annotated).not.toHaveProperty('disputed');
+  });
+
+  it('and no longer marks it for a THIRD repo either, whose store holds neither row', async () => {
+    // The dissent lives in `a`, the rejection in `b`. A reader in `a` holds only its own half,
+    // so without reading the owner's resolutions it would keep showing a dispute that is over.
+    const id = await dissentFromA();
+    const workspaceB = await inB();
+    await rejectDissent(id, ownedByB, 'Measured at fifteen.');
+    await closeDb();
+    void workspaceB;
+
+    await initDb(A);
+    const workspaceA = await resolveWorkspace(A, await loadConfig(A));
+    const [annotated] = await annotateDisputes([{ id: ownedByB }], workspaceA);
+    await closeDb();
+    expect(annotated).not.toHaveProperty('disputed');
+  });
+
+  it('a rewritten atom sheds the dispute, because the objection was to what it said', async () => {
+    await dissentFromA();
+    await initDb(B);
+    await repo.updateKnowledgeItem(ownedByB, { content: 'Auth tokens expire after five minutes.' });
+    const workspace = await resolveWorkspace(B, await loadConfig(B));
+    const [annotated] = await annotateDisputes([{ id: ownedByB }], workspace);
+    await closeDb();
+    expect(annotated).not.toHaveProperty('disputed');
+  });
+
+  it('costs nothing outside a workspace, or with nothing to annotate', async () => {
+    await initDb(B);
+    await expect(annotateDisputes([{ id: ownedByB }], null)).resolves.toEqual([{ id: ownedByB }]);
+    const workspace = await resolveWorkspace(B, await loadConfig(B));
+    await expect(annotateDisputes([], workspace)).resolves.toEqual([]);
+    await closeDb();
+  });
+
+  it('a peer with no dissents table degrades to no annotation, never an error', async () => {
+    await withDissentsTableHidden(A, async () => {
+      const workspace = await inB();
+      await expect(annotateDisputes([{ id: ownedByB }], workspace)).resolves.toEqual([{ id: ownedByB }]);
+      await closeDb();
+    });
   });
 });

--- a/tests/workspace/dissents.test.ts
+++ b/tests/workspace/dissents.test.ts
@@ -11,7 +11,9 @@ import { workspaceManifestPath } from '../../src/workspace/paths.js';
 import { joinWorkspace } from '../../src/workspace/membership.js';
 import { resolveWorkspace } from '../../src/workspace/resolve.js';
 import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
-import { createDissent, withdrawDissent } from '../../src/workspace/dissents.js';
+import {
+  createDissent, listIncomingDissents, listOutgoingDissents, rejectDissent, withdrawDissent,
+} from '../../src/workspace/dissents.js';
 
 /**
  * A dissent is one repo's recorded disagreement with an atom another repo owns.
@@ -231,6 +233,147 @@ describe('createDissent', () => {
   it('withdraw refuses an id this store does not hold', async () => {
     await initDb(A);
     await expect(withdrawDissent('not-a-dissent-here')).rejects.toThrow(/No dissent/i);
+    await closeDb();
+  });
+});
+
+describe('the owner side', () => {
+  let ownedByB = '';
+
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
+    await seed(A, 'a', 'Local auth note', 'Auth tokens expire locally.');
+    ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'ws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'ws', repoName: 'b' });
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  /** Raise a dissent from `a` against `b`'s atom, then leave `a` closed. */
+  async function dissentFromA(claim = 'The TTL is five minutes, not fifteen.'): Promise<string> {
+    await initDb(A);
+    const workspace = await resolveWorkspace(A, await loadConfig(A));
+    const { id } = await createDissent({ targetItemId: ownedByB, claim }, workspace);
+    await closeDb();
+    return id;
+  }
+
+  const inB = async () => {
+    await initDb(B);
+    return resolveWorkspace(B, await loadConfig(B));
+  };
+
+  it('the owning repo sees an open dissent raised against its atom', async () => {
+    await dissentFromA();
+    const workspace = await inB();
+    const incoming = await listIncomingDissents(workspace);
+    await closeDb();
+
+    expect(incoming).toHaveLength(1);
+    expect(incoming[0].fromRepo).toBe('a');
+    expect(incoming[0].targetItemId).toBe(ownedByB);
+    expect(incoming[0].targetTitle).toBe('Auth token TTL');
+    expect(incoming[0].claim).toContain('five minutes');
+    expect(incoming[0].staleAgainstCurrentRevision).toBe(false);
+  });
+
+  it('a withdrawn dissent stops being incoming', async () => {
+    const id = await dissentFromA();
+    await initDb(A);
+    await withdrawDissent(id);
+    await closeDb();
+
+    const workspace = await inB();
+    const incoming = await listIncomingDissents(workspace);
+    await closeDb();
+    expect(incoming).toHaveLength(0);
+  });
+
+  it('rejecting it clears it, and the rejection is written in the owner\'s own store', async () => {
+    const id = await dissentFromA();
+    const workspace = await inB();
+    await rejectDissent(id, ownedByB, 'Measured at fifteen; the five-minute figure is the refresh window.');
+    const incoming = await listIncomingDissents(workspace);
+    const local = await getClient().execute({ sql: 'SELECT * FROM dissent_resolutions', args: [] });
+    await closeDb();
+
+    expect(incoming).toHaveLength(0);
+    expect(local.rows).toHaveLength(1);
+    expect(String(local.rows[0].resolution)).toBe('rejected');
+    // Written by the owner, about a dissent that lives in the peer's store. That asymmetry is
+    // the design: neither repo writes the other's database.
+    expect(String(local.rows[0].dissent_id)).toBe(id);
+  });
+
+  it('the rejection did not reach the dissenting repo\'s store', async () => {
+    const id = await dissentFromA();
+    const workspace = await inB();
+    await rejectDissent(id, ownedByB, 'Measured at fifteen.');
+    await closeDb();
+    void workspace;
+
+    expect(await peerRowCount(A, 'dissent_resolutions')).toBe(0);
+    await initDb(A);
+    const stillOpen = await getClient().execute({ sql: 'SELECT status FROM dissents WHERE id = ?', args: [id] });
+    await closeDb();
+    // The dissenter's own record is untouched -- it still says what that repo believes.
+    expect(String(stillOpen.rows[0].status)).toBe('open');
+  });
+
+  it('rewriting the disputed atom stales the dissent out, because the objection was to what it said', async () => {
+    await dissentFromA();
+    await initDb(B);
+    const item = (await repo.getKnowledgeItem(ownedByB))!;
+    await repo.updateKnowledgeItem(ownedByB, { content: 'Auth tokens expire after five minutes.' });
+    void item;
+    const workspace = await resolveWorkspace(B, await loadConfig(B));
+    const incoming = await listIncomingDissents(workspace);
+    await closeDb();
+
+    expect(incoming.every(entry => entry.staleAgainstCurrentRevision)).toBe(true);
+  });
+
+  it('rejecting refuses a target this repo does not own', async () => {
+    const id = await dissentFromA();
+    await initDb(A);
+    await expect(rejectDissent(id, 'no-such-item-000', 'nope')).rejects.toThrow(/No knowledge item|not yours/i);
+    await closeDb();
+  });
+
+  it('the dissenting repo can list what it has raised', async () => {
+    const id = await dissentFromA();
+    await initDb(A);
+    const outgoing = await listOutgoingDissents();
+    await closeDb();
+
+    // By id rather than by count: on Windows a fixture directory occasionally survives its own
+    // removal while libSQL still holds the sidecar, so a count asserts fixture isolation rather
+    // than the listing this test is about.
+    const raised = outgoing.find(entry => entry.id === id);
+    expect(raised).toBeDefined();
+    expect(raised!.targetRepo).toBe('b');
+    expect(raised!.status).toBe('open');
+  });
+
+  it('a peer with no dissents table contributes nothing rather than failing the listing', async () => {
+    // An older build's store, or one never used. The overlay runs on every workspace read, so
+    // this must degrade to "no dissents" and never to an error.
+    await initDb(A);
+    await getClient().execute('DROP TABLE dissents');
+    await closeDb();
+
+    const workspace = await inB();
+    await expect(listIncomingDissents(workspace)).resolves.toEqual([]);
     await closeDb();
   });
 });

--- a/tests/workspace/dissents.test.ts
+++ b/tests/workspace/dissents.test.ts
@@ -4,6 +4,14 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeDb, getClient, initDb } from '../../src/store/database.js';
 import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { storeKnowledgeItemDeduped } from '../../src/store/knowledge-writer.js';
+import { createManifest, writeManifest } from '../../src/workspace/manifest.js';
+import { workspaceManifestPath } from '../../src/workspace/paths.js';
+import { joinWorkspace } from '../../src/workspace/membership.js';
+import { resolveWorkspace } from '../../src/workspace/resolve.js';
+import { DEFAULT_CONFIG, loadConfig, saveConfig } from '../../src/core/config.js';
+import { createDissent, withdrawDissent } from '../../src/workspace/dissents.js';
 
 /**
  * A dissent is one repo's recorded disagreement with an atom another repo owns.
@@ -75,5 +83,154 @@ describe('dissent schema', () => {
     expect(names).toContain('claim');
     expect(names).toContain('replacement_item_id');
     expect(names).toContain('status');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Two linked repos on one machine: `a` dissents, `b` owns. Under os.tmpdir() for the reason the
+// foreign-item suites record -- inside the repository, saveConfig races a Windows EPERM rename.
+// ---------------------------------------------------------------------------------------------
+
+const HOME = path.join(os.tmpdir(), 'knowl-dissent-home');
+const A = path.join(os.tmpdir(), 'knowl-dissent-a');
+const B = path.join(os.tmpdir(), 'knowl-dissent-b');
+
+async function seed(root: string, name: string, title: string, content: string): Promise<string> {
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await saveConfig(root, { ...DEFAULT_CONFIG });
+  await initDb(root);
+  await getClient().execute('DELETE FROM knowledge_commits');
+  await getClient().execute('DELETE FROM knowledge_items');
+  const projectId = (await repo.createProject(root, name)).id;
+  const stored = await storeKnowledgeItemDeduped(projectId, { category: 'decision', title, content });
+  await getClient().execute({
+    sql: 'UPDATE knowledge_items SET visibility = ?, origin_repo = ? WHERE id = ?',
+    args: ['workspace', name, stored.item.id],
+  });
+  await closeDb();
+  return stored.item.id;
+}
+
+async function peerRowCount(root: string, table: string): Promise<number> {
+  await initDb(root);
+  try {
+    const rows = await getClient().execute({ sql: `SELECT count(*) AS n FROM ${table}`, args: [] });
+    return Number(rows.rows[0].n);
+  } finally {
+    await closeDb();
+  }
+}
+
+describe('createDissent', () => {
+  let ownedByB = '';
+  let ownedByA = '';
+
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await writeManifest(workspaceManifestPath('ws'), createManifest('ws', null));
+    ownedByA = await seed(A, 'a', 'Local auth note', 'Auth tokens expire locally.');
+    ownedByB = await seed(B, 'b', 'Auth token TTL', 'Auth tokens expire after fifteen minutes.');
+    await joinWorkspace({ projectRoot: A, workspaceName: 'ws', repoName: 'a' });
+    await joinWorkspace({ projectRoot: B, workspaceName: 'ws', repoName: 'b' });
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb();
+    await releaseAll();
+    for (const dir of [HOME, A, B]) await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const inA = async () => {
+    await initDb(A);
+    return resolveWorkspace(A, await loadConfig(A));
+  };
+
+  it('records a dissent against a peer\'s atom, pinning the revision it was raised against', async () => {
+    const workspace = await inA();
+    const result = await createDissent({ targetItemId: ownedByB, claim: 'The TTL is five minutes, not fifteen.' }, workspace);
+
+    expect(result.targetRepo).toBe('b');
+    const rows = await getClient().execute({ sql: 'SELECT * FROM dissents', args: [] });
+    await closeDb();
+
+    expect(rows.rows).toHaveLength(1);
+    const row = rows.rows[0];
+    expect(String(row.target_repo)).toBe('b');
+    expect(String(row.target_item_id)).toBe(ownedByB);
+    expect(String(row.status)).toBe('open');
+    expect(String(row.claim)).toContain('five minutes');
+    // The pin is what lets the owner's rewrite stale this out rather than carry it forward.
+    expect(String(row.target_content_hash).length).toBeGreaterThan(0);
+  });
+
+  it('writes nothing whatsoever into the repo it disagrees with', async () => {
+    // The whole design in one assertion: disagreement never reaches the owner's database.
+    const itemsBefore = await peerRowCount(B, 'knowledge_items');
+    const workspace = await inA();
+    await createDissent({ targetItemId: ownedByB, claim: 'The TTL is five minutes, not fifteen.' }, workspace);
+    await closeDb();
+
+    expect(await peerRowCount(B, 'knowledge_items')).toBe(itemsBefore);
+    expect(await peerRowCount(B, 'dissents')).toBe(0);
+  });
+
+  it('refuses an atom this repo owns, and says what to do instead', async () => {
+    const workspace = await inA();
+    await expect(createDissent({ targetItemId: ownedByA, claim: 'Wrong.' }, workspace))
+      .rejects.toThrow(/yours to change/i);
+    await closeDb();
+  });
+
+  it('refuses an id no repo in the workspace holds', async () => {
+    const workspace = await inA();
+    await expect(createDissent({ targetItemId: 'no-such-item-000', claim: 'Wrong.' }, workspace))
+      .rejects.toThrow(/No knowledge item/i);
+    await closeDb();
+  });
+
+  it('refuses outside a workspace rather than recording a dissent nobody can receive', async () => {
+    await initDb(A);
+    await expect(createDissent({ targetItemId: ownedByB, claim: 'Wrong.' }, null))
+      .rejects.toThrow(/workspace/i);
+    await closeDb();
+  });
+
+  it('refuses a claim carrying a secret, and writes nothing', async () => {
+    const workspace = await inA();
+    const countRows = async () => Number(
+      (await getClient().execute({ sql: 'SELECT count(*) AS n FROM dissents', args: [] })).rows[0].n,
+    );
+    // Relative, not absolute: on Windows a previous case's fixture directory occasionally
+    // survives its own removal while libSQL still holds the sidecar, and an absolute zero would
+    // then fail for a reason that has nothing to do with secret handling.
+    const before = await countRows();
+    await expect(createDissent({
+      targetItemId: ownedByB,
+      claim: 'The real value is AKIAIOSFODNN7EXAMPLE and the doc is wrong.',
+    }, workspace)).rejects.toThrow(/secret material/i);
+    const after = await countRows();
+    await closeDb();
+    expect(after).toBe(before);
+  });
+
+  it('withdraw flips this repo\'s own row and nothing else', async () => {
+    const workspace = await inA();
+    const { id } = await createDissent({ targetItemId: ownedByB, claim: 'The TTL is five minutes.' }, workspace);
+    await withdrawDissent(id);
+    const rows = await getClient().execute({ sql: 'SELECT status, withdrawn_at FROM dissents WHERE id = ?', args: [id] });
+    await closeDb();
+
+    expect(String(rows.rows[0].status)).toBe('withdrawn');
+    expect(rows.rows[0].withdrawn_at).not.toBeNull();
+  });
+
+  it('withdraw refuses an id this store does not hold', async () => {
+    await initDb(A);
+    await expect(withdrawDissent('not-a-dissent-here')).rejects.toThrow(/No dissent/i);
+    await closeDb();
   });
 });


### PR DESCRIPTION
## What

A repo can record that a **linked repo's** item is wrong, and from that moment every query returning that item — in any repo in the workspace — carries the dispute.

```
knowl dissent record 5fdbe969633c418d --claim "The TTL is five minutes; measured on staging."
```

Agents get `knowl_dissent` in a linked repo (`record | list | reject | withdraw | reopen`), and a `disputed` block on every `knowl_query` result — search and id-fetch — that names the repo contesting it and the claim.

## Why

One repo owns an item and only that repo may change it. That rule is right — it is what stops a neighbour silently retiring knowledge its owner had good reason to hold. But on its own it leaves the repo that *noticed* the error with nowhere to put what it found: the write is refused and the finding is lost.

This is the resolution recorded in the blocked workspace-v2 decision, way out #2 — *"design an explicit proposal/accept authorization workflow — feature-sized, does not exist."* That decision blocked v2 for promising cross-owner editing and forbidding it in the same document, because the only shape considered was one repo reaching into another's rows. This is the other shape.

## The design in one line

**Neither repo ever writes the other's database.** The dissent lives in the store of the repo that raised it; the resolution lives in the store of the repo that owns the item; they are joined only when something is read. `assertOwnedItem` is untouched and `tests/mcp/foreign-item-refusal.test.ts` passes unchanged.

## The product decision worth arguing about

**A dissent marks the atom at the point of use, rather than sitting in a queue.**

The alternative — record it, notify the owner, change nothing until they act — was considered and rejected. It leaves the system knowingly serving a fact one of its own repos has flagged as wrong, at full confidence, until somebody happens to open a queue. It is also the git-PR model minus the part that makes git work: a PR blocks the merge, so the wrong code does not ship while it is open. A dissent blocks nothing.

Marking is bounded in a way superseding is not. The worst case is that a correct atom reads as *disputed* — it is still returned, still readable, and the owner can reject the dissent. A supersede makes the atom vanish from results. Those are not the same kind of harm.

It is also what the rest of the codebase already does. Supersession retires the predecessor so the wrong one stops being returned; the cross-repo overlap detector fires on every write rather than into a report; drift marks atoms stale; `pathsChanged` says "verify" on the row itself. The house answer to "when should the user learn something" is *at the point of use*.

## Ending a dispute

- **Accept** — supersede the item, as the owner always could. The dispute clears itself because a retired atom is not returned. **There is deliberately no accept verb.**
- **Reject** — the item stands and stops reading as disputed. The other repo keeps its own record of disagreeing; rejecting answers it rather than deleting it.
- **Rewrite** — a dissent is pinned to the revision it was raised against, so the owner rewriting the item stales it out. The objection was to what the item *said*.
- **Withdraw** — the raising repo takes it back.

`reject` has an inverse, `reopen`, and deliberately from the start. A rejection is a judgement made on partial information — the other repo is the one that saw the problem — and shipping it irreversible would repeat the shape of `workspace promote`, whose missing inverse has cost something every day since. It is safe precisely because the resolution row is local and additive.

## Notes for review

- **`KNOWL_MIGRATION_LEVEL` 16 → 17**, and it is load-bearing. `annotateDisputes` reads both tables on every workspace query, so a store left at 16 would skip `SCHEMA_STATEMENTS`, never create them, and fail *ordinary reads* — the failure level 6 records for `knowledge_forget_log`. `KNOWL_SCHEMA_VERSION` stays at 1. The schema pin for 17 is `7a690fc55d186b8106ea27c647685bd3`.
- **The overlay reads both repos' stores.** A third repo holds neither half, so reading only locally would leave every settled dispute looking open to everyone except the two repos involved. Pinned by a test that rejects from `b` and reads from `a`.
- **Staleness is judged against the owner's current row**, not the item passed in — callers hand the overlay compact search results whose content is truncated by design, and hashing that would make every atom read as rewritten.
- **No ranking change.** The overlay annotates and preserves input order exactly, pinned by a test. Demoting on dissent would let a neighbour push another repo's knowledge down the ranking — the blast radius the single-owner rule exists to prevent, arriving by a quieter route. If disputed atoms should rank lower, that is a separate change with its own measurement.
- **Cloud-owned items are refused.** A dissent against a team-replica row would sit on one machine forever, invisible to whoever could act on it, while reading as though something had been done. **This is what keeps the server-side impact of this PR at exactly zero.**
- **`dissents` and `dissent_resolutions` are `preserved` in snapshots**, beside tombstones and the forget log: restoring older knowledge is not a statement that anyone changed their mind, so `restored` would resurrect withdrawn dissents and un-reject settled disputes.
- **The id-fetch path resolves the workspace on a local hit too**, where #109 resolved it only on a miss. A local item can be disputed, and its owner fetching it whole is exactly who needs to be told. The namespace-layered lookup from #261/#264 is kept as-is underneath.
- **One tool more when linked into a local workspace** — README's count moves from 1 to 2 on that clause; the base 28 is unchanged.

## Server / knowl-cloud

**Zero changes, and by construction rather than by luck.** The team replica is a peer with no `dissents` table, which the overlay treats as empty; and cloud-owned targets are refused outright. If dissents should ever cross machines, that lands at the recorded sync-contract seam — dissent and resolution row types in `packages/contract`, a server table with RLS — and the rule at review time is: never land the server half without the client caller.

## Open, for you

Reader-role dissent rights if this ever syncs; rank demotion (only with measurement); whether dissents belong in `knowl export`.

## History

Built 2026-08-15 stacked on #109 and opened, by mistake, against the fork's own `feat/foreign-atom-read` branch rather than here — so it has been finished and invisible for three and a half weeks. Rebased onto `main` at 8e16c55 today; the two #109 commits it carried are dropped since #109 landed, and the seven dissent commits are unchanged in substance. Merge points, for the diff reader: the migration-level and schema-pin bumps, the `WORKSPACE` guidance bullet now sitting after the `repo:` one, the `pathsChanged` and `disputed` annotations coexisting in `tools.ts`, and `AGENTS.md` left untracked per #172.

## Verification

On the rebased branch at its head, after `npm ci` and `npm run build`:

| Gate | Result |
|---|---|
| `npm test` | **424 files passed, 4000 tests passed, 5 skipped, 0 failed** |
| `npm run typecheck` | clean |
| `npm run lint` | clean |
| `npm run docs:check` | "Generated documentation regions are current, and every tool and command is documented." |
| `tests/store/schema-pin.test.ts` | 8/8 — the level-17 pin is the value the test itself demanded, not a guess |
| `tests/mcp/foreign-item-refusal.test.ts` | unchanged and passing — the ownership rule is untouched |

New tests carried by the branch: `tests/workspace/dissents.test.ts` (529 lines: record, list, reject, reopen, withdraw, staleness against a rewrite, the both-stores overlay read from a third repo, order preservation, cloud-owned refusal) and `tests/mcp/dissent-tool.test.ts` (183 lines: the tool's gating on a workspace, each action's shape, and the `disputed` block on search and on id-fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
