### PR TITLE
fix(hermes): hoist the root keys the engine reads out of `extra`, and stop calling the .cmd shim

### DIFF
--- a/integrations/hermes/knowl/__init__.py
+++ b/integrations/hermes/knowl/__init__.py
@@ -229,7 +229,10 @@ def _resolve_knowl_command(ctx: Any) -> List[str]:
     """Where the knowl CLI is: plugin setting, then env, then PATH, then npx."""
     configured = _setting(ctx, "knowl_bin") or os.environ.get("KNOWL_BIN")
     if configured:
-        return [str(configured)]
+        # Unwrapped too, and this is the branch that matters: the documented way to point at a
+        # global install is `knowl_bin: .../npm/knowl.cmd`, so the configured path is MORE
+        # likely to be a batch shim than a discovered one, not less.
+        return _unwrap_batch_shim(str(configured))
     for candidate in ("knowl.cmd", "knowl") if sys.platform == "win32" else ("knowl",):
         found = shutil.which(candidate)
         if found:

--- a/integrations/hermes/knowl/__init__.py
+++ b/integrations/hermes/knowl/__init__.py
@@ -233,8 +233,26 @@ def _resolve_knowl_command(ctx: Any) -> List[str]:
     for candidate in ("knowl.cmd", "knowl") if sys.platform == "win32" else ("knowl",):
         found = shutil.which(candidate)
         if found:
-            return [found]
+            return _unwrap_batch_shim(found)
     return ["npx", "-y", "@dat999zx/knowl"]
+
+
+def _unwrap_batch_shim(found: str) -> List[str]:
+    """`node <dist/index.js>` in place of npm's `.cmd` shim, so no argument crosses cmd.exe.
+
+    A `.cmd` target is run through cmd.exe, which re-parses the argument line: a newline in an
+    atom's body cut the line short and `knowl store` died on a "missing" `--category`, and a
+    `|` ran the rest as a command. Quoting does not help a batch target (cmd parses twice).
+    The shim's own body is `node "%dp0%\\node_modules\\@dat999zx\\knowl\\dist\\index.js" %*`,
+    so calling that entry point directly is what the shim would have done, minus the shell.
+    """
+    if not found.lower().endswith(".cmd"):
+        return [found]
+    entry = os.path.join(os.path.dirname(found), "node_modules", "@dat999zx", "knowl", "dist", "index.js")
+    node = shutil.which("node")
+    if node and os.path.isfile(entry):
+        return [node, entry]
+    return [found]
 
 
 def _hermes_hook_callback_timeout() -> float:
@@ -565,6 +583,14 @@ def _loaded_as_memory_provider() -> bool:
     return __name__.split(".", 1)[0] == MEMORY_LOADER_NAMESPACE
 
 
