### PR TITLE
fix(store): five defects — secret scanning, a bootstrap rollback, import conflicts, an atomic update, and unpreviewed purges

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2020,7 +2020,12 @@ lands. Best-effort vector indexing after import uses only the locally available 
 ```bash
 knowl gc
 knowl gc --apply
+knowl gc --apply --purge <id,id,...>
 ```
+
+Apply archives and compresses on its own, but purges nothing unless `--purge` names ids the
+preview listed; only ids that are still candidates are deleted, and the rest are reported.
+`knowl_gc_apply` takes the same approval as `purgeItemIds`, which `knowl_gc_preview` returns.
 
 The default policy:
 
@@ -2719,7 +2724,7 @@ knowl eval --dataset docs/evals/retrieval-suite.json --json
 | `knowl park --goal <goal> [--next-action <a>] [--completed <c...>] [--blocker <b>] [--artifact <p...>] [--verified\|--unverified]` | Park a workstream and get a key back; hand the key to the user verbatim |
 | `knowl handoff --goal <goal> --next-action <a> [--completed <c...>] [--blocker <b>] [--artifact <p...>] [--verified\|--unverified]` | Leave a baton the next session in this project receives once |
 | `knowl resume [key]` | Resume a parked workstream from its key, or list what is parked here |
-| `knowl gc [--apply] [--stale-days N] [--compress-days N] [--min-bytes N] [--ignore-access] [--tombstone-days N]` | Preview or apply duplicate, archive, compression, and tombstone maintenance |
+| `knowl gc [--apply] [--purge <ids>] [--stale-days N] [--compress-days N] [--min-bytes N] [--ignore-access] [--tombstone-days N]` | Preview or apply duplicate, archive, compression, and tombstone maintenance |
 | `knowl forget-log [--limit N] [--repo <name>] [--json] [--prune-days N]` | Show why knowledge items were destroyed — policy, reason, and the retrieval evidence it overruled — or prune those records |
 | `knowl pr --since <commit> [--dry-run]` | Find drift candidates and, unless dry-run, mark them for review |
 | `knowl reviewed <itemId> [--note <text>]` | Record that an item was re-read and still holds, clearing its review flag here and on the team's copy |

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2450,6 +2450,16 @@ program.command('import').argument('<path>').description('Load portable JSONL me
           `Import did not apply${result.conflicts ? ` (${result.conflicts} conflict(s))` : ''}. ` +
           'Re-run with a different --on-divergence policy, or reconcile the source.',
         );
+        // No divergence policy resolves an exclusive collision: two items both claim to be
+        // the one active value for a key, and only a person can say which. Naming them is the
+        // difference between "try another policy" -- which cannot work -- and an actionable
+        // instruction.
+        for (const clash of result.exclusiveConflicts ?? []) {
+          console.error(
+            `  ${clash.id} claims an exclusive identity already held by the active item ` +
+            `${clash.heldBy}. Retire one of them, then re-import.`,
+          );
+        }
         process.exitCode = 1;
       }
     } catch (error: any) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -3717,6 +3717,10 @@ program
   .option('--min-bytes <bytes>', 'Minimum content bytes before compressing an archived item (default 180)')
   .option('--ignore-access', 'Archive stale state even if it was recently or frequently retrieved (hot)')
   .option('--tombstone-days <days>', 'Remove delete records older than this many days (default 90)')
+  // Purge is the one action with no undo, and `knowl gc` and `knowl gc --apply` are two
+  // processes: the second cannot know what the first printed. So the ids the user read are
+  // handed back by name, and an --apply that names none deletes nothing.
+  .option('--purge <ids>', 'Comma-separated item ids from a `knowl gc` preview, approved for deletion')
   .action(async (options) => {
     try {
       const root = await findProjectRoot(process.cwd());
@@ -3730,6 +3734,9 @@ program
         minCompressBytes: numericOption(options.minBytes, '--min-bytes', { min: 0 }),
         ignoreAccess: Boolean(options.ignoreAccess),
         tombstoneDays: numericOption(options.tombstoneDays, '--tombstone-days', { min: 0 }),
+        ...(typeof options.purge === 'string'
+          ? { approvedPurgeIds: options.purge.split(',').map((id: string) => id.trim()).filter(Boolean) }
+          : {}),
       };
       const result = options.apply
         ? await applyKnowledgeGc(project.id, gcOptions)
@@ -3770,6 +3777,19 @@ program
           }
           console.log(`  Bytes: ${candidate.beforeBytes} -> ${candidate.afterBytes}`);
         }
+      }
+
+      // The line that turns a preview into an approvable one. Printed on a preview so the ids
+      // can be copied, and on an apply so a declined deletion is never silent.
+      const declined = result.unapprovedPurges ?? (options.apply ? [] : result.candidates.filter(c => c.action === 'purge'));
+      if (declined.length > 0) {
+        console.log('');
+        console.log(
+          options.apply
+            ? `Purged nothing: ${declined.length} item(s) were candidates but --purge did not name them.`
+            : `${declined.length} item(s) would be PERMANENTLY deleted. They are not deleted unless named:`,
+        );
+        console.log(`  knowl gc --apply --purge ${declined.map(candidate => candidate.itemId).join(',')}`);
       }
 
       await closeDb();

