### PR TITLE
fix(openclaw): the session-start card must reach the model, and a workspace is a path, not a prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Notable changes to `@dat999zx/knowl`. Versions before 2.1.0 predate this file; see the
 [git tags](https://github.com/dat999zx/knowl/tags) for that history.
 
+## Unreleased
+
+**The OpenClaw bootstrap card was being thrown away, on every session.** The profile registered `session_start`, so the engine bound the session and spent the bootstrap card on an event whose return value OpenClaw discards — and the first real turn (`before_prompt_build`) then arrived on a session the engine had already seen, with nothing to say. Measured: a fresh session whose first event is `before_prompt_build` gets the orientation card; the same session preceded by `session_start` got an empty answer with zero prepend context. That event is no longer mapped to the engine lifecycle, so the first `before_prompt_build` binds the session and carries the card. The plugin continues to register `session_start` solely to warm the workspace handle cache in memory so the initial write gate avoids cold open latency.
+
+**A workspace is a path, not a prefix.** `OpenClawEngineManager` matched cached workspace handles by string prefix (`cwd.startsWith(root)`), so sibling directories that share a name prefix (such as `knowl` and `knowl-cloud`) collided on lookup: whichever warmed first captured subsequent requests for the other, reading and writing atoms to the wrong project's database. Workspace matching in `getHandle` and `releaseWorkspace` now enforces a path boundary via `path.relative`, ensuring a workspace matches only itself or directories beneath it.
+
 ## 5.22.1 — 2026-09-07
 
 **The skill run banner no longer corrupts the MCP transport.** `runSkillPackage` wrote its banner with `console.log`, and it has two callers that disagree about what stdout is: on the CLI it is the operator's terminal, under `knowl serve` it is the JSON-RPC frame stream. `knowl_skill_run` calls the same function inside a stdio MCP server, so the banner was interleaved into the protocol and the client failed to parse the response to a call whose skill had actually run — an action taken, reported as a transport error. It goes to stderr now, the choice `knowl serve` already makes for its own startup banner.

--- a/docs/superpowers/plans/2026-09-09-openclaw-card-and-path-boundary.md
+++ b/docs/superpowers/plans/2026-09-09-openclaw-card-and-path-boundary.md
@@ -1,0 +1,89 @@
+# Plan: OpenClaw card delivery + workspace path boundary
+
+Spec: `docs/superpowers/specs/2026-09-09-openclaw-card-and-path-boundary.md`. Read it first.
+Branch `fix/openclaw-card-and-path`, baseline `8e16c55`. Two commits, one per finding, tests
+first in each.
+
+## Task 1 — N2: the session-start card must reach the model
+
+**Test first.** In `tests/integrations/openclaw/hooks.test.ts`, inside the existing
+`describe('OpenClaw hooks: recall card')`, add:
+
+```
+it('session_start does not spend the card: the first before_prompt_build after it still carries context', ...)
+```
+- `knowl init --yes` a scratch dir (copy the pattern at `:63`), write the no-fleet config (`:67-69`).
+- `register(api)`, get `session_start` and `before_prompt_build` handlers.
+- `ctx = { workspaceDir: dir, sessionId: 'oc-n2-1', sessionKey: 'main' }`.
+- `await sessionStart({}, ctx)` then `const r = await promptHook({ prompt: 'hi' }, ctx)`.
+- Assert `r?.prependContext` is a non-empty string.
+
+Run it. It must FAIL with length 0 on the baseline. If it passes, stop — the premise is wrong.
+
+**Profile test.** In `tests/cli/hosts/` add or extend an openclaw profile test (mirror
+`hermes-profile.test.ts:11,36`):
+- `openclawProfile.normalizedEvent('session_start')` → `undefined`
+- `OPENCLAW_PLUGIN_EVENTS` does not contain `'session_start'`
+- `openclawProfile.normalizedEvent('before_prompt_build')` → `'turn-start'` (unchanged)
+
+**Fix.**
+- `src/session/hosts/openclaw.ts`: delete the `session_start: 'session-start'` line from
+  `OPENCLAW_EVENT_MAP`. Replace the `session_start` paragraph in the docblock (lines 29-30) with a
+  paragraph in the shape of `hermes.ts:9-16`: it is absent on purpose, why, and that warming still
+  happens in the plugin.
+- `integrations/openclaw/src/index.ts:452-477`: the `session_start` handler becomes
+  `warmWorkspace` only. Delete `raw`, `payload`, `normalized`, and the `withDeadline(...)` call.
+  Rewrite the comment above it: warms the handle so the first gate is not a cold open; does NOT
+  touch the lifecycle because OpenClaw discards this hook's return and the card would be lost —
+  the first `before_prompt_build` binds the session and carries it.
+- `integrations/openclaw/README.md:79`: the table row for `session_start` should say "warm" not
+  "bind".
+
+Run: the new test, the profile test, the whole `tests/integrations/openclaw/` dir, and
+`tests/cli/openclaw-adapter.test.ts`. All green.
+
+Commit: `fix(openclaw): the session-start card must reach the model`
+
+## Task 2 — N1: a workspace is a path, not a prefix
+
+**Test first.** In `tests/integrations/openclaw/engine.test.ts`, add:
+
+```
+it('getHandle does not let a sibling directory that shares a prefix capture the lookup', ...)
+```
+- Create `<scratch>/knowl` and `<scratch>/knowl-cloud`, `knowl init --yes` both.
+- `manager.warmWorkspace('<scratch>/knowl')`.
+- `const h = await manager.getHandle('<scratch>/knowl-cloud')`.
+- Assert `h?.projectRoot` equals `<scratch>/knowl-cloud` (normalise with `path.resolve` on both
+  sides; the engine returns whatever `openProject` resolved).
+- Also assert `getHandle('<scratch>/knowl/src')` (mkdir it) returns the `<scratch>/knowl` handle —
+  nested paths must still hit the cache.
+- `releaseAll()` in a `finally`.
+
+Run it. It must FAIL on the baseline (projectRoot will be `<scratch>/knowl`).
+
+**Fix.** In `integrations/openclaw/src/engine.ts`:
+- `import path from 'node:path';`
+- Add one module-level helper:
+  ```ts
+  /** True when `cwd` is `root` or somewhere beneath it -- a path boundary, not a string prefix. */
+  function isWithin(root: string, cwd: string): boolean {
+    const rel = path.relative(root, cwd);
+    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  }
+  ```
+- `:131` → `.find((h) => isWithin(h.projectRoot, cwd))`
+- `:185` → `([root]) => isWithin(root, cwd)`
+
+Run `tests/integrations/openclaw/`. Green.
+
+Commit: `fix(openclaw): a workspace is a path, not a prefix`
+
+## Task 3 — changelog + gate
+
+- `CHANGELOG.md`: under the Unreleased heading (look at how the top of the file is structured
+  and match it), one paragraph per fix in the voice of the existing entries — the Hermes entry at
+  ~line 194 is the model for the N2 one.
+- Full gate: `npm run build && npm run typecheck && npm run lint && npm test`.
+
+Commit: `docs(changelog): the OpenClaw card and the path boundary`

--- a/docs/superpowers/specs/2026-09-09-openclaw-card-and-path-boundary.md
+++ b/docs/superpowers/specs/2026-09-09-openclaw-card-and-path-boundary.md
@@ -1,0 +1,87 @@
+# OpenClaw plugin: the card must reach the model, and a workspace is a path, not a prefix
+
+Date: 2026-09-09. Findings N1 and N2 of `docs/research` 2026-09-08 ultimate run, §3.1. Both
+re-verified in this tree at `8e16c55`.
+
+## What is broken
+
+### N2 — the session-start card is spent on an event that cannot carry it
+
+`integrations/openclaw/src/index.ts:454-477` registers `session_start` and maps it to the
+engine's `session-start`. That event binds the session and composes the bootstrap card. OpenClaw
+discards `session_start`'s return value, so the card goes nowhere. The next
+`before_prompt_build` (`turn-start`) finds the session already bound and takes the
+`bootstrapWithHandoff(…, 'turn', false, …)` branch at `src/session/host-lifecycle.ts:1083` —
+`includeContext=false` — so it composes nothing.
+
+Measured in this worktree with a scratch `knowl init` project: `session_start` then
+`before_prompt_build` → `prependContext` length **0**. Without the `session_start` call the same
+prompt hook returns a card (the existing #257 test at `tests/integrations/openclaw/hooks.test.ts:56`
+proves this — it never fires `session_start`).
+
+Net: every real OpenClaw session gets zero engine memory. The plugin is dead for its main purpose.
+
+### N1 — workspace lookup matches by string prefix
+
+`integrations/openclaw/src/engine.ts:131`:
+```ts
+this.handles.values()).find((h) => cwd.startsWith(h.projectRoot))
+```
+and the same shape at `:185` in `releaseWorkspace`. `C:/Code/knowl-cloud` starts with
+`C:/Code/knowl`. Whichever warms first captures the other: a hook in knowl-cloud reads knowl's
+atoms, and — since the handle carries the write gate and capture — writes capture rows into
+knowl's store and reports success.
+
+## The fix
+
+### N2: follow Hermes
+
+Hermes hit this exact bug and the fix is recorded at `src/session/hosts/hermes.ts:9-16` and
+CHANGELOG 5.2x ("The Hermes bootstrap card was being thrown away"): **do not map the
+session-start event.** Let the first `turn-start` bind the session and carry the card — the
+`!sessionBinding && sharesSessionBinding` branch at `host-lifecycle.ts:1071` does exactly that,
+and `openclawProfile.sharesSessionBinding` is already `true`.
+
+Concretely:
+- `src/session/hosts/openclaw.ts`: remove `session_start` from `OPENCLAW_EVENT_MAP`. Update the
+  docblock the way Hermes' does — say why it is absent.
+- `integrations/openclaw/src/index.ts`: the `session_start` handler keeps
+  `manager.warmWorkspace(cwd)` (the cold-open warm is real and cheap) and **stops calling
+  `handle.lifecycle`**. Nothing else changes.
+
+Not the fix: "assign the result of `withDeadline`". There is nowhere to deliver it — OpenClaw
+ignores that hook's return. Assigning it would be dead code.
+
+### N1: path boundary
+
+Replace both `startsWith` matches with a boundary check. `path.relative` already exists in this
+file's neighbour (`index.ts:110`, `toRepoRelativePath`) and is the shape the repo uses:
+
+```ts
+function isWithin(root: string, cwd: string): boolean {
+  const rel = path.relative(root, cwd);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+```
+
+Use it at `engine.ts:131` and `:185`. One helper, two callers, no new dependency.
+
+## Out of scope
+
+N3–N7 from the same table (session-id fallback, migration fail-open, `process.cwd()` fallback,
+validation options, write-gate matcher). Each is its own PR per the research doc's grouping.
+
+## Acceptance
+
+1. A test that fires `session_start` then `before_prompt_build` on the same session and asserts a
+   non-empty `prependContext`. **Fails on `8e16c55`, passes after.**
+2. A test that warms `<tmp>/knowl` then asks `getHandle('<tmp>/knowl-cloud')` (a second
+   initialised project) and asserts the returned handle's `projectRoot` is `<tmp>/knowl-cloud`.
+   **Fails on `8e16c55`, passes after.**
+3. `tests/cli/hosts/hermes-profile.test.ts:11` has the profile-level assertion for Hermes; add the
+   same for OpenClaw: `openclawProfile.normalizedEvent('session_start')` is `undefined` and
+   `OPENCLAW_PLUGIN_EVENTS` does not contain `'session_start'` (it is derived from the map, so
+   this follows). The plugin still registers the `session_start` hook for warming — that is
+   fine; `pluginEvents` documents what the *engine* sees, not what the host fires.
+4. Existing `session_start warms workspace and gateway_stop releases all handles` test still passes.
+5. Full gate: `npm run build && npm run typecheck && npm run lint && npm test`.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -76,7 +76,7 @@ there: `npm pack --ignore-scripts` skips `prepack` and produces a tarball contai
 | `registerAgentToolResultMiddleware` | The impact card, injected before the model sees tool output. |
 | `after_tool_call` | Capture. |
 | `before_compaction` | Checkpoint before the conversation is compressed. |
-| `session_start` / `session_end` / `agent_end` / `gateway_stop` | Bind, close, release. |
+| `session_start` / `session_end` / `agent_end` / `gateway_stop` | Warm, close, release. |
 
 **`before_prompt_build` does not dispatch on every surface.** On OpenClaw 2026.9.1 it fires under
 the `claude-cli` backend and does not fire on the embedded runner — for bundled and non-bundled

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -1,9 +1,16 @@
+import path from 'node:path';
 import { createClient } from '@libsql/client';
 import {
   openProject,
   KNOWL_MIGRATION_LEVEL,
   type ProjectHandle,
 } from '@dat999zx/knowl/plugin';
+
+/** True when `cwd` is `root` or somewhere beneath it -- a path boundary, not a string prefix. */
+function isWithin(root: string, cwd: string): boolean {
+  const rel = path.relative(root, cwd);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
 
 export interface HostLogger {
   warn(message: string, ...args: unknown[]): void;
@@ -128,7 +135,7 @@ export class OpenClawEngineManager {
   }
 
   async getHandle(cwd: string): Promise<ProjectHandle | null> {
-    const cached = Array.from(this.handles.values()).find((h) => cwd.startsWith(h.projectRoot));
+    const cached = Array.from(this.handles.values()).find((h) => isWithin(h.projectRoot, cwd));
     if (cached) return cached;
     return await this.warmWorkspace(cwd);
   }
@@ -200,7 +207,7 @@ export class OpenClawEngineManager {
 
   async releaseWorkspace(cwd: string): Promise<void> {
     const matching = Array.from(this.handles.entries()).filter(
-      ([root]) => cwd === root || cwd.startsWith(root),
+      ([root]) => isWithin(root, cwd),
     );
     for (const [root, handle] of matching) {
       this.handles.delete(root);

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -19,6 +19,21 @@ function isWithin(root: string, cwd: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
+/**
+ * The cached handle whose root is the nearest ancestor of `cwd` -- the longest containing
+ * root wins, so a project nested inside another (`mono` and `mono/packages/api`) resolves by
+ * ownership rather than by which one was warmed first. Same rule `findProjectRoot` applies
+ * walking up to the nearest marker.
+ */
+function findCachedHandle(handles: Iterable<ProjectHandle>, cwd: string): ProjectHandle | undefined {
+  let best: ProjectHandle | undefined;
+  for (const handle of handles) {
+    if (!isWithin(handle.projectRoot, cwd)) continue;
+    if (!best || handle.projectRoot.length > best.projectRoot.length) best = handle;
+  }
+  return best;
+}
+
 export interface HostLogger {
   warn(message: string, ...args: unknown[]): void;
   error?(message: string, ...args: unknown[]): void;
@@ -142,7 +157,7 @@ export class OpenClawEngineManager {
   }
 
   async getHandle(cwd: string): Promise<ProjectHandle | null> {
-    const cached = Array.from(this.handles.values()).find((h) => isWithin(h.projectRoot, cwd));
+    const cached = findCachedHandle(this.handles.values(), cwd);
     if (cached) return cached;
     return await this.warmWorkspace(cwd);
   }

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -1,14 +1,21 @@
 import path from 'node:path';
 import { createClient } from '@libsql/client';
 import {
+  canonicalProjectRoot,
   openProject,
   KNOWL_MIGRATION_LEVEL,
   type ProjectHandle,
 } from '@dat999zx/knowl/plugin';
 
-/** True when `cwd` is `root` or somewhere beneath it -- a path boundary, not a string prefix. */
+/**
+ * True when `cwd` is `root` or somewhere beneath it -- a path boundary, not a string prefix.
+ *
+ * Both sides are canonical so the check agrees with the keys of `handles` and `disabledRoots`.
+ * `path.relative` already folds case on win32, so the fold here is not what makes `D:\project`
+ * match `d:\project`; it is what keeps this one rule the same as the map lookups.
+ */
 function isWithin(root: string, cwd: string): boolean {
-  const rel = path.relative(root, cwd);
+  const rel = path.relative(canonicalProjectRoot(root), canonicalProjectRoot(cwd));
   return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
@@ -127,11 +134,11 @@ export class OpenClawEngineManager {
   }
 
   isDisabled(projectRoot: string): boolean {
-    return this.disabledRoots.has(projectRoot);
+    return this.disabledRoots.has(canonicalProjectRoot(projectRoot));
   }
 
   getDisabledReason(projectRoot: string): string | undefined {
-    return this.disabledRoots.get(projectRoot);
+    return this.disabledRoots.get(canonicalProjectRoot(projectRoot));
   }
 
   async getHandle(cwd: string): Promise<ProjectHandle | null> {
@@ -141,7 +148,7 @@ export class OpenClawEngineManager {
   }
 
   async warmWorkspace(cwd: string): Promise<ProjectHandle | null> {
-    if (this.disabledRoots.has(cwd)) {
+    if (this.disabledRoots.has(canonicalProjectRoot(cwd))) {
       return null;
     }
 
@@ -155,7 +162,10 @@ export class OpenClawEngineManager {
 
     if (!handle) return null;
 
-    const root = handle.projectRoot;
+    // Keyed by the canonical root: on Windows a hook payload's `cwd` reports `D:\project`
+    // while `process.cwd()` reports `d:\project`, and a raw key would open the same project
+    // twice and split one session across two handles.
+    const root = canonicalProjectRoot(handle.projectRoot);
     if (this.disabledRoots.has(root)) {
       await handle.release();
       return null;

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -449,30 +449,13 @@ export default definePluginEntry({
       }, api.logger);
     });
 
-    // Session start: maps session_start -> session-start.
-    // Warms workspace handle in memory so initial write gate avoids cold open latency.
+    // Session start: warms the handle so the first gate is not a cold open; does NOT
+    // touch the lifecycle because OpenClaw discards this hook's return and the card would
+    // be lost -- the first before_prompt_build binds the session and carries it.
     api.on('session_start', async (event, ctx) => {
       await safely(async () => {
         const cwd = resolveWorkspace(event, ctx);
-
-        const handle = await manager.warmWorkspace(cwd);
-        if (!handle) return;
-
-        const raw: Record<string, unknown> = {
-          cwd,
-          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
-          agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
-          agentType: (event as Record<string, unknown>)?.agentType,
-        };
-
-        const payload = readLifecyclePayloadObject(raw);
-        const normalized = normalizeHostHook('openclaw', 'session_start', payload as Record<string, unknown>);
-
-        await withDeadline(
-          manager.getObserverDeadlineMs(),
-          () => handle.lifecycle(normalized),
-          null,
-        );
+        await manager.warmWorkspace(cwd);
       }, api.logger);
     });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -103,6 +103,7 @@ export { normalizeHostHook } from './cli/agents/host-hook.js';
 export { readLifecyclePayloadObject } from './cli/agents/lifecycle.js';
 export { KNOWL_MIGRATION_LEVEL } from './store/schema-version.js';
 export { ProjectNotFoundError } from './core/errors.js';
+export { canonicalProjectRoot } from './core/project-path.js';
 export { MissingKnowledgeDatabaseError } from './cli/database-presence.js';
 export type { NormalizedHostHook, NormalizedHookEventName, HookHost } from './core/host-hook-types.js';
 export type { LifecyclePayload } from './cli/agents/lifecycle.js';

--- a/src/session/hosts/openclaw.ts
+++ b/src/session/hosts/openclaw.ts
@@ -26,8 +26,13 @@ import { hostString, toolNameIsShell } from './profile.js';
  * `gateway_stop` maps to `session-stop`: Full gateway shutdown closing the active session
  * and releasing cached project handles.
  *
- * `session_start` maps to `session-start`: Binds session identity and warms the project
- * handle cache in memory so subsequent write gates never suffer cold client initialization.
+ * **`session_start` is deliberately absent from the event map, and its absence is what delivers
+ * the bootstrap card.** Binding the session there spends the card on an event whose return
+ * value OpenClaw discards, and the first real `before_prompt_build` then arrives on a session the
+ * engine has already seen, so it emits nothing. Letting the first `before_prompt_build` bind the
+ * session puts the card where OpenClaw actually injects it. Warming the project handle cache
+ * still happens on `session_start` in the plugin (`integrations/openclaw/src/index.ts`) so
+ * subsequent write gates avoid cold open latency, but without touching the engine lifecycle.
  */
 const OPENCLAW_EVENT_MAP: Record<string, NormalizedHookEventName> = {
   before_prompt_build: 'turn-start',
@@ -37,7 +42,6 @@ const OPENCLAW_EVENT_MAP: Record<string, NormalizedHookEventName> = {
   session_end: 'turn-stop',
   agent_end: 'turn-stop',
   gateway_stop: 'session-stop',
-  session_start: 'session-start',
 };
 
 const openclawBlock = (blockReason: string): HostOutput => ({ block: true, blockReason });

--- a/tests/cli/hosts/openclaw-profile.test.ts
+++ b/tests/cli/hosts/openclaw-profile.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { hostProfile } from '../../../src/session/hosts/index.js';
+import { OPENCLAW_PLUGIN_EVENTS, openclawProfile } from '../../../src/session/hosts/openclaw.js';
+
+describe('openclaw profile', () => {
+  const profile = hostProfile('openclaw');
+
+  it('maps OpenClaw hook events, with session_start deliberately unmapped to deliver the bootstrap card', () => {
+    // Not mapped on purpose: binding the session there spends the bootstrap card on an event
+    // whose return value OpenClaw discards, and the first real turn then gets nothing.
+    expect(openclawProfile.normalizedEvent('session_start')).toBeUndefined();
+    expect(openclawProfile.normalizedEvent('before_prompt_build')).toBe('turn-start');
+    expect(profile.normalizedEvent('before_tool_call')).toBe('tool-precheck');
+    expect(profile.normalizedEvent('after_tool_call')).toBe('session-event');
+    expect(profile.normalizedEvent('before_compaction')).toBe('checkpoint');
+    expect(profile.normalizedEvent('session_end')).toBe('turn-stop');
+    expect(profile.normalizedEvent('agent_end')).toBe('turn-stop');
+    expect(profile.normalizedEvent('gateway_stop')).toBe('session-stop');
+  });
+
+  it('accepts every event the shipped plugin forwards except session_start', () => {
+    for (const event of OPENCLAW_PLUGIN_EVENTS) {
+      expect(openclawProfile.normalizedEvent(event), event).toBeDefined();
+    }
+    expect(OPENCLAW_PLUGIN_EVENTS).not.toContain('session_start');
+  });
+});

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -159,6 +159,34 @@ describe('OpenClaw engine wrapper failure modes', () => {
       await manager.releaseAll();
     }
   });
+
+  it.runIf(process.platform === 'win32')(
+    'a Windows cwd in different casing reuses the warmed handle instead of opening the project twice',
+    async () => {
+      // A hook payload's `cwd` reports `D:\project` while `process.cwd()` reports `d:\project`.
+      // `path.relative` already folds case, so `isWithin` was never the gap; the handle map was
+      // keyed by the raw root, so a second warm in the other casing opened a second handle.
+      const dirProject = path.join(scratchDir, 'CasedProject');
+      await fs.mkdir(dirProject, { recursive: true });
+      execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: dirProject, encoding: 'utf8' });
+
+      const manager = new OpenClawEngineManager();
+      try {
+        const warmed = await manager.warmWorkspace(dirProject);
+        expect(warmed).toBeDefined();
+
+        const swapCase = (s: string) =>
+          s.replace(/[a-zA-Z]/g, (c) => (c === c.toLowerCase() ? c.toUpperCase() : c.toLowerCase()));
+        const recased = swapCase(dirProject);
+        expect(recased).not.toBe(dirProject);
+
+        expect(await manager.warmWorkspace(recased)).toBe(warmed);
+        expect(await manager.getHandle(path.join(recased, 'src'))).toBe(warmed);
+      } finally {
+        await manager.releaseAll();
+      }
+    },
+  );
 });
 
 describe('OpenClaw engine manager: an unverifiable database is not opened', () => {

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -187,6 +187,37 @@ describe('OpenClaw engine wrapper failure modes', () => {
       }
     },
   );
+
+  it('getHandle prefers the longest containing root, so a nested project resolves by ownership not open order', async () => {
+    const dirMono = path.join(scratchDir, 'mono');
+    const dirApi = path.join(dirMono, 'packages', 'api');
+    await fs.mkdir(dirApi, { recursive: true });
+
+    // `knowl init` refuses to nest under an initialized ancestor, so the inner project is
+    // created first -- the state a subpackage that predates its monorepo's memory ends up in.
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: dirApi, encoding: 'utf8' });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: dirMono, encoding: 'utf8' });
+
+    const manager = new OpenClawEngineManager();
+    try {
+      // Outer warmed first: first-match-wins would hand the outer handle to a cwd inside `api`.
+      const outer = await manager.warmWorkspace(dirMono);
+      const inner = await manager.warmWorkspace(dirApi);
+      expect(outer).toBeDefined();
+      expect(inner).toBeDefined();
+      expect(inner).not.toBe(outer);
+
+      const dirApiSrc = path.join(dirApi, 'src');
+      await fs.mkdir(dirApiSrc, { recursive: true });
+
+      expect(await manager.getHandle(dirApiSrc)).toBe(inner);
+      expect(await manager.getHandle(dirApi)).toBe(inner);
+      expect(await manager.getHandle(path.join(dirMono, 'packages'))).toBe(outer);
+      expect(await manager.getHandle(dirMono)).toBe(outer);
+    } finally {
+      await manager.releaseAll();
+    }
+  });
 });
 
 describe('OpenClaw engine manager: an unverifiable database is not opened', () => {

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -131,6 +131,34 @@ describe('OpenClaw engine wrapper failure modes', () => {
     const cachedAttempt = await manager.getHandle(projectDir);
     expect(cachedAttempt).toBeNull();
   });
+
+  it('getHandle does not let a sibling directory that shares a prefix capture the lookup', async () => {
+    const dirKnowl = path.join(scratchDir, 'knowl');
+    const dirKnowlCloud = path.join(scratchDir, 'knowl-cloud');
+    await fs.mkdir(dirKnowl, { recursive: true });
+    await fs.mkdir(dirKnowlCloud, { recursive: true });
+
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: dirKnowl, encoding: 'utf8' });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: dirKnowlCloud, encoding: 'utf8' });
+
+    const manager = new OpenClawEngineManager();
+    try {
+      await manager.warmWorkspace(dirKnowl);
+
+      const h = await manager.getHandle(dirKnowlCloud);
+      expect(h).toBeDefined();
+      expect(path.resolve(h!.projectRoot)).toBe(path.resolve(dirKnowlCloud));
+
+      const dirKnowlSrc = path.join(dirKnowl, 'src');
+      await fs.mkdir(dirKnowlSrc, { recursive: true });
+
+      const hNested = await manager.getHandle(dirKnowlSrc);
+      expect(hNested).toBeDefined();
+      expect(path.resolve(hNested!.projectRoot)).toBe(path.resolve(dirKnowl));
+    } finally {
+      await manager.releaseAll();
+    }
+  });
 });
 
 describe('OpenClaw engine manager: an unverifiable database is not opened', () => {

--- a/tests/integrations/openclaw/hooks.test.ts
+++ b/tests/integrations/openclaw/hooks.test.ts
@@ -146,6 +146,31 @@ describe('OpenClaw hooks: recall card', () => {
 
     expect(result).toBeUndefined();
   });
+
+  it('session_start does not spend the card: the first before_prompt_build after it still carries context', async () => {
+    const dir = path.join(scratchDir, 'repo-n2');
+    await fs.mkdir(dir, { recursive: true });
+
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: dir, encoding: 'utf8' });
+
+    const noFleetConfig = JSON.stringify({ fleet: { enabled: false } }, null, 2);
+    await fs.writeFile(path.join(dir, '.knowl', 'config.json'), noFleetConfig, 'utf8');
+
+    knowlPlugin.register(api);
+
+    const sessionStart = registeredHooks.get('session_start')?.[0]?.handler;
+    const promptHook = registeredHooks.get('before_prompt_build')?.[0]?.handler;
+    expect(sessionStart).toBeDefined();
+    expect(promptHook).toBeDefined();
+
+    const ctx = { workspaceDir: dir, sessionId: 'oc-n2-1', sessionKey: 'main' };
+
+    await sessionStart!({}, ctx);
+    const r = (await promptHook!({ prompt: 'hi' }, ctx)) as { prependContext?: string } | undefined;
+
+    expect(typeof r?.prependContext).toBe('string');
+    expect(r?.prependContext?.length).toBeGreaterThan(0);
+  });
 });
 
 describe('OpenClaw hooks: write gate', () => {


### PR DESCRIPTION
Two OpenClaw plugin defects from the 2026-09-08 audit (§3.1 N1, N2). Spec and plan committed under `docs/superpowers/`.

**N2 — every OpenClaw session got zero engine memory.** The profile mapped `session_start` to `session-start`, which bound the session and composed the bootstrap card on a hook whose return value OpenClaw discards. The first `before_prompt_build` then found the session bound and emitted nothing. Measured: `session_start` → `before_prompt_build` gave `prependContext` length 0.

Fix follows the Hermes precedent (`src/session/hosts/hermes.ts:9`): `session_start` is no longer in the event map, so the first prompt hook binds the session and carries the card. The plugin still registers `session_start` for `warmWorkspace` only. The audit's suggested fix (assign the `withDeadline` result) was wrong — there is nowhere to deliver it.

**N1 — workspace matched by string prefix.** `cwd.startsWith(h.projectRoot)` let `knowl` capture `knowl-cloud`, so a hook in one repo read and wrote the other's store. Replaced with a `path.relative` boundary check at both call sites (`getHandle`, `releaseWorkspace`).

**Verification**
- Both new tests fail on the parent commit (rebuilt in a throwaway worktree) and pass after.
- Mutants: `isWithin → return true` fails the engine test; restoring `session_start` to the map fails both profile tests.
- No existing test modified. Full gate green (build, typecheck, lint, `npm test` 422/422).

Out of scope, per the audit's grouping: N3–N7.