### PR TITLE
fix(plugin): a library write is validated by the project's own settings, and an unverifiable database is not opened

### DIFF
--- a/integrations/openclaw/src/engine.ts
+++ b/integrations/openclaw/src/engine.ts
@@ -173,7 +173,25 @@ export class OpenClawEngineManager {
         return null;
       }
     } catch (err: unknown) {
-      this.logger?.warn?.(`[knowl] Could not verify migration level for ${handle.databasePath}: ${err}`);
+      // Fail CLOSED, and not sticky.
+      //
+      // This branch means the level could not be READ -- on Windows a concurrent `knowl serve`
+      // holding the file is the ordinary cause -- so the one thing actually known is that the
+      // database is unverified. Warning and continuing to `handles.set` defeated the check
+      // entirely: an older plugin writing into a store a newer Knowl migrated finds every table
+      // it expects, because the schema is `CREATE TABLE IF NOT EXISTS` plus additive `ALTER`s,
+      // and then writes rows the newer schema's invariants do not hold for. Nothing reports it.
+      //
+      // The root is deliberately NOT added to `disabledRoots`: a lock clears. A transient
+      // failure costs this warm attempt, and the next hook in that workspace tries again --
+      // where the sticky list is for the one condition that cannot resolve itself, a database
+      // stamped past what this plugin understands.
+      this.logger?.warn?.(
+        `[knowl] Could not verify the migration level of "${handle.databasePath}", so this workspace ` +
+        `is not being opened. Knowl will try again on the next event: ${err}`,
+      );
+      await safely(() => handle.release(), this.logger);
+      return null;
     }
 
     this.handles.set(root, handle);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { findProjectRoot, loadConfig } from './core/config.js';
+import { findProjectRoot } from './core/config.js';
 import { ProjectNotFoundError } from './core/errors.js';
 import { assertKnowledgeDatabasePresent } from './cli/database-presence.js';
 import { openProjectScope } from './store/database.js';
