### PR TITLE
fix(store): closeDb closes the fleet database too

### DIFF
--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -463,6 +463,21 @@ export function getConfigRoot(): string {
  * reachable from a second kind of caller.
  */
 export async function closeDb(): Promise<void> {
+  // The fleet database first, and unconditionally: it is not in this pool and it is not
+  // reached through `globalContext`, so neither the guard below nor `releaseAll` has ever
+  // touched it. `openFleetDb` caches its client in a module map that exactly one call site
+  // drains (`knowl fleet`), while every hook process opens it -- `agent-reminder` on the
+  // prompt event, `agent-hook` on tool events -- and exits without closing it. That leaves a
+  // live native handle for process teardown to reclaim instead of `close()`, on the two
+  // commands that run most often and are most often killed the moment they finish.
+  //
+  // Here rather than in each hook's own teardown because both already call this and a third
+  // caller would forget: "shutting the store down" is what this function means, and the
+  // fleet database is part of the store.
+  // Imported here rather than at module top: `src/fleet/store.ts` pulls in config and paths,
+  // and this module sits underneath both. The dynamic form is what the rest of the store uses
+  // for the same reason.
+  await import('../fleet/store.js').then(m => m.closeFleetDb()).catch(() => {});
   if (globalContext) {
     // Release the whole pool, not just the active handle. Tests and CLI commands delete
     // their project directory after closing, and a client still holding the file would

--- a/tests/fleet/close-with-store.test.ts
+++ b/tests/fleet/close-with-store.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, initDb } from '../../src/store/database.js';
+import { releaseAll } from '../../src/store/connection-pool.js';
+import * as repo from '../../src/store/repository.js';
+import { fleetDbPath, openFleetDb, touchFleetSession } from '../../src/fleet/store.js';
+
+/**
+ * `closeDb` shuts the store down, and the fleet database is part of the store.
+ *
+ * It was not. `openFleetDb` caches its libSQL client in a module map that exactly one call site
+ * drains (`knowl fleet`), while `closeDb` released only the knowledge pool -- so every hook
+ * process that touched the fleet (`agent-reminder` on the prompt event, `agent-hook` on tool
+ * events) exited holding a live native handle, left for process teardown to reclaim rather than
+ * closed. Those are the two commands that run most often and are killed the instant they finish.
+ *
+ * Asserted through the client's own behaviour rather than through the module map, because the
+ * map is private and a test that reached into it would pass against a `close()` that never ran:
+ * a closed libSQL client rejects the next statement, an open one answers it.
+ */
+
+const HOME = path.join(os.tmpdir(), `knowl-fleet-close-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+const ROOT = path.join(HOME, 'project');
+
+describe('closeDb closes the fleet database too', () => {
+  beforeEach(async () => {
+    process.env.KNOWL_HOME = HOME;
+    await fs.mkdir(path.join(ROOT, '.knowl'), { recursive: true });
+    await initDb(ROOT);
+    await repo.createProject(ROOT, 'fleet-close');
+  });
+
+  afterEach(async () => {
+    delete process.env.KNOWL_HOME;
+    await closeDb().catch(() => {});
+    await releaseAll().catch(() => {});
+    await fs.rm(HOME, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('leaves no usable fleet client behind', async () => {
+    await touchFleetSession({ host: 'claude', sessionId: 's1', projectRoot: ROOT, repo: 'fleet-close' });
+    const client = await openFleetDb();
+    // Open: it answers.
+    await expect(client.execute('SELECT 1')).resolves.toBeTruthy();
+
+    await closeDb();
+
+    // Closed: the same client refuses. Against the unfixed code this resolves, because nothing
+    // on any hook path ever called `closeFleetDb`.
+    await expect(client.execute('SELECT 1')).rejects.toThrow();
+  });
+
+  it('is idempotent, and safe when the fleet was never opened', async () => {
+    // The ordinary case: most commands never touch the fleet at all, and closing twice is what
+    // an error path does after a successful close.
+    await expect(closeDb()).resolves.toBeUndefined();
+    await expect(closeDb()).resolves.toBeUndefined();
+  });
+
+  it('hands the next caller a working client rather than the closed one', async () => {
+    await touchFleetSession({ host: 'claude', sessionId: 's2', projectRoot: ROOT, repo: 'fleet-close' });
+    await closeDb();
+
+    // The cache was cleared, not poisoned: a later open in the same process reconnects.
+    await initDb(ROOT);
+    const reopened = await openFleetDb();
+    await expect(reopened.execute('SELECT 1')).resolves.toBeTruthy();
+    expect(fleetDbPath().startsWith(HOME)).toBe(true);
+  });
+});


### PR DESCRIPTION
A real leaked native handle, on exactly the two commands #293's crash lands on. **I am not claiming this fixes the crash** — see the last section — but it is a defect on its own terms and it is the best candidate anyone has produced.

## The leak

`openFleetDb` (`src/fleet/store.ts:107`) caches its libSQL client in a module map. Exactly **one** call site drains that map — `knowl fleet`, at `program.ts:3290`. Nothing else ever calls `closeFleetDb`.

`closeDb` released only the knowledge pool, because `fleet.db` is not in that pool and is not reached through `globalContext`.

So both hook commands leak:

- `agent-reminder` → `fleetTurnStartBestEffort` → `touchFleetSession` → `openFleetDb`
- `agent-hook` → `fleetObserveToolEventBestEffort` → same

…then each calls `closeDb()` and exits. The native handle is reclaimed by **process teardown** rather than by `close()`. Those are the two commands that run most often and are killed the moment they finish.

## The fix

In `closeDb`, not in each hook's teardown: both already call it, a third caller would forget, and "shutting the store down" is what that function means — the fleet database is part of the store. Unconditional and ahead of the `globalContext` guard, since the fleet can be open when the knowledge store is not. Dynamic import to avoid the cycle (`fleet/store` pulls in config and paths; `store/database` sits under both), which is the form the rest of the store already uses.

## Verified

Test asserts through the client's own behaviour rather than the private module map — a closed libSQL client rejects the next statement, an open one answers it. A test that poked the map would pass against a `close()` that never ran.

- Fails against the unfixed `closeDb` (`expected promise to reject`), passes with it.
- Also covers idempotency and the never-opened case, since most commands never touch the fleet.
- build, typecheck, lint clean; `tests/fleet` + `tests/store` + the three hook suites = **153 files, 1248 tests**, green.
- Both hook commands still work end to end against a real store with `fleet.enabled`.

## What this does not prove

The 0xC0000005 is still unreproduced here in 388 attempts, so I have no failing test that this turns green. My two earlier hypotheses in that issue are both disproved by measurement, and I am not going to add a third confident guess.

What is true: the crash occurs *after* correct output is written, i.e. during teardown; and until this commit, teardown on those two commands had a live libSQL handle nobody closed. That is a coincidence worth removing whether or not it is the cause.

Refs #293.