### PR TITLE
feat(mcp): the five person-initiated verbs are reachable as prompts

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2861,6 +2861,25 @@ workspace-federated views; `knowl://brain` is bounded rather than a complete dat
 `Auth: Unsupported` is expected for this local stdio server and does not indicate that the tools
 are unavailable.
 
+### Prompts
+
+Five prompts front the verbs a person starts rather than an agent chooses. Hosts render them as
+slash commands, prefixed with the server name — `/knowl:park`, `/knowl:resume`, and so on. Each
+one is a single line that calls the tool below it with the argument supplied; every tool remains
+on `tools/list` and nothing is reachable only through a prompt.
+
+| Prompt | Tool it calls | Arguments |
+| --- | --- | --- |
+| `park` | `knowl_park` | `goal` (required) |
+| `resume` | `knowl_resume` | `key` (optional; omit to list what is parked) |
+| `handoff` | `knowl_handoff` | `goal`, `nextAction` (both required) |
+| `drift` | `knowl_drift` | `since` (required) |
+| `state` | `knowl_state` | none |
+
+MCP prompt arguments are always strings, so a prompt exposes the one or two fields a person
+would type rather than the full tool schema. Anything richer — `completed`, `artifactRefs`,
+`apply` — is supplied by the agent on the resulting tool call.
+
 ## Optional AI
 
 Structured CLI/MCP storage, retrieval, governance, lifecycle, file-backed skills, and synthesis

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,7 +7,7 @@ import { ProjectNotFoundError } from '../core/errors.js';
 import { initDb } from '../store/database.js';
 import { getProjectByRootPath } from '../store/repository.js';
 import { adoptProject, scaffoldProject, scaffoldTarget, serveAutoInitAllowed } from './auto-init.js';