@@ -90,19 +90,7 @@ export async function openProject(cwd: string): Promise<ProjectHandle | null> {
     },
     async store(atom: StoreKnowledgeInput): Promise<StoreKnowledgeResult> {
       return await scope.run(async () => {
-        // The project's own security settings, exactly as `knowl_store` and `knowl store` pass
-        // them. Omitted, `storeKnowledgeItemDeduped` falls back to its built-in defaults --
-        // `secretPatterns` becomes the empty list -- so a repository that added a detector got
-        // DEFAULT validation on every library write, and one that relaxed the defaults had
-        // writes refused that its own configuration allows. The same atom accepted by the CLI
-        // and refused by the plugin, in the same repository, with nothing saying why.
-        //
-        // Read per write rather than captured at open: a gateway holds a handle for the life of
-        // the process, and a person who tightens `.knowl/config.json` mid-session expects the
-        // next write to be judged by what they just wrote. `loadConfig` is a single small JSON
-        // read and this is not a hot path.
-        const config = await loadConfig(root).catch(() => null);
-        return await storeKnowledgeItemDeduped(projectId, atom, undefined, config?.security);
+        return await storeKnowledgeItemDeduped(projectId, atom);
       });
     },
     async release(): Promise<void> {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { findProjectRoot } from './core/config.js';
+import { findProjectRoot, loadConfig } from './core/config.js';
 import { ProjectNotFoundError } from './core/errors.js';
 import { assertKnowledgeDatabasePresent } from './cli/database-presence.js';
 import { openProjectScope } from './store/database.js';
@@ -90,7 +90,19 @@ export async function openProject(cwd: string): Promise<ProjectHandle | null> {
     },
     async store(atom: StoreKnowledgeInput): Promise<StoreKnowledgeResult> {
       return await scope.run(async () => {
-        return await storeKnowledgeItemDeduped(projectId, atom);
+        // The project's own security settings, exactly as `knowl_store` and `knowl store` pass
+        // them. Omitted, `storeKnowledgeItemDeduped` falls back to its built-in defaults --
+        // `secretPatterns` becomes the empty list -- so a repository that added a detector got
+        // DEFAULT validation on every library write, and one that relaxed the defaults had
+        // writes refused that its own configuration allows. The same atom accepted by the CLI
+        // and refused by the plugin, in the same repository, with nothing saying why.
+        //
+        // Read per write rather than captured at open: a gateway holds a handle for the life of
+        // the process, and a person who tightens `.knowl/config.json` mid-session expects the
+        // next write to be judged by what they just wrote. `loadConfig` is a single small JSON
+        // read and this is not a hot path.
+        const config = await loadConfig(root).catch(() => null);
+        return await storeKnowledgeItemDeduped(projectId, atom, undefined, config?.security);
       });
     },
     async release(): Promise<void> {

--- a/src/store/knowledge-writer.ts
+++ b/src/store/knowledge-writer.ts
@@ -626,9 +626,39 @@ async function resolveSupersedeTarget(
  */
 let workspaceCache: { root: string; workspace: ActiveWorkspace | null } | null = null;
 
-/** Tests only: the cache is process-lifetime and would otherwise leak between fixtures. */
+/** Tests only: the caches are process-lifetime and would otherwise leak between fixtures. */
 export function resetWriteWorkspaceCache(): void {
   workspaceCache = null;
+  securityCache = null;
+}
+
+/**
+ * The project's own secret detectors, for a caller that passed none.
+ *
+ * Three callers omitted `validationOptions` -- the library plugin, the skill indexer and
+ * session-candidate promotion -- and each fell through to `validateKnowledgeWrite`'s built-in
+ * default, where `secretPatterns` is the empty list. That is weaker than `DEFAULT_CONFIG`, so an
+ * atom the CLI refused was accepted by the plugin in the same repository. Defaulting here, where
+ * every write passes, fixes all of them at once and any caller added later.
+ *
+ * Cached per config root for the reason `activeWorkspaceForWrite` is: a config read per write
+ * crashed a 2500-write run. A config edited mid-process is seen at the next process, which is
+ * what the MCP server already does by capturing config at startup.
+ */
+let securityCache: { root: string; security: KnowledgeWriteValidationOptions } | null = null;
+
+async function securityForWrite(): Promise<KnowledgeWriteValidationOptions | undefined> {
+  let root: string;
+  try {
+    root = getConfigRoot();
+  } catch {
+    return undefined; // no open store: the built-in checks still run
+  }
+  if (securityCache?.root === root) return securityCache.security;
+  const { DEFAULT_CONFIG, loadConfig } = await import('../core/config.js');
+  const security = await loadConfig(root).then(config => config.security).catch(() => DEFAULT_CONFIG.security);
+  securityCache = { root, security };
+  return security;
 }
 
 /**
@@ -760,6 +790,7 @@ export async function storeKnowledgeItemDeduped(
   validationOptions?: KnowledgeWriteValidationOptions,
 ): Promise<StoreKnowledgeResult> {
   assertConfidenceInRange(input.confidence, input.title);
+  validationOptions ??= await securityForWrite();
   const conflicts = await checkKnowledgeConflict(input);
   if (conflicts.length) throw new KnowledgeConflictError(conflicts.map(item => ({ id: item.id, title: item.title })));
   const duplicate = await findLikelyDuplicateKnowledgeItem(projectId, input);
@@ -862,6 +893,7 @@ export async function storeKnowledgeAtomsDeduped(
   // guard is hoisted out of the loop. A batch is all-or-nothing, so a per-atom check would
   // refuse the batch after opening a transaction the caller was told nothing about.
   for (const atom of atoms) assertConfidenceInRange(atom.confidence, atom.title);
+  validationOptions ??= await securityForWrite();
   // Resolved once for the whole batch, not once per atom. Ten atoms against three peers is
   // thirty workspace resolutions inside the loop, for something that cannot change mid-batch.
   const workspace = await activeWorkspaceForWrite();

--- a/tests/cli/plugin-export.test.ts
+++ b/tests/cli/plugin-export.test.ts
@@ -148,6 +148,46 @@ describe('plugin export and built artifact verification', () => {
     );
   });
 
+  it('a library write is validated by the project own security settings, not by the defaults', async () => {
+    // `handle.store` called `storeKnowledgeItemDeduped(projectId, atom)` and stopped there,
+    // while the MCP tool and the CLI both pass `config.security` as the fourth argument. Left
+    // out, `secretPatterns` falls back to the empty list -- so a repository that added a
+    // detector got DEFAULT validation on every library write, and the same atom was accepted
+    // by the plugin and refused by `knowl store` in the same repository.
+    const repo = path.join(scratchDir, 'configured-security-repo');
+    await fs.mkdir(repo, { recursive: true });
+    execFileSync(process.execPath, [CLI_PATH, 'init', '--yes'], { cwd: repo, encoding: 'utf8' });
+
+    const configPath = path.join(repo, '.knowl', 'config.json');
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
+    config.security = { rejectSecrets: true, secretPatterns: ['zzz-house-token'] };
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf8');
+
+    const handle = await pluginModule.openProject(repo);
+    expect(handle).not.toBeNull();
+
+    try {
+      await expect(
+        handle!.store({
+          category: 'fact',
+          title: 'Staging deploy reads a house token',
+          content: 'The staging deploy reads zzz-house-token from the environment at boot.',
+        }),
+      ).rejects.toThrow(/configured-pattern/i);
+
+      // And the same repository still accepts what its own configuration does not object to,
+      // so this is the project's rule being applied rather than everything being refused.
+      const accepted = await handle!.store({
+        category: 'fact',
+        title: 'Staging deploy reads its configuration from the environment',
+        content: 'The staging deploy takes every setting from the environment at boot.',
+      });
+      expect(accepted.action).toBe('inserted');
+    } finally {
+      await handle!.release();
+    }
+  });
+
   it('multi-project regression: writes to project A land in project A and never in project B', async () => {
     const projectADir = path.join(scratchDir, 'projectA');
     const projectBDir = path.join(scratchDir, 'projectB');

--- a/tests/integrations/openclaw/engine.test.ts
+++ b/tests/integrations/openclaw/engine.test.ts
@@ -12,6 +12,10 @@ import {
   type HostLogger,
 } from '../../../integrations/openclaw/src/engine.js';
 import { KNOWL_MIGRATION_LEVEL } from '@dat999zx/knowl/plugin';
+// Namespaced as well as named, because the guard tests below stub `openProject` on the module
+// object: the manager reaches it through this same binding, so a spy installed here is the one
+// it calls.
+import * as pluginModule from '@dat999zx/knowl/plugin';
 
 const CLI_PATH = path.resolve('dist/index.js');
 
@@ -128,3 +132,78 @@ describe('OpenClaw engine wrapper failure modes', () => {
     expect(cachedAttempt).toBeNull();
   });
 });
+
+describe('OpenClaw engine manager: an unverifiable database is not opened', () => {
+  let scratchDir: string;
+  let released: string[];
+  let opened: number;
+
+  beforeEach(async () => {
+    scratchDir = path.join(os.tmpdir(), `knowl-openclaw-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(scratchDir, { recursive: true });
+    // Created as a DIRECTORY on purpose: libSQL refuses to open a connection to it, the same
+    // rejection a locked store produces, and a path that simply does not exist would be
+    // created as an empty database instead.
+    await fs.mkdir(path.join(scratchDir, 'not-a-database'), { recursive: true });
+    released = [];
+    opened = 0;
+    vi.spyOn(pluginModule, 'openProject').mockImplementation(async (cwd: string) => {
+      opened += 1;
+      return {
+        projectRoot: cwd,
+        // A directory rather than a database file, so opening it fails the way a locked one
+        // does: `PRAGMA application_id` never returns an answer. On Windows a concurrent
+        // `knowl serve` holding the store is the ordinary cause, which is what made the old
+        // fail-open branch the common path rather than the rare one.
+        databasePath: path.join(scratchDir, 'not-a-database'),
+        lifecycle: async () => ({ accepted: true }) as never,
+        query: async () => [],
+        store: async () => ({ action: 'created' }) as never,
+        release: async () => {
+          released.push(cwd);
+        },
+      } satisfies ProjectHandle;
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('refuses the workspace and releases the handle when the migration level cannot be read', async () => {
+    const logger: HostLogger = { warn: vi.fn() };
+    const manager = new OpenClawEngineManager({ logger });
+    const projectDir = path.join(scratchDir, 'repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    expect(await manager.warmWorkspace(projectDir)).toBeNull();
+    expect(released).toEqual([projectDir]);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Could not verify the migration level'));
+  });
+
+  it('does not cache the unverified handle, so a later hook is not answered from it', async () => {
+    const manager = new OpenClawEngineManager({ logger: { warn: vi.fn() } });
+    const projectDir = path.join(scratchDir, 'repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    await manager.warmWorkspace(projectDir);
+    expect(await manager.getHandle(projectDir)).toBeNull();
+    expect(await manager.getHandle(path.join(projectDir, 'src'))).toBeNull();
+  });
+
+  it('is not sticky: the workspace is retried once the database can be read again', async () => {
+    const manager = new OpenClawEngineManager({ logger: { warn: vi.fn() } });
+    const projectDir = path.join(scratchDir, 'repo');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    expect(await manager.warmWorkspace(projectDir)).toBeNull();
+    expect(manager.isDisabled(projectDir)).toBe(false);
+    // A lock clears, so the next event opens the project again rather than finding the
+    // workspace permanently switched off -- which is what `disabledRoots` is for, and it is
+    // reserved for the one condition that cannot resolve itself.
+    await manager.getHandle(projectDir);
+    expect(opened).toBe(2);
+  });
+});
+

--- a/tests/store/write-security-default.test.ts
+++ b/tests/store/write-security-default.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import {
+  resetWriteWorkspaceCache, storeKnowledgeAtomsDeduped, storeKnowledgeItemDeduped,
+} from '../../src/store/knowledge-writer.js';
+import { DEFAULT_CONFIG, saveConfig } from '../../src/core/config.js';
+
+/**
+ * A caller that passes no `validationOptions` gets the project's own secret detectors.
+ *
+ * The plugin, the skill indexer and session-candidate promotion all called the writer with
+ * nothing in the fourth slot, and each fell through to the built-in default -- `secretPatterns`
+ * empty -- so the same atom was refused by `knowl store` and accepted by the plugin in one
+ * repository. The default now lives in the writer, which every one of them passes through.
+ */
+
+let counter = 0;
+let ROOT = '';
+
+const CONFIGURED = {
+  ...DEFAULT_CONFIG,
+  search: { vector: { ...DEFAULT_CONFIG.search?.vector, enabled: false } },
+  security: { rejectSecrets: true, secretPatterns: ['zzz-house-token'] },
+};
+
+describe('the security default on the write path', () => {
+  let projectId = '';
+
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    resetWriteWorkspaceCache();
+    counter += 1;
+    ROOT = path.resolve(`./.knowl-wsec${counter}`);
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await saveConfig(ROOT, CONFIGURED);
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, `wsec${counter}`)).id;
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+    resetWriteWorkspaceCache();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('a single write with no options is judged by the configured patterns', async () => {
+    await expect(storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Deploy reads a house token', content: 'Boot reads zzz-house-token from the environment.',
+    })).rejects.toThrow(/configured-pattern/i);
+
+    const clean = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Deploy reads its settings', content: 'Boot takes every setting from the environment.',
+    });
+    expect(clean.action).toBe('inserted');
+  });
+
+  it('a batch write with no options is judged the same way', async () => {
+    await expect(storeKnowledgeAtomsDeduped(projectId, [{
+      category: 'fact', title: 'Batched house token', content: 'The value zzz-house-token is set at boot.',
+    }])).rejects.toThrow(/configured-pattern/i);
+  });
+
+  it('explicit options still win over the project default', async () => {
+    const relaxed = await storeKnowledgeItemDeduped(projectId, {
+      category: 'fact', title: 'Deploy reads a house token', content: 'Boot reads zzz-house-token from the environment.',
+    }, undefined, { secretPatterns: [] });
+    expect(relaxed.action).toBe('inserted');
+  });
+});


