### PR TITLE
fix(hooks): the correction classifier runs where the prompt event lands

### DIFF
--- a/src/cli/agents/reminder.ts
+++ b/src/cli/agents/reminder.ts
@@ -6,6 +6,9 @@ import {
 } from '../../core/config.js';
 import { closeDb, initDb } from '../../store/database.js';
 import { conversationKey, readCaptureOutcome } from '../../store/capture-outcome.js';
+import { captureEventsMode } from '../../store/capture-config.js';
+import { detectCorrectionSignal } from '../../core/lesson-signals.js';
+import { recordCorrectionLesson, renderCorrectionNudge } from '../../store/pending-lessons.js';
 import { assertKnowledgeDatabasePresent } from '../database-presence.js';
 import { fleetTurnStartBestEffort } from '../../session/fleet-lifecycle.js';
 import { readLifecyclePayload } from './lifecycle.js';
@@ -94,6 +97,12 @@ export async function runAgentReminder(host: string, options: HookOutputOptions 
   // one envelope with the card rather than printing a second, since a host reads one JSON
   // object from a hook.
   let digest: string | undefined;
+  // The correction lesson. `host-lifecycle`'s `turn-start` branch does this for hosts whose
+  // prompt event reaches `agent-hook`, and claude/codex/copilot/openhands are not those hosts:
+  // `hook-config.ts` registers THIS command under their prompt event and strips any lifecycle
+  // handler from the same key. So the classifier ran nowhere in production (#289). It runs here,
+  // where the prompt, the project root and an open store are all already in hand.
+  let correctionLine: string | undefined;
   try {
     const payload = await readLifecyclePayload();
     const identity = hostProfile(host as HookHost).identity(payload);
@@ -101,15 +110,19 @@ export async function runAgentReminder(host: string, options: HookOutputOptions 
     assertKnowledgeDatabasePresent(root);
     await initDb(root);
     try {
-      const outcome = await readCaptureOutcome(conversationKey({
-        host,
-        projectRoot: root,
-        externalSessionId: identity.externalSessionId,
-      }));
+      const conversation = conversationKey({ host, projectRoot: root, externalSessionId: identity.externalSessionId });
+      const outcome = await readCaptureOutcome(conversation);
       const turns = outcome?.turns ?? 0;
       const config = await loadConfig(root).catch(() => null);
       send = turns === 0
         || shouldSendDriftReminder(turns, driftReminderEvery(config), isDriftBackoffEnabled(config));
+      const eventsMode = captureEventsMode(config ?? undefined);
+      // Same order as the engine's: classify, pend, and speak only in enforce. The verdict is
+      // a boolean -- no user text is stored, here or in the row.
+      if (eventsMode !== 'off' && typeof payload.prompt === 'string' && detectCorrectionSignal(payload.prompt)
+        && await recordCorrectionLesson(conversation) && eventsMode === 'enforce') {
+        correctionLine = renderCorrectionNudge();
+      }
       if (identity.externalSessionId) {
         digest = await fleetTurnStartBestEffort({
           host,
@@ -133,7 +146,7 @@ export async function runAgentReminder(host: string, options: HookOutputOptions 
   // This one answers "the card could not be emitted", where emitting it again is the failure
   // repeating. These two lines used to sit outside every try in the function.
   try {
-    const parts = [send ? promptReminderFor(hostLabel(host)) : undefined, digest].filter((part): part is string => Boolean(part));
+    const parts = [correctionLine, send ? promptReminderFor(hostLabel(host)) : undefined, digest].filter((part): part is string => Boolean(part));
     if (parts.length > 0) console.log(JSON.stringify(createAgentReminderOutput(host, parts.join('\n\n'))));
   } catch (error) {
     if (reportHookFailure(host, options, 'Error emitting agent reminder', error)) process.exitCode = 1;

--- a/tests/cli/correction-routing.test.ts
+++ b/tests/cli/correction-routing.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * The correction classifier, over the real stdin path, on the hosts that actually run it.
+ *
+ * `detectCorrectionSignal` and `recordCorrectionLesson` were both covered — one as a pure
+ * function, the other called directly — and neither test would have gone red for the thing that
+ * was true in production: nothing invoked the classifier at all. claude, codex, copilot and
+ * openhands register `agent-reminder <host>` under their prompt event, and that command never
+ * called it (#289).
+ *
+ * So these spawn the built CLI and read the row, which is the only shape that can fail for the
+ * right reason.
+ */
+
+const TEST_DIR = path.join(os.tmpdir(), 'knowl-correction-routing-test');
+const CLI_PATH = path.resolve('./dist/index.js');
+
+function run(args: string[], input?: string) {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], { cwd: TEST_DIR, encoding: 'utf8', input });
+}
+
+async function pendingLessons(): Promise<Array<{ kind: string; conversation: string }>> {
+  const client = createClient({ url: `file:${path.join(TEST_DIR, '.knowl', 'knowl.db')}` });
+  try {
+    const rows = await client.execute('SELECT kind, conversation FROM pending_lessons');
+    return rows.rows.map(row => ({ kind: String(row.kind), conversation: String(row.conversation) }));
+  } finally {
+    client.close();
+  }
+}
+
+// The four hosts whose prompt event runs `agent-reminder` rather than `agent-hook`.
+const HOSTS = ['claude', 'codex', 'copilot', 'openhands'] as const;
+const PROMPT_EVENT: Record<string, string> = {
+  claude: 'UserPromptSubmit', codex: 'UserPromptSubmit', copilot: 'UserPromptSubmit', openhands: 'UserPromptSubmit',
+};
+
+describe('correction capture on the hosts whose prompt event is agent-reminder', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+    await fs.mkdir(TEST_DIR, { recursive: true });
+    run(['init', '--yes']);
+    // The classifier is armed by config and nothing else; `off` is the shipped default.
+    run(['config', 'set', 'capture.events', 'enforce']);
+  }, 120_000);
+
+  afterAll(async () => { await fs.rm(TEST_DIR, { recursive: true, force: true }).catch(() => {}); });
+
+  for (const host of HOSTS) {
+    it(`${host}: a correction prompt writes a pending lesson`, async () => {
+      const sessionId = `corr-${host}`;
+      const before = (await pendingLessons()).length;
+
+      const output = run(['agent-reminder', host], JSON.stringify({
+        session_id: sessionId,
+        cwd: TEST_DIR,
+        prompt: 'no, I already told you not to use that approach',
+      }));
+
+      const after = await pendingLessons();
+      expect(after.length, `${host} wrote no lesson`).toBe(before + 1);
+      expect(after.some(row => row.kind === 'correction')).toBe(true);
+      // enforce speaks; the nudge rides the envelope this event was already sending.
+      expect(output).toContain('LESSON');
+    }, 120_000);
+  }
+
+  it('an ordinary prompt writes nothing', async () => {
+    const before = (await pendingLessons()).length;
+    run(['agent-reminder', 'claude'], JSON.stringify({
+      session_id: 'corr-benign', cwd: TEST_DIR, prompt: 'please add a test for the parser',
+    }));
+    expect((await pendingLessons()).length).toBe(before);
+  }, 120_000);
+});


### PR DESCRIPTION
Option 1, which is the cheap one for the reason the issue names: `runAgentReminder` already reads `payload.prompt`, already resolves the project root, and already has the store open. Classify, pend, speak only in enforce — same order and same boolean-only verdict as the engine's `turn-start` branch, so no user text is stored on either path. The nudge rides the envelope this event was already sending rather than printing a second one.

No routing change, so the `hook-config.ts` "a reminder and a lifecycle handler cannot share a key" trap stays as it is. That is option 2's job and it is a bigger change than this defect needs.

**The test is the point.** Four cases plus a benign control, spawning the built CLI and reading the `pending_lessons` row — the shape that can fail for the right reason. Against `main` all four fail; with the fix all five pass. Gate 3 (plugin hosts not sending a root `prompt`) is separately fixed for Hermes in #291; cline and antigravity still send nothing and are out of scope here.

Gates: typecheck, lint clean; 10 files / 277 tests green.

Closes #289.