### PR TITLE
fix(hooks): a compacted session is handed its card again

### DIFF
--- a/src/session/host-lifecycle.ts
+++ b/src/session/host-lifecycle.ts
@@ -78,6 +78,8 @@ import { toSurfacedSkills } from '../core/skill-surface.js';
 import { listActiveSkillItems } from '../store/repository.js';
 import {
   closeHostSessionBinding,
+  consumeRecompactPending,
+  markRecompactPending,
   closeHostSessionBindings,
   closeInactiveHostSessionBindings,
   bindHostSession,
@@ -1098,7 +1100,13 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
         hostOutput: hostContextOutput(input, withCorrection(context)),
       };
     }
-    const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding, turnBudget);
+    // Compaction erased the card from the model's context without ending the session, so the
+    // card is owed again even though the binding is live. `includeContext` is otherwise
+    // `!sessionBinding` -- once per session -- and this is the one event that makes
+    // once-per-session and once-per-context different things. Spent, not sticky: the flag
+    // clears in the same statement that reports it, so this costs one card per compaction.
+    const recompacted = sessionBinding ? await consumeRecompactPending(input) : false;
+    const started = await bootstrapWithHandoff(projectId, input, 'turn', !sessionBinding || recompacted, turnBudget);
     if (!sessionBinding) await bindHostSession(bindingKey(input, 'session'), started.session.id);
     const context = withRoster(started.context);
     return {
@@ -1157,6 +1165,12 @@ export async function handleHostLifecycleEvent(projectId: string, input: Normali
 
     try {
       const started = await startBoundSession(projectId, input, 'turn');
+      // `checkpoint` is mapped from a compaction event and nothing else on every host that has
+      // one (claude PreCompact, copilot preCompact, cursor preCompact, hermes on_pre_compress,
+      // openclaw before_compaction), so the event itself is the signal -- no payload field and
+      // no allowlist entry. The card cannot be delivered here: on a PRE-compaction hook it
+      // would be composed into the very context about to be discarded. The next turn spends it.
+      if (input.event === 'checkpoint') await markRecompactPending(input);
       const type = input.event === 'checkpoint' ? 'checkpoint' : input.type;
       if (!type) throw new Error('Normalized host session event requires a type.');
       await captureMemorySessionEvent(started.session.id, type, input.payload);

--- a/src/session/host-session-bindings.ts
+++ b/src/session/host-session-bindings.ts
@@ -90,6 +90,39 @@ export async function bindHostSession(input: HostSessionKey, memorySessionId: st
   });
 }
 
+/**
+ * Mark this session as having been compacted, on every binding it holds.
+ *
+ * Both keys deliberately: the turn key is what a turn-start looks up first, and the session
+ * key is what survives a turn boundary -- a compaction between turns must still be spent by
+ * the next one. Only active rows, since a closed binding will never be read again.
+ */
+export async function markRecompactPending(input: Omit<HostSessionKey, 'externalTurnId'>): Promise<void> {
+  const key = normalizedKey({ ...input, externalTurnId: '' });
+  await getClient().execute({
+    sql: `UPDATE host_session_bindings SET recompact_pending = 1, updated_at = ?
+      WHERE host = ? AND project_root = ? AND external_session_id = ? AND active = 1`,
+    args: [new Date().toISOString(), key.host, key.projectRoot, key.externalSessionId],
+  });
+}
+
+/**
+ * Spend the flag: true once per compaction, false forever after.
+ *
+ * Cleared on every binding for the session in the same statement that reports it, so two hook
+ * processes racing the same turn cannot both re-deliver -- `rowsAffected` is zero for the
+ * loser. That is the same claim-before-use shape `claimCapture` uses one level up.
+ */
+export async function consumeRecompactPending(input: Omit<HostSessionKey, 'externalTurnId'>): Promise<boolean> {
+  const key = normalizedKey({ ...input, externalTurnId: '' });
+  const result = await getClient().execute({
+    sql: `UPDATE host_session_bindings SET recompact_pending = 0, updated_at = ?
+      WHERE host = ? AND project_root = ? AND external_session_id = ? AND recompact_pending = 1`,
+    args: [new Date().toISOString(), key.host, key.projectRoot, key.externalSessionId],
+  });
+  return Number(result.rowsAffected ?? 0) > 0;
+}
+
 export async function incrementHostSuccessfulToolCount(input: HostSessionKey): Promise<number> {
   const key = normalizedKey(input);
   const row = (await getClient().execute({

--- a/src/store/bootstrap.ts
+++ b/src/store/bootstrap.ts
@@ -180,6 +180,7 @@ const SCHEMA_STATEMENTS = [
     memory_session_id TEXT NOT NULL REFERENCES memory_sessions(id) ON DELETE CASCADE,
     active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)), successful_tool_count INTEGER NOT NULL DEFAULT 0,
     seen_commit_rowid INTEGER NOT NULL DEFAULT 0, seen_commit_initialized INTEGER NOT NULL DEFAULT 0,
+    recompact_pending INTEGER NOT NULL DEFAULT 0,
     seen_peer_commits TEXT, updated_at TEXT NOT NULL,
     PRIMARY KEY (host, project_root, external_session_id, external_turn_id)
   );`,
@@ -1087,6 +1088,14 @@ async function ensureHostSessionBindingColumns(client: Client): Promise<void> {
   // bound at zero commits is now marked initialized and does report its first commit.
   if (!columns.includes('seen_commit_initialized')) {
     await client.execute('ALTER TABLE host_session_bindings ADD COLUMN seen_commit_initialized INTEGER NOT NULL DEFAULT 0;');
+  }
+  // Compaction erases the card from the model's context without ending the session, so
+  // once-per-session and once-per-context diverge exactly there. Hosts whose only signal is
+  // PRE-compaction cannot re-deliver on the spot -- the card would be composed into the very
+  // context about to be discarded -- so the checkpoint sets this and the next turn-start
+  // spends it. Defaults to 0: an existing session was not mid-compaction when it migrated.
+  if (!columns.includes('recompact_pending')) {
+    await client.execute('ALTER TABLE host_session_bindings ADD COLUMN recompact_pending INTEGER NOT NULL DEFAULT 0;');
   }
   // JSON map of peer repo name -> that peer's last seen commit rowid. Nullable rather
   // than defaulted to '{}': NULL means "never looked at peers", which adopts their heads

--- a/src/store/schema-version.ts
+++ b/src/store/schema-version.ts
@@ -224,7 +224,21 @@ export const KNOWL_SCHEMA_VERSION = 1;
  * `SCHEMA_STATEMENTS`, never create them, and every read would then hit "no such table" -- on
  * ordinary queries, not just on the new command.
  */
-export const KNOWL_MIGRATION_LEVEL = 17;
+/**
+ * 18 adds `host_session_bindings.recompact_pending`.
+ *
+ * Load-bearing rather than bookkeeping, for the reason level 6 records and 17 repeats. The
+ * column is read on the hot path -- `consumeRecompactPending` runs on every turn-start that
+ * finds a live session -- so a store an installed build already stamped at 17 would skip
+ * `ensureHostSessionBindingColumns`, never gain the column, and then fail ordinary turn-start
+ * with "no such column". `KNOWL_SCHEMA_VERSION` stays at 1: an older build reading this
+ * database finds every table it knows intact and never looks at this column.
+ *
+ * No backfill, and none is meaningful: the flag says "this session was compacted a moment
+ * ago", which is not a fact about the past that could be recovered. Existing rows default to
+ * 0, which is the truthful answer for a session that was not mid-compaction when it migrated.
+ */
+export const KNOWL_MIGRATION_LEVEL = 18;
 
 export class SchemaTooNewError extends Error {
   constructor(dbPath: string, found: number, supported: number) {

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -177,6 +177,8 @@ export const hostSessionBindings = sqliteTable('host_session_bindings', {
   active: integer('active', { mode: 'boolean' }).notNull().default(true),
   successfulToolCount: integer('successful_tool_count').notNull().default(0),
   seenCommitRowid: integer('seen_commit_rowid').notNull().default(0),
+  /** Set when the host compacts; consumed by the next turn-start, which re-delivers the card. */
+  recompactPending: integer('recompact_pending', { mode: 'boolean' }).notNull().default(false),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
   primaryKey({ columns: [table.host, table.projectRoot, table.externalSessionId, table.externalTurnId] }),

--- a/tests/store/recompact-card.test.ts
+++ b/tests/store/recompact-card.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * The card is owed again after the host compacts.
+ *
+ * Deliberately once per session (see `hosts/hermes.ts:9-16`) -- but compaction is the one event
+ * that erases the card from the model's context WITHOUT ending the session, so once-per-session
+ * and once-per-context stop being the same thing exactly there. Measured before this fix: a
+ * hermes session got 419 chars on its first turn, then nothing on every turn after
+ * `on_pre_compress`, for the life of the session.
+ *
+ * Driven through the built CLI rather than the engine, because the defect was never in the
+ * composer -- it was in which events reach it with `includeContext` true.
+ */
+
+const TEST_DIR = path.join(os.tmpdir(), 'knowl-recompact-card-test');
+const CLI_PATH = path.resolve('./dist/index.js');
+
+function run(args: string[], input?: string): string {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], { cwd: TEST_DIR, encoding: 'utf8', input });
+}
+
+/**
+ * The context a host would actually receive, or '' for silence.
+ *
+ * Hermes reads a bare `context` key; the Claude-shaped hosts read
+ * `hookSpecificOutput.additionalContext`. Both are checked so this helper is not silently
+ * reading the wrong field and calling an empty string a pass.
+ */
+function card(args: string[], payload: Record<string, unknown>): string {
+  const raw = run(args, JSON.stringify(payload)).trim();
+  if (!raw) return '';
+  try {
+    const parsed = JSON.parse(raw);
+    return String(parsed?.context ?? parsed?.hookSpecificOutput?.additionalContext ?? '');
+  } catch {
+    return raw;
+  }
+}
+
+describe('the bootstrap card after a compaction', () => {
+  beforeAll(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+    await fs.mkdir(TEST_DIR, { recursive: true });
+    run(['init', '--yes']);
+    run(['store', '--category', 'fact', '--title', 'The deploy window is Tuesday',
+      'Releases go out Tuesday 09:00 UTC, agreed with the platform team.']);
+  }, 180_000);
+
+  afterAll(async () => { await fs.rm(TEST_DIR, { recursive: true, force: true }).catch(() => {}); });
+
+  it('is re-delivered on the first turn after the host compacts, then not again', () => {
+    const session = { session_id: 'compact-1', cwd: TEST_DIR };
+
+    // Turn 1: the card, as always.
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'hello' }))
+      .toContain('deploy window');
+
+    // Turn 2: silence, which is the deliberate once-per-session behaviour.
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'still here' }))
+      .toBe('');
+
+    // The host compacts. A PRE-compaction hook cannot carry the card itself -- whatever it
+    // returned would be composed into the very context about to be discarded.
+    card(['agent-hook', 'hermes', 'on_pre_compress', '--json'], session);
+
+    // The next turn is owed it again.
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'where do we deploy' }))
+      .toContain('deploy window');
+
+    // And exactly once: the flag is spent, not sticky.
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'and after that' }))
+      .toBe('');
+  }, 180_000);
+
+  it('a session that never compacts is unchanged', () => {
+    const session = { session_id: 'compact-2', cwd: TEST_DIR };
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'hello' }))
+      .toContain('deploy window');
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'again' }))
+      .toBe('');
+    expect(card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'and again' }))
+      .toBe('');
+  }, 180_000);
+
+  it('one compaction pays one card, however many turns follow', () => {
+    const session = { session_id: 'compact-3', cwd: TEST_DIR };
+    card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt: 'hello' });
+    card(['agent-hook', 'hermes', 'on_pre_compress', '--json'], session);
+
+    const delivered = ['a', 'b', 'c']
+      .map(prompt => card(['agent-hook', 'hermes', 'pre_llm_call', '--json'], { ...session, prompt }))
+      .filter(text => text.includes('deploy window'));
+    expect(delivered.length).toBe(1);
+  }, 180_000);
+});

--- a/tests/store/schema-pin.test.ts
+++ b/tests/store/schema-pin.test.ts
@@ -96,6 +96,9 @@ const SCHEMA_PINS: Record<number, string> = {
   // level does, and load-bearingly: `annotateDisputes` reads both on every workspace query, so a
   // store left at 16 would skip the DDL and fail ordinary reads, not just the new command.
   17: '7a690fc55d186b8106ea27c647685bd3',
+  // 18 adds `host_session_bindings.recompact_pending`: the flag a compaction sets and the
+  // next turn-start spends, so a compacted session is handed its card again.
+  18: 'e8f3b2310e9f008aede3706c68c54e9a',
 };
 
 let root: string;


### PR DESCRIPTION
Implements the narrowed shape from [my triage comment](https://github.com/dat999zx/knowl/issues/290#issuecomment-5610669978), not the one in the issue body — the Claude half of that repro did not reproduce.

**What the issue got right:** the cliff is real on hosts whose only compaction signal is *pre*-compaction. Measured on hermes: 419 chars on turn 1, then `on_pre_compress`, then **empty on every turn after**, for the life of the session.

**What it got wrong:** `SessionStart` with `source: 'compact'` returns a byte-identical 393-char card to a fresh start on Claude — `startBoundSession` re-composes for an already-bound session. So `source` never needed to reach `ROOT_FIELDS`, and Claude needs no fix at all.

**The fix is smaller than the issue assumed.** `checkpoint` is mapped from a compaction event and *nothing else* on every host that has one (`claude.ts:11`, `copilot.ts:26`, `cursor.ts:13`, `hermes.ts:36`, `openclaw.ts:41`), so the event is the signal — no payload field, no allowlist entry. Checkpoint sets a flag on the binding; the next turn-start spends it.

Spent, not sticky: the flag clears in the same UPDATE that reports it, so two hook processes racing one turn cannot both re-deliver (same claim-before-use shape as `claimCapture`), and one compaction pays exactly one card. Pinned by a test.

Delivering at the checkpoint itself is not available on the hosts that need it — a pre-compaction hook's return would be composed into the very context about to be discarded.

**Migration 17 → 18, load-bearing.** `consumeRecompactPending` runs on every turn-start with a live session, so a store an installed build stamped at 17 would skip the ALTER and then fail *ordinary* turn-start with "no such column" — the failure mode level 6 records. `KNOWL_SCHEMA_VERSION` stays 1. Pin `e8f3b2310e9f008aede3706c68c54e9a` is the value the pin test itself demanded.

**Verified:** build, typecheck, lint, docs:check clean. `tests/store` + `tests/session` + `tests/cli/hosts` = 149 files, 1349 passed, 0 failed. New test drives the real CLI through turn → turn → compact → turn → turn; 2 of its 3 cases fail against unfixed `host-lifecycle.ts` and the "never compacts" control passes both ways.

Closes #290.