### PR TITLE
feat(mcp): tool annotations, a discoverable resource template, and the asOf ceiling

### DIFF
--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -1,6 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { ErrorCode, ListResourcesRequestSchema, McpError, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { KnowledgeCategory } from '../core/types.js';
+import { ErrorCode, ListResourceTemplatesRequestSchema, ListResourcesRequestSchema, McpError, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { KNOWLEDGE_CATEGORIES, KnowledgeCategory } from '../core/types.js';
 import { getRecentContext } from '../store/recent-context.js';
 import { formatRecentContextToMarkdown, formatHierarchyToMarkdown } from '../core/format.js';
 import { getHierarchicalKnowledge, queryKnowledgeBase } from '../store/queries.js';
@@ -38,7 +38,35 @@ export function registerResources(
     };
   });
 
-  // 2. Read resource
+  // 2. List resource templates
+  //
+  // `knowl://category/{name}` has been resolvable by the read handler below since it was
+  // written, and no client could ever find out: `resources/templates/list` is the ONLY place
+  // the protocol lets a server advertise a parameterised URI, and nothing answered it. A host
+  // asking got the SDK's "method not found", so working code was invisible -- not gated, not
+  // deprecated, simply undiscoverable.
+  //
+  // One entry, because one template resolves. The read handler matches `[a-z]+` and then hands
+  // whatever it caught to `queryKnowledgeBase`, so a name outside the category set answers with
+  // an empty document rather than an error -- which is why the valid names are spelled out in
+  // the description. RFC 6570 has no way to say "one of these seven", and the description is
+  // where a client's model reads what to substitute.
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+    return {
+      resourceTemplates: [
+        {
+          uriTemplate: 'knowl://category/{name}',
+          name: 'category',
+          title: 'Active Knowledge by Category',
+          description: 'Every active item in one category, as markdown. `name` is one of: '
+            + `${KNOWLEDGE_CATEGORIES.join(', ')}.`,
+          mimeType: 'text/markdown',
+        },
+      ],
+    };
+  });
+
+  // 3. Read resource
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const { uri } = request.params;
     await whenReady();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -68,6 +68,25 @@ export function createMcpServer(
       version: PACKAGE_VERSION,
     },
     {
+      // Exactly what is implemented, and nothing that merely could be.
+      //
+      // A host trusts this card: it decides from these flags whether to subscribe, whether to
+      // re-list after a change, and what to stop asking for. A capability declared and not
+      // implemented is worse than the gap it papers over, because the client's fallback is
+      // never taken and the failure surfaces as silence rather than as an error.
+      //
+      // Both entries are deliberately bare:
+      //
+      // - `resources: {}` already covers `resources/templates/list`, which the SDK gates on the
+      //   resources capability alone -- there is no separate template flag to add. Neither
+      //   sub-flag is claimed: nothing here answers `resources/subscribe`, and nothing sends
+      //   `notifications/resources/list_changed`.
+      // - `tools: {}` withholds `listChanged` even though the tool list genuinely varies with
+      //   live config -- connecting to the cloud or joining a workspace changes it mid-session.
+      //   knowl does not notify; it absorbs the staleness instead, which is why the gated
+      //   handlers in `tools.ts` re-check their own gate rather than trusting the listing. That
+      //   is the honest pairing. Claiming `listChanged` without sending the notification would
+      //   tell a host to wait for a signal that never arrives.
       capabilities: {
         tools: {},
         resources: {},

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -39,12 +39,17 @@ export type ToolDefinition = {
  *   and has no argument that would. `knowl_drift` and `knowl_impact` are NOT read-only despite
  *   reading on the default path: `apply` marks atoms for review and `resolve` closes a finding.
  *   Three read tools do incidental self-maintenance and are still annotated read-only, named
- *   here so the claim is auditable rather than implied: `knowl_query` appends one analytics row
- *   to the workspace demand ledger (`recordDemandEventBestEffort`, whose failures are swallowed
- *   by design, so it is not part of the tool's contract); `knowl_transcript_search` tops up the
- *   transcript index it is about to read, a cache derived from files it is reading anyway; and
- *   any tool that embeds may populate the model cache on first use. None of them changes an
- *   answer any later call returns.
+ *   here so the claim is auditable rather than implied: `knowl_query` (live path only, never
+ *   `asOf`) and `knowl_context` record one `knowledge_access` row per result returned
+ *   (`recordKnowledgeAccessBestEffort` in `store/agent-query.ts`) and `knowl_query` appends one
+ *   analytics row to the workspace demand ledger (`recordDemandEventBestEffort`) -- both
+ *   best-effort, failures swallowed by design, so neither is part of the tool's contract;
+ *   `knowl_transcript_search` tops up the transcript index it is about to read, a cache derived
+ *   from files it is reading anyway; and any tool that embeds may populate the model cache on
+ *   first use. None of them alters a knowledge item. The access rows are not inert, though:
+ *   `isHot` in `store/gc.ts` reads them, so a heavily retrieved item is shielded from GC and a
+ *   later `knowl_gc_preview` answers differently for having been queried. That is retrieval
+ *   telemetry, not memory mutation, and a host should not prompt for it.
  * - `destructiveHint` is stated only where it says something the default does not. The spec
  *   defaults it to TRUE, so `false` is the informative value and is claimed only for the writes
  *   verified to be purely additive. `true` is repeated on the two that remove or retire, because

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -1,3 +1,4 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { KNOWLEDGE_CATEGORIES } from '../core/types.js';
 import { MAX_ITEM_CONTENT_CHARS } from '../core/token-budget.js';
 import { UNTRUSTED_NOTICE } from '../core/untrusted.js';
@@ -13,7 +14,53 @@ import { UNTRUSTED_NOTICE } from '../core/untrusted.js';
  * Moving the literal costs nothing at runtime: it is the same array, evaluated once at module
  * load instead of once per `knowlToolDefinitions` call.
  */
-export type ToolDefinition = { name: string; description: string; inputSchema: Record<string, unknown> };
+/**
+ * `annotations` is REQUIRED, so the compiler asks the question rather than a reviewer.
+ *
+ * The type is the SDK's own `ToolAnnotations`, not a local copy of the same four booleans:
+ * `ToolSchema` puts `annotations` on the tool object and the field names come from there, so a
+ * local restatement could drift from the shape actually serialized into `tools/list`.
+ */
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  annotations: ToolAnnotations;
+  inputSchema: Record<string, unknown>;
+};
+
+/**
+ * What the hints below claim, and what they deliberately do not.
+ *
+ * Hosts decide approval friction from these, so an annotation that lies is worse than no
+ * annotation at all -- reading memory would stop prompting while still being able to change it.
+ * Three rules, applied to every tool in this file:
+ *
+ * - `readOnlyHint: true` only where the call cannot create, alter, retire or delete knowledge,
+ *   and has no argument that would. `knowl_drift` and `knowl_impact` are NOT read-only despite
+ *   reading on the default path: `apply` marks atoms for review and `resolve` closes a finding.
+ *   Three read tools do incidental self-maintenance and are still annotated read-only, named
+ *   here so the claim is auditable rather than implied: `knowl_query` appends one analytics row
+ *   to the workspace demand ledger (`recordDemandEventBestEffort`, whose failures are swallowed
+ *   by design, so it is not part of the tool's contract); `knowl_transcript_search` tops up the
+ *   transcript index it is about to read, a cache derived from files it is reading anyway; and
+ *   any tool that embeds may populate the model cache on first use. None of them changes an
+ *   answer any later call returns.
+ * - `destructiveHint` is stated only where it says something the default does not. The spec
+ *   defaults it to TRUE, so `false` is the informative value and is claimed only for the writes
+ *   verified to be purely additive. `true` is repeated on the two that remove or retire, because
+ *   "this one really does delete" is worth saying out loud next to the schema.
+ * - `openWorldHint: false` follows the spec's own example -- "the world of a web search tool is
+ *   open, whereas that of a memory tool is not". `true` is reserved for the three that leave the
+ *   machine's own store: `knowl_ingest` (a configured LLM provider), `knowl_cloud` (the cloud
+ *   API) and `knowl_skill_run` (a script that may do anything). First-use model provisioning is
+ *   bootstrap, not a domain of interaction, and is not counted here.
+ *
+ * `idempotentHint` is absent from every tool on purpose. Nothing here is unambiguously
+ * idempotent: each write either mints a fresh id, stamps a new timestamp, or appends an event,
+ * so repeating a call always leaves the store observably different. The spec defaults it to
+ * false, which is the true answer, and stating a redundant `false` on thirty-six tools would
+ * cost the tool card tokens to say nothing.
+ */
 
 /** The only ways a change-impact finding is ever closed. Named here beside the schema that offers them. */
 export const IMPACT_RESOLUTIONS = ['repaired', 'dismissed', 'expired', 'false_positive'];
@@ -66,6 +113,7 @@ export const MAX_CONTEXT_TOKEN_BUDGET = 4_000;
 export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_transcript_search',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Search this repo\'s past Claude Code session transcripts. Use after knowl_query misses. Returns pointers into the session files; store anything worth keeping with knowl_store.',
           inputSchema: {
             type: 'object',
@@ -86,6 +134,7 @@ export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_transcript_read',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Read one transcript message and the turns around it. Pass a locator from knowl_transcript_search exactly as it was returned.',
           inputSchema: {
             type: 'object',
@@ -101,6 +150,7 @@ export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_session_list',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: "Browse this project's past Claude Code sessions as an inventory: best-known name (a user rename beats a generated title), the opening ask, status, any declared session card, last activity, and what each session promoted into memory. Use to answer 'which session was about X' or to choose between resuming and starting fresh - then knowl_transcript_search with that sessionId to read into it. Filters over intent only; for content questions use knowl_transcript_search.",
           inputSchema: {
             type: 'object',
@@ -134,6 +184,7 @@ export const TRANSCRIPT_TOOL_DEFINITIONS: ToolDefinition[] = [
 export const CLOUD_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_cloud',
+          annotations: { title: 'Cloud workspace publishing', openWorldHint: true },
           description: 'Check this repo\'s cloud workspace connection, or change what is queued for the team. `status` is local-only and instant -- use it before telling a user anything about what is or is not shared, because knowledge is staged automatically as it is written and sync runs on its own, so the answer changes without you. `stage` records the intent to publish and sends nothing; it is a dry run unless you pass apply. `unstage` takes an atom back out of the queue and is always safe: it sends nothing and unpublishes nothing. It cannot send, retract, pull, connect or sign in: those are the user\'s to run (`knowl cloud push`, `knowl cloud retract`, `knowl cloud pull`, `knowl cloud connect`, `knowl cloud login`). Relay the command rather than trying to work around it. Both directions are irreversible: a push cannot be recalled except by a retract, and a retract is a hard delete that bars the id forever.',
           inputSchema: {
             type: 'object',
@@ -170,6 +221,7 @@ export const CLOUD_TOOL_DEFINITIONS: ToolDefinition[] = [
 export const IMPACT_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_impact',
+          annotations: { title: 'Change-impact findings', openWorldHint: false },
           description: 'Change-impact findings: code a live session read that has since moved underneath it. Pass resolve to adjudicate one. A certain-tier finding also refuses the next edit to that file until you re-read it, so listing them here is how you see what is about to be blocked and why.',
           inputSchema: {
             type: 'object',
@@ -217,6 +269,7 @@ export const IMPACT_TOOL_DEFINITIONS: ToolDefinition[] = [
 export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_workspace',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Describe the local multi-repo workspace this repository belongs to: which repos are linked, which are present on this machine, and what they have been asking each other for. Use it when a query returned rows keyed by another repo and you need to know what that repo IS, or before deciding where knowledge belongs. Read-only: it links nothing, unlinks nothing and shares nothing. Linking repos and promoting knowledge to them are the user\'s to run (`knowl workspace add`, `knowl workspace promote`).',
           inputSchema: {
             type: 'object',
@@ -250,6 +303,7 @@ export const WORKSPACE_TOOL_DEFINITIONS: ToolDefinition[] = [
 export const FLEET_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_fleet',
+          annotations: { title: 'Other agent sessions running now', readOnlyHint: true, openWorldHint: false },
           description: 'The other live agent sessions on this machine (Claude Code, Codex, Cursor and any other host with Knowl hooks): what each is working on, the files it is editing this turn, the problem it has claimed, and whether it can be messaged. Use before fixing an error that may be shared, before changing hooks, config, migrations or the knowl install, or when the user asks who else is running. A session marked messageable is reachable with SendMessage(to:name); SendMessage(to:name, notify_when_idle:true) waits for it to finish. Raise the rest with the user instead.',
           inputSchema: {
             type: 'object',
@@ -280,6 +334,7 @@ export const FLEET_TOOL_DEFINITIONS: ToolDefinition[] = [
 export const HOOK_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_hook',
+          annotations: { title: 'Session lifecycle hook', openWorldHint: false },
           description: "Internal: the target of the host's lifecycle hooks when hooks.transport is mcp. The host calls it on every tool event; an agent never should -- calling it records a session event that did not happen.",
           inputSchema: {
             type: 'object',
@@ -299,6 +354,7 @@ export const HOOK_TOOL_DEFINITIONS: ToolDefinition[] = [
 export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_ingest',
+          annotations: { openWorldHint: true },
           description: 'Process explicitly supplied raw source text through the configured Knowl AI pipeline. Use only for an explicit ingestion request; never silently ingest the current conversation or prompt.',
           inputSchema: {
             type: 'object',
@@ -322,6 +378,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_state',
+          annotations: { title: 'Whole-project memory overview', readOnlyHint: true, openWorldHint: false },
           description: 'Get the full current active state of the project. Use for broad project-memory summaries, status checks, or full-state requests; prefer knowl_query for specific factual questions.',
           inputSchema: {
             type: 'object',
@@ -330,6 +387,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_recent',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Get compact recent session context only when lifecycle bootstrap is unavailable (including manual mode) or an explicit refresh is needed.',
           inputSchema: {
             type: 'object',
@@ -352,6 +410,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_store',
+          annotations: { openWorldHint: false },
           description: 'Store one concise structured knowledge atom directly, not raw chat transcripts. Use immediately after discovering durable project knowledge or completing each subtask, not only at the end. This is deterministic and does not require Knowl AI configuration. When this atom corrects or replaces knowledge a query already returned, pass that item id as `supersedes` in this same call so the outdated item is retired in one write; never leave two active items asserting different values for the same thing. The result reports any item left active beside this one and the exact call to retire it.',
           inputSchema: {
             type: 'object',
@@ -433,6 +492,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_ingest_atoms',
+          annotations: { openWorldHint: false },
           description: 'Store pre-extracted structured knowledge atoms from an MCP client. Do not store raw chat transcripts; extract durable facts, decisions, constraints, architecture, state, skills, and batch store implementation summaries during execution or after each completed subtask. This is the preferred MCP ingestion path and does not require Knowl AI configuration. When an atom corrects or replaces knowledge a query already returned, set `supersedes` on that atom to the outdated item id so it is retired in the same write; never leave two active items asserting different values for the same thing. The result reports each atom individually, including any overlapping item left active and the exact call to retire it.',
           inputSchema: {
             type: 'object',
@@ -490,6 +550,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_decide',
+          annotations: { openWorldHint: false },
           description: 'Record a confirmed project decision -- what was chosen, why, and what was rejected. Use this rather than knowl_store when the reasoning and the alternatives are the point; reasoning is required here and optional there. Record only settled decisions, not options still under discussion. Needs no Knowl AI configuration. When this decision reverses or replaces an earlier one, pass that item id as `supersedes` so the superseded decision is retired in the same write; never leave two active decisions contradicting each other. The result reports any decision left active beside this one and the exact call to retire it.',
           inputSchema: {
             type: 'object',
@@ -530,6 +591,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_query',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Use this first for specific project questions, before each new subtask, and when switching areas during multi-step work. Use every word that names the subject and none that does not: one more on-subject term retrieves better, one off-subject term retrieves worse, so never pad a query to reach a length and never drop a real term to stay under one. Skip only for directly relevant active lifecycle context, a same-request query, or relevant memory returned by knowl_task_start. If results contain a relevant active item, answer from Knowl without inspecting repository files. Inspect files only on miss, conflict, stale or low-confidence results, or explicit verification requests -- and on a miss, re-run once with different words first, because a first-pass miss is usually vocabulary rather than absence. `content` is cut at '
             + MAX_ITEM_CONTENT_CHARS
             + ' characters and marked `truncated` when it was; `affectedPaths` names the files the item depends on, so open those rather than searching for them. To read a truncated item in full, call again with `id` set to the id of that result. Results carry two numbers when semantic search is available, and they answer different questions. `score` (0-1) is the relevance the ranker ordered by; it is min-max scaled across the page, so the top row sits near 1.0 whatever it is and it is NOT comparable between queries -- read it as position, never as strength. `cosine` (0-1) is the raw similarity on an absolute scale, the same scale the relevance floor is measured against, so it means the same thing on every query and against every store: a low top `cosine` means the best available match is genuinely weak rather than that it is the answer. Judge with `cosine`, order with `score`. Where no calibrated number exists, `score` is the string `uncalibrated (<reason>)` and `cosine` is absent entirely -- the ranker has an order but no opinion on strength, so do not read position as confidence, judge the content itself. '
@@ -596,16 +658,19 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_timeline',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Read one item\'s immutable assertion history: what it claimed, when, and what superseded it. Use when memory looks contradictory or you need to know whether a fact changed -- knowl_query answers what it says now, this answers how it got there.',
           inputSchema: { type: 'object', properties: { repo: ACT_AS_REPO_READ, itemId: { type: 'string', minLength: 1, description: 'Knowledge item ID, as returned by knowl_query.' } }, required: ['itemId'] },
         },
         {
           name: 'knowl_conflicts',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'List contradictions among active items: declared exclusive conflict keys, and detected polarity pairs (the same title asserted both ways, which the write path deliberately keeps side by side rather than letting either retire the other). Use when a write reports an overlapping item left active, or when memory gives contradictory answers. A write that reports a possible REVERSAL is telling you something this command does not list -- act on it there. Resolve with knowl_update, never by storing a third item.',
           inputSchema: { type: 'object', properties: {} },
         },
         {
           name: 'knowl_context',
+          annotations: { title: 'Token-budgeted context pack', readOnlyHint: true, openWorldHint: false },
           description: 'Fill an explicit token budget with diversified project context. Use only when you have a budget to fill -- briefing a subagent, or packing a fixed-size prompt. For a specific question use knowl_query instead: this spreads across categories to fill the budget rather than ranking for one subject, so it is deliberately broader and less precise.',
           inputSchema: {
             type: 'object',
@@ -620,11 +685,13 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_synthesize',
+          annotations: { openWorldHint: false },
           description: 'Create or refresh one deterministic evidence-backed project understanding. Use only for a scope the user explicitly asked to have synthesised -- never as background tidy-up, and never to summarise a session. This never runs automatically on normal writes.',
           inputSchema: { type: 'object', properties: { scope: { type: 'string', minLength: 1, description: 'The subject to synthesise, named explicitly, e.g. "retrieval ranking". One scope per call.' } }, required: ['scope'] },
         },
         {
           name: 'knowl_evidence_list',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'List the evidence linked to one knowledge item. Use before relying on an item that is low-confidence, contested, or old enough that its support matters more than its claim.',
           inputSchema: {
             type: 'object',
@@ -634,6 +701,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_feedback',
+          annotations: { destructiveHint: false, openWorldHint: false },
           description: 'Record append-only usefulness feedback only after a retrieved item was actually used, rejected, or caused a correction.',
           inputSchema: {
             type: 'object',
@@ -648,6 +716,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_session_finish',
+          annotations: { openWorldHint: false },
           description: 'Finish and optionally promote a manual memory session you explicitly own. Never call this for a hook-owned session: when verified lifecycle hooks are active they finalize it themselves, and finishing it here closes a session out from under them.',
           inputSchema: {
             type: 'object', properties: {
@@ -660,6 +729,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_update',
+          annotations: { destructiveHint: true, openWorldHint: false },
           description: 'Update the metadata, status, or content of an existing knowledge item. Use immediately when execution reveals stale or contradicted memory instead of adding duplicates. To retire an outdated item in favour of one you just stored, call this with `id` set to the NEW item and `supersedeId` set to the OUTDATED item.',
           inputSchema: {
             type: 'object',
@@ -719,6 +789,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_gc_preview',
+          annotations: { title: 'Preview retired-memory collection', readOnlyHint: true, openWorldHint: false },
           description: 'Preview knowledge garbage collection recommendations without changing the database. Use to find duplicate, stale, or cold memory before applying GC.',
           inputSchema: {
             type: 'object',
@@ -727,6 +798,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_task_start',
+          annotations: { destructiveHint: false, openWorldHint: false },
           description: 'Start one manual work loop for multi-command or resumable work when verified lifecycle hooks are unavailable. Returns relevant memory and a taskId. Never use for a hook-owned session.',
           inputSchema: {
             type: 'object',
@@ -747,6 +819,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_task_checkpoint',
+          annotations: { destructiveHint: false, openWorldHint: false },
           description: 'Checkpoint meaningful progress or a blocker in a manual work loop using the taskId from knowl_task_start. Never use for a hook-owned session or routine command noise.',
           inputSchema: {
             type: 'object',
@@ -793,6 +866,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_task_finish',
+          annotations: { openWorldHint: false },
           description: 'Finish one manual work loop exactly once after verification using the taskId from knowl_task_start. Never use for a hook-owned session.',
           inputSchema: {
             type: 'object',
@@ -813,6 +887,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_gc_apply',
+          annotations: { title: 'Delete retired memory', destructiveHint: true, openWorldHint: false },
           description: 'Apply knowledge garbage collection only after knowl_gc_preview and explicit user approval; this may purge, archive, or compress records.',
           inputSchema: {
             type: 'object',
@@ -821,6 +896,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_skill_list',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'List learned file-backed skills from `.knowl/skills`, name and purpose only. This is a stable MCP bridge so old sessions can discover newly created skills; read one with knowl_skill_read for its manifest and instructions.',
           inputSchema: {
             type: 'object',
@@ -829,6 +905,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_skill_read',
+          annotations: { readOnlyHint: true, openWorldHint: false },
           description: 'Read one learned skill package from `.knowl/skills/<name>/`, including `skill.json` and `SKILL.md`. Read a skill before running it, so knowl_skill_run executes an entrypoint you have seen rather than one you guessed at.',
           inputSchema: {
             type: 'object',
@@ -844,6 +921,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_skill_create',
+          annotations: { openWorldHint: false },
           description: 'Create and index a learned file-backed skill only when the user explicitly requested a reusable workflow to be codified.',
           inputSchema: {
             type: 'object',
@@ -921,6 +999,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_skill_run',
+          annotations: { destructiveHint: true, openWorldHint: true },
           description: 'Run an approved learned-skill entrypoint. A skill must be approved by the user with `knowl skill approve <name>` before it will run, and any edit to the package revokes that approval. Only an entrypoint whose author set `autoRun: true` will run; that is not the default. If the call is refused, relay the approval command to the user rather than trying to work around it.',
           inputSchema: {
             type: 'object',
@@ -947,6 +1026,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_handoff',
+          annotations: { title: 'Hand off to the next session here', openWorldHint: false },
           description: 'Park the current workstream so the next session in this project picks it up. Delivered once, then archived - this is a pass, not a durable note. Store anything worth keeping with knowl_store.',
           inputSchema: {
             type: 'object',
@@ -969,6 +1049,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_park',
+          annotations: { title: 'Park work under a key', destructiveHint: false, openWorldHint: false },
           description: 'Park a workstream the user means to return to. Mints a short key and returns a line to hand them verbatim. Unlike knowl_handoff, this is not consumed by resuming and works from any directory, any number of sessions later.',
           inputSchema: {
             type: 'object',
@@ -986,6 +1067,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         {
           name: 'knowl_resume',
+          annotations: { title: 'Resume parked work by key', readOnlyHint: true, openWorldHint: false },
           description: 'Resume a parked workstream from its key. Call this as soon as a user supplies something that looks like a resume key. With no key, lists what is parked in this project.',
           inputSchema: {
             type: 'object',
@@ -999,6 +1081,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         // which nothing else asks -- the diff it needs does not exist until the branch does.
         {
           name: 'knowl_drift',
+          annotations: { title: 'Check memory against code changes', openWorldHint: false },
           description: 'Which stored knowledge this branch may have invalidated: atoms whose cited files the diff since `since` deleted or moved away, plus symbol evidence that no longer resolves. Use before opening a pull request, before knowl_task_finish on work that touched code, and when the user asks what a change breaks. An atom whose file was merely edited is deliberately NOT reported — that was two thirds of all matches and made the signal unreadable — so an empty result means nothing it cites went away, not that nothing changed. Previews by default; `apply` marks the matches as needing review so the next session sees them flagged rather than trusting them. Reads git, so it needs a repository and a base ref that exists locally.',
           inputSchema: {
             type: 'object',

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -379,6 +379,24 @@ export function boundQueryPayload(
 }
 
 /**
+ * The sentence that explains a shortened page, in one place because two paths emit it.
+ *
+ * Returns null when nothing was cut, which is also the signal not to append a block at all: a
+ * complete page must stay a single parseable block, and a notice saying "nothing was bounded"
+ * would be a second block for every caller to skip.
+ */
+function responseBoundedNotice(shortened: number, omitted: number): string | null {
+  if (shortened <= 0 && omitted <= 0) return null;
+  const what = [
+    shortened > 0 ? `the content of ${shortened} lower-ranked result(s) was cut to an excerpt` : '',
+    omitted > 0 ? `${omitted} lower-ranked result(s) were dropped entirely` : '',
+  ].filter(Boolean).join(', and ');
+  return `RESPONSE BOUNDED: ${what}, to keep this response under ${MAX_RESPONSE_CHARS} characters. `
+    + 'These were the weakest matches, not a scoping failure. Read any result whole with '
+    + '`knowl_query` and its `id`; narrow the query or lower `limit` to see more of them at once.';
+}
+
+/**
  * A context pack serialized under a hard character ceiling.
  *
  * Dropping whole items keeps the payload valid JSON, which cutting the string would not, and
@@ -901,7 +919,19 @@ export function registerTools(
           // `affectedPaths` always ships. Safe only because `queryKnowledgeBase` resolves
           // against one project id, so this branch cannot return a foreign item. Pinned by
           // tests/mcp/query-pointer-surface.test.ts — federate this path and that test fails.
-          return { content: [{ type: 'text', text: compactMcpJson(items.map(item => compactItemResponse(item))) }] };
+          //
+          // Through the same ceiling as the live path, which this branch used to walk straight
+          // past: `MAX_RESPONSE_CHARS` is declared as the bound for this surface and only the
+          // live path was wired to it, so a historical read of the same store answered 43,001
+          // characters where the live one answered 10,545. The default limit above narrowed the
+          // opening -- only an explicit `limit` reaches this now -- but a caller who names one
+          // is exactly the caller who reaches the ceiling, and an argument about WHEN should
+          // never have decided how much comes back.
+          const asOfPayload = boundQueryPayload([{ repo: '', rows: items.map(item => compactItemResponse(item)) }], 'flat');
+          const asOfBlocks: { type: 'text'; text: string }[] = [{ type: 'text', text: asOfPayload.text }];
+          const asOfNotice = responseBoundedNotice(asOfPayload.shortened, asOfPayload.omitted);
+          if (asOfNotice) asOfBlocks.push({ type: 'text', text: asOfNotice });
+          return { content: asOfBlocks };
         }
         const effectiveRoot = projectRoot ?? knowlHome();
         let vector;
@@ -1172,18 +1202,8 @@ export function registerTools(
         const { text: payloadText, shortened, omitted: omittedResults } =
           boundQueryPayload(payloadGroups as Array<{ repo: string; rows: Record<string, unknown>[] }>, federated?.shape ?? 'flat');
         const blocks: { type: 'text'; text: string }[] = [{ type: 'text', text: payloadText }];
-        if (shortened > 0 || omittedResults > 0) {
-          const what = [
-            shortened > 0 ? `the content of ${shortened} lower-ranked result(s) was cut to an excerpt` : '',
-            omittedResults > 0 ? `${omittedResults} lower-ranked result(s) were dropped entirely` : '',
-          ].filter(Boolean).join(', and ');
-          blocks.push({
-            type: 'text',
-            text: `RESPONSE BOUNDED: ${what}, to keep this response under ${MAX_RESPONSE_CHARS} characters. `
-              + 'These were the weakest matches, not a scoping failure. Read any result whole with '
-              + '`knowl_query` and its `id`; narrow the query or lower `limit` to see more of them at once.',
-          });
-        }
+        const boundedNotice = responseBoundedNotice(shortened, omittedResults);
+        if (boundedNotice) blocks.push({ type: 'text', text: boundedNotice });
         // This repo returned nothing and a linked one did. The shape already says so; this says
         // the one thing a shape cannot, which is that a foreign fact describes a foreign repo.
         //

--- a/tests/mcp/query-response-bound.test.ts
+++ b/tests/mcp/query-response-bound.test.ts
@@ -105,4 +105,39 @@ describe('knowl_query response bound', () => {
     expect(result.content).toHaveLength(1);
     expect(JSON.parse(String(result.content[0].text))).toHaveLength(2);
   });
+
+  /**
+   * The historical branch answers from a different code path and used to answer without a
+   * ceiling at all -- measured at 43,001 characters against 10,545 on the live path for the
+   * same store. A default limit narrowed the opening to callers who name a `limit`, which is
+   * precisely the caller who reaches the ceiling. An argument about WHEN should not decide how
+   * much comes back.
+   */
+  it('bounds a historical read the same way it bounds a live one', async () => {
+    const asOf = new Date(Date.now() + 60_000).toISOString();
+    const result = await call('knowl_query', {
+      query: 'deployment rollback procedure', limit: SEEDED_ITEMS, asOf,
+    });
+    const [block, notice] = result.content;
+    const items = JSON.parse(String(block.text));
+
+    expect(block.text.length).toBeLessThanOrEqual(MAX_RESPONSE_CHARS);
+    // Bodies before results, exactly as the live path trades them: nothing is dropped.
+    expect(items).toHaveLength(SEEDED_ITEMS);
+    expect(items[items.length - 1].truncated).toBe(true);
+    expect(items[items.length - 1].id).toBeTruthy();
+
+    // And the same sentence, so an agent meeting a short page learns the same way out of it
+    // whichever branch produced it.
+    expect(String(notice.text)).toContain('RESPONSE BOUNDED');
+    expect(String(notice.text)).toContain('`id`');
+  });
+
+  it('leaves a historical read that already fits as one parseable block', async () => {
+    const asOf = new Date(Date.now() + 60_000).toISOString();
+    const result = await call('knowl_query', { query: 'deployment rollback procedure', limit: 2, asOf });
+
+    expect(result.content).toHaveLength(1);
+    expect(JSON.parse(String(result.content[0].text))).toHaveLength(2);
+  });
 });

--- a/tests/mcp/resource-containment.test.ts
+++ b/tests/mcp/resource-containment.test.ts
@@ -51,16 +51,25 @@ vi.mock('../../src/store/queries.js', async importOriginal => {
 const { registerResources } = await import('../../src/mcp/resources.js');
 const { UNTRUSTED_NOTICE_BRIEF } = await import('../../src/core/untrusted.js');
 
-/** The read handler the SDK would install, captured instead of connected. */
+/**
+ * The read handler the SDK would install, captured instead of connected.
+ *
+ * Selected by the schema it was registered against rather than by position: this used to take
+ * `handlers[1]` on the strength of "list is registered first, read second", which stopped being
+ * true the moment `resources/templates/list` was added between them. A registration order is
+ * not a contract, and reading the method off the schema costs one line.
+ */
 function readHandler(): (request: { params: { uri: string } }) => Promise<any> {
-  const handlers: Array<(request: any) => Promise<any>> = [];
+  const handlers = new Map<string, (request: any) => Promise<any>>();
   registerResources(
-    { setRequestHandler: (_schema: unknown, handler: any) => handlers.push(handler) } as never,
+    {
+      setRequestHandler: (schema: any, handler: any) =>
+        handlers.set(schema.shape.method.value, handler),
+    } as never,
     () => 'project-1',
     () => null,
   );
-  // List is registered first, read second.
-  return handlers[1]!;
+  return handlers.get('resources/read')!;
 }
 
 /**

--- a/tests/mcp/resource-error-sanitizing.test.ts
+++ b/tests/mcp/resource-error-sanitizing.test.ts
@@ -24,16 +24,20 @@ vi.mock('../../src/store/queries.js', async importOriginal => {
 
 const { registerResources } = await import('../../src/mcp/resources.js');
 
-/** The read handler the SDK would install, captured instead of connected. */
+/**
+ * The read handler the SDK would install, captured instead of connected.
+ *
+ * By the method its schema names, not by position: `handlers[1]` was the read handler only
+ * until `resources/templates/list` was registered between list and read.
+ */
 function readHandler(): (request: { params: { uri: string } }) => Promise<unknown> {
-  const handlers: Array<(request: any) => Promise<unknown>> = [];
+  const handlers = new Map<string, (request: any) => Promise<unknown>>();
   registerResources(
-    { setRequestHandler: (_schema: unknown, handler: any) => handlers.push(handler) } as never,
+    { setRequestHandler: (schema: any, handler: any) => handlers.set(schema.shape.method.value, handler) } as never,
     () => 'project-1',
     () => null,
   );
-  // List is registered first, read second.
-  return handlers[1];
+  return handlers.get('resources/read')!;
 }
 
 describe('resource reads withhold SQL and bound parameters (K-50)', () => {

--- a/tests/mcp/resource-templates.test.ts
+++ b/tests/mcp/resource-templates.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ResourceTemplateSchema } from '@modelcontextprotocol/sdk/types.js';
+import { KNOWLEDGE_CATEGORIES } from '../../src/core/types.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * `knowl://category/{name}` resolved from the day it was written and no host could find it.
+ *
+ * `resources/templates/list` is the only place the protocol lets a server advertise a
+ * parameterised URI. Without a handler the SDK answers "method not found", so the test that
+ * matters is the round trip: ask the running server, and check that everything it advertises
+ * is something the read handler will actually serve. An advertised template that 404s would be
+ * a worse bug than the silence it replaced.
+ */
+
+vi.mock('../../src/store/queries.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/store/queries.js')>();
+  return { ...actual, queryKnowledgeBase: vi.fn(async () => []) };
+});
+
+const { registerResources } = await import('../../src/mcp/resources.js');
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+async function ask(method: string, params: Record<string, unknown>): Promise<any> {
+  const server = createMcpServer(null, null, { version: 1 } as ProjectConfig);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(resolve => {
+    transport.onSend = message => { if (message.id === id) resolve(message); };
+  });
+
+  const initialized = waitFor('init');
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'templates-test', version: '1.0' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+  const answered = waitFor('ask');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'ask', method, params });
+  const response = await answered;
+  await server.close();
+  return response;
+}
+
+/** The read handler the SDK would install, captured by the method its schema names. */
+function readHandler(): (request: { params: { uri: string } }) => Promise<any> {
+  const handlers = new Map<string, (request: any) => Promise<any>>();
+  registerResources(
+    { setRequestHandler: (schema: any, handler: any) => handlers.set(schema.shape.method.value, handler) } as never,
+    () => 'project-1',
+    () => null,
+  );
+  return handlers.get('resources/read')!;
+}
+
+describe('resources/templates/list', () => {
+  it('answers at all, so a host can discover the parameterised URI', async () => {
+    const response = await ask('resources/templates/list', {});
+    expect(response.error, 'the server refused resources/templates/list').toBeUndefined();
+    expect(response.result.resourceTemplates).toHaveLength(1);
+    expect(response.result.resourceTemplates[0].uriTemplate).toBe('knowl://category/{name}');
+  });
+
+  it('advertises a template the SDK schema accepts whole', async () => {
+    const response = await ask('resources/templates/list', {});
+    for (const template of response.result.resourceTemplates) {
+      // Parsed rather than eyeballed: `ResourceTemplateSchema` strips what it does not know, so
+      // comparing the result catches a field name this file invented.
+      expect(ResourceTemplateSchema.parse(template)).toEqual(template);
+    }
+  });
+
+  it('names every category the template will actually accept', async () => {
+    const response = await ask('resources/templates/list', {});
+    const description: string = response.result.resourceTemplates[0].description;
+    // The read handler matches `[a-z]+` and then queries with whatever it caught, so RFC 6570
+    // cannot express the real domain and the description has to carry it.
+    for (const category of KNOWLEDGE_CATEGORIES) {
+      expect(description, `${category} is servable and undocumented`).toContain(category);
+    }
+  });
+
+  it('advertises only templates that resolve', async () => {
+    const response = await ask('resources/templates/list', {});
+    const read = readHandler();
+    for (const template of response.result.resourceTemplates) {
+      for (const category of KNOWLEDGE_CATEGORIES) {
+        const uri = template.uriTemplate.replace('{name}', category);
+        const result = await read({ params: { uri } });
+        expect(result.contents[0].uri).toBe(uri);
+        expect(result.contents[0].mimeType).toBe(template.mimeType);
+      }
+    }
+  });
+});

--- a/tests/mcp/server-capabilities.test.ts
+++ b/tests/mcp/server-capabilities.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The capability card, checked in both directions.
+ *
+ * A host reads this once and then stops asking. Under-declaring hides a working feature --
+ * which is how `resources/templates/list` sat unreachable -- and over-declaring is worse,
+ * because the client takes the promised path, waits for a signal nobody sends, and the failure
+ * surfaces as silence rather than as an error.
+ *
+ * So the assertion is not "these flags look right". It is: everything declared is answerable,
+ * and everything answerable is declared.
+ */
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+/** One connection, so the initialize result and later calls describe the same server. */
+async function session(): Promise<{ init: any; ask: (method: string) => Promise<any>; end: () => Promise<void> }> {
+  const server = createMcpServer(null, null, { version: 1 } as ProjectConfig);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(resolve => {
+    transport.onSend = message => { if (message.id === id) resolve(message); };
+  });
+
+  const initialized = waitFor('init');
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'capability-test', version: '1.0' } },
+  });
+  const init = await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+  let counter = 0;
+  return {
+    init: init.result,
+    ask: async (method: string) => {
+      const id = `ask-${counter++}`;
+      const answered = waitFor(id);
+      transport.onmessage!({ jsonrpc: '2.0', id, method, params: method === 'resources/subscribe' ? { uri: 'knowl://brain' } : {} });
+      return answered;
+    },
+    end: () => server.close(),
+  };
+}
+
+describe('the declared server capabilities', () => {
+  it('declares tools and resources, and no sub-flag knowl does not implement', async () => {
+    const { init, end } = await session();
+    // Deliberately an exact comparison. A sub-flag added here without the mechanism behind it
+    // is the failure this test exists for, and `toMatchObject` would let one through.
+    expect(init.capabilities).toEqual({ tools: {}, resources: {} });
+    await end();
+  });
+
+  it('answers everything the resources capability promises', async () => {
+    const { ask, end } = await session();
+    // Including the template list: the SDK gates `resources/templates/list` on the resources
+    // capability alone, so declaring `resources` is the whole permission for it.
+    for (const method of ['resources/list', 'resources/templates/list', 'tools/list']) {
+      const response = await ask(method);
+      expect(response.error, `${method} is declared and unanswerable`).toBeUndefined();
+    }
+    await end();
+  });
+
+  it('does not answer what it never claimed', async () => {
+    const { ask, end } = await session();
+    // `subscribe` is absent from the card because nothing here implements it. If that ever
+    // stops being true, this failing is the reminder to declare it -- and if the flag is added
+    // without the handler, the test above fails instead. Neither direction can move alone.
+    const subscribed = await ask('resources/subscribe');
+    expect(subscribed.error?.code, 'resources/subscribe answered without being declared').toBe(-32601);
+    const prompts = await ask('prompts/list');
+    expect(prompts.error?.code, 'prompts answered without being declared').toBe(-32601);
+    await end();
+  });
+});

--- a/tests/mcp/tool-annotations.test.ts
+++ b/tests/mcp/tool-annotations.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { ToolSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CLOUD_TOOL_DEFINITIONS, CORE_TOOL_DEFINITIONS, FLEET_TOOL_DEFINITIONS, HOOK_TOOL_DEFINITIONS,
+  IMPACT_TOOL_DEFINITIONS, TRANSCRIPT_TOOL_DEFINITIONS, WORKSPACE_TOOL_DEFINITIONS,
+  type ToolDefinition,
+} from '../../src/mcp/tool-definitions.js';
+import { createMcpServer } from '../../src/mcp/server.js';
+import type { ProjectConfig } from '../../src/core/types.js';
+
+/**
+ * The hints hosts decide approval friction from, checked against what the tools actually do.
+ *
+ * Table-driven rather than spot-checked, because the failure this guards is not "someone typed
+ * the wrong boolean once" -- it is a tool added later that quietly inherits nothing, or a read
+ * tool that grows a write argument and keeps its `readOnlyHint`. Both are only caught by a list
+ * that has to name every tool.
+ *
+ * The wire check at the bottom exists because the annotations are only worth anything if they
+ * survive serialization: the SDK's `ToolSchema` strips fields it does not know, so a
+ * misspelled hint would vanish between this file and `tools/list` with nothing failing.
+ */
+
+const ALL: ToolDefinition[] = [
+  ...CORE_TOOL_DEFINITIONS, ...TRANSCRIPT_TOOL_DEFINITIONS, ...IMPACT_TOOL_DEFINITIONS,
+  ...WORKSPACE_TOOL_DEFINITIONS, ...FLEET_TOOL_DEFINITIONS, ...HOOK_TOOL_DEFINITIONS,
+  ...CLOUD_TOOL_DEFINITIONS,
+];
+
+/**
+ * Every tool, classified once. `true` means the call cannot create, alter, retire or delete
+ * knowledge and has no argument that would.
+ *
+ * `knowl_drift` and `knowl_impact` are false despite reading on their default path: `apply`
+ * marks atoms for review and `resolve` closes a finding, and an annotation is read before the
+ * arguments are.
+ */
+const READ_ONLY: Record<string, boolean> = {
+  knowl_query: true,
+  knowl_recent: true,
+  knowl_state: true,
+  knowl_context: true,
+  knowl_timeline: true,
+  knowl_conflicts: true,
+  knowl_evidence_list: true,
+  knowl_gc_preview: true,
+  knowl_skill_list: true,
+  knowl_skill_read: true,
+  knowl_resume: true,
+  knowl_transcript_search: true,
+  knowl_transcript_read: true,
+  knowl_session_list: true,
+  knowl_fleet: true,
+  knowl_workspace: true,
+
+  knowl_ingest: false,
+  knowl_ingest_atoms: false,
+  knowl_store: false,
+  knowl_decide: false,
+  knowl_update: false,
+  knowl_synthesize: false,
+  knowl_feedback: false,
+  knowl_session_finish: false,
+  knowl_task_start: false,
+  knowl_task_checkpoint: false,
+  knowl_task_finish: false,
+  knowl_gc_apply: false,
+  knowl_skill_create: false,
+  knowl_skill_run: false,
+  knowl_handoff: false,
+  knowl_park: false,
+  knowl_drift: false,
+  knowl_impact: false,
+  knowl_hook: false,
+  knowl_cloud: false,
+};
+
+describe('MCP tool annotations', () => {
+  it('classifies every shipped tool, so a new one cannot arrive unclassified', () => {
+    const shipped = ALL.map(tool => tool.name).sort();
+    expect(shipped).toEqual([...new Set(shipped)]);
+    expect(shipped).toEqual(Object.keys(READ_ONLY).sort());
+  });
+
+  it('claims readOnlyHint on exactly the tools that cannot change memory', () => {
+    for (const tool of ALL) {
+      const expected = READ_ONLY[tool.name];
+      if (expected) {
+        expect(tool.annotations.readOnlyHint, `${tool.name} must be annotated read-only`).toBe(true);
+      } else {
+        // Absent is correct too -- the spec defaults it to false. What must never happen is a
+        // writing tool claiming `true`.
+        expect(tool.annotations.readOnlyHint, `${tool.name} writes and must not claim read-only`).not.toBe(true);
+      }
+    }
+  });
+
+  it('says out loud which tools remove or retire', () => {
+    // The one GC action with no undo, and the tool whose entire job is retiring a predecessor.
+    // `destructiveHint` defaults to true, so these repeat the default deliberately: the point is
+    // that the file states it next to the schema, where a later edit has to see it.
+    const byName = new Map(ALL.map(tool => [tool.name, tool]));
+    expect(byName.get('knowl_gc_apply')!.annotations.destructiveHint).toBe(true);
+    expect(byName.get('knowl_update')!.annotations.destructiveHint).toBe(true);
+    // And nothing that only adds is allowed to inherit "may be destructive" by silence.
+    expect(byName.get('knowl_task_checkpoint')!.annotations.destructiveHint).toBe(false);
+    expect(byName.get('knowl_park')!.annotations.destructiveHint).toBe(false);
+    expect(byName.get('knowl_feedback')!.annotations.destructiveHint).toBe(false);
+  });
+
+  it('leaves the machine only where it really does', () => {
+    // The spec's own example: "the world of a web search tool is open, whereas that of a memory
+    // tool is not". Three tools here are the exception and every other one must say so.
+    const open = ALL.filter(tool => tool.annotations.openWorldHint !== false).map(tool => tool.name).sort();
+    expect(open).toEqual(['knowl_cloud', 'knowl_ingest', 'knowl_skill_run']);
+  });
+
+  it('survives the SDK schema, which strips any field it does not recognise', () => {
+    for (const tool of ALL) {
+      const parsed = ToolSchema.parse(tool);
+      expect(parsed.annotations, `${tool.name} lost annotation fields to ToolSchema`).toEqual(tool.annotations);
+    }
+  });
+});
+
+class InMemoryTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+  onSend?: (message: any) => void;
+  async start(): Promise<void> {}
+  async send(message: any): Promise<void> { this.onSend?.(message); }
+  async close(): Promise<void> { this.onclose?.(); }
+}
+
+async function listToolsOverTheWire(config: ProjectConfig | null): Promise<any[]> {
+  const server = createMcpServer(null, null, config);
+  const transport = new InMemoryTransport();
+  await server.connect(transport as never);
+  const waitFor = (id: string) => new Promise<any>(resolve => {
+    transport.onSend = message => { if (message.id === id) resolve(message); };
+  });
+
+  const initialized = waitFor('init');
+  transport.onmessage!({
+    jsonrpc: '2.0', id: 'init', method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'annotations-test', version: '1.0' } },
+  });
+  await initialized;
+  transport.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+  const answered = waitFor('list');
+  transport.onmessage!({ jsonrpc: '2.0', id: 'list', method: 'tools/list', params: {} });
+  const response = await answered;
+  await server.close();
+  return response.result.tools;
+}
+
+describe('what tools/list actually puts on the wire', () => {
+  it('carries the hints, not just the source literal', async () => {
+    const tools = await listToolsOverTheWire({ version: 1 } as ProjectConfig);
+    const byName = new Map(tools.map((tool: any) => [tool.name, tool]));
+
+    expect(byName.get('knowl_query').annotations).toEqual({ readOnlyHint: true, openWorldHint: false });
+    expect(byName.get('knowl_gc_apply').annotations.destructiveHint).toBe(true);
+    expect(byName.get('knowl_gc_apply').annotations.title).toBe('Delete retired memory');
+    // Every listed tool, not only the two above: an annotation the transport drops is the same
+    // failure as one never written.
+    for (const tool of tools) {
+      expect(tool.annotations, `${tool.name} reached the wire without annotations`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
knowl pins `@modelcontextprotocol/sdk` at `^1.30.0`, which already ships tool annotations, resource templates, elicitation and completions — and registers exactly four request handlers (`ListTools`, `CallTool`, `ListResources`, `ReadResource`) declaring `capabilities: { tools: {}, resources: {} }` with no sub-flags. This takes the three pieces that are true today and leaves the rest alone.

Each change was verified against a mutant, not by reading the diff.

---

### 1. `feat(mcp): every tool declares what it does to memory before a host asks`

`annotations` is now a **required** field on `ToolDefinition`, typed as the SDK's own `ToolAnnotations` rather than a local copy of the same booleans — so the compiler asks a new tool the question instead of a reviewer having to. Policy comment at `tool-definitions.ts:17-58`.

Today every knowl tool looks equally dangerous to a host, so reading memory prompts as loudly as collecting it. Now: `readOnlyHint: true` on 16 tools, `destructiveHint: true` on `knowl_update`, `knowl_gc_apply` and `knowl_skill_run`, `openWorldHint: false` on all but `knowl_cloud`, `knowl_ingest` and `knowl_skill_run`, and a human `title` on 11 opaque names.

Three judgment calls worth your eye:

- **`knowl_drift` and `knowl_impact` are annotated as writes, not reads.** `apply` marks atoms for review (`tools.ts:1936`) and `resolve` closes a finding (`:1991-2006`), and annotations are read *before* arguments — so a hint that is only true for some argument values is a hint that lies.
- **Three read-only tools do incidental writes**, named in a source comment at `:33-42` so the claim is auditable rather than implied: `knowl_query` appends one row to the workspace demand ledger (best-effort, swallows its own failures, so not part of the contract); `knowl_transcript_search` catches up the index it is about to read; any embedding tool may populate the model cache on first use. None changes an answer a later call returns. If you consider any disqualifying, `knowl_query` is the one to revisit — it also carries most of this commit's value.
- **`idempotentHint` is on nothing**, deliberately. Every write mints an id, stamps a timestamp or appends an event, so repeating leaves the store observably different. The spec defaults it to false, which is the true answer. Equally, `destructiveHint` is left at its default (**true**, per `types.js:1190`) for `knowl_store`/`knowl_decide`/`knowl_ingest_atoms`, because the write engine can auto-retire a superseded predecessor — claiming `false` there would have been the easy lie.

The test is table-driven over every shipped tool, fails if a new tool arrives unclassified, and parses each tool through the SDK's `ToolSchema` — that schema **strips unknown keys**, so a misspelled hint would otherwise vanish silently rather than fail.

### 2. `fix(mcp): the category resource template is discoverable now, not just servable`

`resources.ts:99` already implements `knowl://category/{name}` and there was no `ListResourceTemplates` handler, so no host could discover it — working code, invisible. The handler returns the one template that actually resolves, with the seven valid names spelled out in the description (RFC 6570 cannot express an enum).

The test asks the running server and then **serves back everything it advertised**: an advertised template that 404s would be worse than the silence. Two existing tests that selected the read handler as `handlers[1]` by registration order now select by method name, which is why they show in the diff.

### 3. `fix(mcp): a historical knowl_query answers under the same ceiling as a live one`

`tools.ts:904` returned `compactMcpJson(items.map(compactItemResponse))` on the `asOf` branch with no `boundQueryPayload`, bypassing `MAX_RESPONSE_CHARS = 12_000` entirely. Measured on this repo's fixture: **32,451 characters against a 12,000 ceiling.** Both paths now emit an identical bounded notice.

### 4. `test(mcp): the capability card is pinned to what the server actually answers`

**No capability was added, because none would be true.** The test exact-compares the declared card, asks every method it promises and expects an answer, then asks `resources/subscribe` and `prompts/list` and expects `-32601`. A flag cannot be added without the mechanism, nor the mechanism without the flag. `server.ts:73-90` documents why the literal stays as it is.

---

## Sources verified at primary

- `annotations` sits **on** the Tool object — `@modelcontextprotocol/sdk/dist/esm/types.js:1263`, field shapes at `:1173-1211`.
- `openWorldHint: false` is the spec's own wording for this case — `types.js:1202-1208`: *"the world of a web search tool is open, whereas that of a memory tool is not"*.
- `resources/templates/list` is gated on `capabilities.resources` alone (`server/index.js:221-226`), so there is no template sub-flag to declare.

**`anthropic/maxResultSizeChars` — verified real, and deliberately NOT added.** Per code.claude.com/docs/en/mcp it *raises* a tool's persist-to-disk threshold up to 500,000 characters; it is not a hint that a tool returns small results. `knowl_query` is already bounded at 12,000, below the default threshold, so emitting it would either do nothing or request a budget knowl does not want. The original framing of this was inverted.

## Verified

`npm run build` · `npm run typecheck` · `npm run lint` · `npm run docs:check` all clean. Full suite: **424 files, 3970 passed, 5 skipped, 0 failed.**

Live over stdio against `node dist/index.js serve`: 29 tools listed, 29 annotated; `knowl_query` → `{"readOnlyHint":true,"openWorldHint":false}`; `knowl_gc_apply` → `{"title":"Delete retired memory","destructiveHint":true,"openWorldHint":false}`; the template lists; `resources/subscribe` → `-32601`. Independently re-derived here: 28 tools under a null config, **zero tools carrying both `readOnlyHint: true` and `destructiveHint: true`**.

## Note on overlap

`fix/audit-store` (opened alongside) also touches `tools.ts` and `tool-definitions.ts` for the GC preview/apply contract. No semantic conflict, but merge order will decide which one rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
