### PR TITLE
test(ranking+ci): the small-peer knife edge, and budgets for the slowest runner

### DIFF
--- a/tests/benchmark/knowl-adapter.test.ts
+++ b/tests/benchmark/knowl-adapter.test.ts
@@ -21,7 +21,9 @@ const records: NormalizedRecord[] = [
   },
 ];
 
-describe('Knowl normalized benchmark adapter', () => {
+// Spawns the real CLI per case; timed out at 32.4s on windows-latest against the 30s default.
+// See #293 -- the Windows runner is ~2x slower than ubuntu on this suite's workload.
+describe('Knowl normalized benchmark adapter', { timeout: 120_000 }, () => {
   it('preserves source IDs, applies supersession, and isolates projects', async () => {
     const adapter = new KnowlBenchmarkAdapter();
     await adapter.reset({ runId: 'knowl-adapter-test', mode: 'normalized', seed: 1 });

--- a/tests/cli/temporal-cli.test.ts
+++ b/tests/cli/temporal-cli.test.ts
@@ -20,7 +20,10 @@ describe('temporal CLI', () => {
     const client = createClient({ url: `file:${path.join(ROOT, '.knowl', 'knowl.db')}` });
     const row = (await client.execute('SELECT id, created_at FROM knowledge_items WHERE title = ?', ['Temporal storage'])).rows[0];
     itemId = String(row.id); createdAt = String(row.created_at); client.close();
-  }, 15_000);
+  // Two cold CLI spawns, on a budget tighter than the suite default. ~300ms each locally and
+  // roughly double on the Windows runner, so this had the least headroom in the repo and is
+  // where a slow runner hit first (#293).
+  }, 120_000);
   afterAll(async () => { await fs.rm(ROOT, { recursive: true, force: true }).catch(() => {}); });
 
   it('prints an item timeline and supports an as-of query', () => {
@@ -28,5 +31,5 @@ describe('temporal CLI', () => {
     const asOf = JSON.parse(execSync(`node "${CLI}" query storage --as-of ${createdAt}`, { cwd: ROOT, encoding: 'utf8' }));
     expect(timeline).toEqual([expect.objectContaining({ knowledgeItemId: itemId, content: 'SQLite is active.' })]);
     expect(asOf).toEqual([expect.objectContaining({ id: itemId, content: 'SQLite is active.' })]);
-  }, 15_000);
+  }, 120_000);
 });

--- a/tests/store/namespace-id-resolution.test.ts
+++ b/tests/store/namespace-id-resolution.test.ts
@@ -43,7 +43,12 @@ function storedId(output: string): string {
   return match[1];
 }
 
-describe('an id that lives in the global namespace', () => {
+// Every case here spawns the real CLI, and a cold Node start is ~300ms locally and roughly
+// double that on the Windows runner (measured on one run: 7.0min wall against ubuntu's 3.7min,
+// same commit). The file takes ~12s locally, so the default 30s per-test budget left under 3x
+// of headroom and two cases crossed it at 33.3s and 30.6s on windows-latest -- reported as a
+// flake, but really a budget sized for a fast machine. See #293.
+describe('an id that lives in the global namespace', { timeout: 120_000 }, () => {
   let globalId = '';
   let projectId = '';
 

--- a/tests/store/recency-scale-free.test.ts
+++ b/tests/store/recency-scale-free.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { scoreCandidates, type Candidate } from '../../src/store/agent-query.js';
+import type { KnowledgeItem } from '../../src/core/types.js';
+
+/**
+ * Recency is min-max normalised over the candidate set, so it is SCALE-FREE: a one-millisecond
+ * gap is worth as much as a one-week gap when it is the only gap in the set.
+ *
+ * That is correct -- position within a page is what recency is for -- but it means the recency
+ * term's magnitude is decided by how wide a span the page happens to cover, which for a test
+ * fixture is decided by how fast the machine wrote it. Two rows whose lexical evidence differs
+ * by 0.4% can therefore swap places between a fast machine and a slow one with nothing in the
+ * ranking having changed.
+ *
+ * This is the mechanism behind the macOS-only failure in #293 (`small-peer-lexical`, run
+ * 34430741581): a fixture seeded rows milliseconds apart, and on that runner the youngest row's
+ * recency outweighed a 0.4% lexical deficit. Pinned here so the property is stated on purpose
+ * rather than discovered again through a flake, and so any change to the recency prior that
+ * removes the knife-edge fails a test that says why it existed.
+ */
+
+const item = (id: string, at: string): KnowledgeItem => ({
+  id, category: 'fact', status: 'active', title: `Row ${id}`, content: `Body ${id}`,
+  freshness: 'fresh', confidence: 1, version: 1, createdAt: at, updatedAt: at,
+} as KnowledgeItem);
+
+/** Two rows, near-identical lexically, separated only by `gapMs` of age. */
+function leaderFor(gapMs: number, spanMs: number): string {
+  const base = Date.parse('2026-09-01T00:00:00.000Z');
+  const candidates: Array<Candidate & { repo?: string }> = [
+    // An anchor that fixes the total span the set covers, and which cannot win on lexical.
+    { item: item('anchor', new Date(base).toISOString()), bm25Rank: 3, lexicalScore: 1e-9, lexicalCoverage: 0 },
+    { item: item('best', new Date(base + spanMs).toISOString()), bm25Rank: 1, lexicalScore: 3.860784043844392e-6, lexicalCoverage: 1 },
+    { item: item('near', new Date(base + spanMs + gapMs).toISOString()), bm25Rank: 2, lexicalScore: 3.846264921786819e-6, lexicalCoverage: 1 },
+  ];
+  return scoreCandidates(candidates, { query: 'build output directory', limit: 3, usingVector: false })[0].item.id;
+}
+
+describe('the recency prior is scale-free, so a millisecond can outrank a lexical gap', () => {
+  it('lets the newest row win when its age gap is the whole span', () => {
+    // 1ms of newness across a 1ms span is a full point of recency -- the maximum the term can
+    // pay -- and it buys more than the 0.4% of lexical evidence it gives up.
+    expect(leaderFor(1, 0)).toBe('near');
+  });
+
+  it('lets the better lexical row win when the same gap is a sliver of a wide span', () => {
+    // The identical one-millisecond gap, now 0.001% of the span, is worth almost nothing.
+    expect(leaderFor(1, 100_000)).toBe('best');
+  });
+
+  it('is the same 0.4% lexical gap in both cases, so only the span decided it', () => {
+    // Stated as an assertion rather than a comment: if someone widens the lexical gap in the
+    // fixture above, these two cases stop testing what they claim to.
+    const ratio = 3.846264921786819e-6 / 3.860784043844392e-6;
+    expect(ratio).toBeGreaterThan(0.99);
+    expect(ratio).toBeLessThan(1);
+  });
+});

--- a/tests/store/small-peer-lexical.test.ts
+++ b/tests/store/small-peer-lexical.test.ts
@@ -90,10 +90,27 @@ describe('a tiny peer whose rows all match is not lost to the IDF clamp', () => 
     expect(mine[0].lexicalScore).toBeGreaterThan(1);
 
     const scored = scoreCandidates([...mine, ...theirs], { query, limit: 10, usingVector: false });
-    // ...and it costs the peer nothing. Its best row leads the page on a full-coverage match,
+    // ...and it costs the peer nothing. A peer row leads the page on a full-coverage match,
     // above a local row that shares one term of three.
     expect(scored[0].repo).toBe('small');
-    expect((scored[0].explanation.contributions as { lexical: number }).lexical).toBeCloseTo(1, 5);
+    // Recovered from the clamp, which is the whole claim: ~3.8e-6 of raw evidence becomes a
+    // lexical contribution of very nearly 1 once divided by its own corpus's best.
+    //
+    // NOT `toBeCloseTo(1, 5)`, which asserted something this test never meant. At two and three
+    // rows the peer holds a second matching row whose raw evidence is 0.4% below the best
+    // ("Build output cleaning" vs "Deploy build output": 3.846e-6 vs 3.861e-6), and it is
+    // written LAST, so it is the newest row in the set. Recency is min-max normalised over the
+    // candidate set, so how much that 1ms of newness is worth depends on the total span the set
+    // happens to cover -- which is a fact about how fast the machine seeded the fixtures, not
+    // about the ranking. When it outweighs the 0.4%, the other peer row leads and the
+    // contribution is 0.9962393332823878 -- observed on macos-latest, run 34430741581, on a
+    // tree that passed everywhere else and on the re-run.
+    //
+    // Both orderings are correct: lexical is a tie-breaker rather than a veto here (see
+    // FUSION_ALPHA), a 0.4% gap is a tie, and the claim under test -- the clamped peer is not
+    // lost -- is true either way. So this asserts the recovery, not which of two
+    // indistinguishable rows won it.
+    expect((scored[0].explanation.contributions as { lexical: number }).lexical).toBeGreaterThan(0.99);
     expect(scored.some(entry => entry.repo === 'big')).toBe(true);
 
     await closeDb();


### PR DESCRIPTION
Root-causes the macOS half of #293. **It is not the same bug as the Windows crashes** — see the issue for that split — but it is fully explained, reproduced, and fixed here.

## The number was the evidence

```
expected 0.9962393332823878 to be close to 1
```

That is not float noise. It is exactly:

```
raw("Build output cleaning") / raw("Deploy build output")
  = 3.846264921786819e-6 / 3.860784043844392e-6
  = 0.9962393332823880          (CI: ...878)
```

So the *other* peer row led the page. Both rows fully cover the query; their raw lexical evidence differs by **0.4%**.

## Why a machine can decide it

`normalizedRecencyScore` (`agent-query.ts:219-232`) is min-max over the candidate set:

```
recency = (row.updatedAt - oldest) / (newest - oldest)
```

That is **scale-free** — a 1ms gap is worth a full point of recency when it is the only gap in the set, and nearly nothing when the set spans a minute. `Build output cleaning` is seeded last, so it is the newest row. How much that newness is worth therefore depends on the total span the fixture happens to cover, which is decided by *how fast the machine wrote the rows*, not by anything in the ranking.

Reproduced by holding the ranking fixed and varying only that span. Same two rows, same lexical gap, different winner.

## What was actually wrong: the assertion, not the code

The test's real claim survives the failure. `expect(scored[0].repo).toBe('small')` — the clamped tiny peer still wins the page, which is the entire point of the test — **passes in the failing case too**. I verified this explicitly (`peerLeadsPage=true` in every configuration, including the one that produces the CI number).

Only `toBeCloseTo(1, 5)` broke, and it was asserting something the test never meant: that of two indistinguishable peer rows, one specific one leads. Lexical is a tie-breaker rather than a veto here (`FUSION_ALPHA`), and a 0.4% gap is a tie. Both orderings are correct.

So it now asserts the recovery (`> 0.99`) rather than the tie-break. **Still strict** — reverting the per-corpus normalisation this test exists to guard fails 4 of its 5 cases.

Second file pins the mechanism, so the property is stated deliberately rather than rediscovered as a flake next time.

Gates: typecheck, lint clean; `tests/store` 144 files / 1178 tests green.

Refs #293 — the Windows access violations and stalls are a separate, still-unreproduced problem and this does not touch them.