### PR TITLE
feat(evals): a standing probe for atom dilution, and the candidate-depth sweep

### DIFF
--- a/docs/evals/atom-dilution-probe-2026-09-10.json
+++ b/docs/evals/atom-dilution-probe-2026-09-10.json
@@ -1,0 +1,588 @@
+{
+  "corpus": {
+    "dbPath": "D:\\coding\\knowl\\.knowl\\knowl.db",
+    "fingerprint": "eeb8ae73e6c641c1",
+    "model": "onnx-community/granite-embedding-small-english-r2-ONNX",
+    "dtype": "q8",
+    "pooling": "cls",
+    "atoms": 1358,
+    "active": 1197,
+    "rankedAgainst": 1197,
+    "oldest": "2026-07-04T03:22:10.013Z",
+    "newest": "2026-09-09T09:33:05.848Z",
+    "medianAgeDays": 34.4
+  },
+  "settings": {
+    "minChars": 3500,
+    "sample": 30,
+    "fusedLimit": 10,
+    "windowChars": 500,
+    "stride": 2
+  },
+  "population": 64,
+  "titleControl": {
+    "ranks": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+    ],
+    "rank1": 10
+  },
+  "vector": {
+    "queries": 30,
+    "rank1": 8,
+    "top3": 12,
+    "top10": 14,
+    "median": 13,
+    "worst": 533,
+    "mrr": 0.3298
+  },
+  "fused": {
+    "queries": 30,
+    "rank1": 21,
+    "top3": 21,
+    "top10": 21,
+    "median": 1,
+    "worst": 11,
+    "mrr": 0.7
+  },
+  "control": {
+    "whole": 0.8331781968515493,
+    "windowed": 0.9078202838596147,
+    "advantage": 0.07464208700806535,
+    "windowWins": 30,
+    "of": 30
+  },
+  "rows": [
+    {
+      "id": "0088845d131d4508",
+      "title": "The offset-backfill 1 ms budget race: root cause, and the second test 0afdd4e left behind",
+      "chars": 3589,
+      "clipped": false,
+      "quote": "The arming condition is a strict comparison against a clock the pass reads itself, so any such window is a race; express the budget semantically via `budgetWasReal` instead, and pin the `runIndexPass` wiring separately with a deadline far in the past.",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.8579651736384456,
+      "windowCosine": 0.8964783280880168
+    },
+    {
+      "id": "0cfd61ca28d54d63",
+      "title": "Plan B of the cloud client is implemented, reviewed and green at a137e21",
+      "chars": 4325,
+      "clipped": false,
+      "quote": "**Known gap, deliberate:** `publishedAt`, `authorUserId` and `review` ride in the payload but are not written -- the local schema has no columns for them, and Plan D adds them.",
+      "vectorRank": 29,
+      "fusedRank": 1,
+      "wholeCosine": 0.8118876609527721,
+      "windowCosine": 0.8782317583926827
+    },
+    {
+      "id": "191f4b87d0754980",
+      "title": "A TS project that sets `target` but not `lib` typechecks browser globals in Node — probe it with a one-line file before trusting tsc",
+      "chars": 3763,
+      "clipped": false,
+      "quote": "A branch reachable only by a human at a terminal is a branch no suite covers — extract the prompt into a module with an injectable `isTTY` (this repo's `cloud-picker.ts`, `sharing-picker.ts`, `confirm-prompt.ts`) so the interactive half can be tested at all.</content>",
+      "vectorRank": 7,
+      "fusedRank": 1,
+      "wholeCosine": 0.8478304992086425,
+      "windowCosine": 0.951931202933042
+    },
+    {
+      "id": "1e39ec4a19484b51",
+      "title": "Hermes Agent integration surfaces verified at source 2026-09-03: a MemoryProvider ABC with prefetch/system_prompt_block/sync_turn is the real slot, plugins DO get pre_tool_call with a block directive, first-party memory plugins live in-tree",
+      "chars": 3587,
+      "clipped": false,
+      "quote": "First-party providers ship IN-TREE under plugins/memory/: byterover, hindsight, holographic, honcho, mem0, openviking, retaindb, supermemory — each a README + plugin.yaml + __init__.py; hindsight's adapts \"PR #1811 by benfrank241\", so outside PRs adding a provider are accepted.",
+      "vectorRank": 4,
+      "fusedRank": 1,
+      "wholeCosine": 0.8413736663192198,
+      "windowCosine": 0.9424436722050685
+    },
+    {
+      "id": "224d11f1f5c74037",
+      "title": "queryCoverage cannot be #169's relevance floor: it is quantized at 1/n, so vague on-topic queries and partial junk land on the same value (gap exactly 0.000)",
+      "chars": 3825,
+      "clipped": false,
+      "quote": "A first run used technical probes copied from the stored finding `4eaf07ef6b6e41d6` — `unreal engine nanite...`, `swift ios coredata...` — and both scored 1.000 because that atom's own table quotes them.",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.8292369141019806,
+      "windowCosine": 0.906424031331321
+    },
+    {
+      "id": "2dcb3c6894214e3b",
+      "title": "Issue #35 default visibility: new links default to workspace-visible, existing manifests never move",
+      "chars": 3634,
+      "clipped": false,
+      "quote": "#34's `safeTerms` already keeps query text so \"a proposal has to be re-runnable against the owning repo's atoms\"; a command that re-runs unanswered cross-repo questions against the owning repo's private items and proposes promotions makes the default matter less than any policy choice would.",
+      "vectorRank": 2,
+      "fusedRank": 1,
+      "wholeCosine": 0.8482229763311945,
+      "windowCosine": 0.9237587868904238
+    },
+    {
+      "id": "312121334d614092",
+      "title": "OpenClaw spec fact-check: tool_result_persist only rewrites the TRANSCRIPT, not what the model reads — the async registerAgentToolResultMiddleware is the real seam, and before_tool_call fails CLOSED on throw or 15s timeout",
+      "chars": 5576,
+      "clipped": false,
+      "quote": "They are three independent hooks returning the same field names; the duplication mechanism is hooks.md:780-781 'Context additions concatenate in priority order'.",
+      "vectorRank": 125,
+      "fusedRank": null,
+      "wholeCosine": 0.7728896568026546,
+      "windowCosine": 0.8331137189989587
+    },
+    {
+      "id": "33ff6c4e2ec441ea",
+      "title": "\"Host X has no channel for this\" was wrong three times out of four — the channel exists under a name that does not contain the obvious word",
+      "chars": 3638,
+      "clipped": false,
+      "quote": "**THE REST OF THE ❌ ARE NOT \"IMPOSSIBLE\" EITHER, they are three other categories** and the matrix now says which: blocked on a vendor bug (Cursor's mid-turn card, ticket T-C20310), waiting on a host to ship hooks at all (OpenCode #39275), or a different product (Cline's npm plugin, an ACP proxy).",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.860499329535725,
+      "windowCosine": 0.9264513424086428
+    },
+    {
+      "id": "3f1fa7ebec504083",
+      "title": "Host-parity audit (b86e23c..8b390d2): Copilot registers two events GitHub never fires, OpenHands is \"configured\" in every repo, and Windsurf's bootstrap ✅ is false",
+      "chars": 6712,
+      "clipped": true,
+      "quote": "Tests are declaration checks, not behaviour checks.** ZERO tests reference `denied`, `denyExitCode`'s effect on process.exitCode, `refusesOnAnyNonZeroExit`, `readToolNames`, `writeToolNames`, or `writesFiles` -- the entire subject of 985a177 has no regression test.",
+      "vectorRank": 101,
+      "fusedRank": null,
+      "wholeCosine": 0.8107363567410908,
+      "windowCosine": 0.9116225295620225
+    },
+    {
+      "id": "4809ea47204e45e9",
+      "title": "Host-parity round-3 review (b86e23c..9f5f8be): all 6 named round-2 fixes verified, but Copilot's new subagentStart card is mis-stamped and `knowl init openhands` now fails without the binary on PATH",
+      "chars": 9479,
+      "clipped": true,
+      "quote": "**Residual of the same field:** for a user who does have `openhands` on PATH, `configured:true` in every repository, so `knowl doctor` WARNs and `doctor --fix` runs `knowl init openhands -y` into every repo they touch.",
+      "vectorRank": 24,
+      "fusedRank": 1,
+      "wholeCosine": 0.8547883244072687,
+      "windowCosine": 0.9283043729610715
+    },
+    {
+      "id": "511bd43059064019",
+      "title": "PR review detail 2026-08-27 for #206/#207/#208: defects found, nits, and why #207's verdict changed from drop to reshape",
+      "chars": 5085,
+      "clipped": false,
+      "quote": "**#208 `feat(recall): attribute a recall observation to the agent that caused it` — MERGED as `780963e`.** Adds `recall_observations.agent_id`, migration level 16, additive, `KNOWL_SCHEMA_VERSION` unmoved, no backfill (an observation already written cannot be re-attributed).",
+      "vectorRank": 11,
+      "fusedRank": 1,
+      "wholeCosine": 0.8324340067682531,
+      "windowCosine": 0.9152296355620744
+    },
+    {
+      "id": "607c764d20dd4181",
+      "title": "Live install found four defects the green unit suite could not: the plugin shipped uncompiled TypeScript and could not install, a root devDependency desynced the lockfile and broke CI, integrations/ was never typechecked, and ctx.workspaceDir does not exist on tool or session hook contexts",
+      "chars": 5075,
+      "clipped": false,
+      "quote": "Fix: a vitest `resolve.alias` for `openclaw/plugin-sdk/plugin-entry` -> `tests/integrations/openclaw/plugin-entry-stub.ts`, an identity-shaped `definePluginEntry` stub (the tests drive `register(api)` directly with a fake api, so nothing real is hidden).",
+      "vectorRank": 3,
+      "fusedRank": 1,
+      "wholeCosine": 0.8656721039774491,
+      "windowCosine": 0.9182596474579109
+    },
+    {
+      "id": "6c53aeaeede74459",
+      "title": "The relevance floor stays, keeps its name, and is documented as off-subject detection rather than unanswerability — no fourth threshold attempt",
+      "chars": 3777,
+      "clipped": false,
+      "quote": "That reframe — \"the agent already receives the rows and can judge them better than a scalar\" — is exactly what fails when atoms are injected unasked, because nothing gets to judge before the context cost is paid.",
+      "vectorRank": 29,
+      "fusedRank": 1,
+      "wholeCosine": 0.8021104021574261,
+      "windowCosine": 0.8760080811810675
+    },
+    {
+      "id": "6ebc3abb506540f7",
+      "title": "Command-surface audit at 4.2.0: 43 top-level CLI commands, 32 MCP tools, and seven structural overlaps — the cloud ones are the worst",
+      "chars": 4414,
+      "clipped": false,
+      "quote": "**Four parallel lifecycle systems.** `knowl session start/event/finish/recover`, `knowl task start/checkpoint/finish/run`, `agent-event`/`agent-hook`/`agent-reminder`, and MCP `knowl_task_*` + `knowl_session_finish`.",
+      "vectorRank": 21,
+      "fusedRank": 1,
+      "wholeCosine": 0.850310579060438,
+      "windowCosine": 0.9501966227016483
+    },
+    {
+      "id": "72963ba149d54fc8",
+      "title": "A Windows CI leg red while every other OS passes: check the signature (timeout OR 0xC0000005 native crash), re-run the job, do not touch the tests",
+      "chars": 3628,
+      "clipped": false,
+      "quote": "<parameter name=\"reasoning\">A second, materially different signature appeared the same day, and the skill as first written would have told the next session to stop (\"if any assertion failed, this does not apply\") when the correct action was the same re-run.",
+      "vectorRank": 3,
+      "fusedRank": 1,
+      "wholeCosine": 0.8236482412300167,
+      "windowCosine": 0.862118188740184
+    },
+    {
+      "id": "80a748a29eef483e",
+      "title": "The five open PRs were cleared on 2026-09-03: main b8b2e60 -> ae09499, one review fix pushed to #237",
+      "chars": 4163,
+      "clipped": false,
+      "quote": "**LOCAL VERIFICATION on the integrated tree before any merge:** `npm.cmd ci`, `npm.cmd run typecheck` exit 0, `npm.cmd run build` clean, `npm.cmd test` -> **390 files, 3720 passed, 5 skipped, 0 failed**, `npm.cmd run docs:check` current.",
+      "vectorRank": 13,
+      "fusedRank": 1,
+      "wholeCosine": 0.873272665198412,
+      "windowCosine": 0.9157415452555336
+    },
+    {
+      "id": "904c8fe68b484675",
+      "title": "5.3.0 published: a linked workspace stops being a wall — act as a sibling repo, and read its shared atoms whole by id",
+      "chars": 3681,
+      "clipped": false,
+      "quote": "Neither is ever a code failure on a lone leg; read the log before investigating, and note `gh run view --job <id> --log` returns EMPTY while the overall run is still in progress, which reads like a failed fetch rather than an unavailable log.",
+      "vectorRank": 414,
+      "fusedRank": null,
+      "wholeCosine": 0.7825710266811573,
+      "windowCosine": 0.9031525099626986
+    },
+    {
+      "id": "9d327f381ede4881",
+      "title": "The Hermes MemoryProvider must not recall: prefetch, recall_status and system_prompt_block are deleted, and the pre_llm_call hook is the only recall channel on every host",
+      "chars": 3772,
+      "clipped": false,
+      "quote": "BONUS BUG FOUND, pre-existing: `test_a_folderless_session_still_gets_a_recall_card` never stubbed `_session_folder()`, so it read the ambient cwd and took the \"folder is not a Knowl project\" branch instead of the folderless one.",
+      "vectorRank": 137,
+      "fusedRank": null,
+      "wholeCosine": 0.8078249025711488,
+      "windowCosine": 0.9115120431608795
+    },
+    {
+      "id": "a28ef7e4f5a347c5",
+      "title": "The CHANGELOG `## Unreleased` section is consumed by every release commit and nobody recreates it, so check for it before assuming a PR needs no changelog entry",
+      "chars": 5736,
+      "clipped": false,
+      "quote": "Confirmed a third time preparing 5.18.0: #234 shipped NO docs at all, and the reference's \"staleness is limited to hashed file evidence\" said nothing about what makes evidence hashed -- vacuous before that PR, load-bearing after it.",
+      "vectorRank": 150,
+      "fusedRank": null,
+      "wholeCosine": 0.7995037540140548,
+      "windowCosine": 0.9119244754196533
+    },
+    {
+      "id": "b7b77bd72000407f",
+      "title": "Do not port knowl-cloud's 2000-character embedding cap here — this repo already clips by tokens, and the cap would truncate a quarter of the corpus",
+      "chars": 3693,
+      "clipped": false,
+      "quote": "**The transfer runs the other way:** knowl-cloud's 2000-character cap has the same JSON-vs-prose blind spot this repo measured and fixed, and would benefit from the token clip.</content>",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.9115566554022703,
+      "windowCosine": 0.9283182186701318
+    },
+    {
+      "id": "bfb061c8eb094559",
+      "title": "OpenClaw ships as an in-process plugin importing a new three-entry library export, not a subprocess shell-out — spec at 2026-09-05-openclaw-plugin-design.md",
+      "chars": 6161,
+      "clipped": false,
+      "quote": "Two host budgets also constrain observers: before_compaction has a 30s per-handler timeout and runs on Codex's serialized notification queue where a hang freezes turn/completed; session_end has a 2-SECOND TOTAL drain budget across all sessions and handlers.",
+      "vectorRank": 59,
+      "fusedRank": null,
+      "wholeCosine": 0.7843268433307768,
+      "windowCosine": 0.8665104313993175
+    },
+    {
+      "id": "ca4db9dd543c4ed1",
+      "title": "OpenClaw does not dispatch before_prompt_build on the embedded agent runner, for bundled AND non-bundled plugins alike -- it fires only on the claude-cli backend, and the knowl plugin was never broken",
+      "chars": 3958,
+      "clipped": false,
+      "quote": "TEST RECIPE, cheap to repeat: install a minimal plugin with one before_prompt_build hook returning a marker string, run the same prompt under a claude-cli model and an embedded-runner model, compare the handler count in the debug log and ask the model whether the marker is present.",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.8686612003016567,
+      "windowCosine": 0.9247026760260475
+    },
+    {
+      "id": "d3e55846d692444e",
+      "title": "Federation searches each peer under its own embedding profile; the knowledge scorer gained a per-profile semantic range and a per-corpus floor because it scores a union rather than rank-fusing",
+      "chars": 3648,
+      "clipped": false,
+      "quote": "**CI NOTE:** the `scan` job failed once here on `ConnectionResetError` while verifying PyPI provenance for `plugin-scanner` — the scanner failed installing ITSELF and the actual scan step reported `skipped`.",
+      "vectorRank": 533,
+      "fusedRank": null,
+      "wholeCosine": 0.7741483586533698,
+      "windowCosine": 0.8775611137148341
+    },
+    {
+      "id": "d87ad9376a3c4e51",
+      "title": "SameSite=Strict is not a CSRF defence on loopback: it ignores the port, so every 127.0.0.1 page is same-site",
+      "chars": 3742,
+      "clipped": false,
+      "quote": "(4) The 413 was undeliverable for genuinely large bodies: breaking out of a `for await` calls the iterator's `return()`, destroying the socket while the client is still writing, so 200 KB got a status and 5 MB got ECONNRESET.",
+      "vectorRank": 92,
+      "fusedRank": null,
+      "wholeCosine": 0.78476796371987,
+      "windowCosine": 0.9527092943932431
+    },
+    {
+      "id": "df4adecddf85489e",
+      "title": "Client-side embedding is designed and specced at 330d74e: vectors travel both ways, one profile per workspace, canary at connect",
+      "chars": 4582,
+      "clipped": false,
+      "quote": "Reading the pull path showed clients already re-embed everything locally, which meant the cross-member matching problem they were worried about did not exist yet — and that the redundant work was far larger than they thought, since it also runs on every laptop.",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.8626206503931624,
+      "windowCosine": 0.9163089023514062
+    },
+    {
+      "id": "e0b6c57c09254af9",
+      "title": "Open-PR sweep 2026-08-15: all four PRs reviewed, fixed and merged — main is eb5158e",
+      "chars": 5236,
+      "clipped": false,
+      "quote": "Defensible rather than an oversight: a repo name only means something inside the workspace that issued it, `origin_repo` already gets dedicated attribution machinery (`importAttribution`, `header.origin`, format version 3), and `written_by` has none.",
+      "vectorRank": 88,
+      "fusedRank": null,
+      "wholeCosine": 0.8153911334411728,
+      "windowCosine": 0.9139778433606277
+    },
+    {
+      "id": "f24629ad17154edc",
+      "title": "Host-parity review (a457e29): Copilot shares Claude's .mcp.json, OpenHands init can never succeed, and the new deny channels are unreachable",
+      "chars": 5328,
+      "clipped": false,
+      "quote": "**Also noted:** `copilot.ts:79` reuses `anthropicDenyToolCall`, which nests the verdict under `hookSpecificOutput`, while this repo's own roadmap research recorded Copilot's channel as a flat `{permissionDecision, permissionDecisionReason}` — unverified contradiction.",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.8671174875732882,
+      "windowCosine": 0.9038538645815261
+    },
+    {
+      "id": "f2da3ff4ad754229",
+      "title": "5.18.0 released at 512a2b8: hooks over MCP, evidence staleness that can fire, feedback in days — and the CHANGELOG repair the release had to make first",
+      "chars": 4126,
+      "clipped": false,
+      "quote": "**npm read-path lag reproduced on a version bump, not just a new name.** `npm view @dat999zx/knowl@5.18.0` returned E404 and `dist-tags.latest` still read 5.17.0 roughly fifteen seconds after the workflow reported success.",
+      "vectorRank": 13,
+      "fusedRank": 1,
+      "wholeCosine": 0.8567149408839184,
+      "windowCosine": 0.9455044444374241
+    },
+    {
+      "id": "f593fee602d24e53",
+      "title": "Hermes Agent v0.21.0 has SHELL hooks in config.yaml that speak Claude Code's wire format — including `pre_verify`, a real stop channel (`{\"decision\":\"block\",\"reason\"}` keeps the turn going) — so Hermes can reach 6/6 without the Python plugin",
+      "chars": 3729,
+      "clipped": false,
+      "quote": "`hermes hooks list|test <event>|doctor|revoke` exist — `hermes hooks test pre_tool_call` fires the hook against a synthetic payload, giving a real end-to-end check WITHOUT an LLM call or login.",
+      "vectorRank": 1,
+      "fusedRank": 1,
+      "wholeCosine": 0.8856269380259132,
+      "windowCosine": 0.9206101305265264
+    },
+    {
+      "id": "f60ae4edd5d54c15",
+      "title": "knowl-first parity: plan written, baseline green at 3925 tests, rebased onto 07dd150",
+      "chars": 3623,
+      "clipped": false,
+      "quote": "The stub is identity-shaped, so it covers what the profile returns and says nothing about gateway delivery; that is why the unstub tasks require a live session, not a green suite.",
+      "vectorRank": 3,
+      "fusedRank": 1,
+      "wholeCosine": 0.8116354941237353,
+      "windowCosine": 0.8216491031144602
+    }
+  ],
+  "candidateDepthSweep": {
+    "note": "candidateLimit measured at 3/5/10 by editing src/store/agent-query.ts:409 and reverting. The constant is unchanged on disk.",
+    "probe": {
+      "3": {
+        "vector": {
+          "queries": 30,
+          "rank1": 8,
+          "top3": 12,
+          "top10": 14,
+          "median": 13,
+          "worst": 533,
+          "mrr": 0.3298
+        },
+        "fused": {
+          "queries": 30,
+          "rank1": 21,
+          "top3": 21,
+          "top10": 21,
+          "median": 1,
+          "worst": 11,
+          "mrr": 0.7
+        },
+        "control": {
+          "whole": 0.8331781968515493,
+          "windowed": 0.9078202838596147,
+          "advantage": 0.07464208700806535,
+          "windowWins": 30,
+          "of": 30
+        }
+      },
+      "5": {
+        "vector": {
+          "queries": 30,
+          "rank1": 8,
+          "top3": 12,
+          "top10": 14,
+          "median": 13,
+          "worst": 533,
+          "mrr": 0.3298
+        },
+        "fused": {
+          "queries": 30,
+          "rank1": 21,
+          "top3": 21,
+          "top10": 21,
+          "median": 1,
+          "worst": 11,
+          "mrr": 0.7
+        },
+        "control": {
+          "whole": 0.8331781968515493,
+          "windowed": 0.9078202838596147,
+          "advantage": 0.07464208700806535,
+          "windowWins": 30,
+          "of": 30
+        }
+      },
+      "10": {
+        "vector": {
+          "queries": 30,
+          "rank1": 8,
+          "top3": 12,
+          "top10": 14,
+          "median": 13,
+          "worst": 533,
+          "mrr": 0.3298
+        },
+        "fused": {
+          "queries": 30,
+          "rank1": 24,
+          "top3": 24,
+          "top10": 24,
+          "median": 1,
+          "worst": 11,
+          "mrr": 0.8
+        },
+        "control": {
+          "whole": 0.8331781968515493,
+          "windowed": 0.9078202838596147,
+          "advantage": 0.07464208700806535,
+          "windowWins": 30,
+          "of": 30
+        }
+      }
+    },
+    "accuracyBenchmark": {
+      "3": {
+        "applicableCoverage": 0.925,
+        "temporalCoverage": 0.5714285714285714,
+        "abstentionCoverage": 1,
+        "provenanceCoverage": 1,
+        "strictAccuracyAtK": 0.745945945945946,
+        "temporalAccuracy": 0.85,
+        "currentStateAccuracy": 0.8,
+        "historicalAsOfAccuracy": null,
+        "timelineOrderAccuracy": null,
+        "contradictionResolutionAccuracy": 1,
+        "failureScenarioAccuracy": 0.6666666666666666,
+        "failedApproachRetrievalRecall": 0.6666666666666666,
+        "recallAt1": 0.3103448275862069,
+        "recallAt3": 0.6137931034482759,
+        "recallAt5": 0.7482758620689656,
+        "recallAt10": 0.7862068965517242,
+        "mrr": 0.7151041666666665,
+        "ndcgAt5": 0.6541345098669705,
+        "ndcgAt10": 0.6653299083157501,
+        "staleResultRate": 0.0020060180541624875,
+        "forbiddenResultRate": 0.007021063189568706,
+        "duplicateResultRate": 0,
+        "abstentionAccuracy": 0.36
+      },
+      "5": {
+        "applicableCoverage": 0.925,
+        "temporalCoverage": 0.5714285714285714,
+        "abstentionCoverage": 1,
+        "provenanceCoverage": 1,
+        "strictAccuracyAtK": 0.745945945945946,
+        "temporalAccuracy": 0.85,
+        "currentStateAccuracy": 0.8,
+        "historicalAsOfAccuracy": null,
+        "timelineOrderAccuracy": null,
+        "contradictionResolutionAccuracy": 1,
+        "failureScenarioAccuracy": 0.6666666666666666,
+        "failedApproachRetrievalRecall": 0.6666666666666666,
+        "recallAt1": 0.3103448275862069,
+        "recallAt3": 0.6137931034482759,
+        "recallAt5": 0.7482758620689656,
+        "recallAt10": 0.7862068965517242,
+        "mrr": 0.7151041666666665,
+        "ndcgAt5": 0.6541345098669705,
+        "ndcgAt10": 0.6653299083157501,
+        "staleResultRate": 0.0020060180541624875,
+        "forbiddenResultRate": 0.007021063189568706,
+        "duplicateResultRate": 0,
+        "abstentionAccuracy": 0.36
+      },
+      "10": {
+        "applicableCoverage": 0.925,
+        "temporalCoverage": 0.5714285714285714,
+        "abstentionCoverage": 1,
+        "provenanceCoverage": 1,
+        "strictAccuracyAtK": 0.745945945945946,
+        "temporalAccuracy": 0.85,
+        "currentStateAccuracy": 0.8,
+        "historicalAsOfAccuracy": null,
+        "timelineOrderAccuracy": null,
+        "contradictionResolutionAccuracy": 1,
+        "failureScenarioAccuracy": 0.6666666666666666,
+        "failedApproachRetrievalRecall": 0.6666666666666666,
+        "recallAt1": 0.3103448275862069,
+        "recallAt3": 0.6137931034482759,
+        "recallAt5": 0.7482758620689656,
+        "recallAt10": 0.7862068965517242,
+        "mrr": 0.7151041666666665,
+        "ndcgAt5": 0.6541345098669705,
+        "ndcgAt10": 0.6653299083157501,
+        "staleResultRate": 0.0020060180541624875,
+        "forbiddenResultRate": 0.007021063189568706,
+        "duplicateResultRate": 0,
+        "abstentionAccuracy": 0.36
+      },
+      "positiveControl_limitTimes1": {
+        "applicableCoverage": 0.925,
+        "temporalCoverage": 0.5714285714285714,
+        "abstentionCoverage": 1,
+        "provenanceCoverage": 1,
+        "strictAccuracyAtK": 0.7351351351351352,
+        "temporalAccuracy": 0.85,
+        "currentStateAccuracy": 0.8,
+        "historicalAsOfAccuracy": null,
+        "timelineOrderAccuracy": null,
+        "contradictionResolutionAccuracy": 1,
+        "failureScenarioAccuracy": 0.6666666666666666,
+        "failedApproachRetrievalRecall": 0.6666666666666666,
+        "recallAt1": 0.3103448275862069,
+        "recallAt3": 0.6137931034482759,
+        "recallAt5": 0.7482758620689656,
+        "recallAt10": 0.7793103448275862,
+        "mrr": 0.7151041666666665,
+        "ndcgAt5": 0.6541345098669705,
+        "ndcgAt10": 0.6623679439816843,
+        "staleResultRate": 0.0020060180541624875,
+        "forbiddenResultRate": 0.007021063189568706,
+        "duplicateResultRate": 0,
+        "abstentionAccuracy": 0.36
+      }
+    },
+    "suites": {
+      "3": "35/35 pass",
+      "5": "34/35 (agent-query-vector-branch pins limit*3 arithmetic)",
+      "10": "34/35 (same)"
+    }
+  }
+}