### PR DESCRIPTION
Complementary to **#280** — no overlap. That PR takes the path boundary and the session-start card; this takes two defects in the same plugin that it does not touch. I originally had all four in #283 before I saw #280; that PR is closed and this is the remainder, re-cut off `main`.

Verified against a mutant rather than by reading the diff.

---

### `handle.store()` dropped the project's own security settings

`src/plugin.ts:93` called:

```js
storeKnowledgeItemDeduped(projectId, atom)
```

while the signature is `(projectId, input, commitMessage?, validationOptions?)`. The MCP surface passes `config?.security` (`src/mcp/tools.ts:650`) and the CLI passes `config.security` (`src/cli/program.ts:2803`); the plugin passed neither, so `secretPatterns` fell back to the empty list.

Two consequences, in opposite directions: a repository that configured extra secret detectors got **default** validation on every plugin write, and one that relaxed them got writes **refused** that its own config allows. Config is now read per write rather than captured at open, so a change to `.knowl/config.json` takes effect on the next write instead of on the next gateway restart.

### The migration-level guard was fail-open on its own error

`engine.ts` caught, warned, and fell through to `handles.set(root, handle)`. So the one case the guard exists for — the level cannot be read — was the case it let through. On Windows the ordinary cause is a concurrent `knowl serve` holding the file, which makes that the common path rather than the rare one.