--- a/src/core/knowledge-validation.ts
+++ b/src/core/knowledge-validation.ts
@@ -71,6 +71,35 @@ function reject(code: string, message: string): never {
 }
 
 /**
+ * The scan set as a projection, so a caller cannot hand over less than it writes.
+ *
+ * `stringFields` below reads `tags`, `alternatives` and `steps`, but three callers built the
+ * object they passed as an object literal of exactly five fields -- title, content, reasoning,
+ * source, affectedPaths -- and the two array columns fell on the floor. An absent field is not
+ * a clean field: `arrayField` returns `[]` for it and the scan silently covers nothing, so the
+ * store-wide audit answered "no integrity findings" over a row whose `tags` held a live
+ * credential, `restoreSnapshot` certified such a snapshot, and import accepted it from a peer.
+ *
+ * Take the projection off the record rather than retyping the literal: a column added later is
+ * then one entry in `SCANNED_FIELDS` instead of four literals that have to be found again.
+ * Only keys the record actually carries are copied, which is what lets the update path pass
+ * `updates` directly and still scan exactly what it is about to write.
+ */
+const SCANNED_FIELDS = [
+  'title', 'content', 'reasoning', 'source', 'affectedPaths', 'tags', 'alternatives', 'steps',
+  'rawOutput',
+] as const;
+
+export function scannableFields(record: unknown): KnowledgeWriteInput {
+  const source = (record ?? {}) as Record<string, unknown>;
+  const projected: Record<string, unknown> = {};
+  for (const field of SCANNED_FIELDS) {
+    if (source[field] !== undefined) projected[field] = source[field];
+  }
+  return projected as KnowledgeWriteInput;
+}
+
+/**
  * Every field a secret can arrive in, not just the prose ones.
  *
  * `tags`, `alternatives` and skill `steps` are all writable from the MCP surface, and all

--- a/src/core/knowledge-validation.ts
+++ b/src/core/knowledge-validation.ts
@@ -116,10 +116,11 @@ function stringFields(input: KnowledgeWriteInput): Array<[string, string]> {
       : [];
 
   const anyInput = input as unknown as Record<string, unknown>;
-  // A skill step is an object; its instruction is the part a caller writes prose into.
+  // A skill step is an object whose instruction is the prose -- or, on the repository's own
+  // `steps` parameter, the bare instruction string.
   const steps = Array.isArray(anyInput.steps)
     ? anyInput.steps.flatMap((step, index): Array<[string, string]> => {
-      const instruction = (step as Record<string, unknown> | null)?.instruction;
+      const instruction = typeof step === 'string' ? step : (step as Record<string, unknown> | null)?.instruction;
       return typeof instruction === 'string' ? [[`steps[${index}].instruction`, instruction]] : [];
     })
     : [];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -575,6 +575,14 @@ export type KnowledgeWriteInput = {
   source?: string | null;
   affectedPaths?: string[] | null;
   rawOutput?: string | null;
+  /**
+   * Declared, not merely read off `any`. The scanner has always looked at these three, but the
+   * type stopped short at the prose fields -- so a caller assembling an input by hand got no
+   * signal that leaving them out narrows the scan, and three of them left them out.
+   */
+  tags?: string[] | null;
+  alternatives?: string[] | null;
+  steps?: Array<{ instruction?: string | null } | null> | null;
 };
 
 export type KnowledgeWriteValidationOptions = {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -582,7 +582,7 @@ export type KnowledgeWriteInput = {
    */
   tags?: string[] | null;
   alternatives?: string[] | null;
-  steps?: Array<{ instruction?: string | null } | null> | null;
+  steps?: Array<string | { instruction?: string | null } | null> | null;
 };
 
 export type KnowledgeWriteValidationOptions = {

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -795,7 +795,7 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_gc_preview',
           annotations: { title: 'Preview retired-memory collection', readOnlyHint: true, openWorldHint: false },
-          description: 'Preview knowledge garbage collection recommendations without changing the database. Use to find duplicate, stale, or cold memory before applying GC.',
+          description: 'Preview knowledge garbage collection recommendations without changing the database. Use to find duplicate, stale, or cold memory before applying GC. Returns `purgeItemIds`: the ids knowl_gc_apply will not delete unless they are handed back to it.',
           inputSchema: {
             type: 'object',
             properties: {},
@@ -893,10 +893,16 @@ export const CORE_TOOL_DEFINITIONS: ToolDefinition[] = [
         {
           name: 'knowl_gc_apply',
           annotations: { title: 'Delete retired memory', destructiveHint: true, openWorldHint: false },
-          description: 'Apply knowledge garbage collection only after knowl_gc_preview and explicit user approval; this may purge, archive, or compress records.',
+          description: 'Apply knowledge garbage collection only after knowl_gc_preview and explicit user approval; this may purge, archive, or compress records. Purge is the one action with no undo, so it deletes nothing unless `purgeItemIds` names the ids the preview listed and the user approved. Archive and compress still run without it.',
           inputSchema: {
             type: 'object',
-            properties: {},
+            properties: {
+              purgeItemIds: {
+                type: 'array',
+                items: { type: 'string', minLength: 1 },
+                description: 'Item ids from the `purgeItemIds` of a knowl_gc_preview run, approved by the user. Only ids that are STILL purge candidates are deleted, so an item written since that preview is never destroyed by this call. Omit to archive and compress without deleting anything.',
+              },
+            },
           },
         },
         {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1667,8 +1667,12 @@ export function registerTools(
 
       else if (name === 'knowl_gc_preview') {
         const result = await previewKnowledgeGc(projectId!);
+        // Every purge id, not the first three. Purge is the one action `knowl_gc_apply` will
+        // not take unless it is handed the ids a preview named, so a truncated list here would
+        // make the approvable set unknowable from the response that is meant to supply it.
+        const purgeItemIds = result.candidates.filter(entry => entry.action === 'purge').map(entry => entry.itemId);
         return {
-          content: [{ type: 'text', text: compactMcpJson({ summary: result.summary, candidateCount: result.candidates.length, candidates: result.candidates.slice(0, 3) }) }],
+          content: [{ type: 'text', text: compactMcpJson({ summary: result.summary, candidateCount: result.candidates.length, candidates: result.candidates.slice(0, 3), purgeItemIds }) }],
         };
       }
 
@@ -1716,9 +1720,24 @@ export function registerTools(
       }
 
       else if (name === 'knowl_gc_apply') {
-        const result = await applyKnowledgeGc(projectId!);
+        const { purgeItemIds } = args as { purgeItemIds?: string[] };
+        const result = await applyKnowledgeGc(projectId!, {
+          ...(Array.isArray(purgeItemIds) ? { approvedPurgeIds: purgeItemIds } : {}),
+        });
         return {
-          content: [{ type: 'text', text: compactMcpJson({ summary: result.summary, candidateCount: result.candidates.length, candidates: result.candidates.slice(0, 3) }) }],
+          content: [{
+            type: 'text',
+            text: compactMcpJson({
+              summary: result.summary,
+              candidateCount: result.candidates.length,
+              candidates: result.candidates.slice(0, 3),
+              // Named rather than silently dropped: fewer deletions than the preview showed is
+              // a result the caller has to be able to see and act on.
+              ...(result.unapprovedPurges?.length
+                ? { unapprovedPurges: result.unapprovedPurges.map(entry => entry.itemId) }
+                : {}),
+            }),
+          }],
         };
       }
 

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -702,6 +702,28 @@ async function foreignKeyTargets(client: Client, table: string): Promise<string[
   return rows.rows.map(row => String(row.table));
 }
 
+/**
+ * Rebuild the skill tables onto the right parent, WITHOUT carrying rows the new key forbids.
+ *
+ * The rows this drops are the ones the wrong foreign key let accumulate: their skill was
+ * deleted and nothing cascaded, which is the whole reason the key is being replaced. The
+ * replacement is `ON DELETE CASCADE`, so copying them across writes rows the schema says
+ * cannot exist -- and every read of a skill joins through `knowledge_items`, so they were
+ * already unreachable. This completes the cascade that never ran rather than destroying
+ * anything a caller could still see.
+ *
+ * Not carrying them is also what keeps the bootstrap survivable. This runs inside the
+ * migration transaction under `defer_foreign_keys`, so a copied orphan is a deferred violation
+ * and a deferred violation fails the COMMIT -- which rolls back the ENTIRE bootstrap, leaving
+ * `application_id` at 0 and ~40 tables uncreated. Every later open then runs the same repair
+ * and fails in the same place, `knowl doctor` included, because doctor opens the store too.
+ *
+ * Whether that failure announced itself was luck. `DROP TABLE` decrements the deferred counter
+ * once per violating row it deletes, so a stale key pointing at a table that no longer exists
+ * cancelled its own violation and committed with the forbidden row in place; a stale key
+ * pointing at a table that still exists cancelled nothing and bricked the store permanently.
+ * Filtering removes both outcomes -- the counter never moves.
+ */
 async function repairSkillForeignKeys(client: Client): Promise<void> {
   const staleSteps = (await foreignKeyTargets(client, 'skill_steps'))
     .some(target => target !== 'knowledge_items');
@@ -712,7 +734,11 @@ async function repairSkillForeignKeys(client: Client): Promise<void> {
     return;
   }
 
-  await client.execute('PRAGMA foreign_keys = OFF;');
+  // No `PRAGMA foreign_keys = OFF` here. The only caller runs inside the migration
+  // transaction, where that pragma is a documented no-op -- see the comment at the BEGIN --
+  // so it read as protection this rebuild never had. `defer_foreign_keys` is what actually
+  // governs, and it postpones every check to COMMIT, where a failure rolls back the entire
+  // bootstrap rather than this function.
 
   if (staleSteps) {
     await client.execute('ALTER TABLE skill_steps RENAME TO skill_steps_stale_fk;');
@@ -726,7 +752,8 @@ async function repairSkillForeignKeys(client: Client): Promise<void> {
     await client.execute(`
       INSERT INTO skill_steps (id, knowledge_item_id, step_order, instruction, created_at)
       SELECT id, knowledge_item_id, step_order, instruction, created_at
-      FROM skill_steps_stale_fk;
+      FROM skill_steps_stale_fk
+      WHERE knowledge_item_id IN (SELECT id FROM knowledge_items);
     `);
     await client.execute('DROP TABLE skill_steps_stale_fk;');
   }
@@ -742,12 +769,11 @@ async function repairSkillForeignKeys(client: Client): Promise<void> {
     await client.execute(`
       INSERT INTO skill_metadata (knowledge_item_id, usage_count, success_count, last_used)
       SELECT knowledge_item_id, usage_count, success_count, last_used
-      FROM skill_metadata_stale_fk;
+      FROM skill_metadata_stale_fk
+      WHERE knowledge_item_id IN (SELECT id FROM knowledge_items);
     `);
     await client.execute('DROP TABLE skill_metadata_stale_fk;');
   }
-
-  await client.execute('PRAGMA foreign_keys = ON;');
 }
 
 /**

--- a/src/store/gc.ts
+++ b/src/store/gc.ts
@@ -32,13 +32,35 @@ export interface KnowledgeGcOptions {
   ignoreAccess?: boolean;
   /** Remove delete records older than this many days. Defaults to 90. */
   tombstoneDays?: number;
+  /**
+   * Ids a preview named as `purge`, approved by whoever read that preview.
+   *
+   * Apply recomputes its candidates -- it has to, because the store may have moved since the
+   * preview and acting on a stale plan is its own bug -- so it purges the INTERSECTION of what
+   * it recomputes and what this names. An atom written between the preview and the apply is
+   * therefore never destroyed by an apply that could not have named it.
+   *
+   * Omitted, nothing is purged. `archive` and `compress` still run: both leave the item, its
+   * id, its assertions and its evidence links in place, so a wrong one is recoverable and
+   * gating them would leave an argument-less apply doing nothing at all. Purge is the one
+   * action with no undo -- the row is gone and only a forget-log entry records that it was --
+   * so it is the one that must be named.
+   */
+  approvedPurgeIds?: readonly string[];
 }
 
 export interface KnowledgeGcResult {
   /** Delete records removed by retention; present only on apply. */
   prunedTombstones?: number;
+  /** On apply, what was actually acted on -- never what was merely considered. */
   candidates: KnowledgeGcCandidate[];
   summary: Record<KnowledgeGcAction, number>;
+  /**
+   * Purge candidates apply declined because `approvedPurgeIds` did not name them. Reported so
+   * a caller learns the items exist and can approve them, rather than silently getting fewer
+   * deletions than the preview showed.
+   */
+  unapprovedPurges?: KnowledgeGcCandidate[];
 }
 
 const DEFAULT_STALE_STATE_DAYS = 60;
@@ -316,15 +338,30 @@ export async function applyKnowledgeGc(
   // Measured separately (2026-08-04): this call is NOT exposed to the wrapper's exit crash.
   // That crash counts `db.transaction()` calls, not statements, and collection makes exactly
   // one of them however many candidates it has -- 5,000 purges, 10,000 statements, clean exit.
+  // A purge acts on the intersection of what apply recomputes and what a preview named, so an
+  // atom written between the two is never destroyed by an apply that could not have named it.
+  // The MCP tool took no arguments at all: `knowl_gc_preview` reported `purge: 0`, a write
+  // landed, and `knowl_gc_apply` hard-deleted an item nobody had ever seen listed.
+  const approvedPurges = options.approvedPurgeIds ? new Set(options.approvedPurgeIds) : new Set<string>();
   return withClientTransaction(async (tx) => {
     const items = await repo.listKnowledgeItems(tx);
     const candidates = buildCandidates(items, options, access, await loadItemHistory(tx));
     const byId = new Map(items.map(item => [item.id, item]));
     const changes: CommitChange[] = [];
+    // What was acted on, never what was merely considered -- the summary has to describe the
+    // writes that happened or a declined purge reads as a completed one.
+    const acted: KnowledgeGcCandidate[] = [];
+    const unapprovedPurges: KnowledgeGcCandidate[] = [];
 
     for (const candidate of candidates) {
       const before = byId.get(candidate.itemId);
       if (!before) continue;
+
+      if (candidate.action === 'purge' && !approvedPurges.has(candidate.itemId)) {
+        unapprovedPurges.push(candidate);
+        continue;
+      }
+      acted.push(candidate);
 
       if (candidate.action === 'purge') {
         // The reason and the retrieval evidence exist here and nowhere else. Before the forget
@@ -387,9 +424,10 @@ export async function applyKnowledgeGc(
     const prunedTombstones = await pruneTombstones(options.tombstoneDays ?? 90, undefined, tx);
 
     return {
-      candidates,
-      summary: summarizeCandidates(candidates),
+      candidates: acted,
+      summary: summarizeCandidates(acted),
       prunedTombstones,
+      ...(unapprovedPurges.length ? { unapprovedPurges } : {}),
     };
   });
 }

--- a/src/store/integrity.ts
+++ b/src/store/integrity.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { KnowledgeWriteValidationOptions } from '../core/types.js';
-import { KnowledgeValidationError, validateKnowledgeWrite } from '../core/knowledge-validation.js';
+import { KnowledgeValidationError, scannableFields, validateKnowledgeWrite } from '../core/knowledge-validation.js';
 import { getDb } from './database.js';
 import { isNormalizedConflictKey, normalizeConflictKey } from './conflicts.js';
 import { supersedeKnowledgeItem } from './repository.js';
@@ -128,13 +128,19 @@ export async function auditKnowledgeStore(
       findings.push({ code: 'invalid-status', severity: 'error', itemId: String(row.id), detail: 'Knowledge item has an invalid status.' });
     }
     try {
-      validateKnowledgeWrite({
+      // Every column the row holds, not the five prose ones. The audit exists to find the
+      // rows written before `tags` and `alternatives` were scanned at all -- and it was the
+      // one caller that could not, because it handed the validator an object those two
+      // columns were never copied into.
+      validateKnowledgeWrite(scannableFields({
         title: row.title,
         content: row.content,
         reasoning: row.reasoning,
         source: row.source,
         affectedPaths: affectedPaths ?? undefined,
-      }, validationOptions);
+        tags: tags ?? undefined,
+        alternatives: alternatives ?? undefined,
+      }), validationOptions);
     } catch (error) {
       if (error instanceof KnowledgeValidationError) {
         findings.push({ code: 'secret', severity: 'error', itemId: String(row.id), detail: `Knowledge validation failed: ${error.code}.` });

--- a/src/store/knowledge-actions.ts
+++ b/src/store/knowledge-actions.ts
@@ -7,6 +7,7 @@ import { getCurrentGitCommit } from './drift.js';
 import { KnowledgeWriteValidationOptions } from '../core/types.js';
 import { attachEvidenceToKnowledge } from './evidence-repository.js';
 import { indexKnowledgeItemsBestEffort } from './write-embedding.js';
+import { withClientTransaction } from './database.js';
 
 /**
  * Queue a committed write for the team, if this repo is connected.
@@ -194,34 +195,47 @@ export async function updateKnowledgeItemWithCommit(
     : (options?.sourceCommit !== undefined ? options.sourceCommit
     : autoSourceCommit);
 
-  const updated = await repo.updateKnowledgeItem(id, {
-    ...updates,
-    ...(resolvedSourceCommit !== undefined ? { sourceCommit: resolvedSourceCommit } : {}),
-    ...(shouldRefreshFreshness || options?.freshness ? { freshness: options?.freshness || 'fresh' } : {}),
-  }, undefined, undefined, options?.validationOptions);
-  let action: CommitChange['action'] = 'update';
-  if (updates.status && updates.status !== beforeItem.status) {
-    if (updates.status === 'active') {
-      action = 'restore';
-    } else if (updates.status === 'archived') {
-      action = 'archive';
-    } else if (updates.status === 'deprecated') {
-      action = 'deprecate';
-    } else if (updates.status === 'rejected') {
-      action = 'reject';
-    } else if (updates.status === 'superseded') {
-      action = 'supersede';
+  // The row and the record of the change land together or not at all -- the invariant
+  // `storeKnowledgeItemDeduped` already holds for a write and its supersession.
+  //
+  // They used to be two transactions on two connections. If `createKnowledgeCommit` threw,
+  // the caller was told the update failed while the row had already changed: an item left
+  // `superseded` with `supersededById` set and nothing logging it. Everything that reads the
+  // change LOG rather than the row then misses the retirement -- the workspace change notice,
+  // so a teammate goes on reading a retired atom as current; blast radius, which decides what
+  // to re-check when something turns out to be wrong; and `readCommitHead`, which is
+  // `MAX(rowid)` of that table and so tells the next session nothing happened.
+  const updated = await withClientTransaction(async (conn) => {
+    const written = await repo.updateKnowledgeItem(id, {
+      ...updates,
+      ...(resolvedSourceCommit !== undefined ? { sourceCommit: resolvedSourceCommit } : {}),
+      ...(shouldRefreshFreshness || options?.freshness ? { freshness: options?.freshness || 'fresh' } : {}),
+    }, undefined, conn, options?.validationOptions);
+    let action: CommitChange['action'] = 'update';
+    if (updates.status && updates.status !== beforeItem.status) {
+      if (updates.status === 'active') {
+        action = 'restore';
+      } else if (updates.status === 'archived') {
+        action = 'archive';
+      } else if (updates.status === 'deprecated') {
+        action = 'deprecate';
+      } else if (updates.status === 'rejected') {
+        action = 'reject';
+      } else if (updates.status === 'superseded') {
+        action = 'supersede';
+      }
     }
-  }
 
-  await repo.createKnowledgeCommit(projectId, options?.commitMessage ?? `Update item: ${updated.title}`, [
-    {
-      itemId: id,
-      action,
-      before: beforeItem,
-      after: updated,
-    },
-  ]);
+    await repo.createKnowledgeCommit(projectId, options?.commitMessage ?? `Update item: ${written.title}`, [
+      {
+        itemId: id,
+        action,
+        before: beforeItem,
+        after: written,
+      },
+    ], conn);
+    return written;
+  });
 
   // Demotion to deprecated/rejected says "this was wrong", which implicates the batch
   // that produced it — unlike a supersede, which as often means "this is outdated" and
@@ -243,8 +257,10 @@ export async function updateKnowledgeItemWithCommit(
     await indexKnowledgeItemsBestEffort(projectId, [updated]);
   }
 
-  // `repo.updateKnowledgeItem` above is called with no `dbConnection`, so it committed on its
-  // own connection before this line -- this is genuinely post-commit rather than merely late.
+  // Outside the transaction above, which has committed by this line -- genuinely post-commit
+  // rather than merely late. Staging a row a rollback then removed is the failure this
+  // ordering prevents, and it is the reason the three best-effort side effects sit here
+  // rather than inside.
   //
   // A published atom re-stages here, which is how a correction reaches the team at all: an atom
   // edited in place would otherwise stay at the version the workspace already holds.

--- a/src/store/portability.ts
+++ b/src/store/portability.ts
@@ -7,7 +7,7 @@ import { normalizeSkillFilePath, validateSkillName } from '../core/skill-paths.j
 import { createKnowledgeCommit, listKnowledgeItems } from './repository.js';
 import { listAssertions } from './assertions.js';
 import { getClient } from './database.js';
-import { validateKnowledgeWrite } from '../core/knowledge-validation.js';
+import { scannableFields, validateKnowledgeWrite } from '../core/knowledge-validation.js';
 import { listEvidenceForItem } from './evidence-repository.js';
 import { indexKnowledgeItemsBestEffort } from './write-embedding.js';
 import { listTombstones } from './tombstones.js';
@@ -654,7 +654,10 @@ export async function importKnowledge(
   }
 
   for (const incoming of items) {
-    validateKnowledgeWrite({ title: incoming.title, content: incoming.content, reasoning: incoming.reasoning, source: incoming.source, affectedPaths: incoming.affectedPaths });
+    // The whole incoming record's scannable columns, not the five prose ones. A peer's export
+    // is the likeliest carrier of a row written before `tags` and `alternatives` were scanned
+    // at all, and this is the door that decides whether it lands here.
+    validateKnowledgeWrite(scannableFields(incoming));
     // The lifecycle fields come along so `classifyIncomingItem` can derive a fingerprint for
     // a row whose `lifecycle_hash` is NULL -- which is every row written before the column
     // was added, since it is not backfilled.

--- a/src/store/portability.ts
+++ b/src/store/portability.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { normalizeSkillFilePath, validateSkillName } from '../core/skill-paths.js';
 import { createKnowledgeCommit, listKnowledgeItems } from './repository.js';
+import { normalizeConflictKey, normalizeConflictScope } from './conflicts.js';
 import { listAssertions } from './assertions.js';
 import { getClient } from './database.js';
 import { scannableFields, validateKnowledgeWrite } from '../core/knowledge-validation.js';
@@ -159,6 +160,14 @@ export type ImportResult = {
    * asked for: divergence was decided on the content rather than on what the file claimed.
    */
   hashRepaired?: number;
+  /**
+   * Incoming items refused because an active local item already holds their exclusive
+   * identity. Named rather than counted alone: `--on-divergence` cannot resolve this one, so
+   * the message that tells a user to try another policy would be wrong without the ids.
+   *
+   * Counted in `conflicts`, which is what makes the import decline rather than apply.
+   */
+  exclusiveConflicts?: Array<{ id: string; title: string; heldBy: string }>;
   /** Present only on a dry run: what the counts WOULD have been. */
   wouldApply?: { inserted: number; identical: number; updated: number; keptLocal: number };
 };
@@ -718,6 +727,62 @@ export async function importKnowledge(
     });
   }
 
+  /**
+   * One active value per exclusive identity, held on this door too.
+   *
+   * `conflictExclusive` means exactly one active item may claim a key within a scope, and a
+   * direct second write is refused with `KNOWLEDGE_CONFLICT`. Import wrote raw SQL and called
+   * nothing, so a peer's export landed the second active row and reported `conflicts: 0` --
+   * the invariant broken silently, by the one path that carries a whole store at a time.
+   *
+   * Identities are normalised on both sides. A key written through an older update path was
+   * stored raw, so comparing the stored forms lets one logical identity sit in two rows and
+   * never collide, which is the same hole `auditConflictIdentities` repairs.
+   */
+  const exclusiveIdentity = (key: unknown, scope: unknown): string | null => {
+    if (typeof key !== 'string' || key.trim() === '') return null;
+    const normalized = normalizeConflictScope(scope as Record<string, unknown> | null | undefined);
+    return `${normalizeConflictKey(key)} ${normalized ? JSON.stringify(normalized) : ''}`;
+  };
+  const heldExclusive = new Map<string, string>();
+  for (const row of (await client.execute(
+    `SELECT id, conflict_key, conflict_scope FROM knowledge_items
+     WHERE status = 'active' AND conflict_exclusive = 1 AND conflict_key IS NOT NULL`,
+  )).rows) {
+    let scope: unknown = null;
+    try { scope = row.conflict_scope === null ? null : JSON.parse(String(row.conflict_scope)); } catch { scope = null; }
+    const identity = exclusiveIdentity(row.conflict_key, scope);
+    if (identity) heldExclusive.set(identity, String(row.id));
+  }
+  // A holder this import retires, archives or deletes releases its identity first, or an
+  // export that replaces a value would be refused for colliding with the value it replaces.
+  const released = new Set<string>(tombstones.map(tombstone => String(tombstone.id)));
+  for (const entry of plan) {
+    if (entry.action === 'keep-local' || entry.action === 'identical') continue;
+    if (entry.item.status !== 'active') released.add(String(entry.item.id));
+  }
+  for (const [identity, holder] of [...heldExclusive]) {
+    if (released.has(holder)) heldExclusive.delete(identity);
+  }
+
+  const exclusiveConflicts: ImportResult['exclusiveConflicts'] = [];
+  for (const entry of plan) {
+    if (entry.action === 'keep-local' || entry.action === 'identical') continue;
+    const item = entry.item;
+    if (!item.conflictExclusive || item.status !== 'active') continue;
+    const identity = exclusiveIdentity(item.conflictKey, item.conflictScope);
+    if (!identity) continue;
+    const holder = heldExclusive.get(identity);
+    // Two incoming items claiming one identity collide with each other for the same reason,
+    // which is why the winner is recorded rather than only the local rows being consulted.
+    if (holder !== undefined && holder !== String(item.id)) {
+      exclusiveConflicts.push({ id: String(item.id), title: String(item.title ?? ''), heldBy: holder });
+      continue;
+    }
+    heldExclusive.set(identity, String(item.id));
+  }
+  conflicts += exclusiveConflicts.length;
+
   const counts = {
     inserted: plan.filter(entry => entry.action === 'insert').length,
     identical: plan.filter(entry => entry.action === 'identical').length,
@@ -737,6 +802,7 @@ export async function importKnowledge(
       conflicts, blockedByTombstone, applied: false, ownership,
       divergent: options.dryRun ? divergent : [],
       ...(hashRepaired ? { hashRepaired } : {}),
+      ...(exclusiveConflicts.length ? { exclusiveConflicts } : {}),
       ...(options.dryRun ? { wouldApply: counts } : {}),
     };
   }

--- a/src/store/portability.ts
+++ b/src/store/portability.ts
@@ -749,7 +749,10 @@ export async function importKnowledge(
     `SELECT id, conflict_key, conflict_scope FROM knowledge_items
      WHERE status = 'active' AND conflict_exclusive = 1 AND conflict_key IS NOT NULL`,
   )).rows) {
-    let scope: unknown = null;
+    let scope: unknown;
+    // A scope that will not parse is treated as no scope rather than failing the import: the
+    // audit reports the malformed row, and refusing every import until someone fixes it would
+    // be a worse answer than comparing it on its key alone.
     try { scope = row.conflict_scope === null ? null : JSON.parse(String(row.conflict_scope)); } catch { scope = null; }
     const identity = exclusiveIdentity(row.conflict_key, scope);
     if (identity) heldExclusive.set(identity, String(row.id));

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -139,7 +139,8 @@ export async function createKnowledgeItem(
   dbConnection?: DbConnection,
   validationOptions?: KnowledgeWriteValidationOptions,
 ): Promise<KnowledgeItem> {
-  validateKnowledgeWrite(item, validationOptions);
+  // `steps` travels as its own parameter, so it has to be joined back on or it is never scanned.
+  validateKnowledgeWrite({ ...item, ...(steps !== undefined ? { steps } : {}) }, validationOptions);
   // The last door before the row, so the invariant is stated here rather than at each caller.
   // `knowledge-writer` checks it earlier as well -- deliberately, so a batch is refused before
   // a transaction the caller was never told about is opened -- but merge, synthesis,
@@ -370,6 +371,7 @@ export async function updateKnowledgeItem(
     const written = {
       ...scannableFields(updates),
       ...(updates.affectedPaths !== undefined ? { affectedPaths } : {}),
+      ...(steps !== undefined ? { steps } : {}),
     };
     validateKnowledgeWrite(written, validationOptions);
     const shouldRefreshHash = updates.contentHash === undefined && (

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -29,7 +29,7 @@ import {
 import { DatabaseError, KnowledgeConflictError } from '../core/errors.js';
 import { DEFAULT_FRESHNESS, hashKnowledgeContent, hashKnowledgeLifecycle, normalizeAffectedPaths } from './freshness.js';
 import { currentAuthorRepo, resolveWriteDefaults } from './write-ownership.js';
-import { assertConfidenceInRange, KnowledgeValidationError, validateKnowledgeWrite } from '../core/knowledge-validation.js';
+import { assertConfidenceInRange, KnowledgeValidationError, scannableFields, validateKnowledgeWrite } from '../core/knowledge-validation.js';
 
 export const LOCAL_PROJECT_ID = 'local';
 
@@ -360,11 +360,15 @@ export async function updateKnowledgeItem(
     // callers of a metadata-only change have no config to pass. `supersedeKnowledgeItem`
     // writes just a status, so an item whose accepted content happened to trip a detector
     // -- a hyphenated model name reads as a high-entropy token -- could never be retired.
+    //
+    // Projected off `updates` rather than retyped as a literal, because the literal listed five
+    // fields while `dbUpdates` below spreads the whole argument: `tags` and `alternatives` were
+    // written and never scanned. Creating an item with a credential in `tags` was refused;
+    // creating it clean and then updating it with the same credential in `tags` was accepted.
+    // `scannableFields` copies only the keys the caller actually supplied, so "only what this
+    // update writes" still holds.
     const written = {
-      ...(updates.title !== undefined ? { title: updates.title } : {}),
-      ...(updates.content !== undefined ? { content: updates.content } : {}),
-      ...(updates.reasoning !== undefined ? { reasoning: updates.reasoning } : {}),
-      ...(updates.source !== undefined ? { source: updates.source } : {}),
+      ...scannableFields(updates),
       ...(updates.affectedPaths !== undefined ? { affectedPaths } : {}),
     };
     validateKnowledgeWrite(written, validationOptions);

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -1077,10 +1077,22 @@ describe('MCP Server Layer', () => {
     expect(preview.summary.purge).toBe(1);
     expect(preview.candidates[0].itemId).toBe(duplicateA.id);
     expect(preview.candidates[0].duplicateOfId).toBe(duplicateB.id);
+    // The preview names every purge id in full, because it is what apply has to be handed.
+    expect(preview.purgeItemIds).toEqual([duplicateA.id]);
+
+    // An apply that names nothing purges nothing, and says which items it declined.
+    const declinedRes = await runRpcRequest('tools/call', {
+      name: 'knowl_gc_apply',
+      arguments: {},
+    });
+    const declined = JSON.parse(declinedRes.result.content[0].text);
+    expect(declined.summary.purge).toBe(0);
+    expect(declined.unapprovedPurges).toEqual([duplicateA.id]);
+    expect(await repo.getKnowledgeItem(duplicateA.id)).not.toBeNull();
 
     const applyRes = await runRpcRequest('tools/call', {
       name: 'knowl_gc_apply',
-      arguments: {},
+      arguments: { purgeItemIds: preview.purgeItemIds },
     });
 
     expect(applyRes.error).toBeUndefined();

--- a/tests/store/forget-log.test.ts
+++ b/tests/store/forget-log.test.ts
@@ -7,7 +7,7 @@ import { closeDb, getClient, getDb, initDb } from '../../src/store/database.js';
 import { bootstrapSchema } from '../../src/store/bootstrap.js';
 import * as repo from '../../src/store/repository.js';
 import { recordKnowledgeAccess } from '../../src/store/access-feedback.js';
-import { applyKnowledgeGc } from '../../src/store/gc.js';
+import { applyKnowledgeGc, previewKnowledgeGc } from '../../src/store/gc.js';
 import { listForgetLog, pruneForgetLog } from '../../src/store/forget-log.js';
 import { listTombstones, pruneTombstones } from '../../src/store/tombstones.js';
 import { exportKnowledge } from '../../src/store/portability.js';
@@ -20,6 +20,17 @@ async function seedDuplicatePair(projectId: string, title: string, content: stri
   const first = await repo.createKnowledgeItem(projectId, { category: 'fact', title, content });
   const second = await repo.createKnowledgeItem(projectId, { category: 'fact', title, content });
   return { first, second };
+}
+
+/**
+ * Collection as a caller performs it: preview, then approve exactly what the preview named.
+ * An apply that names nothing purges nothing, because purge is the one action with no undo.
+ */
+async function collect(projectId: string) {
+  const preview = await previewKnowledgeGc(projectId);
+  return applyKnowledgeGc(projectId, {
+    approvedPurgeIds: preview.candidates.filter(entry => entry.action === 'purge').map(entry => entry.itemId),
+  });
 }
 
 describe('forget log', () => {
@@ -53,7 +64,7 @@ describe('forget log', () => {
       await recordKnowledgeAccess({ itemId: second.id, query: `q${hit}`, surface: 'mcp', rank: 0 });
     }
 
-    const result = await applyKnowledgeGc(projectId);
+    const result = await collect(projectId);
     expect(result.summary.purge).toBeGreaterThan(0);
 
     const log = await listForgetLog();
@@ -85,7 +96,7 @@ describe('forget log', () => {
    */
   it('names the rule in a code and the survivor in a column, not only in a sentence', async () => {
     const { first, second } = await seedDuplicatePair(projectId, 'Absorbed fact', 'Collapsed into its twin.');
-    await applyKnowledgeGc(projectId);
+    await collect(projectId);
 
     const [entry] = await listForgetLog();
     const survivor = entry.itemId === first.id ? second.id : first.id;
@@ -167,7 +178,7 @@ describe('forget log', () => {
 
   it('outlives the tombstone that pruning removes', async () => {
     await seedDuplicatePair(projectId, 'Prunable fact', 'Collected then forgotten about.');
-    await applyKnowledgeGc(projectId);
+    await collect(projectId);
 
     expect(await listTombstones()).toHaveLength(1);
     expect(await listForgetLog()).toHaveLength(1);
@@ -191,7 +202,7 @@ describe('forget log', () => {
     for (let hit = 0; hit < 5; hit++) {
       await recordKnowledgeAccess({ itemId: second.id, query: `q${hit}`, surface: 'mcp', rank: 0 });
     }
-    await applyKnowledgeGc(projectId);
+    await collect(projectId);
     const [entry] = await listForgetLog();
 
     const out = path.join(os.tmpdir(), `knowl-forget-log-export-${process.pid}.jsonl`);

--- a/tests/store/gc-approved-purge.test.ts
+++ b/tests/store/gc-approved-purge.test.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, getClient, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { applyKnowledgeGc, previewKnowledgeGc } from '../../src/store/gc.js';
+import { resetWriteOwnershipCache } from '../../src/store/write-ownership.js';
+
+/**
+ * Collection acts on the set the preview named.
+ *
+ * `applyKnowledgeGc` recomputed its candidates from scratch and the MCP tool took no arguments,
+ * so a preview reporting `purge: 0`, a write landing, and an apply were enough to hard-delete
+ * an item nobody had ever seen listed. Purge is the one action with no undo.
+ */
+let counter = 0;
+let ROOT = '';
+const NOW = new Date().toISOString();
+const OLDER = new Date(Date.now() - 5 * 86_400_000).toISOString();
+const NEWER = new Date(Date.now() - 1 * 86_400_000).toISOString();
+const ANCIENT = new Date(Date.now() - 400 * 86_400_000).toISOString();
+
+async function setUpdatedAt(itemId: string, iso: string) {
+  await getClient().execute({ sql: 'UPDATE knowledge_items SET updated_at = ? WHERE id = ?', args: [iso, itemId] });
+}
+
+const TWIN = { category: 'fact' as const, title: 'Rate limit', content: 'The API allows 100 requests per minute.' };
+
+describe('GC purges only what a preview named', () => {
+  let projectId = '';
+  beforeEach(async () => {
+    await closeDb();
+    await releaseAll();
+    resetWriteOwnershipCache();
+    counter += 1;
+    ROOT = path.resolve(`./.knowl-gc-approved${counter}`);
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    projectId = (await repo.createProject(ROOT, 'gc-approved')).id;
+  });
+  afterEach(async () => {
+    await closeDb();
+    await releaseAll();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('destroys nothing an empty preview could not have named', async () => {
+    const first = await repo.createKnowledgeItem(projectId, TWIN);
+    const preview = await previewKnowledgeGc(projectId, { now: NOW });
+    expect(preview.summary.purge).toBe(0);
+
+    // The write that lands between the preview and the apply. It is the whole defect: the
+    // preview named nothing, and an argument-less apply used to delete one of these two.
+    const second = await repo.createKnowledgeItem(projectId, TWIN);
+    await setUpdatedAt(first.id, OLDER);
+    await setUpdatedAt(second.id, NEWER);
+
+    const result = await applyKnowledgeGc(projectId, { now: NOW });
+    expect(result.summary.purge).toBe(0);
+    expect(await repo.getKnowledgeItem(first.id)).not.toBeNull();
+    expect(await repo.getKnowledgeItem(second.id)).not.toBeNull();
+    // Declined, not hidden: the caller has to be able to see what it did not do.
+    expect(result.unapprovedPurges).toHaveLength(1);
+    expect([first.id, second.id]).toContain(result.unapprovedPurges![0].itemId);
+  });
+
+  it('purges exactly the id a preview named and a caller approved', async () => {
+    const older = await repo.createKnowledgeItem(projectId, TWIN);
+    const newer = await repo.createKnowledgeItem(projectId, TWIN);
+    await setUpdatedAt(older.id, OLDER);
+    await setUpdatedAt(newer.id, NEWER);
+
+    const preview = await previewKnowledgeGc(projectId, { now: NOW });
+    const named = preview.candidates.filter(entry => entry.action === 'purge').map(entry => entry.itemId);
+    expect(named).toHaveLength(1);
+    const survivor = named[0] === newer.id ? older.id : newer.id;
+
+    const result = await applyKnowledgeGc(projectId, { now: NOW, approvedPurgeIds: named });
+    expect(result.summary.purge).toBe(1);
+    expect(result.unapprovedPurges).toBeUndefined();
+    expect(await repo.getKnowledgeItem(named[0])).toBeNull();
+    expect(await repo.getKnowledgeItem(survivor)).not.toBeNull();
+  });
+
+  it('does not delete an approved id that is no longer a candidate', async () => {
+    const survivor = await repo.createKnowledgeItem(projectId, {
+      category: 'fact', title: 'Unique claim', content: 'Nothing else says this.',
+    });
+
+    // An id carried over from an older preview, when this item had a twin that has since gone.
+    const result = await applyKnowledgeGc(projectId, { now: NOW, approvedPurgeIds: [survivor.id] });
+    expect(result.summary.purge).toBe(0);
+    expect(await repo.getKnowledgeItem(survivor.id)).not.toBeNull();
+  });
+
+  it('still archives without any approval, because archiving is recoverable', async () => {
+    const stale = await repo.createKnowledgeItem(projectId, {
+      category: 'state', title: 'Working on the parser', content: 'Mid-refactor.',
+    });
+    await setUpdatedAt(stale.id, ANCIENT);
+
+    const result = await applyKnowledgeGc(projectId, { now: NOW });
+    expect(result.summary.archive).toBe(1);
+    expect((await repo.getKnowledgeItem(stale.id))!.status).toBe('archived');
+  });
+});

--- a/tests/store/gc-duplicate-survivor.test.ts
+++ b/tests/store/gc-duplicate-survivor.test.ts
@@ -20,6 +20,18 @@ async function setUpdatedAt(itemId: string, iso: string) {
 const OLDER = new Date(Date.now() - 5 * 86_400_000).toISOString();
 const NEWER = new Date(Date.now() - 1 * 86_400_000).toISOString();
 
+/**
+ * Collection as a caller performs it: preview, then approve exactly what the preview named.
+ * An apply that names nothing purges nothing, because purge is the one action with no undo.
+ */
+async function collect(projectId: string) {
+  const preview = await previewKnowledgeGc(projectId, { now: NOW });
+  return applyKnowledgeGc(projectId, {
+    now: NOW,
+    approvedPurgeIds: preview.candidates.filter(entry => entry.action === 'purge').map(entry => entry.itemId),
+  });
+}
+
 describe('GC never purges the richer of two twins', () => {
   let projectId = '';
   beforeEach(async () => {
@@ -59,7 +71,7 @@ describe('GC never purges the richer of two twins', () => {
     const purged = preview.candidates.filter(candidate => candidate.action === 'purge').map(candidate => candidate.itemId);
     expect(purged).toEqual([bare.id]);
 
-    await applyKnowledgeGc(projectId, { now: NOW });
+    await collect(projectId);
     const survivor = await repo.getKnowledgeItem(rich.id);
     expect(survivor).not.toBeNull();
     expect(survivor!.tags).toEqual(['api', 'limits']);
@@ -79,7 +91,7 @@ describe('GC never purges the richer of two twins', () => {
     await setUpdatedAt(evidenced.id, OLDER);
     await setUpdatedAt(bare.id, NEWER);
 
-    await applyKnowledgeGc(projectId, { now: NOW });
+    await collect(projectId);
 
     expect(await repo.getKnowledgeItem(evidenced.id)).not.toBeNull();
     expect(await listEvidenceForItem(evidenced.id)).toHaveLength(1);
@@ -101,7 +113,7 @@ describe('GC never purges the richer of two twins', () => {
     const preview = await previewKnowledgeGc(projectId, { now: NOW });
     expect(preview.candidates.filter(candidate => candidate.action === 'purge')).toHaveLength(0);
 
-    await applyKnowledgeGc(projectId, { now: NOW });
+    await collect(projectId);
     expect(await repo.getKnowledgeItem(tagged.id)).not.toBeNull();
     expect(await repo.getKnowledgeItem(pathed.id)).not.toBeNull();
   });

--- a/tests/store/gc-protections.test.ts
+++ b/tests/store/gc-protections.test.ts
@@ -222,7 +222,13 @@ describe('GC protections', () => {
     });
     await setUpdatedAt(older.id, daysAgo(5));
 
-    const result = await applyKnowledgeGc(projectId, { now: NOW_ISO });
+    // Approved from a preview, because purge is the one action an apply will not take on a
+    // set nobody read: an atom written between the two would otherwise be destroyed unseen.
+    const preview = await previewKnowledgeGc(projectId, { now: NOW_ISO });
+    const result = await applyKnowledgeGc(projectId, {
+      now: NOW_ISO,
+      approvedPurgeIds: preview.candidates.filter(c => c.action === 'purge').map(c => c.itemId),
+    });
     expect(result.summary.purge).toBeGreaterThanOrEqual(1);
     expect(result.prunedTombstones).toBe(0);
     expect((await listTombstones()).map(tombstone => tombstone.id)).toContain(older.id);

--- a/tests/store/import-exclusive-conflict.test.ts
+++ b/tests/store/import-exclusive-conflict.test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Same reason as tests/store/portability.test.ts: the indexer is imported as a named binding,
+// which a namespace spy cannot intercept, and the real function is already a no-op with no
+// embedding model on disk.
+vi.mock('../../src/store/write-embedding.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/store/write-embedding.js')>();
+  return { ...actual, indexKnowledgeItemsBestEffort: vi.fn(async () => {}) };
+});
+
+import { closeDb, initDb } from '../../src/store/database.js';
+import { createKnowledgeItem, listKnowledgeItems, updateKnowledgeItem } from '../../src/store/repository.js';
+import * as portability from '../../src/store/portability.js';
+
+/**
+ * An import cannot land a second active exclusive value.
+ *
+ * `conflictExclusive` means exactly one active item may claim a key within a scope. A direct
+ * second write is refused with `KNOWLEDGE_CONFLICT`; import wrote raw SQL, called no guard,
+ * and reported `conflicts: 0` while landing the second row.
+ */
+const SOURCE = path.resolve('./.knowl-import-exclusive-source');
+const TARGET = path.resolve('./.knowl-import-exclusive-target');
+const KEY = 'database.production.engine';
+const SCOPE = { environment: 'production' };
+
+async function useStore(root: string) {
+  await closeDb();
+  await fs.mkdir(path.join(root, '.knowl'), { recursive: true });
+  await initDb(root);
+}
+
+describe('import and the exclusive-conflict guard', () => {
+  let exportPath = '';
+  let incomingId = '';
+
+  beforeAll(async () => {
+    await fs.rm(SOURCE, { recursive: true, force: true });
+    await fs.rm(TARGET, { recursive: true, force: true });
+    await fs.mkdir(path.join(SOURCE, '.knowl'), { recursive: true });
+    await initDb(SOURCE);
+    const item = await createKnowledgeItem('local', {
+      category: 'decision',
+      title: 'Postgres in production',
+      content: 'Production runs Postgres 16.',
+      conflictKey: KEY,
+      conflictScope: SCOPE,
+      conflictExclusive: true,
+    });
+    incomingId = item.id;
+    exportPath = path.join(SOURCE, 'peer.jsonl');
+    await portability.exportKnowledge('local', exportPath, SOURCE, [item.id]);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(SOURCE, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(TARGET, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('refuses an export whose item claims an identity a local active item already holds', async () => {
+    await useStore(path.join(TARGET, 'held'));
+    const local = await createKnowledgeItem('local', {
+      category: 'decision',
+      title: 'MySQL in production',
+      content: 'Production runs MySQL 8.',
+      conflictKey: KEY,
+      conflictScope: SCOPE,
+      conflictExclusive: true,
+    });
+
+    const result = await (portability as any).importKnowledge(exportPath);
+    expect(result).toMatchObject({ applied: false, conflicts: 1, inserted: 0 });
+    expect(result.exclusiveConflicts).toEqual([
+      { id: incomingId, title: 'Postgres in production', heldBy: local.id },
+    ]);
+    // Nothing landed, so the invariant still holds.
+    expect((await listKnowledgeItems()).map(entry => entry.id)).toEqual([local.id]);
+  });
+
+  it('reports the collision on a dry run, before anyone applies it', async () => {
+    await useStore(path.join(TARGET, 'dry'));
+    const local = await createKnowledgeItem('local', {
+      category: 'decision',
+      title: 'MySQL in production',
+      content: 'Production runs MySQL 8.',
+      conflictKey: KEY,
+      conflictScope: SCOPE,
+      conflictExclusive: true,
+    });
+
+    const result = await (portability as any).importKnowledge(exportPath, { dryRun: true });
+    expect(result.conflicts).toBe(1);
+    expect(result.exclusiveConflicts).toEqual([
+      { id: incomingId, title: 'Postgres in production', heldBy: local.id },
+    ]);
+  });
+
+  it('still imports when the local holder is not active', async () => {
+    await useStore(path.join(TARGET, 'retired'));
+    const local = await createKnowledgeItem('local', {
+      category: 'decision',
+      title: 'MySQL in production',
+      content: 'Production runs MySQL 8.',
+      conflictKey: KEY,
+      conflictScope: SCOPE,
+      conflictExclusive: true,
+    });
+    await updateKnowledgeItem(local.id, { status: 'superseded' });
+
+    const result = await (portability as any).importKnowledge(exportPath);
+    expect(result).toMatchObject({ applied: true, conflicts: 0, inserted: 1 });
+    expect((await listKnowledgeItems()).map(entry => entry.id)).toContain(incomingId);
+  });
+
+  it('does not treat an item colliding with its own local copy as a conflict', async () => {
+    await useStore(path.join(TARGET, 'same-id'));
+    await (portability as any).importKnowledge(exportPath);
+    // Second round: the identity is now held by the very row the file describes.
+    const result = await (portability as any).importKnowledge(exportPath);
+    expect(result).toMatchObject({ applied: true, conflicts: 0, identical: 1 });
+    expect(result.exclusiveConflicts).toBeUndefined();
+  });
+
+  it('leaves a non-exclusive key alone', async () => {
+    await useStore(path.join(TARGET, 'shared-key'));
+    const local = await createKnowledgeItem('local', {
+      category: 'decision',
+      title: 'MySQL in production',
+      content: 'Production runs MySQL 8.',
+      conflictKey: KEY,
+      conflictScope: SCOPE,
+      conflictExclusive: false,
+    });
+
+    const result = await (portability as any).importKnowledge(exportPath);
+    expect(result).toMatchObject({ applied: true, conflicts: 0, inserted: 1 });
+    expect((await listKnowledgeItems()).map(entry => entry.id).sort())
+      .toEqual([local.id, incomingId].sort());
+  });
+});

--- a/tests/store/skill-fk-repair.test.ts
+++ b/tests/store/skill-fk-repair.test.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { afterAll, describe, expect, it } from 'vitest';
+import { bootstrapSchema } from '../../src/store/bootstrap.js';
+import { KNOWL_MIGRATION_LEVEL } from '../../src/store/schema-version.js';
+
+/**
+ * A skill FK repair must not roll back bootstrap.
+ *
+ * `repairSkillForeignKeys` rebuilds `skill_steps` and `skill_metadata` onto the correct
+ * `knowledge_items` foreign key and copies every row across unfiltered. It runs inside the
+ * migration transaction, where its own `PRAGMA foreign_keys = OFF` is a documented no-op and
+ * `defer_foreign_keys` postpones every check to COMMIT -- so a copied orphan is a deferred
+ * violation, and a deferred violation at COMMIT rolls back the WHOLE bootstrap: no tables,
+ * `application_id` left at 0, and every later open failing identically. `knowl doctor` opens
+ * the store too, so the diagnosis sits inside the failure.
+ *
+ * An orphan child row is the expected state in exactly the stores this repair exists for --
+ * the wrong parent table is why skill deletes never cascaded.
+ *
+ * Measured 2026-09-09, and worth writing down because it is not obvious: whether the COMMIT
+ * actually fails depends on the stale table's own foreign key. `DROP TABLE` decrements the
+ * deferred counter once per violating row it deletes, so when the stale key points at a table
+ * that no longer exists -- the historical `knowledge_items_legacy` shape -- every carried-over
+ * orphan is +1 on the insert and -1 on the drop, and the COMMIT survives by cancellation. When
+ * the stale key points at a table that still exists and satisfies the row, nothing cancels and
+ * the store is bricked. Both cases leave a row the new foreign key forbids, which is the defect
+ * either way; only one of them announces itself.
+ */
+const ROOT = path.resolve('./.knowl-skill-fk-repair-test');
+
+const LEGACY_ITEMS = `CREATE TABLE knowledge_items (
+  id TEXT PRIMARY KEY,
+  category TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  reasoning TEXT,
+  alternatives TEXT,
+  tags TEXT,
+  source TEXT,
+  confidence REAL NOT NULL DEFAULT 1.0,
+  superseded_by_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);`;
+
+const SEED_ITEM = `INSERT INTO knowledge_items (
+  id, category, status, title, content, confidence, version, created_at, updated_at
+) VALUES (
+  'item1', 'skill', 'active', 'Migrated skill', 'Migrated skill content', 1.0, 1,
+  '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+);`;
+
+/**
+ * A store whose skill tables carry the wrong foreign key and the orphan rows that key let
+ * accumulate. `staleTarget` is the table the wrong key points at; a caller passing a table it
+ * also creates gets the shape that cannot cancel its own violation at COMMIT.
+ */
+async function seedStaleStore(dbPath: string, staleTarget: string, liveTarget: boolean) {
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+  const client = createClient({ url: `file:${dbPath}` });
+  await client.execute('PRAGMA foreign_keys = OFF;');
+  // The compact pre-workspace shape: no `project_id`, so `migrateLegacyProjectSchema` returns
+  // early and the stale-FK repair is the only rebuild in play.
+  await client.execute(LEGACY_ITEMS);
+  if (liveTarget) {
+    await client.execute(`CREATE TABLE ${staleTarget} (id TEXT PRIMARY KEY);`);
+    await client.execute(`INSERT INTO ${staleTarget} (id) VALUES ('deleted-item'), ('item1');`);
+  }
+  await client.execute(`CREATE TABLE skill_steps (
+    id TEXT PRIMARY KEY,
+    knowledge_item_id TEXT NOT NULL REFERENCES ${staleTarget}(id) ON DELETE CASCADE,
+    step_order INTEGER NOT NULL,
+    instruction TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  );`);
+  await client.execute(`CREATE TABLE skill_metadata (
+    knowledge_item_id TEXT PRIMARY KEY REFERENCES ${staleTarget}(id) ON DELETE CASCADE,
+    usage_count INTEGER NOT NULL DEFAULT 0,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    last_used TEXT
+  );`);
+  await client.execute(SEED_ITEM);
+  await client.execute(`INSERT INTO skill_steps (id, knowledge_item_id, step_order, instruction, created_at)
+    VALUES ('step1', 'item1', 1, 'Still linked', '2026-01-01T00:00:00.000Z');`);
+  // The orphan: its skill was deleted, and the wrong foreign key meant nothing cascaded.
+  await client.execute(`INSERT INTO skill_steps (id, knowledge_item_id, step_order, instruction, created_at)
+    VALUES ('step-orphan', 'deleted-item', 1, 'Left behind', '2026-01-01T00:00:00.000Z');`);
+  await client.execute(`INSERT INTO skill_metadata (knowledge_item_id, usage_count, success_count)
+    VALUES ('item1', 3, 2), ('deleted-item', 9, 9);`);
+  client.close();
+}
+
+describe('skill foreign-key repair', () => {
+  afterAll(async () => { await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {}); });
+
+  it('completes a bootstrap when the stale key points at a table that still exists', async () => {
+    const dbPath = path.join(ROOT, 'live-target', '.knowl', 'knowl.db');
+    // `projects` is the table the pre-compact schema hung skill rows off, and nothing drops it
+    // unless the legacy item migration runs. Its rows satisfy the stale key, so the drop of the
+    // stale table cancels nothing and the deferred violation reaches COMMIT.
+    await seedStaleStore(dbPath, 'projects', true);
+
+    const client = createClient({ url: `file:${dbPath}` });
+    try {
+      await expect(bootstrapSchema(client)).resolves.toBeUndefined();
+
+      // The transaction COMMITTED: the level is stamped and the rest of the schema exists.
+      // Without that, `application_id` stays 0, ~40 tables are never created, and every
+      // later open -- `knowl doctor` included -- fails in exactly the same place.
+      const stamped = await client.execute('PRAGMA application_id');
+      expect(Number(stamped.rows[0].application_id)).toBe(KNOWL_MIGRATION_LEVEL);
+      const commitItems = await client.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'knowledge_commit_items'",
+      );
+      expect(commitItems.rows).toHaveLength(1);
+    } finally {
+      client.close();
+    }
+
+    const reopened = createClient({ url: `file:${dbPath}` });
+    try {
+      await expect(bootstrapSchema(reopened)).resolves.toBeUndefined();
+      const items = await reopened.execute('SELECT id FROM knowledge_items');
+      expect(items.rows.map(row => String(row.id))).toEqual(['item1']);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  it('leaves no row the rebuilt foreign key forbids', async () => {
+    const dbPath = path.join(ROOT, 'dead-target', '.knowl', 'knowl.db');
+    // The historical shape: the stale key points at a table the legacy migration already
+    // dropped. This one survives COMMIT by cancellation -- and still lands an orphan in a
+    // table whose own key forbids it, which `PRAGMA foreign_key_check` reports and the
+    // integrity audit reports as a dangling reference.
+    await seedStaleStore(dbPath, 'knowledge_items_legacy', false);
+
+    const client = createClient({ url: `file:${dbPath}` });
+    try {
+      await bootstrapSchema(client);
+
+      const stepForeignKeys = await client.execute('PRAGMA foreign_key_list(skill_steps)');
+      const metadataForeignKeys = await client.execute('PRAGMA foreign_key_list(skill_metadata)');
+      expect(stepForeignKeys.rows.map(row => String(row.table))).toEqual(['knowledge_items']);
+      expect(metadataForeignKeys.rows.map(row => String(row.table))).toEqual(['knowledge_items']);
+
+      // The reachable row survives; the orphan is the cascade that never ran.
+      const steps = await client.execute('SELECT id FROM skill_steps ORDER BY id');
+      expect(steps.rows.map(row => String(row.id))).toEqual(['step1']);
+      const metadata = await client.execute('SELECT knowledge_item_id FROM skill_metadata ORDER BY knowledge_item_id');
+      expect(metadata.rows.map(row => String(row.knowledge_item_id))).toEqual(['item1']);
+
+      const violations = await client.execute('PRAGMA foreign_key_check');
+      expect(violations.rows).toEqual([]);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -1176,10 +1176,18 @@ describe('Storage Layer', () => {
     } as any);
     await setKnowledgeItemUpdatedAt(archived.id, '2026-01-03T00:00:00.000Z');
 
-    const result = await applyKnowledgeGc(projectId, {
+    const gcOptions = {
       now: '2026-07-05T00:00:00.000Z',
       staleStateDays: 0,
       compressArchivedDays: 0,
+    };
+    // Approved from a preview, because purge is the one action apply will not take on a set
+    // nobody read: an atom written between preview and apply would otherwise be destroyed
+    // unseen, and purge is the one action with no undo.
+    const preview = await previewKnowledgeGc(projectId, gcOptions);
+    const result = await applyKnowledgeGc(projectId, {
+      ...gcOptions,
+      approvedPurgeIds: preview.candidates.filter(entry => entry.action === 'purge').map(entry => entry.itemId),
     });
 
     expect(result.summary.purge).toBeGreaterThanOrEqual(1);

--- a/tests/store/update-commit-atomic.test.ts
+++ b/tests/store/update-commit-atomic.test.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+
+/**
+ * An update and its commit record are one transaction.
+ *
+ * They used to be two, on two connections. When `createKnowledgeCommit` threw, the caller was
+ * told the update failed while the row had already changed -- an item left `superseded` with
+ * `supersededById` set and nothing logging it. Everything that reads the change LOG rather
+ * than the row then misses the retirement: the workspace change notice, blast radius, and
+ * `readCommitHead`, which is `MAX(rowid)` of `knowledge_commits`.
+ *
+ * The failure is injected at the commit writer because that is the half that has to be able to
+ * fail for the invariant to mean anything -- a disk error, a lock, a constraint. Mocking the
+ * whole repository module and spreading the real one keeps every other caller genuine.
+ */
+vi.mock('../../src/store/repository.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/store/repository.js')>();
+  return { ...actual, createKnowledgeCommit: vi.fn(actual.createKnowledgeCommit) };
+});
+
+import { closeDb, getDb, initDb } from '../../src/store/database.js';
+import { createKnowledgeCommit, createKnowledgeItem, getKnowledgeItem } from '../../src/store/repository.js';
+import { updateKnowledgeItemWithCommit } from '../../src/store/knowledge-actions.js';
+
+const ROOT = path.resolve('./.knowl-update-commit-atomic-test');
+
+async function commitRowsFor(itemId: string): Promise<number> {
+  const db = getDb() as any;
+  const rows = await db.all(sql`SELECT commit_id FROM knowledge_commit_items WHERE item_id = ${itemId}`);
+  return rows.length;
+}
+
+describe('an update and its commit', () => {
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('leaves the row untouched when the commit record cannot be written', async () => {
+    const item = await createKnowledgeItem('local', {
+      category: 'fact', title: 'Retired by a failing commit', content: 'Still current.',
+    });
+    const replacement = await createKnowledgeItem('local', {
+      category: 'fact', title: 'The replacement', content: 'Supersedes the other.',
+    });
+    const before = await commitRowsFor(item.id);
+
+    vi.mocked(createKnowledgeCommit).mockRejectedValueOnce(new Error('commit log unavailable'));
+    await expect(updateKnowledgeItemWithCommit('local', item.id, {
+      status: 'superseded', supersededById: replacement.id,
+    })).rejects.toThrow(/commit log unavailable/);
+
+    // The caller was told it failed, so the retirement must not have happened.
+    const after = (await getKnowledgeItem(item.id))!;
+    expect(after.status).toBe('active');
+    expect(after.supersededById ?? null).toBeNull();
+    expect(after.version).toBe(item.version);
+    expect(await commitRowsFor(item.id)).toBe(before);
+  });
+
+  it('writes both halves when the commit record succeeds', async () => {
+    const item = await createKnowledgeItem('local', {
+      category: 'fact', title: 'Retired cleanly', content: 'Still current.',
+    });
+    const replacement = await createKnowledgeItem('local', {
+      category: 'fact', title: 'The clean replacement', content: 'Supersedes the other.',
+    });
+    const before = await commitRowsFor(item.id);
+
+    await updateKnowledgeItemWithCommit('local', item.id, {
+      status: 'superseded', supersededById: replacement.id,
+    });
+
+    const after = (await getKnowledgeItem(item.id))!;
+    expect(after.status).toBe('superseded');
+    expect(after.supersededById).toBe(replacement.id);
+    expect(await commitRowsFor(item.id)).toBe(before + 1);
+  });
+});

--- a/tests/store/write-scan-fields.test.ts
+++ b/tests/store/write-scan-fields.test.ts
@@ -93,6 +93,19 @@ describe('the write-scan projection', () => {
     expect((await repo.getKnowledgeItem(item.id))!.tags).toEqual(['ops']);
   });
 
+  it('scans skill steps on create and on update', async () => {
+    const project = await repo.createProject(ROOT, 'Write scan');
+    await expect(repo.createKnowledgeItem(project.id, {
+      category: 'skill', title: 'Poisoned skill', content: 'Safe.',
+    }, ['run it', `export TOKEN=${GITHUB_SHAPED}`])).rejects.toThrow(/secret/i);
+
+    const skill = await repo.createKnowledgeItem(project.id, {
+      category: 'skill', title: 'Clean skill', content: 'Safe.',
+    }, ['run it']);
+    await expect(repo.updateKnowledgeItem(skill.id, {}, [`export TOKEN=${GITHUB_SHAPED}`]))
+      .rejects.toThrow(/secret/i);
+  });
+
   it('still allows a metadata-only update of an item whose stored prose trips a detector', async () => {
     const project = await repo.createProject(ROOT, 'Write scan');
     const item = await repo.createKnowledgeItem(project.id, {

--- a/tests/store/write-scan-fields.test.ts
+++ b/tests/store/write-scan-fields.test.ts
@@ -1,0 +1,129 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { closeDb, getDb, initDb } from '../../src/store/database.js';
+import * as repo from '../../src/store/repository.js';
+import { auditKnowledgeStore } from '../../src/store/integrity.js';
+import * as portability from '../../src/store/portability.js';
+
+/**
+ * Every write path scans every field it writes.
+ *
+ * `validateKnowledgeWrite` reads `tags` and `alternatives`, but three callers assembled the
+ * object they handed it as a literal of exactly five fields -- title, content, reasoning,
+ * source, affectedPaths. An absent field is not a clean field: the scan silently covered
+ * nothing. So the store-wide audit answered "no integrity findings" over a row whose `tags`
+ * held a live credential, an update could put in `tags` what create had refused, and import
+ * accepted the same row from a peer.
+ *
+ * The literals below are fixtures, not real credentials: `ghp_` is the GitHub token shape and
+ * `AKIA` the AWS access-key-id shape, both of which `KNOWN_TOKEN` matches by prefix alone.
+ */
+const GITHUB_SHAPED = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789';
+const AWS_SHAPED = 'AKIAIOSFODNN7EXAMPLE';
+
+const ROOT = path.resolve('./.knowl-write-scan-test');
+const TARGET = path.resolve('./.knowl-write-scan-target');
+
+describe('the write-scan projection', () => {
+  beforeAll(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    await fs.rm(TARGET, { recursive: true, force: true });
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(TARGET, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('audits the tags column, not just the prose columns', async () => {
+    const project = await repo.createProject(ROOT, 'Write scan');
+    const poisoned = await repo.createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Tagged item', content: 'Safe durable knowledge.',
+    });
+    const clean = await repo.createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Untagged item', content: 'Safe durable knowledge.',
+    });
+    // Raw SQL on purpose: the create path already refuses this, which is exactly the
+    // asymmetry -- the row can only exist because an older writer let it in.
+    const db = getDb() as any;
+    await db.run(sql`UPDATE knowledge_items SET tags = ${JSON.stringify(['ops', GITHUB_SHAPED])} WHERE id = ${poisoned.id}`);
+
+    const findings = (await auditKnowledgeStore()).findings;
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'secret', itemId: poisoned.id }),
+    ]));
+    expect(findings.filter(finding => finding.itemId === clean.id)).toEqual([]);
+    expect(JSON.stringify(findings)).not.toContain(GITHUB_SHAPED);
+  });
+
+  it('audits the alternatives column, not just the prose columns', async () => {
+    const project = await repo.createProject(ROOT, 'Write scan');
+    const poisoned = await repo.createKnowledgeItem(project.id, {
+      category: 'decision', title: 'Item with alternatives', content: 'Safe durable knowledge.',
+    });
+    const db = getDb() as any;
+    await db.run(sql`UPDATE knowledge_items SET alternatives = ${JSON.stringify(['keep it', AWS_SHAPED])} WHERE id = ${poisoned.id}`);
+
+    expect((await auditKnowledgeStore()).findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'secret', itemId: poisoned.id }),
+    ]));
+  });
+
+  it('refuses an update that puts in tags what create would have refused', async () => {
+    const project = await repo.createProject(ROOT, 'Write scan');
+    const item = await repo.createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Clean on create', content: 'Safe durable knowledge.', tags: ['ops'],
+    });
+
+    await expect(repo.createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Rejected on create', content: 'Safe.', tags: ['ops', GITHUB_SHAPED],
+    })).rejects.toThrow(/secret/i);
+    await expect(repo.updateKnowledgeItem(item.id, { tags: ['ops', GITHUB_SHAPED] }))
+      .rejects.toThrow(/secret/i);
+    await expect(repo.updateKnowledgeItem(item.id, { alternatives: ['keep it', AWS_SHAPED] }))
+      .rejects.toThrow(/secret/i);
+
+    // Refused means nothing landed: `dbUpdates` spreads the whole argument, so a validator
+    // that passed would have written the credential into the row.
+    expect((await repo.getKnowledgeItem(item.id))!.tags).toEqual(['ops']);
+  });
+
+  it('still allows a metadata-only update of an item whose stored prose trips a detector', async () => {
+    const project = await repo.createProject(ROOT, 'Write scan');
+    const item = await repo.createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Ordinary item', content: 'Safe durable knowledge.',
+    });
+    const db = getDb() as any;
+    await db.run(sql`UPDATE knowledge_items SET content = ${'sk-test-123456789012345678901234567890'} WHERE id = ${item.id}`);
+
+    const superseded = await repo.updateKnowledgeItem(item.id, { status: 'superseded' });
+    expect(superseded.status).toBe('superseded');
+  });
+
+  it('refuses an import whose incoming tags carry a credential', async () => {
+    const project = await repo.createProject(ROOT, 'Write scan');
+    const item = await repo.createKnowledgeItem(project.id, {
+      category: 'fact', title: 'Exported with a poisoned tag', content: 'Safe durable knowledge.',
+    });
+    const db = getDb() as any;
+    await db.run(sql`UPDATE knowledge_items SET tags = ${JSON.stringify(['ops', GITHUB_SHAPED])} WHERE id = ${item.id}`);
+
+    const exportPath = path.join(ROOT, 'peer.jsonl');
+    // Just this item: earlier cases in this file rewrite other rows' content behind the
+    // write path, which leaves their `content_hash` deliberately misdescribing them and
+    // would trip the import's own hash guard before the scan is ever reached.
+    await portability.exportKnowledge(project.id, exportPath, ROOT, [item.id]);
+
+    await closeDb();
+    await fs.mkdir(path.join(TARGET, '.knowl'), { recursive: true });
+    await initDb(TARGET);
+
+    await expect((portability as any).importKnowledge(exportPath)).rejects.toThrow(/secret/i);
+    expect((await repo.listKnowledgeItems()).map(entry => entry.id)).not.toContain(item.id);
+  });
+});


### PR DESCRIPTION
Five store defects from an audit of `main`. One revertable commit each, every one verified against a mutant rather than by reading the diff.

**No new table, no new migration level** — still 16, so this does not collide with #279's 17.

---

### 1. `fix(store): every write path scans every field it writes`

`validateKnowledgeWrite` reads `tags` and `alternatives`, but three callers handed it a five-field object literal and an absent field makes `arrayField` return `[]` — so the scan covered nothing:

- `src/store/integrity.ts:118-137` selects and parses both arrays, then drops them. So `knowl audit` and `knowl doctor` print **"No integrity findings" over a store whose `tags` column holds a live credential** — and snapshot-restore verification inherits the false clean. A check that answers "clean" is worse than no check.
- `src/store/repository.ts:363-370` validates five fields and writes the whole spread at `:425`. Creating an atom with a credential in `tags` is refused; creating it clean and then *updating* with the same credential is accepted.
- `src/store/portability.ts:657` — same hole on the path that ingests a peer's export.

All three now use one projection (`scannableFields`) taken off the record, which copies only the keys the caller supplied — so the update path scans exactly what it writes and a metadata-only edit does not re-scan stored prose.

**Scope note, so this is not oversold:** this is local-store integrity, snapshot trust and import trust. It is *not* a disclosure bug — knowl-cloud's publish path already scans tags and alternatives before authorization, so a poisoned tag wedges the outbound queue rather than reaching a team store.

Mutant: reverted the five files → 4 of 5 tests fail; the fifth is the false-positive guard that must pass both ways.

### 2. `fix(store): a skill FK repair must not roll back bootstrap` — shipped alone

`repairSkillForeignKeys` copies every row into a table whose new FK is `ON DELETE CASCADE`. Its own `PRAGMA foreign_keys = OFF` is inert inside the migration transaction — `bootstrap.ts:1278-1280` already says so — and `defer_foreign_keys` pushes the check to COMMIT, where a failure rolls back the **entire bootstrap**: `application_id` stays 0, ~40 tables are never created, and every later open fails identically. `doctor` calls `initDb` too, so the repair path is inside the failure.

**The finding's stated trigger is refuted, and the commit body carries both halves.** "Any store with an orphan `skill_steps` row" does *not* brick: `DROP TABLE` decrements the deferred-FK counter once per violating row it deletes, so when the stale key points at a table that no longer exists each orphan is +1 on the insert and −1 on the drop, and COMMIT survives. Verified three ways — a standalone libSQL probe of the exact rename/create/insert/drop sequence (`nodrop` throws, `full` commits), a variant with an extra unbalanced orphan (throws, so the drop decrements rather than resets), and instrumented `bootstrapSchema` runs.

**The brick is still reachable** — when the stale key points at a table that still exists and satisfies the row, nothing cancels — and that is the case the first test pins. Both cases leave a row the new key forbids (`PRAGMA foreign_key_check` reports it); only one announces itself. Say the word if you want the commit reframed as *"the repair leaves a row its own key forbids"* rather than *"bricks the store"*; the body already supports either.

Mutant: reverted `bootstrap.ts` → both tests fail, the live-target case with `SQLITE_CONSTRAINT` thrown from the COMMIT at `:1304`.

### 3. `fix(store): an import cannot land a second exclusive value`

`portability.ts:769` was a raw INSERT with no `checkKnowledgeConflict` caller in the file. A direct second exclusive write is refused with `KNOWLEDGE_CONFLICT`; importing a peer's export landed it and reported `conflicts: 0`.

Import now resolves every planned write against the identities the store holds — normalised on both sides, since a raw stored key would never collide with a normalised one — counts a collision in `conflicts` (which declines the whole import and writes nothing, the shape `--on-divergence fail` already has), and names the pairs. A holder the same import retires, archives or deletes releases its identity first, so an export *replacing* a value is not refused for colliding with the value it replaces.

Mutant: 2 of 5 fail — the two asserting the refusal; the other three are false-positive guards.

### 4. `fix(store): an update and its commit are one transaction`

`knowledge-actions.ts:217` ran the row and the change record as two transactions on two connections; the comment at `:246` states the problem. A throwing `createKnowledgeCommit` left the item `superseded` with `supersededById` set and nothing logging it — invisible to the change notice, blast radius and `readCommitHead`, while the row says it happened and the caller is told it failed.

Both now run inside one `withClientTransaction`, following `storeKnowledgeItemDeduped`. The three best-effort side effects (sibling flagging, re-embed, cloud staging) stay outside and after, so nothing stages a row a rollback removed.

Mutant: `expected 'superseded' to be 'active'` — exactly the described leak.

### 5. `fix(store): collection acts on the set the preview named`

`gc.ts:319-321` recomputed candidates and the MCP tool took no arguments, so: preview shows `purge: 0`, an atom is written, apply hard-deletes an item the preview never named. Purge is the one GC action with no undo.

**The contract choice is yours to confirm.** The gate is on `purge` alone. `knowl_gc_apply` gains optional `purgeItemIds`, `knowl gc` gains `--purge <ids>`, and an apply naming nothing purges nothing while reporting what it declined (`unapprovedPurges`). Archive and compress still run unapproved — both leave the item, its id, its assertions and its evidence links in place, so a wrong one is recoverable, and gating them would leave an argument-less apply doing nothing at all. That is what makes a no-preview apply *safe* rather than merely refused. Apply still recomputes, because a stale plan is its own bug; it purges only the intersection with the approved ids.

Ids are carried by the caller rather than persisted — `knowl gc` and `knowl gc --apply` are separate processes, so no table and no migration level. `knowl_gc_preview` now returns every purge id, since it is the response that must supply them.

Mutant: *"destroys nothing an empty preview could not have named"* fails with `expected 1 to be +0` — the unpreviewed atom was deleted.

---

## Verified

`npm run build`, `npm run typecheck`, `npm run lint` (0 errors, 0 warnings), `npm run docs:check` all clean. Full suite: **426 files passed, 3973 passed, 5 skipped, 0 failed.** The schema-pin and snapshot-table-ownership guards passed untouched.

## Notes

- **Five existing test files changed** for the commit-5 contract (`forget-log`, `gc-duplicate-survivor`, `gc-protections`, `store`, `mcp/server`). Each now previews and approves, which is what a caller does; no assertion was weakened.
- **Not done, flagged rather than scoped in:** `repository.ts` has a separate `steps` parameter that is a genuine unscanned field on the create/update path. It sits outside the three call sites above and carries real refusal risk for existing skills, so it is named here rather than fixed.
- **Overlap:** #284 also touches `tools.ts` and `tool-definitions.ts` (tool annotations). No semantic conflict, but merge order decides which rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