+# Keys the engine reads at the ROOT of a hook payload. Everything else goes under `extra`,
+# which the engine's stdin allowlist drops whole -- so a field the engine reads has to be
+# named here or it is sent and silently lost. Each of these was: `prompt` fed the correction
+# classifier that had never fired on this host, `status`/`error` turned a failed write into a
+# recorded success, and `last_assistant_message` left the fleet's per-turn summary empty.
+_ROOT_KEYS = ("prompt", "status", "error", "last_assistant_message")
+
+
 def _payload(event: str, session_id: str, cwd: str, **extra: Any) -> Dict[str, Any]:
     """The shape Hermes' own shell-hook serializer emits (agent/shell_hooks.py:_serialize_payload)."""
     body: Dict[str, Any] = {
@@ -578,6 +604,10 @@ def _payload(event: str, session_id: str, cwd: str, **extra: Any) -> Dict[str, A
         body["tool_name"] = str(tool_name)
     if isinstance(tool_input, dict):
         body["tool_input"] = tool_input
+    for key in _ROOT_KEYS:
+        value = extra.pop(key, None)
+        if value is not None:
+            body[key] = str(value)
     body["extra"] = {k: v for k, v in extra.items() if v is not None}
     return body
 
@@ -773,7 +803,9 @@ def register(ctx: Any) -> None:
             data, _code, _err = fire(
                 "pre_llm_call",
                 session_id,
-                user_message=str(user_message or "")[:4000],
+                # Root `prompt`, the key the engine's correction classifier reads. It derives
+                # one boolean from it and discards the text; nothing stores it.
+                prompt=str(user_message or "")[:4000],
                 is_first_turn=bool(is_first_turn),
                 turn_id=turn_id,
                 model=model,
@@ -914,17 +946,24 @@ def register(ctx: Any) -> None:
         args: Optional[Dict[str, Any]] = None,
         session_id: str = "",
         status: Any = None,
+        error_type: Any = None,
+        error_message: Any = None,
         **_: Any,
     ) -> None:
         def collect() -> None:
             try:
+                # Hermes reports "ok" or "error" here; the engine reads root `status`/`error`
+                # in its own vocabulary. Without them a failed write_file was captured as a
+                # successful one.
+                failed = str(status or "") == "error"
                 data, _code, _err = fire(
                     "post_tool_call",
                     session_id,
                     timeout=POST_TOOL_TIMEOUT_SECONDS,
                     tool_name=tool_name,
                     tool_input=args or {},
-                    status=status,
+                    status=("failed" if failed else "finished"),
+                    error=(str(error_message or error_type or "tool_error")[:2000] if failed else None),
                 )
                 if not (data and isinstance(data.get("context"), str) and data["context"].strip()):
                     return
@@ -1036,7 +1075,8 @@ def register(ctx: Any) -> None:
                 coding=bool(coding),
                 attempt=int(attempt or 0),
                 changed_paths=list(changed_paths or []),
-                final_response=str(final_response or "")[:2000],
+                # Root key: the fleet's one-line "what did this turn do", held in memory only.
+                last_assistant_message=str(final_response or "")[:2000],
             )
         except Exception as exc:
             logger.debug("knowl pre_verify: %s", exc)
@@ -1051,7 +1091,11 @@ def register(ctx: Any) -> None:
     # -- every turn's end (the name is historical) and the real session end.
     def on_session_end(session_id: str = "", turn_id: str = "", completed: Any = None, interrupted: Any = None, **_: Any) -> None:
         try:
-            fire("on_session_end", session_id, turn_id=turn_id, completed=completed, interrupted=interrupted)
+            # A Ctrl-C'd turn arrives as completed=False, interrupted=True; the engine reads
+            # root `status`, and without it every interrupted turn closed as a clean finish.
+            failed = bool(interrupted) or completed is False
+            fire("on_session_end", session_id, turn_id=turn_id, completed=completed, interrupted=interrupted,
+                 status=("failed" if failed else None))
         except Exception as exc:
             logger.debug("knowl on_session_end: %s", exc)
 

--- a/src/cli/agents/host-hook.ts
+++ b/src/cli/agents/host-hook.ts
@@ -230,13 +230,25 @@ function toolEvent(host: HookHost, eventName: string, projectRoot: string, raw: 
   // Shell events already fingerprint on the command itself, so they were never affected.
   if (isShell) {
     const command = commandEvent(projectRoot, raw);
-    const failed = typeof raw.exit_code === 'number' && raw.exit_code !== 0;
+    const failed = (typeof raw.exit_code === 'number' && raw.exit_code !== 0) || stringValue(raw.status) === 'failed';
     // A non-zero exit is a problem this session hit, and the text is the only way to tell
     // whether another session hit the same one. Attached only on failure, so a passing
     // command's output never leaves the hook process at all.
     const exitedNonZero = failed || (typeof command.payload.exitCode === 'number' && command.payload.exitCode !== 0);
-    const errorText = exitedNonZero ? failedCommandOutput(raw) : undefined;
+    const errorText = exitedNonZero ? (failedCommandOutput(raw) ?? stringValue(raw.error)) : undefined;
     return { ...command, status: failed ? 'failed' : undefined, ...named, knowlTool, ...changeKeys, ...(errorText ? { errorText } : {}) };
+  }
+
+  // Claude names a failed tool call by event (PostToolUseFailure, handled by the caller);
+  // plugin hosts (Hermes, OpenClaw) report one tool event with `status: 'failed'` and the reason
+  // under `error`. Same outcome: an error event, never a checkpoint crediting a write that did
+  // not happen.
+  if (stringValue(raw.status) === 'failed') {
+    const errorText = stringValue(raw.error) ?? stringValue(recordValue(raw.error)?.message);
+    return {
+      type: 'error', status: 'failed', payload: { message: errorText ?? 'Tool failed' },
+      ...named, knowlTool, ...changeKeys, ...(errorText ? { errorText } : {}),
+    };
   }
 
   const captureKey = toolCaptureKey(toolName, input);

--- a/src/cli/agents/lifecycle.ts
+++ b/src/cli/agents/lifecycle.ts
@@ -22,9 +22,11 @@ export const ROOT_FIELDS = new Set([
   // shared main-thread row and SubagentStart/Stop cannot resolve an agent at all.
   'agent_id', 'agentId', 'agent_type', 'agentType',
   // The turn's ask and the turn's answer, for the fleet's one-line "what is this session on".
-  // `prompt` was already read by the correction-signal classifier in `host-hook.ts`, which
-  // could never fire in production because this list dropped the field before it arrived --
-  // a hook that computes from a field it never receives passes every test that bypasses stdin.
+  // `prompt` is also read by the correction-signal classifier in `host-hook.ts`, which this
+  // list dropped before it arrived -- a hook that computes from a field it never receives
+  // passes every test that bypasses stdin. Allowlisting it made the classifier REACHABLE, not
+  // live: on claude/codex/copilot/openhands the prompt event runs `agent-reminder`, which never
+  // calls the classifier, and Hermes sent the text under `extra` until its plugin hoisted it.
   // Neither reaches `payload`; see `errorText` / `assistantMessage` on NormalizedHostHook.
   'prompt', 'last_assistant_message',
   // Antigravity's payload is protojson: every key camelCase, the session under

--- a/src/session/hosts/hermes.ts
+++ b/src/session/hosts/hermes.ts
@@ -79,7 +79,9 @@ const hermesBlock = (reason: string): HostOutput => ({ decision: 'block', reason
  * `agent/shell_hooks.py`): `hook_event_name`, `tool_name`, `tool_input`, `session_id`, `cwd`, and
  * the rest under `extra`. Those top-level keys are the ones the normaliser reads, so this profile
  * stays Claude's dialect on the way in, and `extra` still never reaches the engine -- the stdin
- * allowlist keeps root fields only.
+ * allowlist keeps root fields only. Which is why the plugin hoists the four other root keys the
+ * normaliser reads -- `prompt`, `status`, `error`, `last_assistant_message` -- out of `extra`
+ * itself (`_ROOT_KEYS` in the plugin): each was being sent, dropped, and read as absent.
  *
  * **Refusal**: `{"decision": "block", "reason"}` **and** exit 2, because the plugin reads both.
  * Same pair as OpenHands.
@@ -135,6 +137,11 @@ export const hermesProfile: HostProfile = {
   writeTools: ['write_file', 'patch'],
   readsFiles: (_event, tool) => tool === 'read_file',
   identity(raw): HostIdentity {
+    // Session only, on purpose. Hermes sends `turn_id` on pre_llm_call, the tool events and
+    // on_session_end but NOT on pre_verify (`get_pre_verify_continue_message` has no such
+    // kwarg), so keying turns on it would split one turn across two bindings and the stop
+    // nudge pre_verify carries would find neither. The engine resets a reused turn key's
+    // counters at every turn-start, which is what a per-turn key would have bought.
     return { externalSessionId: hostString(raw.session_id) };
   },
   normalizedEvent(hostEvent) {

--- a/tests/cli/hermes-plugin.test.ts
+++ b/tests/cli/hermes-plugin.test.ts
@@ -3,28 +3,41 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 import { normalizeHostHook } from '../../src/cli/agents/host-hook.js';
+import { readLifecyclePayloadObject } from '../../src/cli/agents/lifecycle.js';
 import { commandExistsOnPath } from '../../src/cli/agents/command-exists.js';
 
 /**
- * The payload the plugin sends -- the shape `_serialize_payload` in `agent/shell_hooks.py`
- * (v0.21.0) builds -- checked against the normaliser that has to accept it. The failure this
- * guards is total silence: a payload the normaliser rejects throws
- * `IncompleteHostHookPayloadError`, which `runAgentHook` swallows, so the integration reports
- * nothing and looks unconfigured.
+ * The payload the plugin sends -- the shape `_payload` in `integrations/hermes/knowl/__init__.py`
+ * builds, which mirrors `_serialize_payload` in Hermes' `agent/shell_hooks.py` -- checked against
+ * the normaliser that has to accept it. Two failures are guarded here.
+ *
+ * Total silence: a payload the normaliser rejects throws `IncompleteHostHookPayloadError`, which
+ * `runAgentHook` swallows, so the integration reports nothing and looks unconfigured.
+ *
+ * Silent loss: every payload goes through the stdin allowlist (`readLifecyclePayloadObject`)
+ * before the normaliser sees it, and that allowlist drops `extra` whole. A field the plugin nests
+ * there and the engine reads at the root is sent, dropped, and read as absent -- which is how a
+ * failed write_file was captured as a success and the correction classifier never fired on this
+ * host. So `normalize` below runs the allowlist first; a test that hands the normaliser the raw
+ * object passes for a field production never delivers.
  */
 const ROOT = path.resolve('.knowl-hermes-hook-test');
 
-const hermesPayload = (event: string, extra: Record<string, unknown> = {}, tool?: { name: string; args: Record<string, unknown> }) => ({
+const hermesPayload = (event: string, root: Record<string, unknown> = {}, tool?: { name: string; args: Record<string, unknown> }) => ({
   hook_event_name: event,
   tool_name: tool?.name ?? null,
   tool_input: tool?.args ?? null,
   session_id: 'sess-1',
   cwd: ROOT,
-  extra,
+  ...root,
+  extra: { model: 'm', platform: 'cli', is_first_turn: true, turn_id: 't1' },
 });
 
-describe('Hermes shell-hook payloads', () => {
-  it('are accepted for every event knowl init registers', () => {
+const normalize = (event: string, payload: Record<string, unknown>) =>
+  normalizeHostHook('hermes', event, readLifecyclePayloadObject(payload));
+
+describe('Hermes plugin payloads, through the stdin allowlist', () => {
+  it('are accepted for every event the plugin sends', () => {
     const cases: Array<[string, string]> = [
       ['pre_llm_call', 'turn-start'],
       ['pre_tool_call', 'tool-precheck'],
@@ -35,7 +48,7 @@ describe('Hermes shell-hook payloads', () => {
     ];
     for (const [hostEvent, normalized] of cases) {
       const tool = hostEvent.endsWith('tool_call') ? { name: 'write_file', args: { path: path.join(ROOT, 'src/a.py') } } : undefined;
-      const result = normalizeHostHook('hermes', hostEvent, hermesPayload(hostEvent, { model: 'm', platform: 'cli' }, tool));
+      const result = normalize(hostEvent, hermesPayload(hostEvent, {}, tool));
       expect(result.event, hostEvent).toBe(normalized);
       expect(result.externalSessionId, hostEvent).toBe('sess-1');
       expect(result.projectRoot, hostEvent).toBe(ROOT);
@@ -43,14 +56,47 @@ describe('Hermes shell-hook payloads', () => {
   });
 
   it('carries the edited path through from tool_input.path, and names the tool', () => {
-    const result = normalizeHostHook('hermes', 'pre_tool_call', hermesPayload('pre_tool_call', {}, { name: 'write_file', args: { path: path.join(ROOT, 'src/a.py') } }));
+    const result = normalize('pre_tool_call', hermesPayload('pre_tool_call', {}, { name: 'write_file', args: { path: path.join(ROOT, 'src/a.py') } }));
     expect(result.toolName).toBe('write_file');
     expect(result.payload.changedPaths).toEqual(['src/a.py']);
   });
 
   it('tolerates the null tool fields Hermes sends on non-tool events', () => {
-    const result = normalizeHostHook('hermes', 'pre_llm_call', hermesPayload('pre_llm_call', { user_message: 'hi', is_first_turn: true }));
+    const result = normalize('pre_llm_call', hermesPayload('pre_llm_call', { prompt: 'hi' }));
     expect(result.toolName).toBeUndefined();
+    expect(result.payload.correctionSignal).toBeUndefined();
+  });
+
+  it('classifies a correction from the root prompt, and keeps the text out of the payload', () => {
+    const result = normalize('pre_llm_call', hermesPayload('pre_llm_call', { prompt: 'no, i already told you not to do that' }));
+    expect(result.payload).toEqual({ correctionSignal: true });
+    expect(JSON.stringify(result)).not.toContain('told you');
+  });
+
+  it('records a failed tool call as an error event, not a checkpoint crediting the write', () => {
+    const tool = { name: 'write_file', args: { path: path.join(ROOT, 'src/a.py') } };
+    const failed = normalize('post_tool_call', hermesPayload('post_tool_call', { status: 'failed', error: 'EACCES' }, tool));
+    expect(failed).toMatchObject({ type: 'error', status: 'failed', payload: { message: 'EACCES' }, errorText: 'EACCES' });
+    expect(failed.payload.changedPaths).toBeUndefined();
+
+    const ok = normalize('post_tool_call', hermesPayload('post_tool_call', { status: 'finished' }, tool));
+    expect(ok).toMatchObject({ type: 'checkpoint', payload: { changedPaths: ['src/a.py'] } });
+    expect(ok.status).toBeUndefined();
+  });
+
+  it('records a failed terminal call as a failed command, keeping its fingerprint', () => {
+    const tool = { name: 'terminal', args: { command: 'npm test' } };
+    const result = normalize('post_tool_call', hermesPayload('post_tool_call', { status: 'failed', error: '3 tests failed' }, tool));
+    expect(result).toMatchObject({ type: 'command', status: 'failed', payload: { command: 'npm test' }, errorText: '3 tests failed' });
+  });
+
+  it('closes an interrupted turn as failed and a finished one with its last message', () => {
+    const interrupted = normalize('on_session_end', hermesPayload('on_session_end', { status: 'failed' }));
+    expect(interrupted).toMatchObject({ event: 'turn-stop', status: 'failed' });
+    expect(interrupted.assistantMessage).toBeUndefined();
+
+    const finished = normalize('pre_verify', hermesPayload('pre_verify', { last_assistant_message: 'Renamed the helper.' }));
+    expect(finished).toMatchObject({ event: 'turn-stop', status: 'finished', assistantMessage: 'Renamed the helper.' });
   });
 });
 

--- a/tests/integrations/hermes/test_plugin.py
+++ b/tests/integrations/hermes/test_plugin.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import os
 import unittest
+import unittest.mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PLUGIN = os.path.join(HERE, "..", "..", "..", "integrations", "hermes", "knowl", "__init__.py")
@@ -119,6 +120,23 @@ class PluginTest(unittest.TestCase):
         self.plugin.register(self.ctx)
 
     # -- registration ---------------------------------------------------------
+
+    def test_a_cmd_shim_is_unwrapped_to_node_and_the_entry_point(self):
+        # npm's `.cmd` shim runs through cmd.exe, which re-parses arguments: a body with a
+        # newline lost every flag after it and `knowl store` failed on a "missing" category.
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            entry = os.path.join(d, "node_modules", "@dat999zx", "knowl", "dist", "index.js")
+            os.makedirs(os.path.dirname(entry))
+            open(entry, "w").close()
+            shim = os.path.join(d, "knowl.cmd")
+            open(shim, "w").close()
+            with unittest.mock.patch.object(self.plugin.shutil, "which", return_value="/usr/bin/node"):
+                self.assertEqual(self.plugin._unwrap_batch_shim(shim), ["/usr/bin/node", entry])
+                # Without the entry point beside it, the shim is left alone.
+                lone = os.path.join(d, "elsewhere", "knowl.cmd")
+                self.assertEqual(self.plugin._unwrap_batch_shim(lone), [lone])
+        self.assertEqual(self.plugin._unwrap_batch_shim("/usr/bin/knowl"), ["/usr/bin/knowl"])
 
     def test_registers_every_hook_the_profile_expects(self):
         self.assertEqual(
@@ -349,9 +367,55 @@ class PluginTest(unittest.TestCase):
 
     def test_pre_verify_forwards_the_paths_hermes_supplies(self):
         self.results["pre_verify"] = (None, 0, "")
-        self.ctx.hooks["pre_verify"](session_id="s", coding=True, changed_paths=["src/a.py"], attempt=1)
+        self.ctx.hooks["pre_verify"](session_id="s", coding=True, changed_paths=["src/a.py"], attempt=1, final_response="done")
         _event, payload, _cwd = self.calls[-1]
+        # `changed_paths` stays under `extra`: no turn-stop reader on any host takes it. The
+        # fleet's per-turn summary reads `last_assistant_message`, at the root.
         self.assertEqual(payload["extra"]["changed_paths"], ["src/a.py"])
+        self.assertEqual(payload["last_assistant_message"], "done")
+
+    # -- the root keys the engine reads --------------------------------------
+    #    Everything under `extra` is dropped by the engine's stdin allowlist, so a field the
+    #    engine reads has to sit at the root. Each of these was sent under `extra` once and
+    #    read as absent -- the tests below are the ones that would have caught it.
+
+    def test_the_prompt_reaches_the_root_for_the_correction_classifier(self):
+        self.results["pre_llm_call"] = (None, 0, "")
+        self.ctx.hooks["pre_llm_call"](session_id="s", user_message="no, i told you already", is_first_turn=False)
+        _event, payload, _cwd = self.calls[-1]
+        self.assertEqual(payload["prompt"], "no, i told you already")
+        self.assertNotIn("user_message", payload["extra"])
+
+    def test_a_failed_tool_call_reports_failed_status_and_the_error_at_the_root(self):
+        self.results["post_tool_call"] = (None, 0, "")
+        self.ctx.hooks["post_tool_call"](tool_name="write_file", args={"path": "a.py"}, session_id="s",
+                                         status="error", error_type="tool_error", error_message="EACCES")
+        self._join_post_tool_threads()
+        _event, payload, _cwd = self.calls[-1]
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["error"], "EACCES")
+
+    def test_a_successful_tool_call_carries_no_error(self):
+        self.results["post_tool_call"] = (None, 0, "")
+        self.ctx.hooks["post_tool_call"](tool_name="write_file", args={"path": "a.py"}, session_id="s", status="ok")
+        self._join_post_tool_threads()
+        _event, payload, _cwd = self.calls[-1]
+        self.assertEqual(payload["status"], "finished")
+        self.assertNotIn("error", payload)
+
+    def test_an_interrupted_turn_ends_as_failed(self):
+        self.ctx.hooks["on_session_end"](session_id="s", turn_id="t", completed=False, interrupted=True)
+        _event, payload, _cwd = self.calls[-1]
+        self.assertEqual(payload["status"], "failed")
+        self.ctx.hooks["on_session_end"](session_id="s", turn_id="t", completed=True, interrupted=False)
+        _event, payload, _cwd = self.calls[-1]
+        self.assertNotIn("status", payload)
+
+    def _join_post_tool_threads(self):
+        import threading
+        for thread in threading.enumerate():
+            if thread.name == "knowl-post_tool_call":
+                thread.join(timeout=5)
 
     # -- impact card ----------------------------------------------------------
 

--- a/tests/integrations/hermes/test_plugin.py
+++ b/tests/integrations/hermes/test_plugin.py
@@ -9,6 +9,7 @@ this test invented.
 import importlib.util
 import json
 import os
+import types
 import unittest
 import unittest.mock
 
@@ -137,6 +138,21 @@ class PluginTest(unittest.TestCase):
                 lone = os.path.join(d, "elsewhere", "knowl.cmd")
                 self.assertEqual(self.plugin._unwrap_batch_shim(lone), [lone])
         self.assertEqual(self.plugin._unwrap_batch_shim("/usr/bin/knowl"), ["/usr/bin/knowl"])
+
+    def test_a_configured_knowl_bin_is_unwrapped_too(self):
+        # The documented way to point at a global install is `knowl_bin: .../npm/knowl.cmd`,
+        # so the configured branch is the one most likely to hold a batch shim. Unwrapping
+        # only the PATH lookup left every multi-line `knowl store` broken for that config.
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            entry = os.path.join(d, "node_modules", "@dat999zx", "knowl", "dist", "index.js")
+            os.makedirs(os.path.dirname(entry))
+            open(entry, "w").close()
+            shim = os.path.join(d, "knowl.cmd")
+            open(shim, "w").close()
+            ctx = types.SimpleNamespace(get_config=lambda key, default=None: shim if key == "knowl_bin" else default)
+            with unittest.mock.patch.object(self.plugin.shutil, "which", return_value="/usr/bin/node"):
+                self.assertEqual(self.plugin._resolve_knowl_command(ctx), ["/usr/bin/node", entry])
 
     def test_registers_every_hook_the_profile_expects(self):
         self.assertEqual(


### PR DESCRIPTION
## What

Triage of #275, verified against source and reproduced on `dist/index.js`. Of the three claims, two are by design and one is real — and the real one is much larger than the issue says.

### Not fixed, by design

- **A — query-scored recall.** The proposed fix is `knowl query <user's sentence>` at turn-start. That is exactly what the Hermes `MemoryProvider.prefetch` did until `3f02b09`, removed on measurement: keyword search over prose retrieves badly, and a card that looks like an answer suppresses the agent's own `knowl_query` (6/6 → 1/6, p=0.008). Decision `9d327f381ede4881`, constraint `6676fd41b5dc410c` rule 2.
- **B — first-turn-only card.** Deliberate; `hermes.ts:9-16` documents why. Also inaccurate for claude/codex/copilot/openhands, whose prompt event runs `agent-reminder` and never reaches `turn-start` at all (#289).

### Fixed here

**C, widened.** `_payload()` nests everything under `extra`, which the stdin allowlist drops whole. Verified with `readLifecyclePayloadObject` on real payloads — hermes kept `[session_id, cwd]` and nothing else. Four root-read fields were sent, dropped, and read as absent:

| field | event | consequence |
|---|---|---|
| `prompt` | pre_llm_call | correction classifier never fired on Hermes |
| `status` / `error` | post_tool_call | a failed `write_file`/`patch`/`terminal` was captured as a **successful checkpoint**: read-set recorded, impact run on a write that didn't happen, terminal failures stored as `exitCode 0`, fleet error-signature never populated |
| `completed` / `interrupted` | on_session_end | every Ctrl-C'd turn closed as a clean `finished`; `finalizeFailedStop` never ran |
| `last_assistant_message` | pre_verify | fleet per-turn summary always null for Hermes |

Plus a fourth defect found while trying to store these findings: **`knowl_store` from the plugin fails on Windows for any multi-line content.** `_resolve_knowl_command` returned npm's `knowl.cmd`, which runs through cmd.exe and re-parses argv — a newline truncates the line (`required option '--category'`), a `|` executes. It now calls `node <dist/index.js>` directly, which is all the shim did. Reproduced before and after against a throwaway project.

### Engine side

`toolEvent` turns a root `status: 'failed'` into an error event on any host — same outcome `PostToolUseFailure` gets by event name — and a failed shell call keeps its command fingerprint. OpenClaw was already sending this pair (`integrations/openclaw/src/index.ts:380`) and silently taking the checkpoint path too.

### Tests

Every existing Hermes engine test bypassed the allowlist — `normalizeHostHook` was called with `extra` intact, so a field could be nested on either side and the suite stayed green. `tests/cli/hermes-plugin.test.ts` now routes every payload through `readLifecyclePayloadObject` first, with one case per hoisted field. `test_plugin.py` asserts each key at the root and covers the shim unwrap. The `hermes-profile.test.ts` case that pinned the `turn_id` loss as expected is left alone: Hermes does not send `turn_id` on `pre_verify`, so keying turns on it would split one turn across two bindings.

Verified: build, typecheck, lint clean; 421 files / 3959 tests pass; 52/52 Python.

Follow-ups filed: #289 (correction capture dead on all hosts — routing), #290 (no card after compaction).

Closes #275.
