### PR TITLE
fix(openclaw): the plugin answers hooks from the right repo, and its session card reaches the model

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -89,6 +89,11 @@ run normally.
 
 Three of these carry constraints that are not obvious from the catalog:
 
+- **The session-start card also leaves through `before_prompt_build`.** OpenClaw ignores what a
+  `session_start` handler returns, so the card the engine composes there is parked in the plugin
+  and prepended to the first prompt of that session. It has to be: the session binding
+  `session_start` creates is what makes the engine's own turn-start answer empty, so a card left
+  unclaimed there is one nothing else ever produces.
 - **Recall never reads the prompt.** `before_prompt_build` emits a *fixed* orientation card. Building
   a query from the user's sentence is the defect fixed in knowl#257 on another host, and the
   "never prompts, never transcripts" promise depends on it not recurring here.

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -1,5 +1,7 @@
+import path from 'node:path';
 import { createClient } from '@libsql/client';
 import {
+  canonicalProjectRoot,
   openProject,
   KNOWL_MIGRATION_LEVEL,
   type ProjectHandle,
@@ -100,6 +102,32 @@ export async function checkMigrationLevel(
 }
 
 /**
+ * Is `candidate` the directory `root`, or a directory inside it?
+ *
+ * `String.prototype.startsWith` is not this question and never was. It has no separator
+ * boundary, so on a machine holding `C:/Code/knowl` and `C:/Code/knowl-cloud` -- an ordinary
+ * pair, since a project and its satellite share a prefix by convention -- the second answers
+ * true against the first. The handle that answer selects carries query, the write gate and
+ * lifecycle capture, so a hook fired in one repository reads the other's atoms, is judged
+ * against the other's constraints, and writes capture rows into the other's store, with every
+ * layer reporting success.
+ *
+ * `canonicalProjectRoot` is the folding the engine already applies to a path used as a key:
+ * `path.resolve` plus a case fold on Windows only, because a hook payload's `cwd` reports
+ * `D:\project` where `process.cwd()` reports `d:\project`, while POSIX paths are genuinely
+ * case-sensitive and must not be folded together. `path.relative` then supplies the separator
+ * boundary that the string comparison lacked: a sibling yields a relative path that climbs out.
+ */
+export function pathIsWithin(root: string, candidate: string): boolean {
+  if (!root || !candidate) return false;
+  const canonicalRoot = canonicalProjectRoot(root);
+  const canonicalCandidate = canonicalProjectRoot(candidate);
+  if (canonicalRoot === canonicalCandidate) return true;
+  const relative = path.relative(canonicalRoot, canonicalCandidate);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/**
  * Manages project handles across multiple workspaces in an in-process OpenClaw gateway.
  *
  * Handles are keyed by resolved project root.
@@ -128,9 +156,33 @@ export class OpenClawEngineManager {
   }
 
   async getHandle(cwd: string): Promise<ProjectHandle | null> {
-    const cached = Array.from(this.handles.values()).find((h) => cwd.startsWith(h.projectRoot));
+    const cached = this.findCachedHandle(cwd);
     if (cached) return cached;
     return await this.warmWorkspace(cwd);
+  }
+
+  /**
+   * The open handle whose project root contains `cwd`, preferring the LONGEST such root.
+   *
+   * First-match-wins is the wrong answer for nested repositories, and the map's order is warm
+   * order rather than depth order: a monorepo at `C:/Code/mono` and a project of its own at
+   * `C:/Code/mono/packages/api` both contain a file under the second, and the file belongs to
+   * the repository that owns it, not to whichever of the two the gateway happened to open
+   * first. Longest wins, which is the same rule `findProjectRoot` applies when it walks up from
+   * a directory and stops at the nearest marker.
+   */
+  private findCachedHandle(cwd: string): ProjectHandle | undefined {
+    let best: ProjectHandle | undefined;
+    let bestLength = -1;
+    for (const handle of this.handles.values()) {
+      if (!pathIsWithin(handle.projectRoot, cwd)) continue;
+      const length = canonicalProjectRoot(handle.projectRoot).length;
+      if (length > bestLength) {
+        best = handle;
+        bestLength = length;
+      }
+    }
+    return best;
   }
 
   async warmWorkspace(cwd: string): Promise<ProjectHandle | null> {
@@ -181,8 +233,10 @@ export class OpenClawEngineManager {
   }
 
   async releaseWorkspace(cwd: string): Promise<void> {
+    // Same containment test as `findCachedHandle`, and for the same reason: released by string
+    // prefix, closing a session in `knowl-cloud` also tore down the live handle for `knowl`.
     const matching = Array.from(this.handles.entries()).filter(
-      ([root]) => cwd === root || cwd.startsWith(root),
+      ([root]) => pathIsWithin(root, cwd),
     );
     for (const [root, handle] of matching) {
       this.handles.delete(root);

--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -225,7 +225,25 @@ export class OpenClawEngineManager {
         return null;
       }
     } catch (err: unknown) {
-      this.logger?.warn?.(`[knowl] Could not verify migration level for ${handle.databasePath}: ${err}`);
+      // Fail CLOSED, and not sticky.
+      //
+      // This branch means the level could not be READ -- on Windows a concurrent `knowl serve`
+      // holding the file is the ordinary cause -- so the one thing actually known is that the
+      // database is unverified. Warning and continuing to `handles.set` defeated the check
+      // entirely: an older plugin writing into a store a newer Knowl migrated finds every table
+      // it expects, because the schema is `CREATE TABLE IF NOT EXISTS` plus additive `ALTER`s,
+      // and then writes rows the newer schema's invariants do not hold for. Nothing reports it.
+      //
+      // The root is deliberately NOT added to `disabledRoots`: a lock clears. A transient
+      // failure costs this warm attempt, and the next hook in that workspace tries again --
+      // where the sticky list is for the one condition that cannot resolve itself, a database
+      // stamped past what this plugin understands.
+      this.logger?.warn?.(
+        `[knowl] Could not verify the migration level of "${handle.databasePath}", so this workspace ` +
+        `is not being opened. Knowl will try again on the next event: ${err}`,
+      );
+      await safely(() => handle.release(), this.logger);
+      return null;
     }
 
     this.handles.set(root, handle);

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -42,6 +42,50 @@ function resolveWorkspace(event: unknown, ctx: unknown): string {
   return process.cwd();
 }
 
+function firstNonEmptyString(...candidates: unknown[]): string | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * The session a hook event belongs to, or `undefined` when OpenClaw named none.
+ *
+ * Six copies of `ctx?.sessionId ?? ctx?.sessionKey ?? event?.sessionId ?? event?.sessionKey ??
+ * 'openclaw-session'` used to answer this, and the literal at the end was the defect. A gateway
+ * is one process serving many sessions, so two runs that both fell through to it shared every
+ * slot keyed by the answer: `midturnPending` deletes on read, so the second session CONSUMED
+ * the first's card, and `impactSeen` marks `${sessionId}:${file}`, so the second was told a file
+ * had already been carded when it had not been. Neither failure is visible from inside either
+ * session.
+ *
+ * `sessionKey` is a fallback and not an equal. OpenClaw's contexts identify a run by
+ * `sessionKey`/`agentId` TOGETHER -- the key alone is a name, and two live sessions in this
+ * plugin's own tests both carry `main` -- so the pair is preferred whenever both are present.
+ */
+export function resolveSessionId(event: unknown, ctx: unknown): string | undefined {
+  const e = event as Record<string, unknown> | undefined;
+  const c = ctx as Record<string, unknown> | undefined;
+  const sessionId = firstNonEmptyString(c?.sessionId, e?.sessionId);
+  if (sessionId) return sessionId;
+  const sessionKey = firstNonEmptyString(c?.sessionKey, e?.sessionKey);
+  const agentId = firstNonEmptyString(c?.agentId, e?.agentId);
+  if (sessionKey && agentId) return `${sessionKey}:${agentId}`;
+  return sessionKey;
+}
+
+/**
+ * The session id sent to the ENGINE when the host named none.
+ *
+ * The engine requires one: `normalizeHostHook` throws `IncompleteHostHookPayloadError` on a
+ * payload with no session id, so a hook arriving from a context that carries no identity would
+ * otherwise do nothing at all. It is never used as a plugin-side key -- `resolveSessionId`
+ * answering `undefined` is what keeps two anonymous sessions out of each other's card slots,
+ * and a card that cannot be attributed is dropped rather than handed to whoever asks next.
+ */
+const ANONYMOUS_SESSION_ID = 'openclaw-session';
+
 const MAX_IMPACT_SEEN = 512;
 const impactSeen = new Map<string, true>();
 
@@ -267,7 +311,7 @@ export default definePluginEntry({
 
         const raw: Record<string, unknown> = {
           cwd,
-          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          sessionId: resolveSessionId(event, ctx) ?? ANONYMOUS_SESSION_ID,
           turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId ?? ctx?.jobId,
           agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
           agentType: (event as Record<string, unknown>)?.agentType,
@@ -284,10 +328,11 @@ export default definePluginEntry({
         );
 
         // Read before the early return below, and consumed whether or not it is used: a card
-        // left parked would be delivered later, out of the session it orients.
-        const sessionKey = String(raw.sessionId);
-        const parked = pendingSessionCards.get(sessionKey);
-        if (parked !== undefined) pendingSessionCards.delete(sessionKey);
+        // left parked would be delivered later, out of the session it orients. Keyed by the
+        // session OpenClaw named -- never by the anonymous fallback, which is shared.
+        const sessionId = resolveSessionId(event, ctx);
+        const parked = sessionId ? pendingSessionCards.get(sessionId) : undefined;
+        if (parked !== undefined && sessionId) pendingSessionCards.delete(sessionId);
 
         // The engine's own answer first when it has one -- it is composed for this turn -- and
         // the session-start card otherwise. On the first prompt of a session the engine has
@@ -319,7 +364,7 @@ export default definePluginEntry({
 
           const raw: Record<string, unknown> = {
             cwd,
-            sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+            sessionId: resolveSessionId(event, ctx) ?? ANONYMOUS_SESSION_ID,
             turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
             agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
             agentType: (event as Record<string, unknown>)?.agentType,
@@ -364,18 +409,17 @@ export default definePluginEntry({
             const handle = await manager.getHandle(cwd);
             if (!handle) return undefined;
 
-            const sessionId = ctx?.sessionId
-              ?? ctx?.sessionKey
-              ?? (event as Record<string, unknown>)?.sessionId as string | undefined
-              ?? (event as Record<string, unknown>)?.sessionKey as string | undefined
-              ?? 'openclaw-session';
+            // `undefined` when OpenClaw named no session, and that is load-bearing here: every
+            // slot below is keyed by it, and a shared literal made two concurrent sessions read
+            // and clear each other's. See `resolveSessionId`.
+            const sessionId = resolveSessionId(event, ctx);
 
             // The engine's card, parked by `after_tool_call` on an earlier call. Read before
             // the impact lookup and on EVERY tool, not just writes: the drift reminder counts
             // consecutive non-Knowl calls of any kind, so a write-only path would drop it
             // during exactly the read-and-shell runs it exists to interrupt.
-            const engineCard = midturnPending.get(String(sessionId));
-            if (engineCard) midturnPending.delete(String(sessionId));
+            const engineCard = sessionId ? midturnPending.get(sessionId) : undefined;
+            if (engineCard && sessionId) midturnPending.delete(sessionId);
 
             const writtenPaths = extractWrittenPaths(event.toolName, event.args);
             if (writtenPaths.length === 0) {
@@ -386,8 +430,13 @@ export default definePluginEntry({
               const rel = toRepoRelativePath(rawPath, handle.projectRoot || cwd);
               if (!rel) continue;
 
-              const cacheKey = `${sessionId}:${rel.toLowerCase()}`;
-              if (impactSeen.has(cacheKey)) continue;
+              // Suppression needs a session to be suppressed within. With no id there is no
+              // honest key -- `openclaw-session:<file>` told the NEXT session a file had
+              // already been carded when it had not been -- so an unattributable call simply
+              // does not consult or feed the cache. A repeated card costs a few lines; a
+              // suppressed one costs the warning entirely.
+              const cacheKey = sessionId ? `${sessionId}:${rel.toLowerCase()}` : undefined;
+              if (cacheKey && impactSeen.has(cacheKey)) continue;
 
               const stem = path.basename(rel, path.extname(rel)).replace(/[-_]/g, ' ');
               const items = await withDeadline(
@@ -399,7 +448,7 @@ export default definePluginEntry({
               const hits = items.filter((item) => coversAffectedPath(item.affectedPaths, rel));
               if (hits.length === 0) continue;
 
-              markImpactSeen(cacheKey);
+              if (cacheKey) markImpactSeen(cacheKey);
 
               const lines = [
                 `[Knowl] ${hits.length} stored item(s) depend on ${rel}. Check them before you move on:`,
@@ -439,7 +488,7 @@ export default definePluginEntry({
 
         const raw: Record<string, unknown> = {
           cwd,
-          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          sessionId: resolveSessionId(event, ctx) ?? ANONYMOUS_SESSION_ID,
           turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
           agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
           agentType: (event as Record<string, unknown>)?.agentType,
@@ -475,9 +524,15 @@ export default definePluginEntry({
         // because a refusal does NOT have that property. Same trade as the Hermes plugin, for
         // the same reason -- collecting it inline would put the engine's latency in front of
         // every tool call, including the overwhelming majority carrying no card at all.
+        //
+        // Parked only under a session OpenClaw actually named. A card filed under the
+        // anonymous fallback is one the next unattributable call in this gateway would take
+        // and clear, so it is dropped instead: an advisory card lost is a line the model does
+        // not see, where a card misdelivered is one session reading another's.
         const card = result?.hostOutput?.appendContent;
-        if (typeof card === 'string' && card.trim()) {
-          parkCard(midturnPending, String(raw.sessionId), card, MIDTURN_PENDING_MAX, MIDTURN_CARD_MAX);
+        const sessionId = resolveSessionId(event, ctx);
+        if (sessionId && typeof card === 'string' && card.trim()) {
+          parkCard(midturnPending, sessionId, card, MIDTURN_PENDING_MAX, MIDTURN_CARD_MAX);
         }
       }, api.logger);
     });
@@ -493,7 +548,7 @@ export default definePluginEntry({
 
         const raw: Record<string, unknown> = {
           cwd,
-          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          sessionId: resolveSessionId(event, ctx) ?? ANONYMOUS_SESSION_ID,
           turnId: (event as Record<string, unknown>)?.turnId ?? (event as Record<string, unknown>)?.runId ?? ctx?.runId,
           agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
           agentType: (event as Record<string, unknown>)?.agentType,
@@ -521,7 +576,7 @@ export default definePluginEntry({
 
         const raw: Record<string, unknown> = {
           cwd,
-          sessionId: ctx?.sessionId ?? ctx?.sessionKey ?? (event as Record<string, unknown>)?.sessionId ?? (event as Record<string, unknown>)?.sessionKey ?? 'openclaw-session',
+          sessionId: resolveSessionId(event, ctx) ?? ANONYMOUS_SESSION_ID,
           agentId: ctx?.agentId ?? (event as Record<string, unknown>)?.agentId,
           agentType: (event as Record<string, unknown>)?.agentType,
         };
@@ -540,9 +595,13 @@ export default definePluginEntry({
         // here by design -- the profile answers an envelope for `turn-start` alone -- so the
         // host-neutral `context` is where the card is, and taking it is what stops it being
         // computed and dropped. See `pendingSessionCards`.
+        // Parked only under a session OpenClaw named, for the reason `resolveSessionId` gives:
+        // the anonymous slot is shared, and an orientation card handed to the wrong session is
+        // worse than one nobody receives.
         const card = (result?.hostOutput?.prependContext as string | undefined) ?? result?.context;
-        if (typeof card === 'string' && card.trim()) {
-          parkCard(pendingSessionCards, String(raw.sessionId), card, SESSION_PENDING_MAX, SESSION_CARD_MAX);
+        const sessionId = resolveSessionId(event, ctx);
+        if (sessionId && typeof card === 'string' && card.trim()) {
+          parkCard(pendingSessionCards, sessionId, card, SESSION_PENDING_MAX, SESSION_CARD_MAX);
         }
       }, api.logger);
     });
@@ -564,7 +623,7 @@ export default definePluginEntry({
           const e = event as Record<string, unknown> | undefined;
           const raw: Record<string, unknown> = {
             cwd,
-            sessionId: c?.sessionId ?? c?.sessionKey ?? e?.sessionId ?? e?.sessionKey ?? 'openclaw-session',
+            sessionId: resolveSessionId(event, ctx) ?? ANONYMOUS_SESSION_ID,
             turnId: e?.turnId ?? e?.runId ?? c?.runId,
             agentId: c?.agentId ?? e?.agentId,
             agentType: e?.agentType,

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -17,8 +17,21 @@ export { OpenClawEngineManager, safely, withDeadline };
  *
  * So the event is asked first (it carries `cwd` on the hooks that know one), the context
  * second, and `process.cwd()` last -- and the caller decides what an unresolvable workspace
- * means. `getHandle` answers `null` for a directory that is not a Knowl project, so a wrong
- * guess degrades to "no memory this turn" rather than to another project's database.
+ * means.
+ *
+ * **The last step is a real guess, and it does not always degrade to silence.** This docblock
+ * used to claim it did, on the grounds that `getHandle` answers `null` for a directory that is
+ * not a Knowl project. That is true only when the gateway was started outside every repository.
+ * Started INSIDE one -- the ordinary case for anyone who launches OpenClaw from a project
+ * directory -- `process.cwd()` names a real project, `getHandle` opens it, and the hook is
+ * answered from a repository the event never mentioned: its atoms are read, its constraints
+ * judge the write gate, and its store takes the capture rows.
+ *
+ * The fallback stays anyway, because the alternative is worse: returning nothing whenever a
+ * context carries no directory would silence the plugin on every surface that identifies a run
+ * by `sessionKey`/`agentId` alone, which is half the hooks. What was wrong here was the claim,
+ * not the fallback -- and the containment fix in `engine.ts` narrows the blast radius to this
+ * one path, where before any prefix neighbour could be selected as well.
  */
 function resolveWorkspace(event: unknown, ctx: unknown): string {
   const fromEvent = (event as { cwd?: unknown } | undefined)?.cwd;
@@ -43,9 +56,54 @@ const MIDTURN_PENDING_MAX = 256;
 const MIDTURN_CARD_MAX = 1500;
 const midturnPending = new Map<string, string>();
 
+/**
+ * The engine's session-start card, parked by `session_start` for the first prompt to deliver.
+ *
+ * `session_start` is an observer here: the gateway ignores what the handler returns, which is
+ * exactly what the host profile already says by answering an envelope for `turn-start` and
+ * nothing for `session-start`. So the card the engine composed on that event had no channel at
+ * all and was computed and dropped -- and the loss was silent in both directions, because by
+ * the time `before_prompt_build` ran, the session binding `session_start` had just created made
+ * the engine take its `turn` branch with `includeContext: false`. Every later turn returned
+ * nothing too. An OpenClaw user got zero engine memory while every layer reported success.
+ *
+ * Parked rather than re-requested, because the card is not idempotent: the pending handoff it
+ * merges in is CONSUMED as it is composed, so asking again returns a card missing the one part
+ * a new session most needs.
+ *
+ * Bounded and insertion-ordered like `midturnPending`, and for the same reason -- a gateway is a
+ * long-lived process serving many sessions, and a session whose prompt hook never fires (the
+ * embedded runner, see the README) would otherwise leave its card here forever.
+ */
+const SESSION_PENDING_MAX = 256;
+const SESSION_CARD_MAX = 8000;
+const pendingSessionCards = new Map<string, string>();
+
+/**
+ * Park `text` under `key`, evicting the oldest entries past `max`.
+ *
+ * The delete-then-set is what makes the map insertion-ordered by *freshness* rather than by
+ * first sight, so the eviction below drops the stalest card instead of the one most recently
+ * refreshed.
+ */
+function parkCard(store: Map<string, string>, key: string, text: string, max: number, cap: number): void {
+  store.delete(key);
+  store.set(key, text.slice(0, cap));
+  while (store.size > max) {
+    const oldest = store.keys().next().value;
+    if (oldest === undefined) break;
+    store.delete(oldest);
+  }
+}
+
 /** Test seam: the pending cards do not survive a run, and a leaked one would cross tests. */
 export function resetMidturnPendingForTest(): void {
   midturnPending.clear();
+}
+
+/** Test seam, as above: a session card parked by one test must not be read by the next. */
+export function resetSessionCardsForTest(): void {
+  pendingSessionCards.clear();
 }
 
 /**
@@ -225,9 +283,19 @@ export default definePluginEntry({
           null,
         );
 
-        if (!result) return undefined;
+        // Read before the early return below, and consumed whether or not it is used: a card
+        // left parked would be delivered later, out of the session it orients.
+        const sessionKey = String(raw.sessionId);
+        const parked = pendingSessionCards.get(sessionKey);
+        if (parked !== undefined) pendingSessionCards.delete(sessionKey);
 
-        const card = (result.hostOutput?.prependContext as string | undefined) ?? result.context;
+        // The engine's own answer first when it has one -- it is composed for this turn -- and
+        // the session-start card otherwise. On the first prompt of a session the engine has
+        // nothing to say precisely because `session_start` already bound the session, so this
+        // is the ordinary path rather than the exceptional one.
+        const card = (result?.hostOutput?.prependContext as string | undefined)
+          ?? result?.context
+          ?? parked;
         if (card) {
           return { prependContext: card };
         }
@@ -409,14 +477,7 @@ export default definePluginEntry({
         // every tool call, including the overwhelming majority carrying no card at all.
         const card = result?.hostOutput?.appendContent;
         if (typeof card === 'string' && card.trim()) {
-          const key = String(raw.sessionId);
-          midturnPending.delete(key);
-          midturnPending.set(key, card.slice(0, MIDTURN_CARD_MAX));
-          while (midturnPending.size > MIDTURN_PENDING_MAX) {
-            const oldest = midturnPending.keys().next().value;
-            if (oldest === undefined) break;
-            midturnPending.delete(oldest);
-          }
+          parkCard(midturnPending, String(raw.sessionId), card, MIDTURN_PENDING_MAX, MIDTURN_CARD_MAX);
         }
       }, api.logger);
     });
@@ -468,11 +529,21 @@ export default definePluginEntry({
         const payload = readLifecyclePayloadObject(raw);
         const normalized = normalizeHostHook('openclaw', 'session_start', payload as Record<string, unknown>);
 
-        await withDeadline(
+        const result = await withDeadline(
           manager.getObserverDeadlineMs(),
           () => handle.lifecycle(normalized),
           null,
         );
+
+        // Park the session card for the first `before_prompt_build` of this session, which is
+        // the only hook OpenClaw reads a context contribution from. `hostOutput` is undefined
+        // here by design -- the profile answers an envelope for `turn-start` alone -- so the
+        // host-neutral `context` is where the card is, and taking it is what stops it being
+        // computed and dropped. See `pendingSessionCards`.
+        const card = (result?.hostOutput?.prependContext as string | undefined) ?? result?.context;
+        if (typeof card === 'string' && card.trim()) {
+          parkCard(pendingSessionCards, String(raw.sessionId), card, SESSION_PENDING_MAX, SESSION_CARD_MAX);
+        }
       }, api.logger);
     });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -101,6 +101,11 @@ export async function openProject(cwd: string): Promise<ProjectHandle | null> {
 
 export { normalizeHostHook } from './cli/agents/host-hook.js';
 export { readLifecyclePayloadObject } from './cli/agents/lifecycle.js';
+// The one folding used anywhere in this codebase for a path that will be compared or used as a
+// key. Exported because an in-process host plugin holds several project roots open at once and
+// has to decide which of them a working directory belongs to -- a question no plugin should be
+// answering with a second convention of its own.
+export { canonicalProjectRoot } from './core/project-path.js';
 export { KNOWL_MIGRATION_LEVEL } from './store/schema-version.js';
 export { ProjectNotFoundError } from './core/errors.js';
 export { MissingKnowledgeDatabaseError } from './cli/database-presence.js';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { findProjectRoot } from './core/config.js';
+import { findProjectRoot, loadConfig } from './core/config.js';
 import { ProjectNotFoundError } from './core/errors.js';
 import { assertKnowledgeDatabasePresent } from './cli/database-presence.js';
 import { openProjectScope } from './store/database.js';
@@ -90,7 +90,19 @@ export async function openProject(cwd: string): Promise<ProjectHandle | null> {
     },
     async store(atom: StoreKnowledgeInput): Promise<StoreKnowledgeResult> {
       return await scope.run(async () => {
-        return await storeKnowledgeItemDeduped(projectId, atom);
+        // The project's own security settings, exactly as `knowl_store` and `knowl store` pass
+        // them. Omitted, `storeKnowledgeItemDeduped` falls back to its built-in defaults --
+        // `secretPatterns` becomes the empty list -- so a repository that added a detector got
+        // DEFAULT validation on every library write, and one that relaxed the defaults had
+        // writes refused that its own configuration allows. The same atom accepted by the CLI
+        // and refused by the plugin, in the same repository, with nothing saying why.
+        //
+        // Read per write rather than captured at open: a gateway holds a handle for the life of
+        // the process, and a person who tightens `.knowl/config.json` mid-session expects the
+        // next write to be judged by what they just wrote. `loadConfig` is a single small JSON
+        // read and this is not a hot path.
+        const config = await loadConfig(root).catch(() => null);
+        return await storeKnowledgeItemDeduped(projectId, atom, undefined, config?.security);
       });
     },
     async release(): Promise<void> {

--- a/src/session/hosts/openclaw.ts
+++ b/src/session/hosts/openclaw.ts
@@ -28,6 +28,13 @@ import { hostString, toolNameIsShell } from './profile.js';
  *
  * `session_start` maps to `session-start`: Binds session identity and warms the project
  * handle cache in memory so subsequent write gates never suffer cold client initialization.
+ *
+ * **The session-start card leaves through `before_prompt_build`, not through this event.**
+ * `startContext` below deliberately answers an envelope for `turn-start` alone, because
+ * OpenClaw ignores what a `session_start` handler returns -- so the plugin parks the
+ * host-neutral `context` this event produces and hands it to the first prompt of the session.
+ * The binding created here is what makes the engine's own `turn-start` answer empty, so
+ * without that hand-off the card is composed and lost and the user gets no memory at all.
  */
 const OPENCLAW_EVENT_MAP: Record<string, NormalizedHookEventName> = {
   before_prompt_build: 'turn-start',

--- a/tests/cli/plugin-export.test.ts
+++ b/tests/cli/plugin-export.test.ts
@@ -148,6 +148,46 @@ describe('plugin export and built artifact verification', () => {
     );
   });
 
+  it('a library write is validated by the project own security settings, not by the defaults', async () => {
+    // `handle.store` called `storeKnowledgeItemDeduped(projectId, atom)` and stopped there,
+    // while the MCP tool and the CLI both pass `config.security` as the fourth argument. Left
+    // out, `secretPatterns` falls back to the empty list -- so a repository that added a
+    // detector got DEFAULT validation on every library write, and the same atom was accepted
+    // by the plugin and refused by `knowl store` in the same repository.
+    const repo = path.join(scratchDir, 'configured-security-repo');
+    await fs.mkdir(repo, { recursive: true });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: repo, encoding: 'utf8' });
+
+    const configPath = path.join(repo, '.knowl', 'config.json');
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
+    config.security = { rejectSecrets: true, secretPatterns: ['zzz-house-token'] };
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf8');
+
+    const handle = await pluginModule.openProject(repo);
+    expect(handle).not.toBeNull();
+
+    try {
+      await expect(
+        handle!.store({
+          category: 'fact',
+          title: 'Staging deploy reads a house token',
+          content: 'The staging deploy reads zzz-house-token from the environment at boot.',
+        }),
+      ).rejects.toThrow(/configured-pattern/i);
+
+      // And the same repository still accepts what its own configuration does not object to,
+      // so this is the project's rule being applied rather than everything being refused.
+      const accepted = await handle!.store({
+        category: 'fact',
+        title: 'Staging deploy reads its configuration from the environment',
+        content: 'The staging deploy takes every setting from the environment at boot.',
+      });
+      expect(accepted.action).toBe('inserted');
+    } finally {
+      await handle!.release();
+    }
+  });
+
   it('multi-project regression: writes to project A land in project A and never in project B', async () => {
     const projectADir = path.join(scratchDir, 'projectA');
     const projectBDir = path.join(scratchDir, 'projectB');

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -7,11 +7,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   OpenClawEngineManager,
   checkMigrationLevel,
+  pathIsWithin,
   safely,
   withDeadline,
   type HostLogger,
 } from '../../../integrations/openclaw/src/engine.js';
 import { KNOWL_MIGRATION_LEVEL } from '@dat999zx/knowl/plugin';
+import * as pluginModule from '@dat999zx/knowl/plugin';
+import type { ProjectHandle } from '@dat999zx/knowl/plugin';
 
 const CLI_PATH = path.resolve('dist/index.js');
 
@@ -126,5 +129,110 @@ describe('OpenClaw engine wrapper failure modes', () => {
     // Subsequent handle request returns null immediately without attempting to open
     const cachedAttempt = await manager.getHandle(projectDir);
     expect(cachedAttempt).toBeNull();
+  });
+});
+
+describe('OpenClaw engine manager: a workspace is a path, not a prefix', () => {
+  let scratchDir: string;
+  let dbPath: string;
+  let released: string[];
+
+  // Fixture roots are built with `path.resolve` rather than typed as `C:\...` literals: a
+  // Windows literal is a single relative segment on Linux, so `path.relative` inside
+  // `pathIsWithin` would compare nonsense and the suite would pass here and fail on CI.
+  const under = (...segments: string[]) => path.resolve(scratchDir, ...segments);
+
+  /**
+   * A handle standing in for a real project, so the cache can be loaded with the exact pair of
+   * roots this is about without initialising two repositories per assertion.
+   *
+   * `projectRoot` is the directory it was opened at, which is what `openProject` answers when a
+   * workspace is warmed at its own root -- the case `session_start` always produces.
+   */
+  const stubHandle = (projectRoot: string): ProjectHandle => ({
+    projectRoot,
+    databasePath: dbPath,
+    lifecycle: async () => ({ accepted: true }) as never,
+    query: async () => [],
+    store: async () => ({ action: 'created' }) as never,
+    release: async () => {
+      released.push(projectRoot);
+    },
+  });
+
+  beforeEach(async () => {
+    scratchDir = path.join(os.tmpdir(), `knowl-openclaw-roots-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+    dbPath = path.join(scratchDir, 'migration-probe.db');
+    released = [];
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => stubHandle(cwd));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('pathIsWithin refuses a sibling that merely shares a prefix, and accepts a real descendant', () => {
+    const root = under('knowl');
+    expect(pathIsWithin(root, root)).toBe(true);
+    expect(pathIsWithin(root, path.join(root, 'src', 'index.ts'))).toBe(true);
+    // The whole defect in one line: string-prefixed, not path-contained.
+    expect(pathIsWithin(root, under('knowl-cloud'))).toBe(false);
+    expect(pathIsWithin(root, under('knowl.old'))).toBe(false);
+    expect(pathIsWithin(path.join(root, 'src'), root)).toBe(false);
+  });
+
+  it.runIf(process.platform === 'win32')('pathIsWithin folds case on Windows, where the same directory arrives spelled two ways', () => {
+    const root = under('Knowl');
+    expect(pathIsWithin(root, root.toLowerCase())).toBe(true);
+    expect(pathIsWithin(root.toLowerCase(), path.join(root, 'src'))).toBe(true);
+  });
+
+  it('does not answer a hook from knowl-cloud with the handle warmed for knowl', async () => {
+    const manager = new OpenClawEngineManager();
+    const knowl = under('knowl');
+    const knowlCloud = under('knowl-cloud');
+
+    // knowl warms first, which is what makes the prefix bug fire: `'…/knowl-cloud'
+    // .startsWith('…/knowl')` is true, so the cached handle was returned for the wrong repo.
+    expect((await manager.warmWorkspace(knowl))?.projectRoot).toBe(knowl);
+
+    const handle = await manager.getHandle(knowlCloud);
+    expect(handle?.projectRoot).toBe(knowlCloud);
+
+    // And a file inside it resolves to the same handle, not to the neighbour.
+    const nested = await manager.getHandle(path.join(knowlCloud, 'web', 'app'));
+    expect(nested?.projectRoot).toBe(knowlCloud);
+  });
+
+  it('resolves a nested workspace to the longest matching root, not the first one warmed', async () => {
+    const manager = new OpenClawEngineManager();
+    const mono = under('mono');
+    const api = path.join(mono, 'packages', 'api');
+
+    await manager.warmWorkspace(mono);
+    await manager.warmWorkspace(api);
+
+    const handle = await manager.getHandle(path.join(api, 'src', 'server.ts'));
+    expect(handle?.projectRoot).toBe(api);
+
+    // The outer repository still owns everything the inner one does not.
+    const outer = await manager.getHandle(path.join(mono, 'docs'));
+    expect(outer?.projectRoot).toBe(mono);
+  });
+
+  it('releaseWorkspace releases only the workspace it was given, not its prefix neighbour', async () => {
+    const manager = new OpenClawEngineManager();
+    const knowl = under('knowl');
+    const knowlCloud = under('knowl-cloud');
+
+    await manager.warmWorkspace(knowl);
+    await manager.warmWorkspace(knowlCloud);
+
+    await manager.releaseWorkspace(knowlCloud);
+
+    expect(released).toEqual([knowlCloud]);
+    expect(released).not.toContain(knowl);
   });
 });

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -132,6 +132,80 @@ describe('OpenClaw engine wrapper failure modes', () => {
   });
 });
 
+describe('OpenClaw engine manager: an unverifiable database is not opened', () => {
+  let scratchDir: string;
+  let released: string[];
+  let opened: number;
+
+  beforeEach(async () => {
+    scratchDir = path.join(os.tmpdir(), `knowl-openclaw-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+    // Created as a DIRECTORY on purpose: libSQL refuses to open a connection to it, the same
+    // rejection a locked store produces, and a path that simply does not exist would be
+    // created as an empty database instead.
+    await fs.mkdir(path.join(scratchDir, 'not-a-database'), { recursive: true });
+    released = [];
+    opened = 0;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      opened += 1;
+      return {
+        projectRoot: cwd,
+        // A directory rather than a database file, so opening it fails the way a locked one
+        // does: `PRAGMA application_id` never returns an answer. On Windows a concurrent
+        // `knowl serve` holding the store is the ordinary cause, which is what made the old
+        // fail-open branch the common path rather than the rare one.
+        databasePath: path.join(scratchDir, 'not-a-database'),
+        lifecycle: async () => ({ accepted: true }) as never,
+        query: async () => [],
+        store: async () => ({ action: 'created' }) as never,
+        release: async () => {
+          released.push(cwd);
+        },
+      } satisfies ProjectHandle;
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('refuses the workspace and releases the handle when the migration level cannot be read', async () => {
+    const logger: HostLogger = { warn: vi.fn() };
+    const manager = new OpenClawEngineManager({ logger });
+    const projectDir = path.join(scratchDir, 'repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    expect(await manager.warmWorkspace(projectDir)).toBeNull();
+    expect(released).toEqual([projectDir]);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Could not verify the migration level'));
+  });
+
+  it('does not cache the unverified handle, so a later hook is not answered from it', async () => {
+    const manager = new OpenClawEngineManager({ logger: { warn: vi.fn() } });
+    const projectDir = path.join(scratchDir, 'repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    await manager.warmWorkspace(projectDir);
+    expect(await manager.getHandle(projectDir)).toBeNull();
+    expect(await manager.getHandle(path.join(projectDir, 'src'))).toBeNull();
+  });
+
+  it('is not sticky: the workspace is retried once the database can be read again', async () => {
+    const manager = new OpenClawEngineManager({ logger: { warn: vi.fn() } });
+    const projectDir = path.join(scratchDir, 'repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    expect(await manager.warmWorkspace(projectDir)).toBeNull();
+    expect(manager.isDisabled(projectDir)).toBe(false);
+    // A lock clears, so the next event opens the project again rather than finding the
+    // workspace permanently switched off -- which is what `disabledRoots` is for, and it is
+    // reserved for the one condition that cannot resolve itself.
+    await manager.getHandle(projectDir);
+    expect(opened).toBe(2);
+  });
+});
+
 describe('OpenClaw engine manager: a workspace is a path, not a prefix', () => {
   let scratchDir: string;
   let dbPath: string;

--- a/tests/integrations/openclaw/hooks.test.ts
+++ b/tests/integrations/openclaw/hooks.test.ts
@@ -479,6 +479,100 @@ describe('OpenClaw hooks: impact card and capture (Task 9)', () => {
     expect(await middleware!(readEvent, ctx)).toBeUndefined();
   });
 
+  it('a card parked by one session is not consumed by a sibling that shares its sessionKey', async () => {
+    // Two runs in one gateway with no `sessionId` between them -- the shape OpenClaw's tool and
+    // session contexts have, which identify a run by `sessionKey`/`agentId`. Both used to
+    // resolve to `sessionKey` and, failing that, to the literal `'openclaw-session'`, so they
+    // shared one slot; and the slot deletes on read, so whichever asked first CONSUMED the
+    // other's card. Neither session could see it happen.
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.query = async () => [];
+      handle.lifecycle = async () => ({
+        hostOutput: { appendContent: '[Knowl] 12 tool calls without memory. Query before you continue.' },
+      } as any);
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const middleware = registeredMiddleware[0]?.handler;
+    const afterToolCall = registeredHooks.get('after_tool_call')?.[0]?.handler;
+    expect(middleware).toBeDefined();
+    expect(afterToolCall).toBeDefined();
+
+    const ctxA = { runtime: 'openclaw', sessionKey: 'main', agentId: 'agent-a' };
+    const ctxB = { runtime: 'openclaw', sessionKey: 'main', agentId: 'agent-b' };
+    const readEvent = {
+      toolName: 'read_file',
+      args: { path: 'src/core.ts' },
+      cwd: scratchDir,
+      result: { content: [{ type: 'text', text: 'file contents' }] },
+      toolCallId: 'call-read-shared-key',
+    };
+
+    // Session A's observer parks a card.
+    await afterToolCall!({ toolName: 'read_file', params: {}, cwd: scratchDir, durationMs: 3 }, ctxA);
+
+    // Session B's next tool result must not carry it, and must not clear it.
+    expect(await middleware!(readEvent, ctxB)).toBeUndefined();
+
+    // Session A still has its own card.
+    const delivered = (await middleware!(readEvent, ctxA)) as any;
+    expect(delivered?.result?.content).toHaveLength(2);
+    expect(delivered.result.content[1].text).toContain('12 tool calls without memory');
+  });
+
+  it('the impact cache does not tell a second session that a file was already carded', async () => {
+    // `impactSeen` is keyed `${sessionId}:${file}`, so the collision above suppressed the impact
+    // card too -- session B was told its write had already been reported when nothing had told
+    // it anything.
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
+
+    const origOpenProject = pluginModule.openProject;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      const handle = await origOpenProject(cwd);
+      if (!handle) return null;
+      handle.query = async () => [
+        {
+          id: 'atom-core-invariant',
+          title: 'Database connection pooling invariant',
+          category: 'architecture',
+          affectedPaths: ['src/core.ts'],
+        } as any,
+      ];
+      return handle;
+    });
+
+    knowlPlugin.register(api);
+    const middleware = registeredMiddleware[0]?.handler;
+    expect(middleware).toBeDefined();
+
+    const event = {
+      toolName: 'apply_patch',
+      args: { path: 'src/core.ts' },
+      cwd: scratchDir,
+      result: { content: [{ type: 'text', text: 'Patch applied successfully' }] },
+      toolCallId: 'call-impact-shared-key',
+    };
+    const ctxA = { runtime: 'openclaw', sessionKey: 'main', agentId: 'agent-a' };
+    const ctxB = { runtime: 'openclaw', sessionKey: 'main', agentId: 'agent-b' };
+
+    const firstRun = (await middleware!(event, ctxA)) as any;
+    expect(firstRun?.result?.content?.[1]?.text).toContain('[Knowl] 1 stored item(s) depend on src/core.ts');
+
+    // A different session writing the same file is a different agent that has been told
+    // nothing, so it gets the card too.
+    const otherSession = (await middleware!(event, ctxB)) as any;
+    expect(otherSession?.result?.content?.[1]?.text).toContain('[Knowl] 1 stored item(s) depend on src/core.ts');
+
+    // The per-session suppression itself still holds.
+    expect(await middleware!(event, ctxA)).toBeUndefined();
+  });
+
   it('Step 2: appends impact card to result.content (never only details) and cards once per (session, file)', async () => {
     execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: scratchDir, encoding: 'utf8' });
 

--- a/tests/integrations/openclaw/hooks.test.ts
+++ b/tests/integrations/openclaw/hooks.test.ts
@@ -3,7 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import knowlPlugin, { resetImpactSeenForTest, resetMidturnPendingForTest } from '../../../integrations/openclaw/src/index.js';
+import knowlPlugin, {
+  resetImpactSeenForTest,
+  resetMidturnPendingForTest,
+  resetSessionCardsForTest,
+} from '../../../integrations/openclaw/src/index.js';
 import type { NormalizedHostHook } from '../../../src/core/host-hook-types.js';
 import * as pluginModule from '@dat999zx/knowl/plugin';
 
@@ -15,6 +19,7 @@ describe('OpenClaw hooks: recall card', () => {
   let api: any;
 
   beforeEach(async () => {
+    resetSessionCardsForTest();
     scratchDir = path.join(os.tmpdir(), `knowl-openclaw-hooks-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await fs.mkdir(scratchDir, { recursive: true });
 
@@ -131,6 +136,39 @@ describe('OpenClaw hooks: recall card', () => {
       expect(payloadStr).not.toContain('population of Tokyo');
       expect(payloadStr).not.toContain('Another follow-up message');
     }
+  });
+
+  it('delivers the session_start card on the first prompt instead of computing and dropping it', async () => {
+    // The session-start card had no channel of its own: `session_start` is an observer whose
+    // return value the gateway ignores, which is what the host profile says by answering an
+    // envelope for `turn-start` alone. So it was computed and dropped -- and because the
+    // binding it created made every later `turn-start` take the `includeContext: false`
+    // branch, the prompt hook returned nothing too. Zero memory, reported as success at every
+    // layer. The prompt hook alone was already covered above, and passed, which is exactly why
+    // this went unnoticed: the defect only appears once session_start has run first.
+    const repo = path.join(scratchDir, 'session-card-repo');
+    await fs.mkdir(repo, { recursive: true });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: repo, encoding: 'utf8' });
+
+    knowlPlugin.register(api);
+
+    const sessionStart = registeredHooks.get('session_start')?.[0]?.handler;
+    const promptHook = registeredHooks.get('before_prompt_build')?.[0]?.handler;
+    expect(sessionStart).toBeDefined();
+    expect(promptHook).toBeDefined();
+
+    const ctx = { workspaceDir: repo, sessionId: 'sess-start-card', sessionKey: 'main' };
+    await sessionStart!({ cwd: repo }, ctx);
+
+    const first = (await promptHook!({ prompt: 'first turn' }, ctx)) as { prependContext?: string } | undefined;
+    expect(first?.prependContext).toBeDefined();
+    expect(first?.prependContext?.length).toBeGreaterThan(0);
+
+    // Delivered once. The slot is consumed on read, and the engine's turn branch has nothing
+    // to add for a session it has already bootstrapped -- so a second prompt is silent rather
+    // than repeating the card.
+    const second = (await promptHook!({ prompt: 'second turn' }, ctx)) as { prependContext?: string } | undefined;
+    expect(second?.prependContext).toBeUndefined();
   });
 
   it('returns undefined cleanly when run outside a knowl project directory', async () => {


### PR DESCRIPTION
Four defects in the OpenClaw plugin from #260. It is the newest host integration and had not been audited; two of these mean an OpenClaw user's memory is either absent or someone else's.

Every fix was verified against a mutant rather than by reading the diff — for each one, the fix was reverted, the new test confirmed failing, then restored.

---

### 1. `fix(openclaw): a workspace is a path, not a prefix`

`engine.ts:131` was:

```js
const cached = Array.from(this.handles.values()).find((h) => cwd.startsWith(h.projectRoot));
```

No separator boundary, first-match-wins. On a machine holding `C:/Code/knowl` and `C:/Code/knowl-cloud` — an ordinary pair, since a project and its satellite share a prefix by convention — the second matches a handle warmed for the first. That handle carries query, the write gate **and** lifecycle capture, so a hook fired in one repository reads the other's atoms, is judged against the other's constraints, and writes capture rows into the other's store, with every layer reporting success.

New `pathIsWithin` uses `path.relative` for the boundary over `canonicalProjectRoot` — the fold the engine already applies to a path used as a key (`path.resolve`, plus a case fold **on Windows only**, because a hook payload's `cwd` reports `D:\project` where `process.cwd()` reports `d:\project`, while POSIX paths are genuinely case-sensitive). Selection now prefers the **longest** containing root rather than the first warmed, which is the same rule `findProjectRoot` applies walking up to the nearest marker — first-match is wrong for a monorepo that contains a project of its own.

### 2. `fix(openclaw): the session-start card must reach the model`

`index.ts:471` awaited `handle.lifecycle(normalized)` and never assigned the result. The card was composed and dropped — and the binding it created then forced every later `turn-start` down the `includeContext: false` branch, so OpenClaw users got **no engine memory at all**, silently.

Fixed in the plugin rather than in shared lifecycle code: the host-neutral context is parked and the first `before_prompt_build` of that session prepends it. Parked rather than recomputed because the pending handoff is consumed as the card is composed.

**Deliberately not the Hermes route.** Dropping `session_start` from the event map would also silently drop the session-start maintenance pass — abandoned-session recovery, event purge, read-set sweep, the auto-drift check and the two promotion passes — for OpenClaw users.

The `resolveWorkspace` docblock claimed a wrong guess "degrades to no memory this turn rather than to another project's database". That is false exactly when the gateway was started inside a repo. Behaviour left alone (removing the `process.cwd()` fallback would silence the plugin on every context carrying no directory); the docblock now says what actually happens.

### 3. `fix(openclaw): a card is keyed by a real session`

`sessionId` fell back to the literal `'openclaw-session'` on six paths, and `:310` deletes on read — so two concurrent sessions in one gateway shared one `midturnPending` slot and session B consumed session A's card. `impactSeen`'s `${sessionId}:${rel}` key collided the same way.

One helper replaces six copies of the fallback chain and returns `undefined` when OpenClaw named no session. It also stops treating `sessionKey` as an id: OpenClaw's contexts identify a run by `sessionKey` **and** `agentId` together, and the plugin's own tests carry two sessions both keyed `main`. Unattributable calls now drop the parked card and skip the impact cache rather than sharing a slot.

### 4. `fix(plugin): a library write is validated by the project's own settings`

`src/plugin.ts:93` called `storeKnowledgeItemDeduped(projectId, atom)` while the signature takes `(projectId, input, commitMessage?, validationOptions?)`. MCP passes `config?.security` and the CLI passes `config.security`; the plugin passed neither, so `secretPatterns` fell back to empty and a repo's own detectors never ran on a plugin write. Config is now read per write rather than captured at open.

Same commit: the migration-level guard at `engine.ts:175-177` caught, warned, and fell through to `handles.set` — so a database locked by a concurrent `knowl serve` (the normal case on Windows) was used anyway, possibly written by a newer knowl. It now releases and returns `null`, and deliberately does **not** add the root to `disabledRoots`, so a transient lock costs one warm attempt rather than the session.

---

## Verified

`npm run build`, `npm run typecheck`, `npm run lint`, `npm run docs:check` all clean. Full suite: **421 files passed, 3967 passed, 5 skipped, 0 failed.** `tests/integrations/openclaw/` on its own: 32 passed.

## Not changed — needs your call

**The write-gate matcher is still `['exec', 'apply_patch', 'spawn_agent']`** (`index.ts:278`), so no plain file-write tool name is matched. I could not settle it from a primary source: `openclaw` is a peer dependency deliberately not installed, so there are no vendored typings here.

The only in-repo evidence is second-hand and **contradicts what shipped**. `docs/superpowers/plans/2026-09-03-harness-integrations.md:888` records "Tool ids from docs.openclaw.ai/tools (2026-09-03): `read`, `write`, `edit`, `apply_patch`, `exec`" with `writesFiles: (_event, tool) => ['write', 'edit', 'apply_patch'].includes(tool)`. The shipped profile (`src/session/hosts/openclaw.ts:76`) and the plugin matcher both list `spawn_agent` — absent from that catalog — and omit `write` and `edit`.

If that catalog is current, the gate misses every ordinary file write and the fix is adding `write` and `edit` in both places. But the plan is a superseded draft rather than the docs, and changing a fail-closed gate on a superseded draft is not a call to make from here.

**One more, found while reading and left alone as out of scope:** `disabledRoots` is written under `handle.projectRoot` but probed with the raw `cwd` at `engine.ts:190`, so a permanently-disabled workspace short-circuits only when the hook's cwd is exactly the project root. Correct, just not cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
