### PR TITLE
fix: the three rulings from #282 — repo: under a per-call root, local:true on a duplicate, and the registry publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,3 +89,30 @@ jobs:
           else
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file notes.md --latest
           fi
+
+  # Separate job on purpose: the registry login mints its own OIDC token, and nothing here
+  # should run beside the npm one. Runs only after npm has the tarball, because the registry
+  # verifies package ownership by reading `mcpName` out of the published package.
+  mcp-registry:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Pinned by version AND digest, for the same reason every action above is pinned by SHA:
+      # a `latest` download is a standing invitation to run whatever is uploaded next.
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -sSL -o mcp-publisher.tgz https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+          echo 'a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc  mcp-publisher.tgz' | sha256sum -c -
+          tar xzf mcp-publisher.tgz mcp-publisher
+
+      - name: Publish to the MCP registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2805,6 +2805,7 @@ program
 
         if (result.action === 'duplicate') {
           console.log(`NOT STORED — already held verbatim as ${result.item.id}. Nothing was written and nothing was lost.`);
+          if (options.local) console.log(`  Not marked local: restating an atom cannot unpublish a shared one. Run \`knowl cloud unstage ${result.item.id} --forever\` to keep it off the team store.`);
           return;
         }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -683,7 +683,7 @@ export function registerTools(
           return {
             // The quoted title is stored text echoed back on one line, so it gets the same
             // treatment as every other stored value that reaches the agent.
-            content: [{ type: 'text', text: `NOT STORED — this ${category} is already held verbatim as item ${result.item.id} ("${inlineUntrusted(result.item.title)}"), so nothing was written and nothing was lost. No action needed.` }],
+            content: [{ type: 'text', text: `NOT STORED — this ${category} is already held verbatim as item ${result.item.id} ("${inlineUntrusted(result.item.title)}"), so nothing was written and nothing was lost.${local === true ? ` It was NOT marked local: restating an atom cannot unpublish one someone else may share. To keep it off the team store, call knowl_cloud with action "unstage", id "${result.item.id}", forever true.` : ' No action needed.'}` }],
           };
         }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -2254,7 +2254,12 @@ export function registerTools(
   const OVERRIDE_KEY = '__projectRoot';
   const overrideHost = 'hermes';
 
-  const callToolForRoot = async (request: CallToolRequest): Promise<CallToolResult | null> => {
+  type ActingAs = { projectId: string; projectRoot: string; config: ProjectConfig | null };
+
+  const callToolForRoot = async (
+    request: CallToolRequest,
+    next: (actingAs: ActingAs) => Promise<CallToolResult>,
+  ): Promise<CallToolResult | null> => {
     const args = request.params.arguments as Record<string, unknown> | undefined;
     const root = args?.[OVERRIDE_KEY];
     if (typeof root !== 'string' || root.length === 0) return null;
@@ -2284,15 +2289,24 @@ export function registerTools(
       if (!project) {
         return { isError: true, content: [{ type: 'text', text: `No Knowl project at "${root}". Run \`knowl init\` there once, then retry.` }] };
       }
-      return callTool(request, { projectId: project.id, projectRoot: resolved, config: await loadConfig(resolved) });
+      return next({ projectId: project.id, projectRoot: resolved, config: await loadConfig(resolved) });
     });
   };
 
+  /**
+   * `repo:` on top of `__projectRoot`, in that order of specificity. The root says where this
+   * SESSION is anchored; `repo` says which linked repo this ONE call does the work of. A host
+   * that injects the root into every call (Hermes does) must not thereby make `repo` inert, so
+   * the workspace is resolved from the session's root and the hop runs inside its swap.
+   */
   const callToolAsRepo = async (request: CallToolRequest): Promise<CallToolResult> => {
-    const forRoot = await callToolForRoot(request);
-    if (forRoot) return forRoot;
+    const forRoot = await callToolForRoot(request, actingAs => callToolWithinRepo(request, actingAs));
+    return forRoot ?? callToolWithinRepo(request, null);
+  };
+
+  const callToolWithinRepo = async (request: CallToolRequest, caller: ActingAs | null): Promise<CallToolResult> => {
     const asRepo = (request.params.arguments as Record<string, unknown> | undefined)?.repo;
-    if (typeof asRepo !== 'string' || asRepo.length === 0) return callTool(request);
+    if (typeof asRepo !== 'string' || asRepo.length === 0) return callTool(request, caller ?? undefined);
     const declared = (SCHEMA_BY_TOOL.get(request.params.name)?.properties as Record<string, unknown> | undefined)?.repo;
     if (!declared) {
       return {
@@ -2306,8 +2320,9 @@ export function registerTools(
       };
     }
     await whenReady();
-    const callerRoot = getProjectRoot();
-    const workspace = callerRoot ? await resolveWorkspace(callerRoot, getConfig() ?? undefined) : null;
+    const callerRoot = caller ? caller.projectRoot : getProjectRoot();
+    const callerConfig = caller ? caller.config : getConfig();
+    const workspace = callerRoot ? await resolveWorkspace(callerRoot, callerConfig ?? undefined) : null;
     try {
       return await withRepoContext(asRepo, workspace, async () => {
         const root = ambientProjectRoot();

--- a/tests/mcp/act-as-repo.test.ts
+++ b/tests/mcp/act-as-repo.test.ts
@@ -37,8 +37,8 @@ class InMemoryTransport {
   async close(): Promise<void> { this.onclose?.(); }
 }
 
-async function callTool(root: string, config: ProjectConfig, name: string, args: Record<string, unknown>) {
-  const server = createMcpServer('local', root, config);
+async function callTool(root: string | null, config: ProjectConfig, name: string, args: Record<string, unknown>, host?: string) {
+  const server = createMcpServer('local', root, config, null, { host });
   const transport = new InMemoryTransport();
   await server.connect(transport as any);
   const initialized = new Promise<any>(resolve => { transport.onSend = m => { if (m.id === 'init') resolve(m); }; });
@@ -149,6 +149,21 @@ describe('acting as a linked repo through the tool surface', { timeout: 180_000 
     expect(allowed.isError).toBeFalsy();
 
     expect(String((await rowIn(B, ownedByB))?.content)).toContain('five minutes');
+  });
+
+  it('repo:"b" still means b when the session root arrives per call, as Hermes sends it', async () => {
+    // `__projectRoot` anchors the session; `repo` names whose work this one call does. A host
+    // that injects the root into EVERY call must not make `repo` inert -- that is the misfile
+    // where a write meant for b lands in a and is reported as success.
+    const result = await callTool(null, DEFAULT_CONFIG, 'knowl_store', {
+      __projectRoot: A, repo: 'b', category: 'fact', title: 'Rotation cadence', content: 'Keys rotate every ninety days.',
+    }, 'hermes');
+    expect(result.isError).toBeFalsy();
+
+    const id = /([0-9a-f]{16})/.exec(String(result.content[0].text))?.[1] ?? '';
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+    expect(String((await rowIn(B, id))?.origin_repo)).toBe('b');
+    expect(await rowIn(A, id)).toBeNull();
   });
 
   it('omitting repo is unchanged in every way', async () => {


### PR DESCRIPTION
Answers all three questions in #282, one commit each.

**1. `local: true` on the dedupe path — the guard stays.** #266 put it there on purpose: a duplicate write returns the *existing* row, and excluding that would let anyone unpublish a shared atom by retyping it. What was wrong is the silence. Both `knowl_store` and `knowl store --local` now say the atom was *not* marked local and name the command that does it deliberately (`knowl cloud unstage <id> --forever`). Two lines.

**2. `repo:` wins over `__projectRoot` — they compose, not compete.** The root anchors the session; `repo` names whose work this one call does. `callToolAsRepo` returned from the root swap before ever reading `repo`, so under a root-injecting host (Hermes) `repo` was inert on all six act-as tools. Now the root swap runs the repo hop *inside* it, resolving the workspace from the session's root. Test: server rooted nowhere, `__projectRoot: A, repo: 'b'` → the row is in B stamped `b`, absent from A. Fails on `main`.

**3. `server.json` gets published.** Second job in `cd.yml`, `needs: publish`, `mcp-publisher login github-oidc` — no secret. Binary pinned by release (v1.8.1) and sha256, same reason every action there is pinned by commit. Runs after npm because the registry verifies `mcpName` in the tarball.

Typecheck, lint, docs:check clean; scoped tests 97/97.

Closes #282.