--- a/docs/evals/atom-dilution-probe.md
+++ b/docs/evals/atom-dilution-probe.md
@@ -1,0 +1,234 @@
+# Atom dilution and candidate depth — probe, 2026-09-10
+
+[#281](https://github.com/dat999zx/knowl/issues/281) measured that one atom gets one embedding
+vector, so a verbatim quote from a long atom's tail does not reliably retrieve its own parent.
+This is that measurement ported to a standing script, re-run against this repo's real store, plus
+the candidate-depth sweep the maintainer asked for in the same ruling.
+
+**Two findings, and they point in opposite directions.** The dilution effect is real and
+reproduces almost exactly on an independently sampled set — the windowed control lands at
+**+0.0746** against the issue's +0.0749. But the *shipped* path is much healthier than the
+vector-only number suggests: fusion recovers tail quotes that vector search alone loses, 21/30
+against 8/30 at rank 1. Chunking would be fixing a number no user's query is scored by.
+
+**On candidate depth: the constant should not change.** `limit * 10` moves 3 of 30 tail queries
+from unfound to rank 1 and moves *nothing else anywhere* — every metric of the 200-question
+accuracy benchmark is byte-identical at 3, 5 and 10. That is a real gain with no measured cost,
+and it is still not enough, for the reason given under [Recommendation](#recommendation).
+
+Reproduce with `npx tsx scripts/probe-atom-dilution.ts <root-or-db>`. The probe is read-only over
+any store and prints the corpus's size and age before any conclusion, because every claim here is
+a claim about **long** atoms and a store without them can only report that it has none.
+
+## Corpus
+
+Everything below is one store, and its shape is the first thing that would falsify any of it.
+
+```
+db             D:\coding\knowl\.knowl\knowl.db
+model          granite-embedding-small-english-r2 q8/cls  (eeb8ae73e6c641c1)
+atoms          1358 total, 1197 active
+ranked against 1197 vectors under this profile
+age            oldest 2026-07-04, newest 2026-09-09, median atom 34.4 days old
+```
+
+The population under test is the 64 active atoms whose embed text reaches 3,500 characters —
+**5.3% of the store.** 30 were sampled by even stride over id order (stride 2), spanning 3,587 to
+9,479 characters, median 3,958. Two of the 30 are clipped by the token budget.
+
+This is a two-month-old corpus, and that is a caveat rather than a footnote: the long-atom
+population is small, it is written in one house style, and 60 of the 64 sit in the narrow 3.5–6k
+band. A store with genuinely long documents — imported design docs, pasted transcripts — would
+have a different tail and could move every number here.
+
+## Method
+
+Each sampled atom contributes one query: the longest 60–300 character sentence beginning in the
+final third of its embed text, quoted verbatim and embedded through `embedQuery` (so it carries
+the model's query prefix, as a real query would).
+
+Three details that decide whether the measurement means anything:
+
+- **Quotes are cut from the CLIPPED text**, the same `clipToBudget` the embedder applies on the
+  way in. A quote past the token budget was never in the vector at all, so finding it missing
+  would measure truncation ([#132](https://github.com/dat999zx/knowl/issues/132)) rather than
+  dilution — a different defect with a different fix.
+- **A sentence must BEGIN in the final third**, not merely overlap it. One that starts mid-atom
+  and runs into the tail is not a tail quote, and counting it would weaken the effect being
+  measured.
+- **The title control asserts rather than prints.** A title is the first line of the embed text
+  and the least diluted query available; if titles cannot find their own parents, the probe is
+  measuring itself. It scored **10/10 at rank 1**, so the ranking path is sound and the tail
+  numbers below are about the tail.
+
+Two rankings are reported because they answer different questions. Vector-only over all 1,197
+stored vectors is the dilution measurement, and nothing in the fusion layer can move it. Fused
+through `rankKnowledge` is the path a real query actually takes.
+
+## Tail-quote retrieval
+
+| metric | vector-only (1,197 vectors) | fused (`rankKnowledge`, limit 10) |
+| --- | --- | --- |
+| queries | 30 | 30 |
+| parent at rank 1 | **8/30** | **21/30** |
+| parent in top 3 | 12/30 | 21/30 |
+| parent in top 10 | 14/30 | 21/30 |
+| median rank | 13 | 1 |
+| worst rank | 533 / 1197 | not returned |
+| MRR@10 | **0.3298** | **0.7000** |
+
+The vector-only column reproduces #281 (which recorded 6/30 at rank 1, median 4, MRR@10 0.3567)
+on an independently drawn sample: the same shape, the same order of magnitude, a worse median.
+**Half the long atoms in this store cannot be found by quoting their own tails, semantically.**
+
+The fused column is the finding the issue did not have. BM25 does not pool — a verbatim quote is
+a near-perfect lexical match against the atom containing it — so the lexical half of the fusion
+recovers most of what pooling loses. The tail defect is real in the vector index and largely
+absorbed before it reaches a user.
+
+That is also the strongest argument for the deferral the maintainer already ruled: chunking would
+carry a composite key, a migration, an `EMBED_RECIPE_VERSION` bump and a publish/pull contract
+change, in order to improve a number (0.3298) that no shipped query path reports, on 5.3% of one
+store's atoms, where the number that *is* shipped reads 0.7000.
+
+## Windowed control
+
+The same 30 queries scored against a 500-character window cut around the quoted sentence,
+embedded as a document by the same embedder, against the whole-atom vector actually stored.
+
+| quantity | mean cosine |
+| --- | --- |
+| whole-atom vector (the one stored) | 0.8332 |
+| 500-char window around the sentence | 0.9078 |
+| **window advantage** | **+0.0746** |
+
+**The window wins for 30 of 30 atoms** — min +0.0100, median +0.0755, max +0.1679. The issue
+recorded +0.0749 on its own sample; this is +0.0746 on a different one.
+
+This is what makes the result a statement about **pooling** rather than about the model or the
+text. The same embedder, the same query, the same sentence: the only variable is how much
+unrelated text was averaged into the document vector. The text was always retrievable, and
+averaging is what lost it.
+
+## Candidate-depth sweep
+
+`src/store/agent-query.ts:409` caps how many rows reach scoring:
+
+```ts
+const candidateLimit = Math.max(limit * 3, 10);
+```
+
+`docs/evals/mutation-deep.md:141` records why this is not a page size: recency is normalised
+against the candidate set and the convex combination is scored over it, so widening it moves
+scores for rows already in. It is a fusion change, and it gets the ranking-change treatment. Each
+setting was measured by editing the constant, running everything below, and reverting it — the
+constant is **not** changed by this PR.
+
+### The probe
+
+| candidateLimit | vec rank 1 | vec top 3 | vec top 10 | vec median | vec MRR@10 | fused rank 1 | fused top 3 | fused top 10 | fused MRR@10 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `limit * 3` (shipped) | 8/30 | 12/30 | 14/30 | 13 | 0.3298 | 21/30 | 21/30 | 21/30 | 0.7000 |
+| `limit * 5` | 8/30 | 12/30 | 14/30 | 13 | 0.3298 | 21/30 | 21/30 | 21/30 | 0.7000 |
+| `limit * 10` | 8/30 | 12/30 | 14/30 | 13 | 0.3298 | **24/30** | **24/30** | **24/30** | **0.8000** |
+
+Two sanity checks that the sweep was valid rather than merely green. The vector-only column is
+**identical across all three settings** for all 30 queries, which is the prediction: the constant
+is not on that path, and any movement there would have meant the harness was varying something
+else. The windowed control is likewise byte-identical (+0.0746 at every setting).
+
+**`limit * 5` changes nothing at all, and the mechanism says why.** The three queries that improve
+at `* 10` have their parent at vector rank 59, 88 and 92. At limit 10 those are outside a
+30-candidate pool and outside a 50-candidate pool, and inside a 100-candidate one. Each goes from
+*not returned at all* to **rank 1** — they are not marginal re-orderings, they are recoveries. No
+query got worse at any setting.
+
+### The existing suites
+
+Cross-repo retrieval, semantic cross-repo, cross-repo archetypes, `rank-knowledge` and the
+agent-query vector branch, at each setting:
+
+| candidateLimit | result |
+| --- | --- |
+| `limit * 3` | 35/35 pass |
+| `limit * 5` | 34/35 — one failure |
+| `limit * 10` | 34/35 — the same one failure |
+
+The single failure at both widened settings is
+`tests/store/agent-query-vector-branch.test.ts > passes the query profile and candidate limit
+through to the vector search`, asserting `options.limit === 15` for `limit: 5`. It is a pin on the
+constant's arithmetic (5 × 3), not a ranking regression, and it would be updated by whatever
+change ships the new value. **No scored retrieval assertion moved at any setting.**
+
+### The accuracy benchmark
+
+`coding-memory-v1`, 200 questions, 3 runs, median of run-level metrics — the full release
+protocol, at each setting:
+
+| metric | `limit * 3` | `limit * 5` | `limit * 10` |
+| --- | --- | --- | --- |
+| strict accuracy@k | 0.7459 | 0.7459 | 0.7459 |
+| Recall@1 | 0.3103 | 0.3103 | 0.3103 |
+| Recall@3 | 0.6138 | 0.6138 | 0.6138 |
+| Recall@5 | 0.7483 | 0.7483 | 0.7483 |
+| Recall@10 | 0.7862 | 0.7862 | 0.7862 |
+| MRR | 0.7151 | 0.7151 | 0.7151 |
+| nDCG@5 | 0.6541 | 0.6541 | 0.6541 |
+| stale result rate | 0.0020 | 0.0020 | 0.0020 |
+| forbidden result rate | 0.0070 | 0.0070 | 0.0070 |
+| abstention accuracy | 0.3600 | 0.3600 | 0.3600 |
+
+**Every metric is identical at every setting.** A table of unchanged numbers is exactly what a
+broken measurement looks like, so it was checked rather than believed: the constant was crushed to
+`Math.max(limit * 1, 1)` and the same benchmark re-run.
+
+| metric | `limit * 3` (shipped) | `limit * 1` (positive control) | delta |
+| --- | --- | --- | --- |
+| strict accuracy@k | 0.7459 | 0.7351 | **−0.0108** |
+| Recall@10 | 0.7862 | 0.7793 | **−0.0069** |
+
+The benchmark **can** see this constant, and reports no change between 3 and 10 because there is
+none to report on that dataset. Its atoms are short — the generator writes one fact per record —
+so it has no long-atom tail for a wider pool to reach into. That is the honest reading: this
+benchmark is not sensitive to the defect, and its flat row is evidence of *no regression*, not of
+no effect.
+
+## Recommendation
+
+**Leave `candidateLimit` at `limit * 3` in this PR.** The probe lands, the constant does not.
+
+The case for `limit * 10` is real: +3/30 tail queries recovered from nothing to rank 1, fused
+MRR@10 0.70 → 0.80, and not one measured regression across 35 suite tests and 14 benchmark
+metrics. If the number changes, `* 10` is the value — `* 5` is measurably worthless here, because
+the ranks that matter sit at 59–92.
+
+What stops it is that the evidence is 3 queries on 30 samples from one 5.3%-of-one-store
+population, against a cost that is real and unmeasured. Widening the pool 3.3× is 3.3× the rows
+decoded, hydrated and scored on **every** query in the product, to fix a case that arises when
+somebody quotes a long atom's tail verbatim. Nothing here measured that latency, and
+`docs/evals/mutation-deep.md` is explicit that the rows already in the pool have their scores
+moved by the widening — this sweep shows that no *measured* ordering changed, not that none can.
+
+The lazy correct move is to keep the probe as the standing check and let the constant ride on
+evidence that actually needs it — the same discipline `FUSION_ALPHA` got.
+
+### What would change this recommendation
+
+- **A latency measurement showing `* 10` is free.** If widening the pool costs nothing on the p99
+  query, the argument against it collapses and it should ship.
+- **The same +3/30 on a second store**, particularly one with a real long-atom population rather
+  than this repo's 64. One store is an anecdote.
+- **A user-visible report of the failure.** The fused path already finds 21/30, so the defect
+  reaching a person requires quoting the tail of a long atom whose lexical match also fails.
+
+### What would falsify the dilution finding itself
+
+- **The windowed advantage disappearing on another corpus.** +0.0746 across 30/30 atoms on two
+  independent samples is the load-bearing number; if a different store shows the whole-atom vector
+  matching or beating its own window, pooling is not the mechanism and this document is wrong.
+- **The title control failing.** It is an assertion in the probe for that reason: 10/10 at rank 1
+  is what licenses reading the tail numbers as a claim about tails.
+- **A longer-atom corpus showing the fused path collapsing too.** The recommendation rests on
+  fusion absorbing the defect (21/30 against 8/30). If BM25 stops rescuing tail quotes at greater
+  atom lengths, the vector-only number becomes the user-visible one and chunking is back on the
+  table.

--- a/scripts/probe-atom-dilution.ts
+++ b/scripts/probe-atom-dilution.ts
@@ -1,0 +1,378 @@
+/**
+ * Does one vector per atom still find that atom when the query quotes its TAIL?
+ *
+ * An atom gets exactly one embedding, built from `buildKnowledgeEmbeddingText` -- title,
+ * content, reasoning and tags concatenated -- and pooled into a single vector. Pooling is an
+ * average, so every sentence in a long atom is one of many contributors and none of them
+ * dominates. A short atom's vector nearly *is* its one idea; a 6,000-character atom's vector is
+ * the centroid of a dozen. The prediction that follows is that a verbatim quote from the end of
+ * a long atom retrieves its own parent badly, because the parent's vector has been diluted by
+ * everything the quote is not about. #281 measured that it does.
+ *
+ * This is the standing form of that measurement. It reads any repo's store, never writes to it,
+ * and prints the corpus's own size and age first, because the whole finding is a claim about
+ * LONG atoms and a store with none of them can only report that it has none.
+ *
+ * Two rankings are reported, and they answer different questions:
+ *
+ * - **Vector-only, over every stored vector.** This is the dilution measurement itself. Nothing
+ *   in the fusion layer can move it, so it is the number that would falsify or confirm #281.
+ * - **Fused, through `rankKnowledge` at the shipped limit.** This is the path a real query
+ *   takes -- BM25 and cosine combined, priors applied, candidates capped. It is here because
+ *   the vector-only table cannot see `candidateLimit` (`agent-query.ts`) at all, and that
+ *   constant is the one candidate remedy that does not require chunking.
+ *
+ * The windowed control is what makes the result a statement about POOLING rather than about the
+ * model: the same query is scored against a 500-character window cut around the quoted sentence,
+ * embedded as a document by the same embedder. If the window beats the whole-atom vector, the
+ * text was always retrievable and the averaging is what lost it.
+ *
+ * A TITLE control runs alongside and is an assertion rather than a print. A title is the first
+ * line of the embed text and the least diluted query available, so if titles cannot find their
+ * own parents either, the harness is broken and every number below it is meaningless -- see the
+ * assertion for the exact bar and why it is set where it is.
+ *
+ * Usage:
+ *   npx tsx scripts/probe-atom-dilution.ts                        # this repo
+ *   npx tsx scripts/probe-atom-dilution.ts D:/other/repo          # a project root
+ *   npx tsx scripts/probe-atom-dilution.ts /path/to/knowl.db      # a database directly
+ *   npx tsx scripts/probe-atom-dilution.ts --sample 30 --min-chars 3500 --json out.json
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { findProjectRoot, loadConfig } from '../src/core/config.js';
+import { createLocalEmbeddingProvider } from '../src/ai/embeddings.js';
+import { fingerprintProfile, resolveVectorProfile } from '../src/core/vector-profile.js';
+import { openPeerStore } from '../src/store/store-handle.js';
+import { LOCAL_PROJECT_ID, getKnowledgeItems } from '../src/store/repository.js';
+import { buildKnowledgeEmbeddingText } from '../src/store/vector-index.js';
+import { cosineSimilarity, decodeVector, searchKnowledgeEmbeddings } from '../src/store/vector.js';
+import { rankKnowledge } from '../src/store/agent-query.js';
+import { releaseAll } from '../src/store/connection-pool.js';
+
+const flag = (name: string): string | undefined => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+};
+const number = (name: string, fallback: number): number => {
+  const raw = flag(name);
+  return raw === undefined ? fallback : Number(raw);
+};
+
+/** Atoms at or above this many characters of embed text are the population under test. */
+const MIN_CHARS = number('min-chars', 3_500);
+/** How many of them to quote. Even stride over the id-sorted population, so it is reproducible. */
+const SAMPLE = number('sample', 30);
+/** The page size the fused half asks for. 10 matches MRR@10 and the accuracy bench's topK. */
+const FUSED_LIMIT = number('fused-limit', 10);
+/** Characters of context the control gets, centred on the quoted sentence. */
+const WINDOW_CHARS = number('window', 500);
+const JSON_OUT = flag('json');
+
+/** A quote shorter than this is not distinctive; longer than this is not a quote. */
+const MIN_SENTENCE = 60;
+const MAX_SENTENCE = 300;
+
+/** The first argument that is neither a `--flag` nor a flag's value. */
+const positional = (() => {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) { i++; continue; }
+    return args[i];
+  }
+  return undefined;
+})();
+
+/**
+ * Accept either half of the pair, because the two are not interchangeable to a reader: a path
+ * ending in `.db` is unambiguous, and anything else is a project root. The config that names the
+ * embedding profile lives beside the database, so one is always derivable from the other.
+ */
+async function resolveTarget(arg: string | undefined): Promise<{ root: string; dbPath: string }> {
+  if (!arg) {
+    const root = await findProjectRoot(process.cwd());
+    return { root, dbPath: path.join(root, '.knowl', 'knowl.db') };
+  }
+  const resolved = path.resolve(arg);
+  if (resolved.endsWith('.db')) return { root: path.dirname(path.dirname(resolved)), dbPath: resolved };
+  return { root: resolved, dbPath: path.join(resolved, '.knowl', 'knowl.db') };
+}
+
+/**
+ * Sentences with their offsets, because the control needs to cut a window around one and a
+ * sentence with no position cannot be located in the text it came from.
+ *
+ * Newlines end a sentence as firmly as a full stop does: atom content is full of bullet lists
+ * and table rows that never terminate with punctuation, and treating those as one continuous
+ * sentence produces "quotes" spanning half the atom.
+ */
+function sentencesWithOffsets(text: string): Array<{ text: string; start: number }> {
+  const boundary = /(?<=[.!?])\s+|\n+/g;
+  const out: Array<{ text: string; start: number }> = [];
+  let start = 0;
+  let match: RegExpExecArray | null;
+  while ((match = boundary.exec(text)) !== null) {
+    out.push({ text: text.slice(start, match.index), start });
+    start = match.index + match[0].length;
+  }
+  out.push({ text: text.slice(start), start });
+  // Trimmed, with the offset moved by however much leading whitespace was dropped, so `start`
+  // still points at the first character of the returned string.
+  return out.map(entry => {
+    const lead = entry.text.length - entry.text.trimStart().length;
+    return { text: entry.text.trim(), start: entry.start + lead };
+  });
+}
+
+/**
+ * The longest quotable sentence from the final third of the text, or null when the atom has none.
+ *
+ * `start >= tailStart` rather than "overlaps the tail": a sentence that begins in the middle
+ * third and runs into the last one is not a tail quote, and counting it would weaken exactly the
+ * effect being measured.
+ */
+function tailQuote(text: string): { text: string; start: number } | null {
+  const tailStart = Math.floor((text.length * 2) / 3);
+  const candidates = sentencesWithOffsets(text).filter(entry =>
+    entry.start >= tailStart && entry.text.length >= MIN_SENTENCE && entry.text.length <= MAX_SENTENCE);
+  if (candidates.length === 0) return null;
+  return candidates.reduce((longest, entry) => (entry.text.length > longest.text.length ? entry : longest));
+}
+
+/** `WINDOW_CHARS` centred on the sentence and clamped to the text -- the control's document. */
+function windowAround(text: string, quote: { text: string; start: number }): string {
+  const centre = quote.start + quote.text.length / 2;
+  const from = Math.max(0, Math.min(text.length - WINDOW_CHARS, Math.round(centre - WINDOW_CHARS / 2)));
+  return text.slice(from, from + WINDOW_CHARS);
+}
+
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+};
+const mean = (values: number[]): number =>
+  values.reduce((total, value) => total + value, 0) / (values.length || 1);
+const days = (from: string, to: number) => (to - new Date(from).getTime()) / 86_400_000;
+
+async function main() {
+  const { root, dbPath } = await resolveTarget(positional);
+  // The read-only claim, stated as a measurement rather than as a promise. `openPeerStore` opens
+  // with `PRAGMA query_only = ON`, so SQLite itself refuses a write -- this is the second belt.
+  const before = await fs.stat(dbPath);
+
+  const config = await loadConfig(root);
+  const profile = resolveVectorProfile(config);
+  const fingerprint = fingerprintProfile(profile);
+  const embedder = await createLocalEmbeddingProvider(config, root);
+  const store = await openPeerStore(dbPath);
+  const sql = async (text: string, args: unknown[] = []) =>
+    (await store.client.execute({ sql: text, args: args as any[] })).rows as any[];
+
+  // ---- the corpus, stated before anything is concluded about it -------------------------------
+  const [counts] = await sql(
+    `SELECT COUNT(*) AS total,
+            SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active,
+            MIN(created_at) AS oldest, MAX(created_at) AS newest
+     FROM knowledge_items`);
+  const [embedded] = await sql(
+    `SELECT COUNT(*) AS total FROM knowledge_embeddings e
+     JOIN knowledge_items i ON i.id = e.knowledge_item_id
+     WHERE i.status = 'active' AND e.profile_fingerprint = ?`, [fingerprint]);
+  const ages = (await sql(`SELECT created_at FROM knowledge_items WHERE status = 'active'`))
+    .map(row => days(String(row.created_at), Date.now()));
+  const corpus = {
+    dbPath,
+    fingerprint,
+    model: profile.model,
+    dtype: profile.dtype,
+    pooling: profile.pooling,
+    atoms: Number(counts.total),
+    active: Number(counts.active),
+    /** The ranking denominator: every vector a query is actually scored against. */
+    rankedAgainst: Number(embedded.total),
+    oldest: String(counts.oldest),
+    newest: String(counts.newest),
+    medianAgeDays: Number(median(ages).toFixed(1)),
+  };
+  console.log(`\n## Corpus\n`);
+  console.log('```');
+  console.log(`db                ${corpus.dbPath}`);
+  console.log(`model             ${corpus.model} ${corpus.dtype}/${corpus.pooling}  (${corpus.fingerprint})`);
+  console.log(`atoms             ${corpus.atoms} total, ${corpus.active} active`);
+  console.log(`ranked against    ${corpus.rankedAgainst} vectors under this profile`);
+  console.log(`age               oldest ${corpus.oldest.slice(0, 10)}, newest ${corpus.newest.slice(0, 10)},`
+    + ` median atom ${corpus.medianAgeDays}d old`);
+  console.log('```');
+
+  // ---- the population, sampled by even stride over id order -----------------------------------
+  const ids = (await sql(
+    `SELECT i.id FROM knowledge_items i JOIN knowledge_embeddings e ON e.knowledge_item_id = i.id
+     WHERE i.status = 'active' AND e.profile_fingerprint = ?
+       AND LENGTH(i.title) + LENGTH(i.content) + LENGTH(COALESCE(i.reasoning, '')) >= ?
+     ORDER BY i.id`, [fingerprint, MIN_CHARS])).map(row => String(row.id));
+
+  // The SQL length is a prefilter over three columns; the real population is defined by the text
+  // the embedder was actually given, which also carries the tag line.
+  const items = await getKnowledgeItems(ids, store.db);
+  const population = ids
+    .map(id => items.get(id)!)
+    .filter(item => item && buildKnowledgeEmbeddingText(item).length >= MIN_CHARS);
+
+  if (population.length === 0) {
+    console.log(`\n**No atom in this store reaches ${MIN_CHARS} characters. Nothing to measure.**\n`);
+    store.client.close();
+    return;
+  }
+
+  const stride = Math.max(1, Math.floor(population.length / SAMPLE));
+  const sampled = [];
+  for (let i = 0; sampled.length < SAMPLE && i * stride < population.length; i++) {
+    sampled.push(population[i * stride]);
+  }
+
+  // Stored vectors for the control, read once. `decodeVector` handles both encodings.
+  const vectorRows = await sql(
+    `SELECT knowledge_item_id AS id, vector FROM knowledge_embeddings
+     WHERE profile_fingerprint = ? AND knowledge_item_id IN (${sampled.map(() => '?').join(', ')})`,
+    [fingerprint, ...sampled.map(item => item.id)]);
+  const storedVectors = new Map(vectorRows.map(row => [String(row.id), decodeVector(row.vector)]));
+
+  /** The parent's position in the full vector ranking, or `rankedAgainst + 1` when unreachable. */
+  const vectorRankOf = async (embedding: number[], parentId: string): Promise<number> => {
+    const ranked = await searchKnowledgeEmbeddings(LOCAL_PROJECT_ID, {
+      vector: embedding, status: 'active', profileFingerprint: fingerprint, limit: corpus.rankedAgainst,
+    }, store);
+    const at = ranked.findIndex(hit => hit.item.id === parentId);
+    return at < 0 ? corpus.rankedAgainst + 1 : at + 1;
+  };
+
+  const rows: any[] = [];
+  const skipped: string[] = [];
+  for (const item of sampled) {
+    const full = buildKnowledgeEmbeddingText(item);
+    // Quote from the CLIPPED text, not the full text. A quote past the token budget was never in
+    // the vector at all, and finding it missing would measure truncation (#132) rather than
+    // dilution -- a different defect with a different fix.
+    const clip = embedder.clipToBudget?.(full) ?? { text: full, tokens: 0, clipped: false };
+    const quote = tailQuote(clip.text);
+    if (!quote) { skipped.push(item.id); continue; }
+
+    const queryVector = await embedder.embedQuery(quote.text);
+    const [windowVector] = await embedder.embed([windowAround(clip.text, quote)], { maxBatch: 1 });
+    const stored = storedVectors.get(item.id);
+
+    const fused = await rankKnowledge(LOCAL_PROJECT_ID, {
+      query: quote.text,
+      status: 'active',
+      limit: FUSED_LIMIT,
+      vector: {
+        enabled: true,
+        profileFingerprint: fingerprint,
+        embedding: queryVector,
+        relevanceFloor: embedder.relevanceFloor,
+      },
+    }, store);
+    const fusedAt = fused.findIndex(hit => hit.id === item.id);
+
+    rows.push({
+      id: item.id,
+      title: item.title,
+      chars: full.length,
+      clipped: clip.clipped,
+      quote: quote.text,
+      vectorRank: await vectorRankOf(queryVector, item.id),
+      fusedRank: fusedAt < 0 ? null : fusedAt + 1,
+      wholeCosine: stored ? cosineSimilarity(queryVector, stored) : null,
+      windowCosine: cosineSimilarity(queryVector, windowVector),
+    });
+  }
+
+  // ---- the control that decides whether any of the above is evidence --------------------------
+  //
+  // A title is the first line of the embed text and the shortest, least diluted query this store
+  // can be asked. If titles cannot find their own parents, the store, the profile filter or the
+  // embedder is wrong and the tail numbers measure the harness. The bar is deliberately far below
+  // any plausible healthy value and far above a broken one: a working store returns the parent at
+  // rank 1 for very nearly every title, and a broken one returns it for none.
+  const titleRanks: number[] = [];
+  for (const item of sampled.slice(0, Math.min(10, sampled.length))) {
+    titleRanks.push(await vectorRankOf(await embedder.embedQuery(item.title), item.id));
+  }
+  const titleTop1 = titleRanks.filter(rank => rank === 1).length;
+  if (!(titleTop1 >= Math.ceil(titleRanks.length / 2))) {
+    throw new Error(
+      `CONTROL FAILED: only ${titleTop1}/${titleRanks.length} atom titles retrieve their own atom at `
+      + `rank 1 (ranks: ${titleRanks.join(', ')}). The probe cannot rank this store correctly, so `
+      + `nothing it says about tail quotes is evidence about pooling.`);
+  }
+
+  // ---- the table from #281 --------------------------------------------------------------------
+  const table = (label: string, ranks: Array<number | null>, ceiling: number) => {
+    const found = ranks.map(rank => rank ?? ceiling);
+    const atMost = (n: number) => found.filter(rank => rank <= n).length;
+    const mrr = mean(found.map(rank => (rank <= 10 ? 1 / rank : 0)));
+    console.log(`\n### ${label}\n`);
+    console.log('| metric | value |');
+    console.log('| --- | --- |');
+    console.log(`| queries | ${found.length} |`);
+    console.log(`| parent at rank 1 | ${atMost(1)}/${found.length} |`);
+    console.log(`| parent in top 3 | ${atMost(3)}/${found.length} |`);
+    console.log(`| parent in top 10 | ${atMost(10)}/${found.length} |`);
+    console.log(`| median rank | ${median(found)} |`);
+    console.log(`| worst rank | ${Math.max(...found)}${label.startsWith('Vector') ? ` / ${ceiling - 1}` : ` (of ${FUSED_LIMIT} returned)`} |`);
+    console.log(`| MRR@10 | ${mrr.toFixed(4)} |`);
+    return {
+      queries: found.length, rank1: atMost(1), top3: atMost(3), top10: atMost(10),
+      median: median(found), worst: Math.max(...found), mrr: Number(mrr.toFixed(4)),
+    };
+  };
+
+  console.log(`\n## Tail-quote retrieval\n`);
+  console.log(`Sampled ${rows.length} of ${population.length} atoms at or above ${MIN_CHARS} characters`
+    + ` (stride ${stride}${skipped.length ? `, ${skipped.length} skipped for having no ${MIN_SENTENCE}-${MAX_SENTENCE} char tail sentence` : ''}).`);
+  console.log(`Title control: ${titleTop1}/${titleRanks.length} at rank 1.`);
+  const vectorTable = table('Vector-only, over all ' + corpus.rankedAgainst + ' stored vectors', rows.map(row => row.vectorRank), corpus.rankedAgainst + 1);
+  const fusedTable = table(`Fused (rankKnowledge, limit ${FUSED_LIMIT})`, rows.map(row => row.fusedRank), FUSED_LIMIT + 1);
+
+  // ---- the windowed control -------------------------------------------------------------------
+  const scored = rows.filter(row => row.wholeCosine !== null);
+  const whole = mean(scored.map(row => row.wholeCosine));
+  const windowed = mean(scored.map(row => row.windowCosine));
+  const advantage = mean(scored.map(row => row.windowCosine - row.wholeCosine));
+  const windowWins = scored.filter(row => row.windowCosine > row.wholeCosine).length;
+  console.log(`\n### Windowed control (${WINDOW_CHARS}-char window around the quoted sentence)\n`);
+  console.log('| quantity | mean cosine |');
+  console.log('| --- | --- |');
+  console.log(`| whole-atom vector (the one stored) | ${whole.toFixed(4)} |`);
+  console.log(`| ${WINDOW_CHARS}-char window around the sentence | ${windowed.toFixed(4)} |`);
+  console.log(`| **window advantage** | **${advantage >= 0 ? '+' : ''}${advantage.toFixed(4)}** |`);
+  console.log(`\nThe window scores higher for ${windowWins}/${scored.length} sampled atoms.`);
+
+  const after = await fs.stat(dbPath);
+  console.log(`\n### Read-only\n`);
+  console.log('```');
+  console.log(`before  ${before.size} bytes  mtime ${before.mtime.toISOString()}`);
+  console.log(`after   ${after.size} bytes  mtime ${after.mtime.toISOString()}`);
+  console.log(before.size === after.size && before.mtimeMs === after.mtimeMs
+    ? 'unchanged' : 'CHANGED -- this probe wrote to the database, which is a bug in it');
+  console.log('```');
+
+  if (JSON_OUT) {
+    await fs.writeFile(JSON_OUT, JSON.stringify({
+      corpus,
+      settings: { minChars: MIN_CHARS, sample: SAMPLE, fusedLimit: FUSED_LIMIT, windowChars: WINDOW_CHARS, stride },
+      population: population.length,
+      titleControl: { ranks: titleRanks, rank1: titleTop1 },
+      vector: vectorTable,
+      fused: fusedTable,
+      control: { whole, windowed, advantage, windowWins, of: scored.length },
+      rows,
+    }, null, 2));
+    console.error(`\nwrote ${JSON_OUT}`);
+  }
+
+  store.client.close();
+  await releaseAll();
+}
+
+await main();


### PR DESCRIPTION
Ports the probe, per the ruling on #281. **No source change** — the candidate-depth constant stays at `Math.max(limit * 3, 10)`, and the reasoning is below.

Lives at `scripts/probe-atom-dilution.ts`, beside the three existing `probe-*.ts` standing probes. It reuses `loadConfig`, `createLocalEmbeddingProvider`, `searchKnowledgeEmbeddings`, `rankKnowledge` and `cosineSimilarity` rather than reimplementing any of them; no new dependency.

## Dilution reproduces

Against this repo's own store (1,197 active atoms, all embedded, median atom 34d old), 30 atoms ≥3500 chars sampled by even stride:

| metric | vector-only | fused (`rankKnowledge`) |
|---|---|---|
| rank 1 | **8/30** | **21/30** |
| top 10 | 14/30 | 21/30 |
| median rank | 13 | **1** |
| worst | 533/1197 | not returned |
| MRR@10 | 0.3298 | 0.7000 |

Windowed control: whole-atom 0.8332 vs 500-char window **0.9078**, advantage **+0.0746** — the issue measured +0.0749 on a different store. Window wins 30/30.

**The fused column is new information the issue did not have.** BM25 does not pool, so a verbatim quote is a near-perfect lexical match and fusion recovers most of what averaging loses: 21/30 rank-1 where the vector arm alone gets 8/30. The defect is largely absorbed before a user sees it, which independently supports the chunking deferral.

## The candidate-depth sweep, and why the constant does not move

| candidateLimit | vector-only | fused MRR@10 |
|---|---|---|
| `limit*3` (shipped) | 8/12/14, median 13 | 0.7000 |
| `limit*5` | identical | 0.7000 |
| `limit*10` | identical | **0.8000** (24/30 rank 1) |

Two validity checks passed: vector-only is byte-identical at all three (the constant is not on that path — the prediction), and the windowed control never moves. `limit*5` is measurably worthless because the three parents that move sit at vector rank 59, 88, 92 — outside a 50-candidate pool, inside a 100-candidate one.

Suites: 35/35 at `*3`; 34/35 at `*5` and `*10`, and the one failure is `agent-query-vector-branch` asserting `options.limit === 15`, a pin on `5*3` arithmetic, not a ranking assertion. Accuracy benchmark (200 questions, 3 runs): **every metric identical** at 3/5/10.

**A flat table is what a blind harness looks like, so it got a positive control**: crushing the constant to `limit*1` moved strictAccuracy 0.7459 → 0.7351 and Recall@10 0.7862 → 0.7793. The bench *can* see this constant; its flat sweep is evidence of no regression, not of blindness.

**Recommendation: leave it.** The case for `*10` is real (+3/30 recovered, no measured regression), but the evidence is 3 queries from 30 samples of a 64-atom population — 5.3% of one store — against a 3.3× widening of a pool that every query in the product decodes, hydrates and scores, and **nobody measured that latency**. `mutation-deep.md:141` says widening moves scores for rows already in the pool; this sweep shows no *measured* ordering changed, not that none can. If it ever changes, `*10` is the value.

Would change the recommendation: a latency measurement showing `*10` is free; the same +3/30 on a second store; or a user-visible report of the failure.

## Read-only, three ways

Opens via `openPeerStore` (`PRAGMA query_only = ON`, so SQLite itself refuses writes); stats the db before and after each run and prints both (5/5 runs `unchanged`); and the atom count and newest `created_at` are byte-identical after all runs. I re-ran the probe independently and got the same table with the same before/after mtime.

Gates: typecheck, lint, docs:check clean.

Closes #281.