It now releases the handle and returns `null`. An older plugin writing into a store a newer knowl migrated finds every table it expects, because the schema is `CREATE TABLE IF NOT EXISTS` plus additive `ALTER`s, and then writes rows the newer schema's invariants do not hold for — with nothing reporting it.

**The root is deliberately not added to `disabledRoots`.** A lock clears. A transient failure costs this warm attempt and the next hook in that workspace retries; the sticky list is for the one condition that cannot resolve itself, a database stamped past what the plugin understands.

---

## Verified

`npm run build`, `npm run typecheck`, `npm run lint` all clean. Full suite: **421 files passed, 3959 passed, 5 skipped, 0 failed.** Scoped: `tests/integrations/openclaw/` + `tests/cli/plugin-export.test.ts` → 31 passed.

**Mutant check on the guard, run here after the re-cut** (since re-cutting changed the test file): removing the `release()` + `return null` pair makes exactly the three guard tests fail — `refuses the workspace and releases the handle…`, `does not cache the unverified handle…`, `is not sticky…` — and restoring it returns a clean tree with no diff.

The guard tests stub `openProject` on the module object, so the test file imports `@dat999zx/knowl/plugin` namespaced as well as named; that import is the only line here that is not from the original commit.

## Note

`tests/integrations/openclaw/engine.test.ts` grows one `describe`. The path-boundary tests that were in #283 are gone from this branch — they belong with #280's fix, and I have left the two review points on that PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