-import { registerTools } from './tools.js';
+import { registerTools, registerPrompts } from './tools.js';
 import { registerResources } from './resources.js';
 import { PACKAGE_VERSION } from '../version.js';
 import {
@@ -75,7 +75,7 @@ export function createMcpServer(
       // implemented is worse than the gap it papers over, because the client's fallback is
       // never taken and the failure surfaces as silence rather than as an error.
       //
-      // Both entries are deliberately bare:
+      // All three entries are deliberately bare:
       //
       // - `resources: {}` already covers `resources/templates/list`, which the SDK gates on the
       //   resources capability alone -- there is no separate template flag to add. Neither
@@ -87,9 +87,14 @@ export function createMcpServer(
       //   handlers in `tools.ts` re-check their own gate rather than trusting the listing. That
       //   is the honest pairing. Claiming `listChanged` without sending the notification would
       //   tell a host to wait for a signal that never arrives.
+      // - `prompts: {}` is here because `registerPrompts` answers both `prompts/list` and
+      //   `prompts/get`; the flag arrived in the same commit as the mechanism, which is the
+      //   rule this comment states. Its `listChanged` is withheld for the same reason tools'
+      //   is: the five prompts are a fixed literal today, and nothing sends the notification.
       capabilities: {
         tools: {},
         resources: {},
+        prompts: {},
       },
       // From the getter, not the positional argument. The real startup passes `null`
       // positionally and hands the live config over through `deferred`, so this card was
@@ -126,6 +131,11 @@ export function createMcpServer(
     getInitError,
     deferred.whenReady ?? (async () => {})
   );
+
+  // No state passed, and none needed: a prompt body is the tool name and the argument the
+  // person typed, so nothing here reads the project, the config or the database. The call it
+  // produces goes back through `tools/call`, which does all of that already.
+  registerPrompts(server);
 
   return server;
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ErrorCode, GetPromptRequestSchema, ListPromptsRequestSchema, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { captureChangeWatermark, consumeCaptureNudge, consumeChangeNotice } from './change-notice.js';
 import { KNOWLEDGE_CATEGORIES, ProjectConfig, KnowledgeCategory, KnowledgeItem, KnowledgeStatus } from '../core/types.js';
@@ -2457,6 +2457,126 @@ export function registerTools(
     return {
       ...result,
       content: [...result.content, ...extra.map(text => ({ type: 'text' as const, text }))],
+    };
+  });
+}
+
+/**
+ * The five verbs a person starts, offered as MCP prompts as well as tools.
+ *
+ * Every one of these tools stays on `tools/list` and nothing moves off it. A prompt is not a
+ * second way to implement a verb, it is a second way to *reach* one: tools are chosen by the
+ * model mid-turn, prompts are chosen by the person up front -- a slash command in the host's
+ * menu, before any turn exists to choose within. These five are the only ones where that is
+ * the real entry point. "Park this", "resume <key>", "hand this off", "what drifted", "what do
+ * you know" are things a human says to open a session; the other thirty tools are things an
+ * agent decides mid-work, and a slash command for `knowl_feedback` would be a menu entry
+ * nobody picks.
+ *
+ * Everything but the name and the argument list is DERIVED from the tool definition, so this
+ * table cannot drift from the surface it fronts. `annotations.title` is already the
+ * person-facing one-liner for each of these five, the tool description is already the accurate
+ * statement of what the call does, and each argument's description and required-ness already
+ * live in the tool's own inputSchema. Restating any of them here would create a second copy
+ * that a later edit to the tool would silently leave behind.
+ *
+ * The names are bare verbs, not the `knowl_` tool names: hosts prefix a prompt with the
+ * server's own name when they render it, so `park` becomes `/knowl:park` and `knowl_park`
+ * would become `/knowl:knowl_park`.
+ *
+ * The argument list is written out rather than derived from the schema's `required` array,
+ * because the two answer different questions. `knowl_resume` requires nothing -- a bare call
+ * lists what is parked -- yet the key is the entire reason a person reaches for it, and
+ * `knowl_park` accepts seven fields of which a person supplies one.
+ */
+const PERSON_INITIATED_PROMPTS: { name: string; tool: string; arguments: string[] }[] = [
+  { name: 'park', tool: 'knowl_park', arguments: ['goal'] },
+  { name: 'resume', tool: 'knowl_resume', arguments: ['key'] },
+  { name: 'handoff', tool: 'knowl_handoff', arguments: ['goal', 'nextAction'] },
+  { name: 'drift', tool: 'knowl_drift', arguments: ['since'] },
+  { name: 'state', tool: 'knowl_state', arguments: [] },
+];
+
+/**
+ * One prompt, resolved against the tool it fronts.
+ *
+ * Throws rather than skipping when a name or an argument does not resolve. A prompt that
+ * quietly drops itself because a tool was renamed is the same invisible-surface failure that
+ * left `resources/templates/list` unanswered -- and this runs at module load, so the failure
+ * lands on the process that made the mistake instead of on a client months later.
+ */
+function resolvePrompt(entry: typeof PERSON_INITIATED_PROMPTS[number]) {
+  const tool = CORE_TOOL_DEFINITIONS.find(definition => definition.name === entry.tool);
+  if (!tool) throw new Error(`Prompt "${entry.name}" fronts unknown tool ${entry.tool}.`);
+  const properties = (tool.inputSchema.properties ?? {}) as Record<string, { description?: string }>;
+  const required = (tool.inputSchema.required ?? []) as string[];
+  return {
+    name: entry.name,
+    tool: tool.name,
+    title: tool.annotations.title ?? tool.name,
+    description: tool.description,
+    arguments: entry.arguments.map(argument => {
+      const property = properties[argument];
+      if (!property) throw new Error(`Prompt "${entry.name}" names ${entry.tool}.${argument}, which has no schema.`);
+      return {
+        name: argument,
+        // Verbatim from the tool, and it reads correctly for a person because the schema
+        // descriptions were already written in plain language rather than as type notes.
+        description: property.description,
+        required: required.includes(argument),
+      };
+    }),
+  };
+}
+
+const KNOWL_PROMPTS = PERSON_INITIATED_PROMPTS.map(resolvePrompt);
+
+/**
+ * The prompt body: one line that calls the tool with what the person typed.
+ *
+ * Deliberately not a rewritten instruction. The model already has this tool's full description
+ * from `tools/list`, so a prompt that restated it would be a third copy of the same text and
+ * the first one to go stale. All this has to do is turn a menu selection into the call.
+ *
+ * Values are interpolated raw. They come from the person's own client, which is the same trust
+ * level as the message they would otherwise have typed -- there is no third party here to
+ * contain, and collapsing a pasted multi-line goal would corrupt the very thing being parked.
+ */
+function promptBody(prompt: typeof KNOWL_PROMPTS[number], args: Record<string, string>): string {
+  const supplied = prompt.arguments
+    .filter(argument => args[argument.name])
+    .map(argument => `${argument.name}: ${args[argument.name]}`);
+  return supplied.length === 0
+    ? `Call ${prompt.tool} now.`
+    : `Call ${prompt.tool} now with ${supplied.join(', ')}`;
+}
+
+export function registerPrompts(server: Server): void {
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: KNOWL_PROMPTS.map(({ name, title, description, arguments: args }) => ({
+      name, title, description, arguments: args,
+    })),
+  }));
+
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    const prompt = KNOWL_PROMPTS.find(candidate => candidate.name === request.params.name);
+    // -32602, for the reason `resources.ts` spells out at its own not-found: the caller asked
+    // for something that is not here, which is not the server having failed.
+    if (!prompt) throw new McpError(ErrorCode.InvalidParams, `Prompt not found: ${request.params.name}`);
+    const args = request.params.arguments ?? {};
+    // The SDK validates the request envelope and stops there, so a declared-required argument
+    // is only required if something checks. Without this the body silently degrades to a bare
+    // `Call knowl_drift now.` -- a call that cannot succeed, phrased as though it could.
+    const missing = prompt.arguments.filter(argument => argument.required && !args[argument.name]);
+    if (missing.length > 0) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Prompt "${prompt.name}" requires ${missing.map(argument => argument.name).join(', ')}.`,
+      );
+    }
+    return {
+      description: prompt.title,
+      messages: [{ role: 'user' as const, content: { type: 'text' as const, text: promptBody(prompt, args) } }],
     };
   });
 }

--- a/tests/mcp/server-capabilities.test.ts
+++ b/tests/mcp/server-capabilities.test.ts
@@ -25,7 +25,7 @@ class InMemoryTransport {
 }
 
 /** One connection, so the initialize result and later calls describe the same server. */
-async function session(): Promise<{ init: any; ask: (method: string) => Promise<any>; end: () => Promise<void> }> {
+async function session(): Promise<{ init: any; ask: (method: string, params?: any) => Promise<any>; end: () => Promise<void> }> {
   const server = createMcpServer(null, null, { version: 1 } as ProjectConfig);
   const transport = new InMemoryTransport();
   await server.connect(transport as never);
@@ -44,10 +44,15 @@ async function session(): Promise<{ init: any; ask: (method: string) => Promise<
   let counter = 0;
   return {
     init: init.result,
-    ask: async (method: string) => {
+    ask: async (method: string, params?: any) => {
       const id = `ask-${counter++}`;
       const answered = waitFor(id);
-      transport.onmessage!({ jsonrpc: '2.0', id, method, params: method === 'resources/subscribe' ? { uri: 'knowl://brain' } : {} });
+      transport.onmessage!({
+        jsonrpc: '2.0', id, method,
+        // `resources/subscribe` needs a uri to clear envelope validation, so a call that omits
+        // params still reaches the capability check this file is actually about.
+        params: params ?? (method === 'resources/subscribe' ? { uri: 'knowl://brain' } : {}),
+      });
       return answered;
     },
     end: () => server.close(),
@@ -55,11 +60,11 @@ async function session(): Promise<{ init: any; ask: (method: string) => Promise<
 }
 
 describe('the declared server capabilities', () => {
-  it('declares tools and resources, and no sub-flag knowl does not implement', async () => {
+  it('declares tools, resources and prompts, and no sub-flag knowl does not implement', async () => {
     const { init, end } = await session();
     // Deliberately an exact comparison. A sub-flag added here without the mechanism behind it
     // is the failure this test exists for, and `toMatchObject` would let one through.
-    expect(init.capabilities).toEqual({ tools: {}, resources: {} });
+    expect(init.capabilities).toEqual({ tools: {}, resources: {}, prompts: {} });
     await end();
   });
 
@@ -67,10 +72,59 @@ describe('the declared server capabilities', () => {
     const { ask, end } = await session();
     // Including the template list: the SDK gates `resources/templates/list` on the resources
     // capability alone, so declaring `resources` is the whole permission for it.
-    for (const method of ['resources/list', 'resources/templates/list', 'tools/list']) {
+    for (const method of ['resources/list', 'resources/templates/list', 'tools/list', 'prompts/list']) {
       const response = await ask(method);
       expect(response.error, `${method} is declared and unanswerable`).toBeUndefined();
     }
+    await end();
+  });
+
+  it('lists exactly the five person-initiated prompts', async () => {
+    const { ask, end } = await session();
+    const listed = await ask('prompts/list');
+    // Exact and ordered, so a sixth prompt added without a maintainer deciding it is
+    // person-initiated fails here rather than appearing in every host's slash menu unnoticed.
+    expect(listed.result.prompts.map((prompt: any) => prompt.name))
+      .toEqual(['park', 'resume', 'handoff', 'drift', 'state']);
+    // Prompt arguments are strings in MCP and have no schema, so `required` is the only thing
+    // a client can enforce -- it has to survive being derived from the tool's own schema.
+    const byName = new Map(listed.result.prompts.map((prompt: any) => [prompt.name, prompt]));
+    for (const [name, args] of [
+      ['park', [['goal', true]]],
+      ['resume', [['key', false]]],
+      ['handoff', [['goal', true], ['nextAction', true]]],
+      ['drift', [['since', true]]],
+      ['state', []],
+    ] as [string, [string, boolean][]][]) {
+      const prompt: any = byName.get(name);
+      expect(prompt.description, `${name} carries no description`).toBeTruthy();
+      expect(prompt.arguments.map((argument: any) => [argument.name, argument.required ?? false]))
+        .toEqual(args);
+      for (const argument of prompt.arguments) {
+        expect(argument.description, `${name}.${argument.name} carries no description`).toBeTruthy();
+      }
+    }
+    await end();
+  });
+
+  it('answers prompts/get with a message naming the tool and the argument', async () => {
+    const { ask, end } = await session();
+    const got = await ask('prompts/get', { name: 'resume', arguments: { key: 'blue-otter-42' } });
+    expect(got.result.messages[0].role).toBe('user');
+    // The whole prompt body: the tool to call and what the person typed. Nothing paraphrased,
+    // because `tools/list` already carries the tool's own description.
+    expect(got.result.messages[0].content.text).toBe('Call knowl_resume now with key: blue-otter-42');
+
+    // A required argument the person did not supply is refused rather than dropped: the body
+    // would otherwise read as a call that could work, for a tool that cannot run without it.
+    const missing = await ask('prompts/get', { name: 'drift', arguments: {} });
+    expect(missing.error?.code).toBe(-32602);
+    // And a name that is not here is the caller's mistake, not the server having failed.
+    const unknown = await ask('prompts/get', { name: 'elicit', arguments: {} });
+    expect(unknown.error?.code).toBe(-32602);
+    // The one prompt that takes nothing still produces a runnable call.
+    const state = await ask('prompts/get', { name: 'state', arguments: {} });
+    expect(state.result.messages[0].content.text).toBe('Call knowl_state now.');
     await end();
   });
 
@@ -81,8 +135,6 @@ describe('the declared server capabilities', () => {
     // without the handler, the test above fails instead. Neither direction can move alone.
     const subscribed = await ask('resources/subscribe');
     expect(subscribed.error?.code, 'resources/subscribe answered without being declared').toBe(-32601);
-    const prompts = await ask('prompts/list');
-    expect(prompts.error?.code, 'prompts answered without being declared').toBe(-32601);
     await end();
   });
 });


### PR DESCRIPTION
Implements the ruling on #288: prompts, additive only. Elicitation was ruled no and is not here.

`prompts/list` + `prompts/get` for the five verbs a **person** starts — `park`, `resume`, `handoff`, `drift`, `state`. Every tool stays on `tools/list`; nothing moved off, so no context saving is claimed. A prompt is not a second implementation of a verb, it is a second way to reach one: tools are chosen by the model mid-turn, prompts by the person up front, from the host's slash-command menu, before a turn exists to choose within.

**Everything but the name and argument list is derived from the tool definition**, so the table cannot drift from the surface it fronts — `annotations.title` (from #284) is already the person-facing one-liner, the tool description is already accurate, and each argument's description and required-ness already live in the tool's own `inputSchema`. `resolvePrompt` throws at module load if a name or argument stops resolving, so a rename fails on the process that made the mistake rather than silently dropping a prompt.

Names are bare verbs because hosts prefix with the server name: `/knowl:park`, not `/knowl:knowl_park`.

`capabilities.prompts: {}` arrives in the same commit as the mechanism, which is the rule `server.ts` already states. `listChanged` is withheld for the same reason tools' is — the five are a fixed literal and nothing sends the notification.

**Verified against the running server over stdio, not just the source:**

```
capabilities: {"tools": {}, "resources": {}, "prompts": {}}
prompts: ['park', 'resume', 'handoff', 'drift', 'state']
prompts/get resume   -> "Call knowl_resume now with key: abc-123"
prompts/get drift {} -> -32602  Prompt "drift" requires since.
resources/subscribe  -> -32601   (unchanged)
```

That last refusal is deliberate: the SDK validates the envelope and stops, so a declared-required argument is only required if something checks. Without it `drift` degrades to a bare `Call knowl_drift now.` — a call that cannot succeed, phrased as though it could.

The #284 capability-pin test moves from "prompts/list → -32601" to asserting the exact five, in the same commit as the flag.

Gates: build, typecheck, lint, docs:check clean; `tests/mcp` 40 files / 319 tests green. Mutant: deleting one entry from the registry fails 2 tests.

Closes #288.